### PR TITLE
Replace eval() with AST-based coercion in CodeAct return_result

### DIFF
--- a/src/nooa/strategies/codeact.py
+++ b/src/nooa/strategies/codeact.py
@@ -1803,8 +1803,8 @@ Standard Python builtins and agent instance (`self`) are available."""
                         normalized_args["result"] = parsed
                     else:
                         # Constructor-call coercion: if the string looks like a Python
-                        # constructor call (e.g. "Answer(answer=1, reason='...')"), eval it
-                        # in the session namespace where the type is available.
+                        # constructor call (e.g. "Answer(answer=1, reason='...')"),
+                        # parse its arguments without evaluating against session state.
                         coerced = self._maybe_eval_constructor_string(
                             result_str, return_type, session
                         )
@@ -2009,13 +2009,87 @@ Standard Python builtins and agent instance (`self`) are available."""
 
         return {"result": corrected_result}
 
+    def _json_detached_session_value(self, name: str, session: Any) -> Any:
+        """Return a JSON-round-tripped session value if it is a plain value."""
+        session_locals = getattr(session, "session_locals", {})
+        if name not in session_locals:
+            raise ValueError(f"Unknown constructor argument reference: {name}")
+
+        value = session_locals[name]
+        if not self._is_plain_json_value(value):
+            raise TypeError(f"Session value {name!r} is not a plain JSON value")
+
+        return json.loads(json.dumps(value, allow_nan=False))
+
+    def _is_plain_json_value(self, value: Any, seen: set[int] | None = None) -> bool:
+        """True for exact JSON-compatible builtin values, excluding subclasses."""
+        if value is None or type(value) in {bool, int, float, str}:
+            return True
+
+        if seen is None:
+            seen = set()
+
+        if type(value) in {list, tuple}:
+            value_id = id(value)
+            if value_id in seen:
+                return False
+            seen.add(value_id)
+            try:
+                return all(self._is_plain_json_value(item, seen) for item in value)
+            finally:
+                seen.remove(value_id)
+
+        if type(value) is dict:
+            value_id = id(value)
+            if value_id in seen:
+                return False
+            seen.add(value_id)
+            try:
+                return all(
+                    type(key) is str and self._is_plain_json_value(item, seen)
+                    for key, item in value.items()
+                )
+            finally:
+                seen.remove(value_id)
+
+        return False
+
+    def _safe_constructor_arg_value(self, node: ast.AST, session: Any) -> Any:
+        """Parse one constructor argument without executing Python code."""
+        if isinstance(node, ast.Call):
+            raise ValueError("Constructor argument calls are not allowed")
+
+        if isinstance(node, ast.Name):
+            return self._json_detached_session_value(node.id, session)
+
+        if isinstance(node, ast.List):
+            return [self._safe_constructor_arg_value(item, session) for item in node.elts]
+
+        if isinstance(node, ast.Tuple):
+            return tuple(self._safe_constructor_arg_value(item, session) for item in node.elts)
+
+        if isinstance(node, ast.Set):
+            return {self._safe_constructor_arg_value(item, session) for item in node.elts}
+
+        if isinstance(node, ast.Dict):
+            result: dict[Any, Any] = {}
+            for key_node, value_node in zip(node.keys, node.values, strict=True):
+                if key_node is None:
+                    raise ValueError("Dictionary unpacking is not allowed")
+                key = self._safe_constructor_arg_value(key_node, session)
+                result[key] = self._safe_constructor_arg_value(value_node, session)
+            return result
+
+        return ast.literal_eval(node)
+
     def _maybe_eval_constructor_string(self, value: str, return_type: Any, session: Any) -> Any:
-        """Eval a string that looks like a Python constructor call.
+        """Safely coerce a string that looks like a constructor call.
 
         Detects patterns like 'ClassName(field=value, ...)' where ClassName
-        matches the expected return type. Evaluates in the session namespace
-        so the type is available. Returns the constructed object on success,
-        or the original string on failure.
+        matches the expected return type. Constructor arguments may contain
+        Python literals or references to plain JSON-compatible session values.
+        Session values are copied through JSON before use, and executable
+        expressions such as function calls or attribute access are rejected.
 
         This handles a common LLM failure mode where the model calls
         return_result as a tool with the constructor as a string argument
@@ -2024,41 +2098,45 @@ Standard Python builtins and agent instance (`self`) are available."""
         """
         stripped = value.strip()
 
-        # Must look like a constructor call: Identifier(...)
-        # Quick check before parsing
-        paren_idx = stripped.find("(")
-        if paren_idx <= 0 or not stripped.endswith(")"):
-            return value
-
-        candidate_name = stripped[:paren_idx].strip()
-        if not candidate_name.isidentifier():
-            return value
-
-        # Check that the candidate name matches the expected return type
-        # or is available in session locals
-        type_name = getattr(return_type, "__name__", None)
-        if candidate_name != type_name and candidate_name not in session.session_locals:
-            return value
-
-        # Build eval namespace: session locals + the return type itself (which may
-        # live in module globals rather than session_locals).
-        eval_ns = dict(session.session_locals)
-        if type_name and type_name not in eval_ns and isinstance(return_type, type):
-            eval_ns[type_name] = return_type
-
-        # Try to eval in the combined namespace
         try:
-            result = eval(stripped, {"__builtins__": {}}, eval_ns)  # noqa: S307
+            expression = ast.parse(stripped, mode="eval")
+        except SyntaxError:
+            return value
+
+        if not isinstance(expression.body, ast.Call):
+            return value
+
+        call = expression.body
+        if not isinstance(call.func, ast.Name):
+            return value
+
+        base_return_type, _ = self._extract_annotated_description(return_type)
+        type_name = getattr(base_return_type, "__name__", None)
+        candidate_name = call.func.id
+        if candidate_name != type_name or not isinstance(base_return_type, type):
+            return value
+
+        if any(keyword.arg is None for keyword in call.keywords):
+            return value
+
+        try:
+            args = [self._safe_constructor_arg_value(arg, session) for arg in call.args]
+            kwargs = {
+                keyword.arg: self._safe_constructor_arg_value(keyword.value, session)
+                for keyword in call.keywords
+                if keyword.arg is not None
+            }
+            result = base_return_type(*args, **kwargs)
             get_harness_metrics().constructor_string_coerced(candidate_name)
             logger.debug(
-                "[CODEACT] Coerced constructor-call string %r into %s instance",
+                "[CODEACT] Safely coerced constructor-call string %r into %s instance",
                 stripped[:80],
                 type(result).__name__,
             )
             return result
         except Exception:
             logger.debug(
-                "[CODEACT] Failed to eval constructor string %r, returning as-is",
+                "[CODEACT] Failed to safely coerce constructor string %r, returning as-is",
                 stripped[:80],
             )
             return value

--- a/tests/strategies/test_codeact_pure_python_coverage.py
+++ b/tests/strategies/test_codeact_pure_python_coverage.py
@@ -4177,7 +4177,7 @@ class TestCodeActGenerationIdNone:
 
 
 class TestMaybeEvalConstructorString:
-    """Tests for _maybe_eval_constructor_string constructor-call coercion."""
+    """Tests for safe _maybe_eval_constructor_string constructor-call coercion."""
 
     def _make_session(self, **locals_):
         """Create a mock session with given session_locals."""
@@ -4186,7 +4186,7 @@ class TestMaybeEvalConstructorString:
         return session
 
     def test_basic_constructor_with_type_in_locals(self):
-        """Should eval 'Answer(answer=1, reason="test")' when Answer is in locals."""
+        """Should coerce 'Answer(answer=1, reason="test")' when Answer is return type."""
         from pydantic import BaseModel
 
         class Answer(BaseModel):
@@ -4203,7 +4203,7 @@ class TestMaybeEvalConstructorString:
         assert result.reason == "the minimum"
 
     def test_constructor_with_type_injected_from_return_type(self):
-        """Should inject return_type into eval ns when not in session_locals."""
+        """Should use return_type when not in session_locals."""
         from pydantic import BaseModel
 
         class MyResult(BaseModel):
@@ -4220,7 +4220,7 @@ class TestMaybeEvalConstructorString:
         assert result.note == "computed"
 
     def test_constructor_with_variable_reference_in_args(self):
-        """Should resolve variables from session_locals inside constructor args."""
+        """Should resolve plain JSON values from session_locals inside constructor args."""
         from pydantic import BaseModel
 
         class Answer(BaseModel):
@@ -4235,6 +4235,21 @@ class TestMaybeEvalConstructorString:
         assert isinstance(result, Answer)
         assert result.answer == 7
         assert result.reason == "found it"
+
+    def test_constructor_with_session_value_is_json_detached(self):
+        """Should copy plain session values through JSON before constructor use."""
+        from pydantic import BaseModel
+
+        class Answer(BaseModel):
+            payload: dict[str, list[int]]
+
+        payload = {"numbers": [1, 2, 3]}
+        strat = CodeActStrategy()
+        session = self._make_session(Answer=Answer, payload=payload)
+        result = strat._maybe_eval_constructor_string("Answer(payload=payload)", Answer, session)
+        assert isinstance(result, Answer)
+        assert result.payload == {"numbers": [1, 2, 3]}
+        assert result.payload is not payload
 
     def test_non_constructor_string_returns_as_is(self):
         """Plain string should be returned unchanged."""
@@ -4253,12 +4268,12 @@ class TestMaybeEvalConstructorString:
     def test_unknown_type_returns_as_is(self):
         """Constructor with unknown type name should return as-is."""
         strat = CodeActStrategy()
-        session = self._make_session()
+        session = self._make_session(Unknown=lambda **kwargs: "should not run")
         result = strat._maybe_eval_constructor_string("Unknown(x=1)", object, session)
         assert result == "Unknown(x=1)"
 
-    def test_eval_failure_returns_as_is(self):
-        """If eval raises, return original string."""
+    def test_constructor_coercion_failure_returns_as_is(self):
+        """If safe argument parsing fails, return original string."""
         from pydantic import BaseModel
 
         class Answer(BaseModel):
@@ -4267,15 +4282,15 @@ class TestMaybeEvalConstructorString:
 
         strat = CodeActStrategy()
         session = self._make_session(Answer=Answer)
-        # Missing required field should raise ValidationError in eval
+        # Missing variable should fail safe argument parsing.
         result = strat._maybe_eval_constructor_string(
             'Answer(answer="not_an_int_but_coerced", reason=missing_var)', Answer, session
         )
-        # missing_var is not in session_locals → NameError → returns as-is
+        # missing_var is not in session_locals, so the original value is preserved.
         assert result == 'Answer(answer="not_an_int_but_coerced", reason=missing_var)'
 
-    def test_nested_parens_work(self):
-        """Nested parens in args should be handled by eval."""
+    def test_nested_calls_return_as_is(self):
+        """Nested calls in args should be rejected instead of executed."""
         from pydantic import BaseModel
 
         class Answer(BaseModel):
@@ -4287,8 +4302,53 @@ class TestMaybeEvalConstructorString:
         result = strat._maybe_eval_constructor_string(
             'Answer(answer=min(3, 1, 2), reason="picked smallest")', Answer, session
         )
-        assert isinstance(result, Answer)
-        assert result.answer == 1
+        assert result == 'Answer(answer=min(3, 1, 2), reason="picked smallest")'
+
+    def test_constructor_does_not_call_session_object(self):
+        """Pre-planted callable session objects must not be invoked."""
+        from pydantic import BaseModel
+
+        class Answer(BaseModel):
+            answer: str
+            reason: str
+
+        class Trap:
+            called = False
+
+            def __call__(self):
+                self.called = True
+                return "owned"
+
+        trap = Trap()
+        strat = CodeActStrategy()
+        session = self._make_session(Answer=Answer, payload=trap)
+        result = strat._maybe_eval_constructor_string(
+            'Answer(answer=payload(), reason="should not execute")', Answer, session
+        )
+        assert result == 'Answer(answer=payload(), reason="should not execute")'
+        assert trap.called is False
+
+    def test_constructor_rejects_non_plain_session_object(self):
+        """Session references to arbitrary objects should not be serialized or used."""
+        from pydantic import BaseModel
+
+        class Answer(BaseModel):
+            answer: object
+            reason: str
+
+        class Trap:
+            def __iter__(self):
+                raise AssertionError("object serialization should not be attempted")
+
+            def __repr__(self):
+                raise AssertionError("object repr should not be needed")
+
+        strat = CodeActStrategy()
+        session = self._make_session(Answer=Answer, payload=Trap())
+        result = strat._maybe_eval_constructor_string(
+            'Answer(answer=payload, reason="should not serialize")', Answer, session
+        )
+        assert result == 'Answer(answer=payload, reason="should not serialize")'
 
     def test_non_identifier_prefix_returns_as_is(self):
         """String starting with non-identifier before parens should return as-is."""


### PR DESCRIPTION
## Summary

Fixes an indirect code-execution path in CodeAct's `return_result` argument coercion.

### The issue

When the model calls `return_result` as a tool with a stringified constructor (e.g. `{"result": "Answer(answer=1, reason='ok')"}`), `_maybe_eval_constructor_string` in `src/nooa/strategies/codeact.py` coerces that string into an actual `Answer` instance. The previous implementation did this with `eval(stripped, {"__builtins__": {}}, session.session_locals)`.

`session.session_locals` accumulates every object created by prior `execute_python` cells (populated from `result.captured_locals` at `codeact.py:1506` and `2446`). Stripping `__builtins__` blocked `open` / `__import__` etc., but it did **not** block attribute access or method invocation on session objects. A constructor string like `Answer(answer=planted.trigger())` — where `planted` was any object bound in an earlier cell — would execute `planted.trigger()` as a side effect of coercion.

Impact: the `return_result` tool-call surface is nominally a "return a value" boundary, but this made it a second path to arbitrary code execution driven by LLM-controlled strings, distinct from the intended `execute_python` cell path. Concretely relevant when the payload flows in from a less-trusted layer (e.g. a delegated/subagent result) that a caller might assume is inert.

### Fix

Replace `eval()` with an AST-based coercion:

- Parse via `ast.parse(mode="eval")` and require a bare `Call(func=Name(...))`.
- Require `call.func.id == return_type.__name__` **and** `isinstance(base_return_type, type)` — no fallback to arbitrary session-local classes. `Annotated[T, ...]` return types are unwrapped via `_extract_annotated_description`.
- Reject `**kwargs` unpacking (`kw.arg is None`); reject nested calls, attribute access, subscripting, and starred args (they fall through to `ast.literal_eval` which raises).
- Constructor args accept Python literals or `Name` references to plain-JSON session values only (exact `bool`/`int`/`float`/`str`/`list`/`tuple`/`dict`, no subclasses). Session values are detached via `json.loads(json.dumps(..., allow_nan=False))` before use, so custom `__getitem__` / dunder methods on subclassed containers can't leak into `return_type(**...)`.
- Instantiate `base_return_type(*args, **kwargs)` directly rather than eval'ing source.

## Behavior changes

`_maybe_eval_constructor_string` is a fallback for a documented anti-pattern (LLMs calling `return_result` as a tool with a stringified constructor instead of `return_result(value)` from inside `execute_python`; see the guidance at `codeact.py:564`). The sanctioned paths are unaffected:

- `return_result(literal)` — works.
- `return_result(var)` where `var` is any session local — works (handled by the variable-ref resolution path at `codeact.py:1792`, which runs before coercion).
- `return_result("ClassName(field=literal, ...)")` with only literals or plain-JSON session values — works, values are JSON-copied.

Newly rejected (each falls back to Pydantic validation, which fails and the LLM retries):

- Nested calls in args: `Answer(answer=min(3, 1, 2))`.
- Attribute access: `Answer(reason=obj.description)`.
- Constructor args referencing non-plain-JSON session values (e.g. Pydantic model instances). Note: passing the model directly via `return_result(var)` still works — only the "re-wrap in a constructor call" form is blocked.

## Test plan

- [x] `tests/strategies/test_codeact_pure_python_coverage.py::TestMaybeEvalConstructorString` — 12/12 pass, including new regression tests:
  - `test_constructor_does_not_call_session_object` — planted callable in session_locals is not invoked.
  - `test_constructor_rejects_non_plain_session_object` — arbitrary object references rejected without triggering `__iter__` / `__repr__`.
  - `test_constructor_with_session_value_is_json_detached` — plain values pass through and are copied (identity-distinct from the source).
  - `test_nested_calls_return_as_is` — replaces the old `test_nested_parens_work`; nested calls are now rejected.
- [x] Full file: 176/176 pass.
- [x] All strategy tests: 893/893 pass.
- [ ] Reviewer: confirm no downstream consumers rely on the previously permissive coercion (nested calls, attribute lookups, non-JSON session refs inside constructor args).