### PR TITLE
docs: remove blog references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
 
 [![NVIDIA](https://img.shields.io/badge/NVIDIA-76B900?logo=nvidia&logoColor=white)](https://www.nvidia.com/)
 [![Paper](https://img.shields.io/badge/paper-arXiv-b31b1b?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2607.20709)
-[![Blog](https://img.shields.io/badge/blog-coming%20soon-lightgrey)](BLOG_URL)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
 **[Quick Start](#quick-start)** &nbsp;·&nbsp; **[Examples](examples/README.md)** &nbsp;·&nbsp; **[Paper](https://arxiv.org/abs/2607.20709)**
@@ -160,7 +159,6 @@ If the viewer isn't running, tracing is silently disabled — no configuration n
 
 - **[examples/README.md](examples/README.md)** — the full progressive tutorial: structured output, tools via `self`, strategies, progressive disclosure with `doc()`, tracing, dynamic prompts, context blocks, summarization, skills, MCP, sandbox, and more.
 - **[Paper](https://arxiv.org/abs/2607.20709)** — design principles, harness details, capability tests, and SWE-bench Verified / Terminal-Bench 2.0 results.
-- **[Blog post](BLOG_URL)** — WIP.
 - **[AGENTS.md](AGENTS.md)** — conventions used inside this repo (helpful when reading the source).
 
 ## Contributing


### PR DESCRIPTION
## Summary
- remove the coming-soon blog badge from the README header
- remove the WIP blog post link from the Learn more section

## Verification
- rg -n -i "blog|blogpost|blog post|BLOG_URL" README.md