### PR TITLE
Rename bundled skills to nooa

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/commands/start_dev.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/start_dev.py
@@ -70,7 +70,7 @@ def _find_pid_on_port(port: int) -> str | None:
     type=click.Path(dir_okay=False),
     default=None,
     help="SQLite trace store path. Defaults to ~/.config/nooa/traces.db "
-    "(or $NEMO_OO_TRACE_DB if set). Pass an explicit path to run a second viewer "
+    "(or $NOOA_TRACE_DB if set). Pass an explicit path to run a second viewer "
     "side-by-side with the default one.",
 )
 def command(port: int, host: str, db_path_opt: str | None):
@@ -80,16 +80,19 @@ def command(port: int, host: str, db_path_opt: str | None):
 
     from nooa.paths import get_user_dir
 
-    # Resolve the DB path with --db winning, then $NEMO_OO_TRACE_DB, then the
-    # user-dir default. Set NEMO_OO_TRACE_DB unconditionally so the viewer
-    # module picks it up at import time (it reads the env var at the top).
+    # Resolve the DB path with --db winning, then $NOOA_TRACE_DB, then the
+    # legacy $NEMO_OO_TRACE_DB, then the user-dir default. Set both env vars
+    # unconditionally so the viewer module picks it up at import time.
     if db_path_opt:
         db_path = Path(db_path_opt).expanduser().resolve()
+    elif "NOOA_TRACE_DB" in os.environ:
+        db_path = Path(os.environ["NOOA_TRACE_DB"]).expanduser().resolve()
     elif "NEMO_OO_TRACE_DB" in os.environ:
         db_path = Path(os.environ["NEMO_OO_TRACE_DB"]).expanduser().resolve()
     else:
         db_path = get_user_dir("traces.db")
     db_path.parent.mkdir(parents=True, exist_ok=True)
+    os.environ["NOOA_TRACE_DB"] = str(db_path)
     os.environ["NEMO_OO_TRACE_DB"] = str(db_path)
 
     try:
@@ -97,7 +100,7 @@ def command(port: int, host: str, db_path_opt: str | None):
     except ImportError:
         click.secho(
             "Error: viewer dependencies are not installed.\n"
-            'Install them with:  uv add "nemo-oo-agents[viewer]"',
+            'Install them with:  uv add "nooa[viewer]"',
             fg="red",
             err=True,
         )

--- a/skills/README.md
+++ b/skills/README.md
@@ -8,17 +8,17 @@ These are instructions *for coding agents about the framework* — not `nooa.Ski
 
 | Skill | Use for |
 |---|---|
-| [`nemo-oo-agent-authoring`](nemo-oo-agent-authoring/SKILL.md) | Core authoring: Agent subclasses, generation methods (`...`), docstring prompts, structured output, strategies (CodeAct/Predict), visibility, orchestrators, subagents, LLM config, prompt debugging |
-| [`nemo-oo-codeact-advanced`](nemo-oo-codeact-advanced/SKILL.md) | Advanced strategy tuning: prefill (custom/disable/pre-ellipsis), loop guards, truncation tuning, code restrictions, execution internals, PredictConfig |
-| [`nemo-oo-agentdoc`](nemo-oo-agentdoc/SKILL.md) | Making types render beautiful docs for the LLM: `doc()`, `spec()`, `hidden`, `Annotated` descriptions, `pformat`/`pprint` tuning |
-| [`nemo-oo-context-and-state`](nemo-oo-context-and-state/SKILL.md) | Context blocks, event history and `EventQuery`, history summarization, persistence and memory |
-| [`nemo-oo-tools-and-skills`](nemo-oo-tools-and-skills/SKILL.md) | Methods as tools, built-in tools (Bash/File/Todo), MCP integration, agent skills (`Skill`/`TextSkill`), multimodal media |
-| [`nemo-oo-channels`](nemo-oo-channels/SKILL.md) | Reactive input: Channel/QueueManager, race() dispatch loops, spawn() background jobs, monitor/cron/tail producers |
-| [`nemo-oo-self-extending`](nemo-oo-self-extending/SKILL.md) | Agent-authored code: persistent skill libraries (self.libs), in-cell helpers and standalone @strategy sub-calls, @slash_command |
-| [`nemo-oo-middleware-hooks`](nemo-oo-middleware-hooks/SKILL.md) | Intercepting execution: middleware (`intercept()` guardrails/transforms/blocking), event observers (`on()`), InstrumentationHooks protocol |
-| [`nemo-oo-capturing-traces`](nemo-oo-capturing-traces/SKILL.md) | Capturing traces: auto-tracing, `enable_tracing` + exporters (jsonl/otlp/langfuse/journal), `@no_trace`, span model, env vars |
-| [`nemo-oo-trace-viewer`](nemo-oo-trace-viewer/SKILL.md) | Running and using the trace viewer (`nooa start-dev`): UI, import/export, REST API |
-| [`nemo-oo-trace-explorer`](nemo-oo-trace-explorer/SKILL.md) | Programmatic trace analysis: `trace-explorer` CLI, `TraceExplorer` library, thin client, experiment-level debugging |
+| [`nooa-agent-authoring`](nooa-agent-authoring/SKILL.md) | Core authoring: Agent subclasses, generation methods (`...`), docstring prompts, structured output, strategies (CodeAct/Predict), visibility, orchestrators, subagents, LLM config, prompt debugging |
+| [`nooa-codeact-advanced`](nooa-codeact-advanced/SKILL.md) | Advanced strategy tuning: prefill (custom/disable/pre-ellipsis), loop guards, truncation tuning, code restrictions, execution internals, PredictConfig |
+| [`nooa-agentdoc`](nooa-agentdoc/SKILL.md) | Making types render beautiful docs for the LLM: `doc()`, `spec()`, `hidden`, `Annotated` descriptions, `pformat`/`pprint` tuning |
+| [`nooa-context-and-state`](nooa-context-and-state/SKILL.md) | Context blocks, event history and `EventQuery`, history summarization, persistence and memory |
+| [`nooa-tools-and-skills`](nooa-tools-and-skills/SKILL.md) | Methods as tools, built-in tools (Bash/File/Todo), MCP integration, agent skills (`Skill`/`TextSkill`), multimodal media |
+| [`nooa-channels`](nooa-channels/SKILL.md) | Reactive input: Channel/QueueManager, race() dispatch loops, spawn() background jobs, monitor/cron/tail producers |
+| [`nooa-self-extending`](nooa-self-extending/SKILL.md) | Agent-authored code: persistent skill libraries (self.libs), in-cell helpers and standalone @strategy sub-calls, @slash_command |
+| [`nooa-middleware-hooks`](nooa-middleware-hooks/SKILL.md) | Intercepting execution: middleware (`intercept()` guardrails/transforms/blocking), event observers (`on()`), InstrumentationHooks protocol |
+| [`nooa-capturing-traces`](nooa-capturing-traces/SKILL.md) | Capturing traces: auto-tracing, `enable_tracing` + exporters (jsonl/otlp/langfuse/journal), `@no_trace`, span model, env vars |
+| [`nooa-trace-viewer`](nooa-trace-viewer/SKILL.md) | Running and using the trace viewer (`nooa start-dev`): UI, import/export, REST API |
+| [`nooa-trace-explorer`](nooa-trace-explorer/SKILL.md) | Programmatic trace analysis: `trace-explorer` CLI, `TraceExplorer` library, thin client, experiment-level debugging |
 
 All content was verified against `src/nooa` at the time of writing; where the skills contradict older docs (e.g. `SkillManager`, `from agentdoc import ...`, `enable_tracing(trace_dir=...)`, "private methods aren't traced"), the skills reflect the code.
 
@@ -29,11 +29,11 @@ Copy or symlink skill directories into the location your coding agent reads:
 ```bash
 # Claude Code — all skills, user-global
 mkdir -p ~/.claude/skills
-cp -R skills/nemo-oo-* ~/.claude/skills/
+cp -R skills/nooa-* ~/.claude/skills/
 
 # Or one skill into a project
 mkdir -p .claude/skills
-cp -R skills/nemo-oo-agent-authoring .claude/skills/
+cp -R skills/nooa-agent-authoring .claude/skills/
 ```
 
 Other hosts read from different directories (e.g. `.codex/skills/`, `.agents/skills/`).

--- a/skills/nooa-agent-authoring/SKILL.md
+++ b/skills/nooa-agent-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: nemo-oo-agent-authoring
+name: nooa-agent-authoring
 description: Author agents with the NVIDIA OO Agents (nooa) framework. Use when writing or modifying an Agent subclass, agentic methods (ellipsis bodies), docstring prompts, structured output contracts, strategy selection (CodeAct/Predict), visibility control, orchestrators, or subagent composition.
-compatibility: Python >= 3.12, uv, nemo-oo-agents core package (CLI: nooa)
+compatibility: Python >= 3.12, uv, nooa package (CLI: nooa)
 ---
 
 # Authoring NVIDIA OO Agents (nooa)
@@ -104,7 +104,7 @@ async def summarize(self, text: str) -> str:
     ...
 ```
 
-There are cases where `{param}` is appropriate — e.g. when prefill is disabled and you need custom rendering, or when you want to embed a short value directly in the instruction. For advanced prefill and truncation control, see `nemo-oo-codeact-advanced`.
+There are cases where `{param}` is appropriate — e.g. when prefill is disabled and you need custom rendering, or when you want to embed a short value directly in the instruction. For advanced prefill and truncation control, see `nooa-codeact-advanced`.
 
 Template expansion is primarily for values the signature *can't* show: `{self.attr}` instance state and computed expressions like `{len(items)}`. Escape literal braces as `{{ }}`.
 
@@ -158,7 +158,7 @@ async def implement(self, task: str) -> str: ...
 
 **Constructors take `config=` only.** `PredictStrategy(max_retries=3)` and `CodeActStrategy(max_iterations=10)` are errors — wrap options in `PredictConfig(...)`/`CodeActConfig(...)`. Useful `CodeActConfig` fields: `max_iterations`, `max_retries`, `cell_timeout`, `max_tokens`, `temperature`, `max_consecutive_text_only`, `restrictions`.
 
-`max_iterations` is a safety net, not the main tuning dial — decompose the task instead of raising the cap. For prefill control, truncation tuning, code restrictions, and the full config surface, see `nemo-oo-codeact-advanced`.
+`max_iterations` is a safety net, not the main tuning dial — decompose the task instead of raising the cap. For prefill control, truncation tuning, code restrictions, and the full config surface, see `nooa-codeact-advanced`.
 
 **Reserved parameter:** naming an agentic method parameter `reasoning` raises `ValueError` at class creation (chain-of-thought is provided via the injected `reasoning()` builtin instead).
 
@@ -196,8 +196,8 @@ class SearchAgent(Agent, llm=llm):
 - **Hide the entry-point agentic method** (`@hidden` on `run`/`respond`) when the LLM might recursively call itself through `doc(self)`.
 - Never hide a method the LLM must call as a tool.
 - Module-level imports are the LLM's execution namespace: if generated code needs `json.loads`, `import json  # noqa: F401` at the top of the agent file.
-- `self.context` / `self.events` are always present but hidden; expose with `spec(self, "context", hidden=False)` in `__init__` (see `nemo-oo-context-and-state`).
-- Making the visible surface render *well* — field descriptions, referenced-type expansion, `pformat` caps — is its own craft: see `nemo-oo-agentdoc`.
+- `self.context` / `self.events` are always present but hidden; expose with `spec(self, "context", hidden=False)` in `__init__` (see `nooa-context-and-state`).
+- Making the visible surface render *well* — field descriptions, referenced-type expansion, `pformat` caps — is its own craft: see `nooa-agentdoc`.
 
 ## Orchestration and decomposition
 
@@ -223,10 +223,10 @@ enable_logging(level="DEBUG")                    # nooa.* logger hierarchy
 # kill -USR2 <pid>                               # dump traceback + all registered cells to debug_dump_<pid>.txt
 ```
 
-Most bugs are visible in the rendered prompt. For runtime behavior, capture traces and inspect them — see `nemo-oo-capturing-traces` and `nemo-oo-trace-explorer`.
+Most bugs are visible in the rendered prompt. For runtime behavior, capture traces and inspect them — see `nooa-capturing-traces` and `nooa-trace-explorer`.
 
 ## Where to look
 
 - Guides: `docs/guides/prompt-mechanics.md`, `strategies.md`, `structured-output.md`, `writing-generation-methods.md`, `single-vs-multi-agent.md`.
 - Runnable examples: `examples/quickstart/01`–`15`.
-- Related skills: `nemo-oo-codeact-advanced`, `nemo-oo-context-and-state`, `nemo-oo-tools-and-skills`, `nemo-oo-agentdoc`, `nemo-oo-channels`, `nemo-oo-capturing-traces`, `nemo-oo-trace-viewer`, `nemo-oo-trace-explorer`.
+- Related skills: `nooa-codeact-advanced`, `nooa-context-and-state`, `nooa-tools-and-skills`, `nooa-agentdoc`, `nooa-channels`, `nooa-capturing-traces`, `nooa-trace-viewer`, `nooa-trace-explorer`.

--- a/skills/nooa-agentdoc/SKILL.md
+++ b/skills/nooa-agentdoc/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: nemo-oo-agentdoc
+name: nooa-agentdoc
 description: Make NVIDIA OO agent types render beautiful documentation for the LLM — doc(), spec(), hidden, Annotated field descriptions, and pformat/pprint tuning. Use when designing Pydantic models/dataclasses the LLM will see, controlling what appears in doc(self), hiding internals, adding field descriptions, fixing noisy or missing type docs, or tuning value truncation.
-compatibility: nemo-oo-agents core package (agentdoc ships inside it — import from nooa.agentdoc)
+compatibility: nooa package (agentdoc ships inside it — import from nooa.agentdoc)
 ---
 
 # agentdoc: Beautiful Docs for the LLM
@@ -139,7 +139,7 @@ dict(len=100, items={0: 0, 1: 1, ..., 99: 99})
 
 - Classes with their own `__repr__` (pandas, numpy) are trusted and rendered via their repr (truncated head/tail if huge).
 - Implement `__instance_values__(self) -> dict[str, Any]` (the `SupportsInstanceValues` protocol) to control exactly which fields an instance renders — omitted keys are hidden.
-- These same knobs are what `TruncationConfig`'s `event_format`/`prefill_format` splat into `pformat` framework-wide — see `nemo-oo-codeact-advanced`.
+- These same knobs are what `TruncationConfig`'s `event_format`/`prefill_format` splat into `pformat` framework-wide — see `nooa-codeact-advanced`.
 
 ## Gotchas
 
@@ -151,6 +151,6 @@ dict(len=100, items={0: 0, 1: 1, ..., 99: 99})
 
 ## Related skills
 
-- `nemo-oo-agent-authoring` — visibility rules in the agent context (`doc(self)`, exec_globals).
-- `nemo-oo-codeact-advanced` — how prefill and truncation configs drive `pprint` of your parameters.
-- `nemo-oo-tools-and-skills` — skill docstring conventions (`doc(self.skill)` is the usage guide).
+- `nooa-agent-authoring` — visibility rules in the agent context (`doc(self)`, exec_globals).
+- `nooa-codeact-advanced` — how prefill and truncation configs drive `pprint` of your parameters.
+- `nooa-tools-and-skills` — skill docstring conventions (`doc(self.skill)` is the usage guide).

--- a/skills/nooa-capturing-traces/SKILL.md
+++ b/skills/nooa-capturing-traces/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: nemo-oo-capturing-traces
+name: nooa-capturing-traces
 description: Capture execution traces from NVIDIA OO Agents. Use when instrumenting an agent run, writing traces to JSONL files, sending traces to the viewer or an OTLP/Langfuse/Phoenix backend, controlling which methods are traced, or when traces are mysteriously missing.
-compatibility: nemo-oo-agents core package; the [tracing] extra (opentelemetry + openinference) for exporters
+compatibility: nooa package; the [tracing] extra (opentelemetry + openinference) for exporters
 ---
 
 # Capturing Traces
@@ -105,7 +105,7 @@ Files are OTLP JSON Lines: each line is one `{"resourceSpans": [...]}` object. T
 
 ## Pitfalls
 
-- **Do NOT use** `from openinference_instrumentation_nemo_oo_agents import enable_tracing` or `enable_tracing(trace_dir=...)` — both appear in older docs/comments but do not exist. Tracing lives in `nooa.tracing`; `trace_dir` is an argument of `exporters.jsonl()`, and `enable_tracing()` returns `None`.
+- **Do NOT use** legacy OpenInference instrumentation imports or `enable_tracing(trace_dir=...)` — both appear in older docs/comments but do not exist. Tracing lives in `nooa.tracing`; `trace_dir` is an argument of `exporters.jsonl()`, and `enable_tracing()` returns `None`.
 - Auto-tracing is attempted once per process. If the viewer wasn't running when the first `Agent` was constructed, later agents won't retry — call `enable_tracing(...)` explicitly or restart with the viewer up.
 - For short scripts, call `flush_traces()` before exit; batch exporters flush on a ~1s schedule and a fast exit can drop the tail of a trace.
 - Logic that runs *outside* agent methods (module-level preprocessing, `main()` helpers) is invisible in traces. Keep interesting logic inside agent methods so failures leave trace evidence.
@@ -123,5 +123,5 @@ flush_traces()
 
 ## Related skills
 
-- `nemo-oo-trace-viewer` — run the web viewer and browse captured traces.
-- `nemo-oo-trace-explorer` — programmatic/CLI trace analysis and root-cause debugging.
+- `nooa-trace-viewer` — run the web viewer and browse captured traces.
+- `nooa-trace-explorer` — programmatic/CLI trace analysis and root-cause debugging.

--- a/skills/nooa-channels/SKILL.md
+++ b/skills/nooa-channels/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: nemo-oo-channels
+name: nooa-channels
 description: Reactive input for NVIDIA OO agents — Channel/QueueManager for queued and event-mode input, race() turn dispatch, spawn() background jobs with JobHandle, and the bundled producers (monitor a shell command, cron ticks, one-shot timers, file tails). Use when an agent must react to external input mid-run — user messages, CI output, timers, job completions — or when building an interactive/long-running agent loop.
-compatibility: nemo-oo-agents core package
+compatibility: nooa package
 ---
 
 # Channels: Reactive Agent Input
@@ -76,11 +76,11 @@ qm.spawn(run_job(some_coro(), job_id="batch-7"), channel="jobs")    # {"job_id":
 - `QueueManager` is hidden from the LLM by default; expose deliberately (`spec(self, "queue_manager", hidden=False)`) or, better, expose only the `reader` attributes and keep `put`/`spawn` on the Python side.
 - Registration order is priority order for `race()` — register the highest-priority channel (usually user messages) first.
 - Don't `await channel.get()` (producer object) from LLM code — give the LLM the `.reader`, whose `get(timeout=...)` can't deadlock a cell.
-- The dispatcher belongs in a pure-Python orchestrator method (`run()` above) — see "Orchestrators are pure Python" in `nemo-oo-agent-authoring`.
+- The dispatcher belongs in a pure-Python orchestrator method (`run()` above) — see "Orchestrators are pure Python" in `nooa-agent-authoring`.
 - `spawn()` requires the channel to already exist (`ValueError` otherwise).
 
 ## Related skills
 
-- `nemo-oo-agent-authoring` — the orchestrator pattern the dispatch loop lives in.
-- `nemo-oo-context-and-state` — `QueueOutput`/`StreamEnd`/`JobError` are events; query them like any others.
-- `nemo-oo-middleware-hooks` — `on()` observers if you only need to react to recorded events, not consume input.
+- `nooa-agent-authoring` — the orchestrator pattern the dispatch loop lives in.
+- `nooa-context-and-state` — `QueueOutput`/`StreamEnd`/`JobError` are events; query them like any others.
+- `nooa-middleware-hooks` — `on()` observers if you only need to react to recorded events, not consume input.

--- a/skills/nooa-codeact-advanced/SKILL.md
+++ b/skills/nooa-codeact-advanced/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: nemo-oo-codeact-advanced
+name: nooa-codeact-advanced
 description: Advanced tuning of NVIDIA OO Agents strategies — CodeAct prefill (understanding, disabling, custom, pre-ellipsis code), loop guards (max_iterations, retries, text-only stop), truncation tuning (TruncationConfig/CaptureConfig/FormatConfig), code restrictions (RestrictionsConfig), execution environment internals, and PredictStrategy tuning (retries, param guards, output_serialization). Use when configuring CodeActConfig or PredictConfig beyond defaults, writing a custom prefill, restricting generated code, or debugging truncation/eviction behavior.
-compatibility: nemo-oo-agents core package
+compatibility: nooa package
 ---
 
 # Advanced CodeAct (and Predict) Tuning
 
-The authoring basics are in `nemo-oo-agent-authoring`. This skill covers the deep configuration surface, verified against `strategies/codeact.py`, `strategies/prefill.py`, `strategies/predict.py`, and `config/`.
+The authoring basics are in `nooa-agent-authoring`. This skill covers the deep configuration surface, verified against `strategies/codeact.py`, `strategies/prefill.py`, `strategies/predict.py`, and `config/`.
 
 ## Config plumbing rules (read first)
 
@@ -124,6 +124,6 @@ Single LLM turn, no tools, no code. The prompt is the docstring plus each parame
 
 ## Related skills
 
-- `nemo-oo-agent-authoring` — the basics this builds on (strategy selection, contracts, visibility).
-- `nemo-oo-context-and-state` — the context blocks that truncation/eviction act on.
-- `nemo-oo-capturing-traces` / `nemo-oo-trace-explorer` — see every prefill cell, tool call, and validation retry in the trace.
+- `nooa-agent-authoring` — the basics this builds on (strategy selection, contracts, visibility).
+- `nooa-context-and-state` — the context blocks that truncation/eviction act on.
+- `nooa-capturing-traces` / `nooa-trace-explorer` — see every prefill cell, tool call, and validation retry in the trace.

--- a/skills/nooa-context-and-state/SKILL.md
+++ b/skills/nooa-context-and-state/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: nemo-oo-context-and-state
+name: nooa-context-and-state
 description: Manage what a NVIDIA OO agent sees and remembers — context blocks, event history and queries, history summarization, and persistent memory/storage. Use when pinning information into the system prompt, querying past events, bounding context growth in long conversations, or persisting agent state.
-compatibility: nemo-oo-agents core package
+compatibility: nooa package
 ---
 
 # Context, Events, and State
@@ -132,5 +132,5 @@ See `docs/design/memory-system/design.md` and `examples/advanced/memory.py`.
 
 ## Related skills
 
-- `nemo-oo-agent-authoring` — the core authoring model this builds on.
-- `nemo-oo-capturing-traces` — events vs spans: traces are the observability view of the same run.
+- `nooa-agent-authoring` — the core authoring model this builds on.
+- `nooa-capturing-traces` — events vs spans: traces are the observability view of the same run.

--- a/skills/nooa-middleware-hooks/SKILL.md
+++ b/skills/nooa-middleware-hooks/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: nemo-oo-middleware-hooks
+name: nooa-middleware-hooks
 description: Intercept and observe NVIDIA OO agent execution — middleware via event_manager.intercept() (guardrails, input/output transforms, blocking), event observers via event_manager.on() (react to Task/Error/LLMComplete/turn events), and the InstrumentationHooks protocol for observability backends. Use when adding guardrails, redacting or rewriting prompts, blocking or faking an LLM call or code execution, rate-limiting agent methods, subscribing to lifecycle events, or wiring custom telemetry.
-compatibility: nemo-oo-agents core package
+compatibility: nooa package
 ---
 
 # Middleware and Hooks
@@ -14,7 +14,7 @@ Three interception surfaces, one decision rule:
 | **Observers** | `agent.event_manager.on(event_type, fn)` | no — fire-and-forget after the event is recorded | isolated | per-agent |
 | **InstrumentationHooks** | `set_hooks(obj)` (`nooa.runtime.hooks`) | no — observational timing/tracing pairs | swallowed + logged, overhead metered | one global slot per async context |
 
-Rule of thumb: enforcing or transforming → `intercept()`; reacting → `on()`; building an observability backend → you probably want a tracing exporter (`nemo-oo-capturing-traces`), not raw hooks — the tracing system already occupies the hooks slot.
+Rule of thumb: enforcing or transforming → `intercept()`; reacting → `on()`; building an observability backend → you probably want a tracing exporter (`nooa-capturing-traces`), not raw hooks — the tracing system already occupies the hooks slot.
 
 ## Middleware (`intercept`)
 
@@ -64,7 +64,7 @@ agent.event_manager.on("*", audit)                 # wildcard: every event
 ```
 
 - Useful runtime-only events (never rendered to the model): `BeforeTurn` / `AfterTurn` (per generation turn; `AfterTurn.is_final` marks method completion) and `LLMComplete` (tokens, cost, model_name, tool_calls, reasoning metadata per round-trip — emitted precisely so you don't need `intercept("llm_call")` just to read LLM metrics).
-- Model-visible events (`Task`, `Message`, `Error`, `PythonOutput`, ...) are observable the same way — see `nemo-oo-context-and-state` for the full list.
+- Model-visible events (`Task`, `Message`, `Error`, `PythonOutput`, ...) are observable the same way — see `nooa-context-and-state` for the full list.
 - The summarizers are the house pattern: subscribe to `AfterTurn` to *schedule* work, apply it at the next `BeforeTurn` (`agents/summarization.py:159-160`).
 
 ## InstrumentationHooks (`set_hooks`)
@@ -97,6 +97,6 @@ set_hooks(TimingHooks())   # set_hooks(None) removes
 
 ## Related skills
 
-- `nemo-oo-context-and-state` — the event model that `on()` observes; `EventQuery` filtering.
-- `nemo-oo-capturing-traces` — the tracing system that occupies the hooks slot; exporters are usually the right telemetry surface.
-- `nemo-oo-codeact-advanced` — what `execute_python` middleware wraps (validator pipeline, restrictions, cells).
+- `nooa-context-and-state` — the event model that `on()` observes; `EventQuery` filtering.
+- `nooa-capturing-traces` — the tracing system that occupies the hooks slot; exporters are usually the right telemetry surface.
+- `nooa-codeact-advanced` — what `execute_python` middleware wraps (validator pipeline, restrictions, cells).

--- a/skills/nooa-self-extending/SKILL.md
+++ b/skills/nooa-self-extending/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: nemo-oo-self-extending
+name: nooa-self-extending
 description: Let NVIDIA OO agents extend themselves — persistent skill libraries the agent writes and hot-reloads (SkillWriting / self.libs, LibraryManager), in-cell helper functions and standalone @strategy sub-calls (MethodWriting), and @slash_command user actions. Use when an agent should accumulate reusable code across sessions, define its own helpers or LLM-powered sub-functions at runtime, or ship user-typed /commands from a skill.
-compatibility: nemo-oo-agents core package
+compatibility: nooa package
 ---
 
 # Self-Extending Agents
@@ -33,7 +33,7 @@ return_result(codes)
 
 Standalone functions (`nooa.standalone`) are `@strategy`-decorated async functions **without `self`** — each call runs on a fresh agent stub (no shared state, history discarded after the call; context blocks via the decorator's `ScopedContext`, `llm=` via the decorator or inherited from the calling context). They work in module code too, not just generated cells — the lightest way to get an LLM-powered function without defining an Agent class.
 
-Helpers defined in cells persist as REPL locals for the rest of the method call but are never attached to the agent (attaching callables to `self` is validator-rejected — see `nemo-oo-codeact-advanced`).
+Helpers defined in cells persist as REPL locals for the rest of the method call but are never attached to the agent (attaching callables to `self` is validator-rejected — see `nooa-codeact-advanced`).
 
 ## Persistent libraries (`SkillWriting` / `self.libs`)
 
@@ -86,6 +86,6 @@ class MySkill(Skill):
 
 ## Related skills
 
-- `nemo-oo-tools-and-skills` — the Skill/TextSkill/SkillRegistry model these libraries plug into.
-- `nemo-oo-codeact-advanced` — the validator rules that shape what generated code may define.
-- `nemo-oo-agent-authoring` — standalone `@strategy` functions share generation-method semantics (docstring prompt, return-type contract).
+- `nooa-tools-and-skills` — the Skill/TextSkill/SkillRegistry model these libraries plug into.
+- `nooa-codeact-advanced` — the validator rules that shape what generated code may define.
+- `nooa-agent-authoring` — standalone `@strategy` functions share generation-method semantics (docstring prompt, return-type contract).

--- a/skills/nooa-tools-and-skills/SKILL.md
+++ b/skills/nooa-tools-and-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: nemo-oo-tools-and-skills
+name: nooa-tools-and-skills
 description: Give a NVIDIA OO agent capabilities — methods as tools, built-in tools (ShellTools, TodoManager), MCP servers, agent skills (Skill/TextSkill/SkillRegistry), and multimodal media. Use when adding tools or external integrations to an agent, wiring MCP, or packaging reusable guidance as an agent skill.
-compatibility: nemo-oo-agents core package; [mcp] extra for MCP
+compatibility: nooa package; [mcp] extra for MCP
 ---
 
 # Tools, Skills, and Integrations
@@ -77,7 +77,7 @@ class MyAgent(Agent, llm=llm):
 
 ## MCP servers
 
-Core library keeps MCP optional: `uv sync --extra mcp` (or `uv add 'nemo-oo-agents[mcp]'`).
+Core library keeps MCP optional: `uv sync --extra mcp` (or `uv add 'nooa[mcp]'`).
 
 ```python
 from nooa.mcp import MCPManager
@@ -120,5 +120,5 @@ Only works with multimodal-capable models — text-only models error when handed
 
 ## Related skills
 
-- `nemo-oo-agent-authoring` — visibility rules and method design that make tools discoverable.
-- `nemo-oo-capturing-traces` — every tool invocation becomes a `tool_execution.*` span you can inspect.
+- `nooa-agent-authoring` — visibility rules and method design that make tools discoverable.
+- `nooa-capturing-traces` — every tool invocation becomes a `tool_execution.*` span you can inspect.

--- a/skills/nooa-trace-explorer/SKILL.md
+++ b/skills/nooa-trace-explorer/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: nemo-oo-trace-explorer
+name: nooa-trace-explorer
 description: Analyze NVIDIA OO Agents execution traces programmatically with the trace-explorer CLI and Python API. Use when debugging why an agent run failed, inspecting LLM turns and code executions, diffing two runs, aggregating errors across an eval experiment, or root-causing behavior from a trace file or viewer session.
-compatibility: nemo-oo-agents core package (trace-explorer CLI ships with it); a running viewer only for --viewer / thin-client modes
+compatibility: nooa package (trace-explorer CLI ships with it); a running viewer only for --viewer / thin-client modes
 ---
 
 # Trace Explorer
@@ -102,5 +102,5 @@ Prefer the thin client when the trace is huge, when exploring interactively (cac
 
 ## Related skills
 
-- `nemo-oo-capturing-traces` — produce the `.jsonl` files this tool reads.
-- `nemo-oo-trace-viewer` — the web UI and the server backing `--viewer` / thin-client modes.
+- `nooa-capturing-traces` — produce the `.jsonl` files this tool reads.
+- `nooa-trace-viewer` — the web UI and the server backing `--viewer` / thin-client modes.

--- a/skills/nooa-trace-viewer/SKILL.md
+++ b/skills/nooa-trace-viewer/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: nemo-oo-trace-viewer
+name: nooa-trace-viewer
 description: Run and use the NVIDIA OO Agents trace viewer — the web UI + OTLP receiver for browsing agent traces and eval results. Use when starting the viewer, importing/exporting/deleting traces, querying the viewer's REST API, or wiring an agent run so traces show up at localhost:5001.
-compatibility: nemo-oo-agents with the [viewer] extra (fastapi, uvicorn); nemo-oo-agents-cli for the `nooa` commands
+compatibility: nooa package with the [viewer] extra (fastapi, uvicorn); nooa-cli for the `nooa` commands
 ---
 
 # Trace Viewer
@@ -19,14 +19,14 @@ nooa start-dev --host 127.0.0.1                 # default host is 0.0.0.0
 
 Stop with Ctrl-C. If deps are missing: `uv sync --extra viewer`. If the port is busy, the command reports the offending PID.
 
-- **Database resolution**: `--db` > `$NEMO_OO_TRACE_DB` > `~/.config/nooa/traces.db`.
-- Alternate entry point: `python -m nooa.viewer` (this path honors `$NEMO_OO_TRACE_VIEWER_PORT`, default 5001; `start-dev` uses `--port` instead). DB default for the raw module is `./traces.db` — prefer `start-dev`.
+- **Database resolution**: `--db` > `$NOOA_TRACE_DB` > `~/.config/nooa/traces.db`.
+- Alternate entry point: `python -m nooa.viewer` (this path honors `$NOOA_TRACE_VIEWER_PORT`, default 5001; `start-dev` uses `--port` instead). DB default for the raw module is `./traces.db` — prefer `start-dev`.
 
 ## End-to-end workflow
 
 ```bash
 nooa start-dev                                # terminal 1
-uv run python my_agent.py                        # terminal 2 — auto-traced (see nemo-oo-capturing-traces)
+uv run python my_agent.py                        # terminal 2 — auto-traced (see nooa-capturing-traces)
 open http://localhost:5001/traces                # browse the session
 ```
 
@@ -90,17 +90,17 @@ Base: `http://localhost:5001`. Most useful endpoints:
 | `GET /api/eval/experiment/{id}/summary`, `.../tests` | eval results |
 | `POST /v1/traces` | OTLP JSON ingest (what agents/import use) |
 | `POST /v1/sync` | block until the ingest queue is drained (use before reading back a just-finished run) |
-| `GET /api/explorer/*` | structured analysis endpoints — use via `TraceExplorerClient` (see `nemo-oo-trace-explorer`) |
+| `GET /api/explorer/*` | structured analysis endpoints — use via `TraceExplorerClient` (see `nooa-trace-explorer`) |
 
 Ingestion is queued and written by a single background writer, so a `GET` immediately after a run may miss the tail — `POST /v1/sync` first when scripting.
 
 ## Pitfalls
 
-- `nooa start-dev` resolves the DB and sets `NEMO_OO_TRACE_DB` in its own environment before starting uvicorn (same process); a *separately launched* `python -m nooa.viewer` without that var uses `./traces.db` in the CWD — easy way to "lose" traces into a second DB.
+- `nooa start-dev` resolves the DB and sets `NOOA_TRACE_DB` in its own environment before starting uvicorn (same process); a *separately launched* `python -m nooa.viewer` without that var uses `./traces.db` in the CWD — easy way to "lose" traces into a second DB.
 - The viewer refuses to start (exit 1) if the SQLite DB is locked by another viewer instance — check for an already-running `start-dev`.
-- Old docs mention `packages/nemo-oo-agents-viewer/` and a `nooa viewer` subcommand; the viewer now lives in `src/nooa/viewer/` and `nooa start-dev` is the canonical command.
+- Old docs mention a separate viewer package and a `nooa viewer` subcommand; the viewer now lives in `src/nooa/viewer/` and `nooa start-dev` is the canonical command.
 
 ## Related skills
 
-- `nemo-oo-capturing-traces` — how spans get produced and exported.
-- `nemo-oo-trace-explorer` — programmatic trace analysis (CLI + Python) on top of files or this viewer.
+- `nooa-capturing-traces` — how spans get produced and exported.
+- `nooa-trace-explorer` — programmatic trace analysis (CLI + Python) on top of files or this viewer.

--- a/src/nooa/viewer/__main__.py
+++ b/src/nooa/viewer/__main__.py
@@ -11,6 +11,8 @@ from .main import app
 
 log = logging.getLogger(__name__)
 
-port = int(os.environ.get("NEMO_OO_TRACE_VIEWER_PORT", "5001"))
+port = int(
+    os.environ.get("NOOA_TRACE_VIEWER_PORT") or os.environ.get("NEMO_OO_TRACE_VIEWER_PORT", "5001")
+)
 log.info("Starting viewer on port %d", port)
 uvicorn.run(app, host="0.0.0.0", port=port)

--- a/src/nooa/viewer/main.py
+++ b/src/nooa/viewer/main.py
@@ -407,6 +407,9 @@ def spa_catchall(request: Request, path: str):
 if __name__ == "__main__":
     import uvicorn
 
-    port = int(os.environ.get("NEMO_OO_TRACE_VIEWER_PORT", "5001"))
+    port = int(
+        os.environ.get("NOOA_TRACE_VIEWER_PORT")
+        or os.environ.get("NEMO_OO_TRACE_VIEWER_PORT", "5001")
+    )
     log.info("Starting viewer on port %d", port)
     uvicorn.run(app, host="0.0.0.0", port=port)

--- a/src/nooa/viewer/otlp_store.py
+++ b/src/nooa/viewer/otlp_store.py
@@ -25,7 +25,11 @@ from typing import Any
 
 log = logging.getLogger(__name__)
 
-DB_PATH = Path(os.environ.get("NEMO_OO_TRACE_DB", Path.cwd() / "traces.db"))
+DB_PATH = Path(
+    os.environ.get("NOOA_TRACE_DB")
+    or os.environ.get("NEMO_OO_TRACE_DB")
+    or Path.cwd() / "traces.db"
+)
 
 _db: sqlite3.Connection | None = None  # used only by init_db() for schema setup
 
@@ -228,7 +232,7 @@ def _check_writable(path: Path) -> None:
             f"Diagnose with:\n"
             f"  lsof {path}\n"
             f"  pgrep -af nooa.viewer\n"
-            f"Then kill any stale viewer, or pick a different NEMO_OO_TRACE_DB."
+            f"Then kill any stale viewer, or pick a different NOOA_TRACE_DB."
         ) from e
     finally:
         probe.close()


### PR DESCRIPTION
## Summary

  - Rename bundled coding-agent skills from `nemo-oo-*` to `nooa-*`
  - Update skill frontmatter, cross-skill references, and install docs to use `nooa`
  - Add `NOOA_TRACE_DB` / `NOOA_TRACE_VIEWER_PORT` support for the trace viewer while preserving legacy `NEMO_OO_*` fallbacks