### PR TITLE
Redact secrets from telemetry spans, OAuth logs, and HTTP

### DIFF
--- a/src/nooa/mcp/oauth.py
+++ b/src/nooa/mcp/oauth.py
@@ -550,7 +550,6 @@ class OAuthHandler:
                     client_secret=self.config.client_secret,
                 )
             except httpx.HTTPStatusError as e:
-                error_detail = e.response.text if e.response else str(e)
                 error_json = None
                 try:
                     if e.response:
@@ -558,11 +557,7 @@ class OAuthHandler:
                 except Exception:
                     pass
 
-                logger.error(
-                    f"Token exchange failed: {e.response.status_code}, Request data: {data}, Response: {error_detail}",
-                )
-                if error_json:
-                    logger.error(f"Error details: {error_json}")
+                logger.error("Token exchange failed (HTTP %s)", e.response.status_code)
 
                 # Provide helpful error message for common issues
                 error_msg = f"Failed to exchange authorization code for token (HTTP {e.response.status_code})"
@@ -572,9 +567,6 @@ class OAuthHandler:
                         "Authorization codes are typically valid for only a few minutes. "
                         "Please try the OAuth flow again to get a fresh code."
                     )
-                else:
-                    error_msg += f": {error_detail}"
-
                 raise RuntimeError(error_msg) from e
 
     async def client_credentials_token(self) -> OAuthToken:
@@ -643,7 +635,7 @@ class OAuthHandler:
             logger.info("OAuth flow completed successfully")
             return token
         except Exception as e:
-            logger.error(f"OAuth flow failed: {e}")
+            logger.error("OAuth flow failed (%s)", type(e).__name__)
             raise
 
 

--- a/src/nooa/tracing/_secret_scrubber.py
+++ b/src/nooa/tracing/_secret_scrubber.py
@@ -24,6 +24,37 @@ logger = logging.getLogger(__name__)
 
 REDACTED = "[REDACTED]"
 
+_SENSITIVE_KEYS = frozenset(
+    {
+        "authorization",
+        "proxy_authorization",
+        "api_key",
+        "x_api_key",
+        "access_token",
+        "refresh_token",
+        "auth_token",
+        "session_token",
+        "id_token",
+        "client_secret",
+        "client_assertion",
+        "password",
+        "passwd",
+        "private_key",
+        "secret_key",
+        "code_verifier",
+        "cookie",
+        "set_cookie",
+    }
+)
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "_", str(key).lower()).strip("_")
+    return normalized in _SENSITIVE_KEYS or any(
+        normalized.endswith(f"_{sensitive}") for sensitive in _SENSITIVE_KEYS
+    )
+
+
 # ---------------------------------------------------------------------------
 # Regex-based secret patterns — high precision, low false positives
 # ---------------------------------------------------------------------------
@@ -62,8 +93,9 @@ _SECRET_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
         "generic_api_key",
         re.compile(
             r"(?:api[_-]?key|api[_-]?token|auth[_-]?token|access[_-]?token|"
+            r"client[_-]?secret|refresh[_-]?token|code[_-]?verifier|"
             r"secret[_-]?key|private[_-]?key|password|passwd)"
-            r"[\"\']?\s*[=:]+\s*[\"\'\s]*(?P<secret>[A-Za-z0-9_.\-/+=]{20,})",
+            r"[\"\']?\s*[=:]+\s*[\"\'\s]*(?P<secret>[A-Za-z0-9_.\-/+=]{1,})",
             re.IGNORECASE,
         ),
     ),
@@ -153,7 +185,7 @@ def scrub_string(text: str) -> tuple[str, int]:
     span processing). Returns the original string unchanged with a count of 0
     if no secrets are found (fast path).
     """
-    if not text or len(text) < 10:
+    if not text:
         return text, 0
 
     count = 0
@@ -176,12 +208,25 @@ def scrub_string(text: str) -> tuple[str, int]:
 def scrub_value(value: Any) -> tuple[Any, int]:
     """Scrub secrets from a span attribute value.
 
-    Handles strings and sequences of strings. Other types pass through.
+    Handles strings, mappings, and sequences. Values under credential-bearing
+    keys are always replaced, including short or provider-specific secrets.
     Returns ``(scrubbed_value, redaction_count)`` where the count is the
     number of secrets redacted within this value.
     """
     if isinstance(value, str):
         return scrub_string(value)
+    if isinstance(value, dict):
+        scrubbed: dict[Any, Any] = {}
+        count = 0
+        for key, item in value.items():
+            if _is_sensitive_key(key):
+                scrubbed[key] = REDACTED
+                stats.record("sensitive_key")
+                count += 1
+            else:
+                scrubbed[key], n = scrub_value(item)
+                count += n
+        return scrubbed, count
     if isinstance(value, (list, tuple)):
         new_items = []
         count = 0
@@ -223,7 +268,11 @@ try:
                 redacted_count = 0
 
                 for key, value in span.attributes.items():
-                    new_value, n = scrub_value(value)
+                    if _is_sensitive_key(key):
+                        new_value, n = REDACTED, 1
+                        stats.record("sensitive_key")
+                    else:
+                        new_value, n = scrub_value(value)
                     scrubbed[key] = new_value
                     redacted_count += n
 

--- a/src/nooa/unifiedllm/http_logging.py
+++ b/src/nooa/unifiedllm/http_logging.py
@@ -5,6 +5,8 @@ import os
 from datetime import UTC, datetime
 from pathlib import Path
 
+from nooa.tracing._secret_scrubber import REDACTED, _is_sensitive_key, scrub_value
+
 
 def enable_http_request_logging(
     output_dir: str | Path = ".",
@@ -89,11 +91,23 @@ def enable_http_request_logging(
 
     def _redact_headers(headers: dict) -> dict:
         """Redact sensitive headers like Authorization."""
-        redacted = dict(headers)
-        for key in list(redacted.keys()):
-            if key.lower() in ["authorization", "api-key", "x-api-key"]:
+        redacted = {}
+        for key, value in headers.items():
+            if _is_sensitive_key(key):
                 redacted[key] = "***REDACTED***"
+            else:
+                redacted[key], _ = scrub_value(value)
         return redacted
+
+    def _redact_body(body):
+        """Recursively scrub secrets before a parsed HTTP body is logged."""
+        scrubbed, _ = scrub_value(body)
+        if isinstance(scrubbed, dict) and scrubbed.get("grant_type") == "authorization_code":
+            # "code" is too generic for global key matching, but is a credential
+            # in an OAuth authorization-code exchange.
+            if "code" in scrubbed:
+                scrubbed["code"] = REDACTED
+        return scrubbed
 
     def _write_jsonl_entry(entry: dict):
         """Append a JSON entry to the JSONL error file."""
@@ -113,7 +127,7 @@ def enable_http_request_logging(
                 filename = output_path / f"request_{counter}_{model_name}.json"
 
                 with open(filename, "w") as f:
-                    json.dump(body_dict, f, indent=2)
+                    json.dump(_redact_body(body_dict), f, indent=2)
 
                 if verbose:
                     print(f"\n💾 Saved HTTP request to: {filename}")
@@ -144,7 +158,7 @@ def enable_http_request_logging(
         try:
             response_dict = {
                 "status_code": response.status_code,
-                "headers": dict(response.headers),
+                "headers": _redact_headers(dict(response.headers)),
             }
 
             try:
@@ -169,6 +183,8 @@ def enable_http_request_logging(
             except Exception as read_error:
                 response_dict["body"] = f"[Error reading response: {read_error}]"
 
+            response_dict["body"] = _redact_body(response_dict["body"])
+
             _save_response_file(response_dict, counter, model_name)
         except Exception as e:
             if verbose:
@@ -180,7 +196,7 @@ def enable_http_request_logging(
         try:
             response_dict = {
                 "status_code": response.status_code,
-                "headers": dict(response.headers),
+                "headers": _redact_headers(dict(response.headers)),
             }
 
             try:
@@ -205,6 +221,8 @@ def enable_http_request_logging(
 
             except Exception as read_error:
                 response_dict["body"] = f"[Error reading response: {read_error}]"
+
+            response_dict["body"] = _redact_body(response_dict["body"])
 
             _save_response_file(response_dict, counter, model_name)
         except Exception as e:
@@ -236,7 +254,7 @@ def enable_http_request_logging(
                         "url": str(request.url),
                         "method": request.method,
                         "headers": _redact_headers(dict(request.headers)),
-                        "body": body_dict,
+                        "body": _redact_body(body_dict),
                     }
             except Exception as e:
                 if verbose:
@@ -265,8 +283,8 @@ def enable_http_request_logging(
 
                     response_data = {
                         "status_code": response.status_code,
-                        "headers": dict(response.headers),
-                        "body": body_content,
+                        "headers": _redact_headers(dict(response.headers)),
+                        "body": _redact_body(body_content),
                     }
 
                     # Write JSONL entry
@@ -324,7 +342,7 @@ def enable_http_request_logging(
                         "url": str(request.url),
                         "method": request.method,
                         "headers": _redact_headers(dict(request.headers)),
-                        "body": body_dict,
+                        "body": _redact_body(body_dict),
                     }
             except Exception as e:
                 if verbose:
@@ -353,8 +371,8 @@ def enable_http_request_logging(
 
                     response_data = {
                         "status_code": response.status_code,
-                        "headers": dict(response.headers),
-                        "body": body_content,
+                        "headers": _redact_headers(dict(response.headers)),
+                        "body": _redact_body(body_content),
                     }
 
                     # Write JSONL entry

--- a/tests/tracing/test_secret_scrubber.py
+++ b/tests/tracing/test_secret_scrubber.py
@@ -139,8 +139,13 @@ class TestScrubString:
         assert scrub_string("") == ("", 0)
 
     def test_short_string(self):
-        """Strings below the minimum length are skipped (fast path)."""
+        """A clean short string passes through unchanged."""
         assert scrub_string("hello") == ("hello", 0)
+
+    def test_short_generic_secret(self):
+        result, count = scrub_string("client_secret=s3cr3t")
+        assert "s3cr3t" not in result
+        assert count == 1
 
     def test_preserves_surrounding_text(self):
         """Surrounding non-secret text is preserved around a redaction."""
@@ -202,6 +207,13 @@ class TestScrubValue:
     def test_none_passthrough(self):
         """None passes through unchanged with a zero count."""
         assert scrub_value(None) == (None, 0)
+
+    def test_nested_sensitive_keys(self):
+        result, count = scrub_value(
+            {"safe": {"client_secret": "short", "refresh_token": "provider-specific"}}
+        )
+        assert result == {"safe": {"client_secret": REDACTED, "refresh_token": REDACTED}}
+        assert count == 2
 
 
 class TestScrubStats:

--- a/tests/unifiedllm/test_http_logging.py
+++ b/tests/unifiedllm/test_http_logging.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import json
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+
+import httpx
+import pytest
+
+from nooa.unifiedllm.http_logging import enable_http_request_logging
+
+
+class _SecretHeaderHandler(BaseHTTPRequestHandler):
+    status_code = 500
+
+    def do_POST(self) -> None:  # noqa: N802
+        self.rfile.read(int(self.headers.get("content-length", "0")))
+        self.send_response(self.status_code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Set-Cookie", "sid=response-cookie-secret")
+        self.send_header("X-Api-Key", "response-api-key-secret")
+        self.send_header("X-Session-Token", "response-session-secret")
+        self.send_header("X-Auth-Token", "response-auth-secret")
+        self.end_headers()
+        self.wfile.write(
+            json.dumps(
+                {
+                    "access_token": "response-access-secret",
+                    "nested": {"client_secret": "response-client-secret"},
+                    "message": "safe",
+                }
+            ).encode()
+        )
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+@pytest.fixture
+def secret_header_server() -> Iterator[ThreadingHTTPServer]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _SecretHeaderHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def _post_to_server(server: ThreadingHTTPServer) -> httpx.Response:
+    return httpx.post(
+        f"http://127.0.0.1:{server.server_port}/llm",
+        headers={"Authorization": "Bearer request-auth-secret"},
+        json={
+            "model": "header-redaction-model",
+            "api_key": "request-api-key-secret",
+        },
+    )
+
+
+def test_save_responses_redacts_sensitive_response_headers_and_bodies(
+    tmp_path: Path, secret_header_server: ThreadingHTTPServer
+) -> None:
+    disable = enable_http_request_logging(
+        output_dir=tmp_path, save_responses=True, errors_only=False, verbose=False
+    )
+    try:
+        response = _post_to_server(secret_header_server)
+    finally:
+        disable()
+
+    assert response.headers["x-session-token"] == "response-session-secret"
+
+    response_log = json.loads(next(tmp_path.glob("response_*.json")).read_text())
+    assert response_log["headers"]["set-cookie"] == "***REDACTED***"
+    assert response_log["headers"]["x-api-key"] == "***REDACTED***"
+    assert response_log["headers"]["x-session-token"] == "***REDACTED***"
+    assert response_log["headers"]["x-auth-token"] == "***REDACTED***"
+    assert response_log["body"]["access_token"] == "[REDACTED]"
+    assert response_log["body"]["nested"]["client_secret"] == "[REDACTED]"
+
+    persisted = json.dumps(response_log)
+    assert "response-cookie-secret" not in persisted
+    assert "response-api-key-secret" not in persisted
+    assert "response-session-secret" not in persisted
+    assert "response-auth-secret" not in persisted
+    assert "response-access-secret" not in persisted
+    assert "response-client-secret" not in persisted
+
+
+def test_errors_only_jsonl_redacts_sensitive_headers_and_bodies(
+    tmp_path: Path, secret_header_server: ThreadingHTTPServer
+) -> None:
+    disable = enable_http_request_logging(
+        output_dir=tmp_path, save_responses=True, errors_only=True, verbose=False
+    )
+    try:
+        response = _post_to_server(secret_header_server)
+    finally:
+        disable()
+
+    assert response.status_code == 500
+
+    entry = json.loads((tmp_path / "llm_errors.jsonl").read_text())
+    assert entry["request"]["headers"]["authorization"] == "***REDACTED***"
+    assert entry["request"]["body"]["api_key"] == "[REDACTED]"
+    assert entry["response"]["headers"]["set-cookie"] == "***REDACTED***"
+    assert entry["response"]["headers"]["x-api-key"] == "***REDACTED***"
+    assert entry["response"]["headers"]["x-session-token"] == "***REDACTED***"
+    assert entry["response"]["headers"]["x-auth-token"] == "***REDACTED***"
+    assert entry["response"]["body"]["access_token"] == "[REDACTED]"
+    assert entry["response"]["body"]["nested"]["client_secret"] == "[REDACTED]"
+
+    persisted = json.dumps(entry)
+    assert "request-auth-secret" not in persisted
+    assert "request-api-key-secret" not in persisted
+    assert "response-cookie-secret" not in persisted
+    assert "response-api-key-secret" not in persisted
+    assert "response-session-secret" not in persisted
+    assert "response-auth-secret" not in persisted
+    assert "response-access-secret" not in persisted
+    assert "response-client-secret" not in persisted


### PR DESCRIPTION
## Summary

Redacts secrets from three log/trace paths that previously wrote credentials to disk:

- **Telemetry span scrubber** did not inspect mapping keys, nested structures, short credentials, or the OAuth-specific fields `client_secret`, `refresh_token`, and `code_verifier` — so those values could reach exported spans intact.
- **OAuth token-exchange failures** logged the full request body (`client_secret`, `code`, `code_verifier`) and the raw provider response on error.
- **HTTP debug logger** persisted parsed request and response bodies and response headers verbatim — bodies were never scrubbed, and response headers (including `Set-Cookie`, `X-Api-Key`, `X-Auth-Token`, `X-Session-Token`, etc.) were written in plaintext even though request headers were already redacted.

Together these paths could write authorization codes, PKCE verifiers, client secrets, refresh/access tokens, session cookies, and provider credentials to trace or debug-log storage.

## Changes

- Span scrubber recursively handles mappings and always redacts values under known credential keys; generic assignment matching covers short secrets and OAuth credential names.
- OAuth token-exchange failures log only the HTTP status; the exception chain is preserved via `raise ... from e`.
- HTTP debug logger passes every parsed request/response body through the scrubber before persisting. OAuth authorization-code bodies additionally treat the otherwise-generic `code` field as a credential. The live `httpx.Request` / `httpx.Response` returned to callers is not mutated.
- HTTP debug logger redacts request and response headers via the shared sensitive-key classifier, covering `Authorization`, `Cookie` / `Set-Cookie`, `Proxy-Authorization`, and provider-specific auth headers (`X-Api-Key`, `X-Auth-Token`, `X-Session-Token`, …).

## Test plan

- [x] `uv run ruff check .` passes on touched files
- [x] `uv run ruff format --check .` passes on touched files
- [x] `uv run pytest` — 6242 passed, 0 failures
- [x] New regression tests in `tests/tracing/test_secret_scrubber.py` cover nested mappings, sensitive-key redaction, and short secrets
- [x] New live-transport tests in `tests/unifiedllm/test_http_logging.py` cover response-header and body redaction in both `save_responses` (`response_*.json`) and `errors_only` (`llm_errors.jsonl`) paths