### PR TITLE
ci: expand GitHub Actions — build, frontend-check, secret-scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,58 @@ jobs:
         run: uv sync --all-extras --no-extra sandbox
       - name: Unit tests (no live API calls)
         run: uv run pytest -q -m "not integration and not stress"
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags needed for uv-dynamic-versioning
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+      - name: Build all packages
+        run: |
+          rm -rf dist
+          for pkg in nooa nooa-cli nooa-memory nooa-bench; do
+            uv build --package "$pkg" --out-dir dist
+          done
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+  frontend-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Build the trace viewer
+        working-directory: src/nooa/viewer/frontend-react
+        run: |
+          npm ci --ignore-scripts
+          npm run build
+      - name: Fail if dist/ is stale
+        run: |
+          if ! git diff --quiet src/nooa/viewer/frontend-react/dist/; then
+            echo "ERROR: frontend-react/dist/ is stale. Run 'npm run build' and commit dist/."
+            git diff --stat src/nooa/viewer/frontend-react/dist/
+            exit 1
+          fi
+
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so the scan covers all commits
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+# Gitleaks configuration for the CI secret-scan job.
+title = "NOOA gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Intentionally fake secrets used to test the secret-scrubber feature"
+paths = [
+  '''tests/tracing/test_secret_scrubber\.py''',
+]


### PR DESCRIPTION
Port the remaining GitLab CI gates to GitHub Actions:
- build: uv build all four nooa* packages (uploads wheels as artifacts)
- frontend-build: rebuild the React trace viewer and fail if dist/ is stale
- secret-scan: gitleaks on full history

Add .gitleaks.toml allowlisting the secret-scrubber test, whose fixtures are intentionally fake secrets. Publish job intentionally omitted (pinned with the PyPI decision). pyright not gated (strict; matches prior CI which didn't gate type-checking).

## What does this PR do?

<!-- A clear, concise description of the change. -->

## Related issues

<!-- e.g. Closes #123 -->

## Checklist

- [ ] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [ ] Tests added/updated and passing (`uv run pytest`)
- [ ] Docs updated if behavior or public APIs changed
- [ ] New source files carry an SPDX license header
