### PR TITLE
fix: forward headers for SSE MCP clients 🤖🤖🤖

### DIFF
--- a/src/nooa/mcp/client.py
+++ b/src/nooa/mcp/client.py
@@ -67,15 +67,18 @@ class MCPSSEClient(MCPBaseClient):
     Args:
         url: The URL of the MCP server
         tool_call_timeout: Timeout for tool calls
+        headers: Optional custom HTTP headers to include in requests (e.g., for authentication)
     """
 
     def __init__(
         self,
         url: str,
         tool_call_timeout: timedelta = timedelta(seconds=60),
+        headers: dict[str, str] | None = None,
     ):
         super().__init__(tool_call_timeout=tool_call_timeout)
         self._url = url
+        self._headers = headers or {}
 
     @property
     def transport(self) -> Literal["sse", "stdio", "streamable-http"]:
@@ -87,6 +90,7 @@ class MCPSSEClient(MCPBaseClient):
         """Return the server configuration."""
         return {
             "url": self._url,
+            "headers": self._headers,
             "transport": self.transport,
         }
 
@@ -94,6 +98,11 @@ class MCPSSEClient(MCPBaseClient):
     def url(self) -> str:
         """Return the server URL."""
         return self._url
+
+    @property
+    def headers(self) -> dict[str, str]:
+        """Return the custom headers configured for this client."""
+        return self._headers
 
     @asynccontextmanager
     @override
@@ -107,7 +116,10 @@ class MCPSSEClient(MCPBaseClient):
             RuntimeError: If session initialization fails (MCP protocol error)
         """
         async with (
-            sse_client(url=self._url) as (read, write),
+            sse_client(
+                url=self._url,
+                headers=self._headers if self._headers else None,
+            ) as (read, write),
             ClientSession(read, write) as session,
         ):
             await session.initialize()
@@ -320,7 +332,7 @@ def create_mcp_client(
         case "sse":
             if url is None:
                 raise ValueError("url must be provided for sse transport")
-            return MCPSSEClient(url=url)
+            return MCPSSEClient(url=url, headers=headers)
         case "streamable-http":
             if url is None:
                 raise ValueError("url must be provided for streamable-http transport")

--- a/tests/test_mcp/test_client.py
+++ b/tests/test_mcp/test_client.py
@@ -45,6 +45,7 @@ def sse_client() -> MCPSSEClient:
     """Create an SSE client for testing."""
     return MCPSSEClient(
         url="http://localhost:8000",
+        headers={"Authorization": "Bearer token"},
         tool_call_timeout=timedelta(seconds=45),
     )
 
@@ -253,11 +254,24 @@ def test_sse_client_properties(sse_client: MCPSSEClient):
     """MCPSSEClient properties return correct values."""
     assert sse_client.transport == "sse"
     assert sse_client.url == "http://localhost:8000"
+    assert sse_client.headers == {"Authorization": "Bearer token"}
     assert sse_client.tool_call_timeout == timedelta(seconds=45)
 
     config = sse_client.server_config
     assert config["transport"] == "sse"
     assert config["url"] == "http://localhost:8000"
+    assert config["headers"] == {"Authorization": "Bearer token"}
+
+
+def test_sse_client_preserves_positional_timeout():
+    """The existing second positional argument remains the tool-call timeout."""
+    client = MCPSSEClient(
+        "http://localhost:8000",
+        timedelta(seconds=7),
+    )
+
+    assert client.tool_call_timeout == timedelta(seconds=7)
+    assert client.headers == {}
 
 
 def test_streamable_http_client_properties(streamable_http_client: MCPStreamableHTTPClient):
@@ -326,6 +340,35 @@ async def test_connect_context_manager(
             async with client.connect_to_server() as session:
                 assert session is not None
                 mock_client_session.initialize.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sse_headers_passed_to_transport(
+    mock_mcp_transport: tuple[MagicMock, MagicMock],
+    mock_client_session: AsyncMock,
+):
+    """SSE clients forward custom headers to the transport."""
+    client = create_mcp_client(
+        "sse",
+        url="https://example.test/sse",
+        headers={"Authorization": "Bearer token"},
+    )
+    mock_read, mock_write = mock_mcp_transport
+
+    with (
+        patch("nooa.mcp.client.sse_client") as mock_sse,
+        patch("nooa.mcp.client.ClientSession") as mock_session_class,
+    ):
+        mock_sse.return_value.__aenter__.return_value = (mock_read, mock_write)
+        mock_session_class.return_value.__aenter__.return_value = mock_client_session
+
+        async with client.connect_to_server():
+            pass
+
+    mock_sse.assert_called_once_with(
+        url="https://example.test/sse",
+        headers={"Authorization": "Bearer token"},
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

`create_mcp_client()` accepts custom headers for both HTTP transports, but the SSE branch discarded them before constructing `MCPSSEClient`. As a result, authenticated SSE servers received no bearer token, including on the OAuth retry path.

This change:

- stores SSE headers and forwards them to the MCP SDK `sse_client` transport;
- exposes headers through `MCPSSEClient.headers` and `server_config`, matching streamable HTTP;
- preserves the existing second positional `tool_call_timeout` argument;
- adds regression coverage for transport forwarding and positional API compatibility.

## Related issues

No open issue currently tracks this defect.

## Validation

- `uv run pytest -q tests/test_mcp/test_client.py` — 31 passed
- `uv run pytest -q -m "not integration and not stress"` — 6,444 passed, 6 skipped
- `uv run ruff check .` — passed
- changed-file Ruff formatting — passed
- changed-file Pyright — 0 errors
- DCO sign-off and cryptographic commit signature verified

Repository-wide formatting still reports the pre-existing untouched `tests/viewer/test_main.py` formatting difference.

## Checklist

- [x] Code follows the project style
- [x] Tests added and passing
- [x] Public constructor compatibility preserved
- [x] Existing source-file SPDX headers retained

🤖🤖🤖