### PR TITLE
fix: README snippet + platform-specific test skips

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ llm = get_llm_client("hosted_vllm/Qwen/Qwen3-1.7B", api_base="http://localhost:8
 ***Agents are Python objects***. Methods with `...` bodies are **generation methods** — implemented at runtime by an LLM-driven strategy. The signature defines the contract; the docstring is the prompt.
 
 ```python
+import asyncio
+
 from nooa import Agent
 
 
@@ -111,11 +113,13 @@ class FeedbackAgent(Agent, llm=llm):
         ...
 
 
-@autorun
 async def main():
     agent = FeedbackAgent()
     result = await agent.analyze_feedback("Great product, but shipping was slow")
     print(result)
+
+
+asyncio.run(main())
 ```
 
 Run the same code from your own project with `python`. You can run the checked-in example:

--- a/tests/runtime/test_producers.py
+++ b/tests/runtime/test_producers.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import os
+import platform
 
 import pytest
 
@@ -73,6 +74,10 @@ class TestMonitorProcessIsolation:
         assert lines_a == ["A1", "A2"]
         assert lines_b == ["B1", "B2"]
 
+    @pytest.mark.skipif(
+        platform.system() != "Linux",
+        reason="process-group kill semantics differ on non-Linux; verified in Linux CI",
+    )
     async def test_monitor_cancel_kills_process_group(self):
         """Cancelling monitor must kill the entire process group, not just the shell."""
         gen = monitor("bash -c 'echo $BASHPID; sleep 999 & echo ready; wait'")

--- a/tests/test_sqlite_corruption_resilience.py
+++ b/tests/test_sqlite_corruption_resilience.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for SQLite corruption resilience (P0) and virtiofs detection (P1)."""
 
+import platform
 import sqlite3
 import subprocess
 from unittest.mock import patch
@@ -201,6 +202,10 @@ class TestVirtiofsDetection:
     def test_memory_db_is_not_virtiofs(self):
         assert _is_virtiofs(":memory:") is False
 
+    @pytest.mark.skipif(
+        platform.system() != "Linux",
+        reason="virtiofs detection is a Linux-only code path",
+    )
     @patch("subprocess.run")
     def test_detects_virtiofs_in_df_output(self, mock_run):
         mock_run.return_value = type(


### PR DESCRIPTION
- README 'first agent' snippet used @autorun (never imported) -> NameError on copy-paste. Switch to standard asyncio.run(main()) so it runs as-is.
- Skip two Linux-only tests on other platforms so 'uv run pytest' is green for local (e.g. macOS) users: virtiofs detection (Linux-only code path) and monitor process-group kill (shell semantics differ off Linux; both still run in Linux CI).

## What does this PR do?

<!-- A clear, concise description of the change. -->

## Related issues

<!-- e.g. Closes #123 -->

## Checklist

- [ ] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [ ] Tests added/updated and passing (`uv run pytest`)
- [ ] Docs updated if behavior or public APIs changed
- [ ] New source files carry an SPDX license header
