### PR TITLE
Add LLM routing metadata to generation observability

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -567,7 +567,7 @@ class DataAgent(Agent, llm=llm):
 
 ### LLM cascading resolution
 
-Configure LLMs at any granularity — class default, method override, instance override — for cost/latency optimization, A/B testing, or gradual rollouts.
+Configure LLMs at any granularity — class default, method override, instance override, or per-call override — for cost/latency optimization, A/B testing, or gradual rollouts.
 
 ```python
 class MyAgent(Agent, llm=default_llm):              # 1. class default

--- a/src/nooa/runtime/actor.py
+++ b/src/nooa/runtime/actor.py
@@ -62,6 +62,8 @@ from nooa.runtime.hooks import call_after_hook, call_before_hook
 
 logger = logging.getLogger(__name__)
 
+_MISSING = object()
+
 
 @contextmanager
 def _harness_metrics_lifecycle(should_trace: bool):
@@ -401,6 +403,12 @@ _current_method_var: contextvars.ContextVar[Any] = contextvars.ContextVar(
     "current_method", default=None
 )
 _current_llm_var: contextvars.ContextVar[Any] = contextvars.ContextVar("current_llm", default=None)
+_current_llm_model_name_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "current_llm_model_name", default=None
+)
+_current_llm_selection_source_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "current_llm_selection_source", default=None
+)
 
 # Context variable for the resolved truncation config for the current generation call.
 # Set by _execute_with_generation() so that method-level @strategy(truncation=...)
@@ -1953,6 +1961,14 @@ class ActorRuntime:
         if hasattr(strategy, "prefill") and getattr(strategy, "prefill") is not None:  # noqa: B009
             strategy_kwargs["has_prefill"] = True
 
+        llm_model_name = _current_llm_model_name_var.get()
+        llm_selection_source = _current_llm_selection_source_var.get()
+        llm_kwargs = {}
+        if llm_model_name is not None:
+            llm_kwargs["llm.model_name"] = llm_model_name
+        if llm_selection_source is not None:
+            llm_kwargs["llm.selection_source"] = llm_selection_source
+
         # Call generation hooks (skip for non-traceable strategies like TemplateStrategy)
         should_trace = strategy.traceable
         hook_context = None
@@ -1965,6 +1981,7 @@ class ActorRuntime:
                 generation_id=generation_id,
                 parent_generation_id=parent_generation_id,
                 agent_call_id=self._agent_call_id,
+                **llm_kwargs,
                 **strategy_kwargs,  # Add strategy config parameters
             )
 
@@ -2530,13 +2547,18 @@ class ActorRuntime:
         method_name: str,
     ) -> Any:
         """Execute a method that needs LLM generation."""
+        base_method = getattr(method, "__func__", method)
+        try:
+            has_user_llm_param = "llm" in inspect.signature(method).parameters
+        except (TypeError, ValueError):
+            has_user_llm_param = False
+
         # Extract framework parameters (don't pass to generated method)
         call_strategy = kwargs.pop("_strategy", None)
-        call_llm = kwargs.pop("llm", None)
+        call_llm = kwargs.pop("llm", _MISSING) if not has_user_llm_param else _MISSING
         call_session_locals = kwargs.pop("_session_locals", None)
 
         # Get strategy with priority: call-level > decorator > default
-        base_method = getattr(method, "__func__", method)
         decorator_strategy = getattr(base_method, "_plan_strategy", None)
 
         # DEBUG: Log strategy retrieval for nested method debugging
@@ -2561,17 +2583,21 @@ class ActorRuntime:
         # A @strategy(llm=...) value may be a callable resolved against the agent
         # instance; only invoke it when it would actually be used, so a call-level
         # override doesn't trigger someone else's resolver side effects.
-        if call_llm is not None:
+        plan_llm = getattr(base_method, "_plan_llm", None)
+        if call_llm is not _MISSING and call_llm is not None:
             llm_client = call_llm
-        else:
-            plan_llm = getattr(base_method, "_plan_llm", None)
-            if plan_llm is not None:
-                from nooa.method_llm import resolve_method_llm
+            llm_selection_source = "call_site"
+        elif plan_llm is not None:
+            from nooa.method_llm import resolve_method_llm
 
-                plan_llm = resolve_method_llm(plan_llm, self.agent, method_name)
-            llm_client = plan_llm or getattr(self.agent, "_llm", None)
+            llm_client = resolve_method_llm(plan_llm, self.agent, method_name)
+            llm_selection_source = "decorator"
+        else:
+            llm_client = getattr(self.agent, "_llm", None)
+            llm_selection_source = "agent_default"
         if llm_client is None:
             raise RuntimeError(f"No LLM client available for {method_name}")
+        llm_model_name = getattr(llm_client, "model", "") or ""
 
         # Resolve truncation config: method-level @strategy(truncation=...) > agent-level
         method_truncation = getattr(base_method, "_strategy_truncation", None)
@@ -2615,6 +2641,10 @@ class ActorRuntime:
                 generation_id=generation_id,
                 parent_generation_id=parent_generation_id,
                 agent_call_id=self._agent_call_id,
+                **{
+                    "llm.model_name": llm_model_name,
+                    "llm.selection_source": llm_selection_source,
+                },
                 **strategy_kwargs,  # Add strategy config parameters
             )
 
@@ -2709,6 +2739,10 @@ class ActorRuntime:
                 call_token = _current_call_var.set(call)
                 method_token = _current_method_var.set(method)
                 llm_token = _current_llm_var.set(llm_client)
+                llm_model_name_token = _current_llm_model_name_var.set(llm_model_name)
+                llm_selection_source_token = _current_llm_selection_source_var.set(
+                    llm_selection_source
+                )
                 truncation_token = _current_truncation_config_var.set(resolved_truncation)
                 event_format_token = _current_event_format_var.set(
                     resolved_truncation.event_format.model_dump()
@@ -2749,6 +2783,8 @@ class ActorRuntime:
                     _current_call_var.reset(call_token)
                     _current_method_var.reset(method_token)
                     _current_llm_var.reset(llm_token)
+                    _current_llm_model_name_var.reset(llm_model_name_token)
+                    _current_llm_selection_source_var.reset(llm_selection_source_token)
                     _current_truncation_config_var.reset(truncation_token)
                     _current_event_format_var.reset(event_format_token)
                     _decorator_context_var.reset(decorator_ctx_token)

--- a/src/nooa/runtime/method_wrapper.py
+++ b/src/nooa/runtime/method_wrapper.py
@@ -11,6 +11,7 @@ for context variable management, tracing hooks, and execution routing.
 """
 
 import asyncio
+import inspect
 import logging
 from collections.abc import Callable
 from functools import wraps
@@ -127,9 +128,15 @@ def create_agent_method_wrapper(
             if hasattr(self, "runtime"):
                 _fw_kwargs = {
                     _name: kwargs.pop(_name)
-                    for _name in ("_session_locals", "_strategy", "llm")
+                    for _name in ("_session_locals", "_strategy")
                     if _name in kwargs
                 }
+                try:
+                    _has_user_llm_param = "llm" in inspect.signature(original_func).parameters
+                except (TypeError, ValueError):
+                    _has_user_llm_param = False
+                if not _has_user_llm_param and "llm" in kwargs:
+                    _fw_kwargs["llm"] = kwargs.pop("llm")
             try:
                 ArgumentValidator().validate(original_func, args, kwargs, _tc)
             finally:

--- a/tests/runtime/test_llm_routing_observability.py
+++ b/tests/runtime/test_llm_routing_observability.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""LLM routing controls and generation observability."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, cast
+
+import pytest
+
+from nooa import Agent, strategy
+from nooa.runtime.hooks import set_hooks
+from nooa.strategies import CurrentCall, GenerationStrategy, PredictStrategy, RuntimeServices
+from nooa.unifiedllm import FakeLLMClient, LLMResponse
+
+
+def _resp(value: str) -> LLMResponse:
+    return LLMResponse(
+        raw_response=None,
+        content=f'{{"value": "{value}"}}',
+        tool_calls=[],
+        finish_reason="stop",
+        assistant_message={"role": "assistant", "content": f'{{"value": "{value}"}}'},
+    )
+
+
+def _llm(model: str, value: str) -> FakeLLMClient:
+    client = FakeLLMClient(scripted_responses=[_resp(value)])
+    client.model = model
+    return client
+
+
+class RoutingHooks:
+    """Capture generation hook metadata for routing assertions."""
+
+    def __init__(self) -> None:
+        self.generations: list[dict[str, Any]] = []
+
+    def before_generation(
+        self,
+        agent: Any,
+        method_name: str,
+        strategy: str,
+        generation_id: str,
+        parent_generation_id: str | None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.generations.append(
+            {
+                "method_name": method_name,
+                "strategy": strategy,
+                "generation_id": generation_id,
+                **kwargs,
+            }
+        )
+        return {"generation_id": generation_id}
+
+    def after_generation(
+        self,
+        agent: Any,
+        method_name: str,
+        result: Any,
+        exception: Exception | None,
+        context: Any,
+        generation_id: str,
+    ) -> None:
+        pass
+
+    def on_messages_built(
+        self,
+        agent: Any,
+        method_name: str,
+        messages: list[dict[str, Any]],
+        generation_id: str,
+        **kwargs: Any,
+    ) -> None:
+        pass
+
+    def before_agent_call(
+        self,
+        agent: Any,
+        method_name: str,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        call_id: str,
+        parent_call_id: str | None,
+        **extra: Any,
+    ) -> dict[str, Any]:
+        return {"call_id": call_id}
+
+    def after_agent_call(
+        self,
+        agent: Any,
+        method_name: str,
+        result: Any,
+        exception: Exception | None,
+        context: Any,
+        **kwargs: Any,
+    ) -> None:
+        pass
+
+    def before_code_execution(
+        self,
+        agent: Any,
+        code: str,
+        execution_id: str,
+        generation_id: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        return {"execution_id": execution_id}
+
+    def after_code_execution(
+        self,
+        agent: Any,
+        code: str,
+        result: Any,
+        exception: Exception | None,
+        context: Any,
+        execution_id: str,
+        **kwargs: Any,
+    ) -> None:
+        pass
+
+    def before_method_invocation(
+        self,
+        agent: Any,
+        method_name: str,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        invocation_id: str,
+        **extra: Any,
+    ) -> dict[str, Any]:
+        return {"invocation_id": invocation_id}
+
+    def after_method_invocation(
+        self,
+        agent: Any,
+        method_name: str,
+        result: Any,
+        exception: Exception | None,
+        context: Any,
+        invocation_id: str,
+        **kwargs: Any,
+    ) -> None:
+        pass
+
+    def before_tool_execution(
+        self,
+        agent: Any,
+        tool_name: str,
+        arguments: dict[str, Any],
+        execution_id: str,
+        generation_id: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        return {"execution_id": execution_id}
+
+    def after_tool_execution(
+        self,
+        agent: Any,
+        tool_name: str,
+        arguments: dict[str, Any],
+        result: Any,
+        exception: Exception | None,
+        context: Any,
+        execution_id: str,
+        **kwargs: Any,
+    ) -> None:
+        pass
+
+
+@pytest.fixture
+def routing_hooks() -> Iterator[RoutingHooks]:
+    hooks = RoutingHooks()
+    try:
+        yield hooks
+    finally:
+        set_hooks(None)
+
+
+@pytest.mark.asyncio
+async def test_call_site_llm_override_wins_and_is_observable(routing_hooks: RoutingHooks) -> None:
+    default_llm = _llm("default-model", "default")
+    decorator_llm = _llm("decorator-model", "decorator")
+    override_llm = _llm("override-model", "override")
+
+    class RoutingAgent(Agent, llm=default_llm):
+        @strategy(PredictStrategy(), llm=decorator_llm)
+        async def summarize(self, text: str) -> str:
+            """Summarize text."""
+            ...
+
+    agent = RoutingAgent()
+    set_hooks(cast(Any, routing_hooks))
+
+    assert await agent.summarize("hello", llm=override_llm) == "override"  # pyright: ignore[reportCallIssue]
+
+    assert default_llm.call_count == 0
+    assert decorator_llm.call_count == 0
+    assert override_llm.call_count == 1
+    assert routing_hooks.generations[-1]["llm.model_name"] == "override-model"
+    assert routing_hooks.generations[-1]["llm.selection_source"] == "call_site"
+
+
+@pytest.mark.asyncio
+async def test_nested_generation_inherits_routing_metadata(
+    routing_hooks: RoutingHooks,
+) -> None:
+    default_llm = _llm("default-model", "default")
+    override_llm = _llm("override-model", "nested")
+
+    class NestedPredictStrategy(GenerationStrategy):
+        @property
+        def name(self) -> str:
+            return "NESTED"
+
+        async def execute(self, runtime: RuntimeServices, call: CurrentCall) -> Any:
+            return await runtime.execute_nested(PredictStrategy(), call)
+
+    class RoutingAgent(Agent, llm=default_llm):
+        @strategy(NestedPredictStrategy())
+        async def summarize(self, text: str) -> str:
+            """Summarize text."""
+            ...
+
+    agent = RoutingAgent()
+    set_hooks(cast(Any, routing_hooks))
+
+    assert await agent.summarize("hello", llm=override_llm) == "nested"  # pyright: ignore[reportCallIssue]
+
+    assert default_llm.call_count == 0
+    assert override_llm.call_count == 1
+    assert [g["strategy"] for g in routing_hooks.generations] == ["NESTED", "PREDICT"]
+    for generation in routing_hooks.generations:
+        assert generation["llm.model_name"] == "override-model"
+        assert generation["llm.selection_source"] == "call_site"
+
+
+@pytest.mark.asyncio
+async def test_decorator_llm_selection_is_observable(routing_hooks: RoutingHooks) -> None:
+    default_llm = _llm("default-model", "default")
+    decorator_llm = _llm("decorator-model", "decorator")
+
+    class RoutingAgent(Agent, llm=default_llm):
+        @strategy(PredictStrategy(), llm=decorator_llm)
+        async def summarize(self, text: str) -> str:
+            """Summarize text."""
+            ...
+
+    agent = RoutingAgent()
+    set_hooks(cast(Any, routing_hooks))
+
+    assert await agent.summarize("hello") == "decorator"
+
+    assert default_llm.call_count == 0
+    assert decorator_llm.call_count == 1
+    assert routing_hooks.generations[-1]["llm.model_name"] == "decorator-model"
+    assert routing_hooks.generations[-1]["llm.selection_source"] == "decorator"
+
+
+@pytest.mark.asyncio
+async def test_agent_default_llm_selection_is_observable(routing_hooks: RoutingHooks) -> None:
+    default_llm = _llm("default-model", "default")
+
+    class RoutingAgent(Agent, llm=default_llm):
+        @strategy(PredictStrategy())
+        async def summarize(self, text: str) -> str:
+            """Summarize text."""
+            ...
+
+    agent = RoutingAgent()
+    set_hooks(cast(Any, routing_hooks))
+
+    assert await agent.summarize("hello") == "default"
+
+    assert default_llm.call_count == 1
+    assert routing_hooks.generations[-1]["llm.model_name"] == "default-model"
+    assert routing_hooks.generations[-1]["llm.selection_source"] == "agent_default"
+
+
+@pytest.mark.asyncio
+async def test_user_parameter_named_llm_is_not_consumed_as_framework_override(
+    routing_hooks: RoutingHooks,
+) -> None:
+    default_llm = _llm("default-model", "ok")
+
+    class RoutingAgent(Agent, llm=default_llm):
+        @strategy(PredictStrategy())
+        async def summarize(self, llm: str) -> str:
+            """Summarize using the user-supplied label."""
+            ...
+
+    agent = RoutingAgent()
+    set_hooks(cast(Any, routing_hooks))
+
+    assert await agent.summarize(llm="customer-visible-label") == "ok"
+
+    assert default_llm.call_count == 1
+    assert routing_hooks.generations[-1]["llm.model_name"] == "default-model"
+    assert routing_hooks.generations[-1]["llm.selection_source"] == "agent_default"

--- a/tests/tracing/test_viewer_plugin_attr.py
+++ b/tests/tracing/test_viewer_plugin_attr.py
@@ -94,6 +94,39 @@ class TestViewerPluginAttribute:
             assert len(gen_spans) == 1
             assert gen_spans[0]["attributes"][VIEWER_PLUGIN_ATTR] == ViewerPlugin.GENERATION
 
+    def test_generation_routing_metadata_is_written_to_span_attributes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks, provider = self._make_hooks(tmpdir)
+            agent = self._make_agent()
+
+            ctx = hooks.before_generation(
+                agent=agent,
+                method_name="solve",
+                strategy="PREDICT",
+                generation_id="gen-001",
+                parent_generation_id=None,
+                **{
+                    "llm.model_name": "override-model",
+                    "llm.selection_source": "call_site",
+                },
+            )
+            hooks.after_generation(
+                agent=agent,
+                method_name="solve",
+                result="output",
+                exception=None,
+                context=ctx,
+                generation_id="gen-001",
+            )
+            provider.force_flush()
+
+            spans = self._read_spans(tmpdir)
+            gen_spans = [s for s in spans if s["name"] == "generation"]
+            assert len(gen_spans) == 1
+            attrs = gen_spans[0]["attributes"]
+            assert attrs["generation.llm.model_name"] == "override-model"
+            assert attrs["generation.llm.selection_source"] == "call_site"
+
     def test_code_execution_sets_code_execution_plugin(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             hooks, provider = self._make_hooks(tmpdir)


### PR DESCRIPTION
## What does this PR do?

Adds observable LLM-routing metadata for generation methods.

This change:
- Allows call-site `llm=` overrides to pass through generation-method argument validation when the user method does not explicitly declare an `llm` parameter.
- Preserves user-facing parameters named `llm` when they are explicitly declared in the method signature.
- Records the selected model name and selection source on generation hook metadata.
- Exports that metadata as generation span attributes:
  - `generation.llm.model_name`
  - `generation.llm.selection_source`
- Documents per-call LLM overrides in the existing LLM cascading-resolution example.

Selection source values are:
- `agent_default`
- `decorator`
- `call_site`

## Related issues

N/A

## Validation

- `uv run pytest -q tests/runtime/test_llm_routing_observability.py`
  - `4 passed`
- `uv run pytest -q tests/runtime/test_llm_routing_observability.py tests/tracing/test_viewer_plugin_attr.py`
  - `11 passed`
- `uv run pytest -q tests/runtime/test_llm_routing_observability.py tests/tracing/test_viewer_plugin_attr.py tests/runtime/test_llm_complete_event.py tests/strategies/test_session_locals_injection.py tests/strategies/test_argument_validator.py`
  - `60 passed`
- `uv run pytest -q -m "not integration and not stress"`
  - VM: `6449 passed, 4 skipped, 282 deselected`
- `uv run ruff check .`
  - Passed on VM
- `uv run ruff format --check <touched Python files>`
  - Passed
- `uv run python scripts/check_license_headers.py`
  - All 871 Python files carry SPDX headers
- Focused `uv run pyright <touched Python files>`
  - Only the known pre-existing `actor.py` error was reported

Manual live validation:
- Served real `Qwen/Qwen3-0.6B` through vLLM on a VM with two NVIDIA H100 NVL GPUs.
- Served two model names: `Qwen/Qwen3-0.6B` and `qwen-routing-alias`.
- Confirmed outbound wire requests used both models:
  - default call: `Qwen/Qwen3-0.6B`
  - call-site override: `qwen-routing-alias`
- Confirmed span metadata:
  - `generation.llm.model_name='hosted_vllm/Qwen/Qwen3-0.6B'`
  - `generation.llm.selection_source='agent_default'`
  - `generation.llm.model_name='hosted_vllm/qwen-routing-alias'`
  - `generation.llm.selection_source='call_site'`

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and touched-file `uv run ruff format --check` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [x] Docs updated if behavior or public APIs changed
- [x] New source files carry an SPDX license header



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the language model on individual calls.
  * Call-level selections take precedence over method, decorator, and agent defaults.
  * Nested generations inherit language model routing metadata.
  * Generation tracing records the selected model and how it was chosen.
  * Updated documentation with per-call language model override guidance.

* **Bug Fixes**
  * Methods that define their own `llm` parameter now retain and receive that value correctly.
  * Unspecified overrides are distinguished from explicitly selecting no model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->