### PR TITLE
Constrain playground custom-model endpoint/api_key_env to server-declared pairs

### DIFF
--- a/src/nooa/unifiedllm/registry.py
+++ b/src/nooa/unifiedllm/registry.py
@@ -46,8 +46,9 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import threading
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -74,11 +75,14 @@ _NVIDIA_KEY_SYNONYMS = {
     "NVIDIA_INFERENCE_API_KEY": "NVIDIA_INTERNAL_API_KEY",
     "NVIDIA_INTERNAL_API_KEY": "NVIDIA_INFERENCE_API_KEY",
 }
+_ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def resolve_api_key_from_config(
     model_name: str,
     config: Mapping[str, Any],
+    *,
+    allowed_env_vars: Collection[str] | None = None,
 ) -> str | None:
     """Read the api_key_env-named env var declared by a registry config.
 
@@ -91,6 +95,10 @@ def resolve_api_key_from_config(
 
     Shared helper for callers outside the registry (NAT plugin, viewer
     routes) that need the same resolution + diagnostic semantics.
+
+    ``allowed_env_vars`` is a defense-in-depth boundary for callers handling
+    partially untrusted config. When supplied, only those exact env-var names
+    may be resolved.
     """
     api_key_env = config.get("api_key_env")
     if not api_key_env:
@@ -103,6 +111,20 @@ def resolve_api_key_from_config(
             model_name,
             api_key_env,
             type(api_key_env).__name__,
+        )
+        return None
+    if not _ENV_VAR_NAME_RE.fullmatch(api_key_env):
+        logger.warning(
+            "Model %r has invalid api_key_env %r: expected a shell-style env var name.",
+            model_name,
+            api_key_env,
+        )
+        return None
+    if allowed_env_vars is not None and api_key_env not in allowed_env_vars:
+        logger.warning(
+            "Model %r requested api_key_env %r, which is not in the caller's allowed env-var set.",
+            model_name,
+            api_key_env,
         )
         return None
     api_key = os.getenv(api_key_env)

--- a/src/nooa/viewer/trace_routes.py
+++ b/src/nooa/viewer/trace_routes.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import time
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -141,7 +142,9 @@ def load_custom_models() -> list[dict]:
     """Load custom models from file."""
     if CUSTOM_MODELS_FILE.exists():
         with open(CUSTOM_MODELS_FILE) as f:
-            return json.load(f)
+            data = json.load(f)
+            if isinstance(data, list):
+                return [model for model in data if isinstance(model, dict)]
     return []
 
 
@@ -149,6 +152,59 @@ def save_custom_models(models: list[dict]):
     """Save custom models to file."""
     with open(CUSTOM_MODELS_FILE, "w") as f:
         json.dump(models, f, indent=2)
+
+
+def _normalize_model_pair(model: Mapping[str, Any]) -> tuple[str | None, str | None]:
+    """Return a normalized ``(endpoint, api_key_env)`` pair from model config."""
+    endpoint = model.get("endpoint")
+    api_key_env = model.get("api_key_env")
+    return (
+        endpoint.strip() if isinstance(endpoint, str) and endpoint.strip() else None,
+        api_key_env.strip() if isinstance(api_key_env, str) and api_key_env.strip() else None,
+    )
+
+
+def _trusted_playground_pairs() -> set[tuple[str | None, str | None]]:
+    """Pairs declared by the server-side models file are trusted for playground use.
+
+    Custom models are browser-controlled state. They may alias a pair already
+    approved by the local operator in ``models.yaml`` or use provider defaults,
+    but they must not invent a destination or env-var name.
+    """
+    pairs: set[tuple[str | None, str | None]] = {(None, None)}
+    config = load_models_config()
+    for model_info in config.get("models", {}).values():
+        if isinstance(model_info, Mapping):
+            pairs.add(_normalize_model_pair(model_info))
+    return pairs
+
+
+def _sanitize_custom_model(model: Mapping[str, Any]) -> dict[str, Any]:
+    """Drop untrusted endpoint/key pairs from persisted browser-controlled models."""
+    sanitized = dict(model)
+    pair = _normalize_model_pair(model)
+    if pair not in _trusted_playground_pairs():
+        log.warning(
+            "Ignoring untrusted playground model endpoint/api_key_env pair for model %r.",
+            model.get("model_id"),
+        )
+        sanitized["endpoint"] = None
+        sanitized["api_key_env"] = None
+    else:
+        sanitized["endpoint"], sanitized["api_key_env"] = pair
+    return sanitized
+
+
+def _validate_custom_model_pair(model: Mapping[str, Any]) -> None:
+    pair = _normalize_model_pair(model)
+    if pair not in _trusted_playground_pairs():
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Custom models may only use endpoint/api_key_env pairs already declared "
+                "in the server-side models config."
+            ),
+        )
 
 
 # ============================================================================
@@ -439,7 +495,7 @@ def get_playground_models():
     known_keys = get_known_api_key_patterns()
     available_keys = [key for key in known_keys if os.environ.get(key)]
 
-    custom_models = load_custom_models()
+    custom_models = [_sanitize_custom_model(model) for model in load_custom_models()]
     builtin_models = get_builtin_models()
 
     return {
@@ -454,10 +510,12 @@ def add_custom_model(model: CustomModel):
     """Add a custom model configuration."""
     models = load_custom_models()
 
+    _validate_custom_model_pair(model.model_dump())
+
     if any(m["model_id"] == model.model_id for m in models):
         raise HTTPException(status_code=400, detail="Model with this ID already exists")
 
-    models.append(model.model_dump())
+    models.append(_sanitize_custom_model(model.model_dump()))
     save_custom_models(models)
 
     return {"status": "success", "message": f"Model '{model.name}' added"}
@@ -492,6 +550,7 @@ def get_model_config(model_id: str) -> dict | None:
     custom_models = load_custom_models()
     for model in custom_models:
         if model.get("model_id") == model_id:
+            model = _sanitize_custom_model(model)
             return {
                 "endpoint": model.get("endpoint"),
                 "api_key_env": model.get("api_key_env"),
@@ -626,7 +685,11 @@ async def run_inference(request: InferenceRequest):
             kwargs["custom_llm_provider"] = "openai"
 
         if model_config:
-            api_key = resolve_api_key_from_config(request.model, model_config)
+            api_key = resolve_api_key_from_config(
+                request.model,
+                model_config,
+                allowed_env_vars=get_known_api_key_patterns(),
+            )
             if api_key:
                 kwargs["api_key"] = api_key
 


### PR DESCRIPTION
## Summary

Fixes a secret-exfiltration + SSRF vulnerability in the viewer playground.

Custom models registered via the playground API (`POST /api/playground/models`) are **browser-controlled state**, but their `endpoint` and `api_key_env` were forwarded unvalidated into `litellm` in `run_inference`:

```python
kwargs["api_base"] = model_config["endpoint"]                       # attacker URL
api_key = resolve_api_key_from_config(request.model, model_config)  # os.getenv(any name)
kwargs["api_key"] = api_key
await litellm.acompletion(**kwargs)                                 # key POSTed to that URL
```

An attacker who can reach the viewer could register a model where:
- `endpoint` → their own host and `api_key_env` → any process env var (e.g. a cloud/DB secret) → the resolved secret is sent to the attacker (**secret exfiltration**), or
- `endpoint` → `http://169.254.169.254/...` or an internal service → **SSRF** into the metadata service / internal network.

## Fix

Custom models may only *reuse* an `(endpoint, api_key_env)` pair the operator already declared server-side in `models.yaml` (or provider defaults) — never invent one.

- **`unifiedllm/registry.py`** — `resolve_api_key_from_config` validates `api_key_env` against a shell-style env-var regex and accepts an optional `allowed_env_vars` allowlist (defense-in-depth for callers handling untrusted config).
- **`viewer/trace_routes.py`** — trusted pairs are built from the server-side models config; enforced on write (HTTP 400) and stripped on read (`get_playground_models`, `get_model_config`). `run_inference` resolves keys only from the known api-key allowlist. `load_custom_models` also gains a type-confusion guard.

Extracted from `0001-playground-model-boundary` of the security-hardening patch set (the other patches in that set cover unrelated issues and are not included here).

## Testing

- Full suite: **6437 passed, 4 skipped** (`uv run pytest`).
- All pre-commit hooks pass (ruff, ruff-format, pyright, hygiene checks). One pyright type-inference fix was applied on top of the patch (`pairs` set annotation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)