### PR TITLE
docs: frame code validators as guardrails, not a security boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ class SupportAgent(Agent):
 **What's happening here:**
 
 - **Agents are Python objects.** Fields are state, methods are capabilities, docstrings are prompts, type annotations are contracts.
-- **`...` bodies are LLM-driven.** A method with `...` becomes an agentic loop; a real body stays deterministic Python. 
+- **`...` bodies are LLM-driven.** A method with `...` becomes an agentic loop; a real body stays deterministic Python.
 - **Code as action.** The model acts by writing Python in a Jupyter-style REPL with access to `self`, imports, and helpers — Python methods and type annotations supply the callable interfaces, reducing the need to write separate tool-schema definitions.
 - **Pythonic and agent-ready.** Typed I/O with auto-retry, live-object arguments passed by reference, and model-callable context and event APIs — designed around agent-oriented Python workflows.
 
@@ -98,7 +98,11 @@ uv add "eval_pipeline @ git+https://github.com/NVIDIA-NeMo/labs-OO-Agents.git@ma
 ## WARNING
 This is a research tool that can be configured to execute LLM-generated code. LLM-generated code may take dangerous or unwanted actions, incuding sending private data to uncontrolled locations, deleting files, or modifying its environments.  Ensure you run NOOA agents in a sandboxed environment isolated from your primary filesystem, such as [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell).
 
-> **Research software**  NOOA is research software, not production. We welcome contributions and fixes, but expect rough edges. 
+### Security model
+
+NOOA validates generated code (AST checks) and applies module deny-lists before execution. **These are defense-in-depth guardrails, not a containment boundary.** They exist to keep generated code from freezing the event loop and to catch common mistakes early — not to stop code that is actively trying to escape. A static checker over Python cannot provide that guarantee: `open()` gives arbitrary file access, `importlib` can load modules straight from a path, and reflection reaches the rest. **The containment boundary is OS-level isolation** — always run agents that execute generated code inside a sandbox such as a container, VM, or [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell). Do not rely on the in-process validators alone.
+
+> **Research software**  NOOA is research software, not production. We welcome contributions and fixes, but expect rough edges.
 
 
 ### Choose a model

--- a/src/nooa/runtime/code_validator.py
+++ b/src/nooa/runtime/code_validator.py
@@ -3,9 +3,24 @@
 """Unified AST validation for agent-generated code.
 
 This module provides a single entry point for all code validation:
-- SecurityValidator: Prevents security risks (forbidden builtins, imports, escapes)
+- SecurityValidator: Guardrails against common footguns (forbidden builtins,
+  restricted imports, direct class/dunder mutation)
 - BlockingCallValidator: Prevents blocking calls that freeze the event loop
 - REPLPolicyValidator: Enforces REPL-style coding conventions
+
+Security model — read before extending:
+    These validators are **guardrails, not a security boundary**. They operate on
+    a static AST and reduce the chance that an LLM *accidentally* corrupts runtime
+    state, freezes the event loop, or reaches for a surprising module. They do
+    **not** and **cannot** contain adversarial code: a static Python checker is
+    trivially bypassable (e.g. ``open()`` for arbitrary file I/O, dynamic module
+    loading via ``importlib.util``/``importlib.machinery``, reflection, C-extension
+    loading). Do not treat the deny-lists as a jail or add checks under the belief
+    that they close a real escape — that is unwinnable whack-a-mole.
+
+    The actual containment boundary is OS-level isolation (container / VM / gVisor,
+    e.g. NVIDIA OpenShell). Run agents that execute generated code inside one.
+    See the README security note and ``runtime/restrictions.py``.
 
 Usage:
     validator = UnifiedCodeValidator()
@@ -161,7 +176,9 @@ FORBIDDEN_ATTR_CALLS = frozenset(
     }
 )
 
-# Dangerous dunder attributes that enable sandbox escapes
+# Dunder attributes commonly used to reach runtime internals (introspection
+# ladders like __class__ -> __subclasses__). Blocking them trims easy footguns;
+# it is not a containment guarantee (see the module docstring's security model).
 DANGEROUS_DUNDER_ATTRS = frozenset(
     {
         "__class__",
@@ -177,13 +194,18 @@ DANGEROUS_DUNDER_ATTRS = frozenset(
 
 
 class SecurityValidator:
-    """Validates code for security risks.
+    """Guardrail checks over generated code (not a security boundary).
+
+    Flags common footguns so the LLM fails fast with a clear message rather than
+    corrupting runtime state or silently doing something surprising. This is
+    defense-in-depth, not containment — see the module docstring's security
+    model. Real isolation comes from running the agent in an OS-level sandbox.
 
     Checks for:
     - Forbidden builtins (exec, eval, compile, __import__, input, breakpoint, globals, locals)
     - Restricted/blocked imports (modules in restricted_imports or blocked_modules deny lists)
     - Import * (always forbidden)
-    - Dangerous dunder attribute access (__class__, __bases__, etc.)
+    - Direct dunder attribute access (__class__, __bases__, etc.)
     - Recursive self-calls (infinite recursion prevention)
     - Aliased forbidden builtins
     - Forbidden attribute calls (set_restricted_imports, get_restricted_imports)

--- a/src/nooa/runtime/restrictions.py
+++ b/src/nooa/runtime/restrictions.py
@@ -4,6 +4,15 @@
 
 Single source of truth for blocked modules, blocked calls, and restricted modules.
 Consumed by CodeActConfig (defaults), exec_globals stripping, and BlockingCallValidator.
+
+These lists are **guardrails, not a security boundary.** Their jobs are to keep
+generated code from freezing the event loop (blocked calls/modules) and to trim
+common footguns — not to contain adversarial code. A static deny-list over Python
+cannot do that: ``open()`` gives arbitrary file I/O, ``importlib.util`` /
+``importlib.machinery`` load modules straight from a path, and reflection reaches
+the rest. Extending these lists to "close an escape" is unwinnable whack-a-mole.
+The real containment boundary is OS-level isolation (container / VM, e.g. NVIDIA
+OpenShell); run agents that execute generated code inside one. See the README.
 """
 
 import types
@@ -79,6 +88,11 @@ DEFAULT_BLOCKED_CALLS: dict[str, frozenset[str]] = {
     "threading": frozenset({"Thread.join", "Lock.acquire", "Event.wait", "Condition.wait"}),
     "multiprocessing": frozenset({"Process.join", "Queue.get", "Queue.put"}),
     "asyncio": frozenset({"run", "run_coroutine_threadsafe", "run_until_complete", "run_forever"}),
+    # Blocking import_module() by name trims one accidental way to pull in a
+    # blocked module past the AST import check. It is NOT a security control:
+    # importlib.util.spec_from_file_location(), importlib.machinery.SourceFileLoader(),
+    # and plain open() all remain viable, by design (see module docstring — these
+    # lists are guardrails, not a jail). Containment is the OS-level sandbox.
     "importlib": frozenset({"import_module"}),
 }
 
@@ -106,6 +120,7 @@ class RestrictionsConfig(BaseModel):
     Tier 3 — **allowed** (everything else):
         Any installed module can be imported freely.
 
+    This is a guardrail, not a containment boundary — see the module docstring.
     Keeps defaults co-located with the constants they reference.
     Embed in strategy configs (e.g. CodeActConfig) for composition.
     """


### PR DESCRIPTION
## Summary

Addresses a security-review comment: *"Only `importlib.import_module` blocked; `importlib` itself not restricted, so `spec_from_file_location()` / `SourceFileLoader()` can load `subprocess`, `socket`, etc."* (`restrictions.py:82`, `code_validator.py`).

The observation is **accurate** — I reproduced it against `UnifiedCodeValidator`:

| Code | Result |
|---|---|
| `importlib.import_module('subprocess')` | BLOCKED |
| `importlib.util.spec_from_file_location(...)` + `exec_module` | not blocked |
| `importlib.machinery.SourceFileLoader('subprocess', ...)` | not blocked |
| `open('/etc/passwd').read()` / `open(...,'w').write(...)` | not blocked |
| `import os` (default config) | not blocked |

But it is **symptomatic, not fixable by patching**. A static AST checker over Python cannot be a containment boundary: `open()` alone gives arbitrary file I/O, dynamic loaders (`importlib.util`/`machinery`) load from a path, and reflection reaches the rest. At runtime `exec()` also receives the full real `__builtins__`. Chasing individual bypasses is unwinnable whack-a-mole.

This matches the project's existing stance (README already instructs users to run NOOA inside an OS-level sandbox). The problem was that the **code read as if it were a security boundary** ("SecurityValidator: Prevents security risks... escapes", "dunder attributes that enable sandbox escapes"), which is what keeps generating these reports.

## Changes (documentation only — no behavior change)

- **`code_validator.py`** — reworded the module + `SecurityValidator` docstrings and the `DANGEROUS_DUNDER_ATTRS` comment; added a *"Security model — read before extending"* note (guardrails, not containment; OS-level isolation is the boundary).
- **`restrictions.py`** — same framing on the module + `RestrictionsConfig` docstrings, plus an honest comment on the `importlib` blocked-call entry describing exactly what it does and does not accomplish.
- **`README.md`** — new *"Security model"* subsection making the guardrails-vs-containment distinction explicit.
- **`SECURITY.md`** — intentionally left untouched.

The deny-lists' load-bearing job (event-loop safety + footgun reduction) is unchanged.

## Testing

- Full unit suite: **6439 passed, 4 skipped, 0 failed** (`uv run pytest`).
- Validator/sandbox subset: 296 passed.
- End-to-end quickstarts against a live model: `01_first_generation_method.py` and `03_codeact_tools.py` (exercises the validator + code-execution path) both ran and produced correct output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)