### PR TITLE
fix: preserve sandbox state after recoverable exits 🤖🤖🤖

### DIFF
--- a/src/nooa/runtime/sandbox/cell_core.py
+++ b/src/nooa/runtime/sandbox/cell_core.py
@@ -22,7 +22,7 @@ import io
 import linecache
 import types
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 from nooa.events import _NO_RETURN, ExecutionResult, ExecutionSignal
 
@@ -185,12 +185,13 @@ async def run_cell_source(
             )
 
             exec(compile(wrapper, cell_filename, "exec"), namespace)
-            result_value = await namespace["__repl_wrapper__"]()
-
-            # Persist captured locals into the namespace for the next cell.
-            captured = namespace.pop("__repl_captured_locals__", {})
-            for k, v in captured.items():
-                namespace[k] = v
+            try:
+                result_value = await namespace["__repl_wrapper__"]()
+            finally:
+                # Keep REPL state even when the cell raises or returns via signal.
+                captured = namespace.pop("__repl_captured_locals__", {})
+                for k, v in captured.items():
+                    namespace[k] = v
 
             if has_explicit_return:
                 returned_value = result_value
@@ -198,7 +199,7 @@ async def run_cell_source(
                 returned_value = result_value
 
             # Re-bind top-level function defs so helpers persist by name.
-            func_defs = [
+            func_defs: list[ast.stmt] = [
                 n for n in tree.body if isinstance(n, ast.FunctionDef | ast.AsyncFunctionDef)
             ]
             if func_defs:
@@ -210,7 +211,7 @@ async def run_cell_source(
                 fn = namespace.get(name)
                 if callable(fn):
                     with contextlib.suppress(AttributeError, TypeError):
-                        fn._generated_source = src
+                        cast(Any, fn)._generated_source = src
             defined_methods = {
                 name: namespace[name] for name in method_sources if callable(namespace.get(name))
             }

--- a/tests/runtime/sandbox/test_cell_core_state_persistence.py
+++ b/tests/runtime/sandbox/test_cell_core_state_persistence.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Sandbox cells preserve REPL state across recoverable exits."""
+
+from __future__ import annotations
+
+import pytest
+
+from nooa.events import ExecutionSignal
+from nooa.runtime.sandbox.cell_core import run_cell_source
+
+
+@pytest.mark.asyncio
+async def test_assignments_persist_after_cell_error():
+    namespace: dict = {}
+
+    failed = await run_cell_source(
+        "answer = 41\nraise ValueError('boom')",
+        namespace,
+        execution_count=1,
+    )
+    assert isinstance(failed.error, ValueError)
+
+    resumed = await run_cell_source("answer + 1", namespace, execution_count=2)
+    assert resumed.error is None
+    assert resumed.returned_value == 42
+
+
+@pytest.mark.asyncio
+async def test_assignments_persist_after_execution_signal():
+    class ReturnResultSignal(ExecutionSignal):
+        pass
+
+    def return_result() -> None:
+        raise ReturnResultSignal
+
+    namespace: dict = {"return_result": return_result}
+
+    signaled = await run_cell_source(
+        "answer = 41\nreturn_result()",
+        namespace,
+        execution_count=1,
+    )
+    assert isinstance(signaled.signal, ReturnResultSignal)
+
+    resumed = await run_cell_source("answer + 1", namespace, execution_count=2)
+    assert resumed.error is None
+    assert resumed.returned_value == 42

--- a/tests/runtime/sandbox/test_executor.py
+++ b/tests/runtime/sandbox/test_executor.py
@@ -123,6 +123,34 @@ async def test_persistent_namespace_across_cells():
         await ex.aclose()
 
 
+async def test_persistent_namespace_keeps_assignments_from_failed_cell():
+    ex = _executor()
+    try:
+        failed = await _run(ex, "answer = 41\nraise ValueError('boom')", 1)
+        assert not failed.success
+        assert isinstance(failed.error, ValueError)
+
+        resumed = await _run(ex, "answer + 1", 2)
+        assert resumed.success, resumed.error
+        assert resumed.returned_value == 42
+    finally:
+        await ex.aclose()
+
+
+async def test_persistent_namespace_keeps_assignments_before_return_result():
+    ex = _executor()
+    try:
+        signaled = await _run(ex, "answer = 41\nreturn_result(answer)", 1)
+        assert signaled.error is None
+        assert signaled.signal is not None
+
+        resumed = await _run(ex, "answer + 1", 2)
+        assert resumed.success, resumed.error
+        assert resumed.returned_value == 42
+    finally:
+        await ex.aclose()
+
+
 async def test_stdout_is_captured():
     ex = _executor()
     try:


### PR DESCRIPTION
## What does this PR do?

Sandbox cells capture locals in the generated wrapper finally block, but the worker previously merged them into its persistent namespace only after the wrapper returned successfully. An ordinary exception or an ExecutionSignal from return_result() skipped that merge, so assignments made earlier in the cell disappeared and the next cell failed with NameError.

This change:

- merges captured locals from an outer finally block so state survives errors and control-flow signals;
- keeps sandbox behavior aligned with the in-process ActorRuntime REPL semantics;
- adds normal-CI cell-engine regressions plus real-worker integration coverage;
- resolves the two existing Pyright errors in the touched block so the required pre-commit gate passes.

## Related issues

No open issue currently tracks this defect.

## Validation

- focused regression tests before the fix: 2 failed with NameError
- focused regression tests after the fix: 2 passed
- cell-engine regression suite: 8 passed
- non-live suite: 6,475 passed, 6 skipped
- all pre-commit hooks passed, including Ruff, formatting, Pyright, and SPDX
- DCO sign-off and cryptographic commit signature verified locally

## Checklist

- [x] Change is focused on sandbox REPL state persistence
- [x] Unit and integration tests added
- [x] Existing behavior on successful cells preserved
- [x] Source-file SPDX headers retained

🤖🤖🤖