### PR TITLE
fix(unifiedllm): message-level cache_control on non-Anthropic providers

### DIFF
--- a/src/nooa/unifiedllm/unifiedllm.py
+++ b/src/nooa/unifiedllm/unifiedllm.py
@@ -1280,12 +1280,18 @@ class UnifiedLLM(ABC):
                         msg["cache_control"] = {"type": "ephemeral"}
                         break
 
+        # Anthropic needs cache_control on a content block (parts form); other providers
+        # reject a content list on non-user roles, so mark at the message level instead.
+        anthropic = _is_anthropic_model(self.model)
         for role in roles_to_cache_last:
             # Search for matching messages by role OR by equivalent native type
             native_type = _ROLE_TO_TYPE.get(role)
             for msg in reversed(messages):
                 if msg.get("role") == role or (native_type and msg.get("type") == native_type):
-                    self._inject_cache_control_on_content(msg)
+                    if anthropic:
+                        self._inject_cache_control_on_content(msg)
+                    else:
+                        msg["cache_control"] = {"type": "ephemeral"}
                     break
 
         return messages

--- a/tests/unifiedllm/test_anthropic_detection.py
+++ b/tests/unifiedllm/test_anthropic_detection.py
@@ -91,6 +91,31 @@ def test_inject_cache_control_active_on_anthropic_models() -> None:
     assert tool_content[-1].get("cache_control") == {"type": "ephemeral"}
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        "nvidia/nvidia/nemotron-3-super-v3",
+        "huggingface/meta-llama/Llama-3.1-70B-Instruct",
+    ],
+)
+def test_inject_cache_control_message_level_on_non_anthropic_models(model: str) -> None:
+    """On non-Anthropic models the last tool message keeps its string content, with
+    cache_control on the message envelope rather than the parts format."""
+    client = CompletionClient(model=model)
+    original = _make_messages_with_tool_result()
+    result = client._inject_cache_control(
+        original,
+        [{"role": "system"}, {"role": "tool", "position": "last"}],
+    )
+    # system still gains message-level cache_control (unchanged for every provider)
+    assert result[0]["cache_control"] == {"type": "ephemeral"}
+    # last tool message — content stays a STRING, marked at the message envelope
+    tool_msg = result[3]
+    assert isinstance(tool_msg["content"], str), "tool content must remain a string"
+    assert tool_msg["content"] == "status: complete"
+    assert tool_msg["cache_control"] == {"type": "ephemeral"}
+
+
 def test_inject_cache_control_noop_on_empty_injection_points() -> None:
     """Empty injection_points short-circuits without mutation."""
     client = CompletionClient(model="anthropic/claude-sonnet")

--- a/tests/unifiedllm/test_cache_control.py
+++ b/tests/unifiedllm/test_cache_control.py
@@ -256,7 +256,11 @@ class TestPositionBasedInjection:
 
     @pytest.fixture
     def client(self):
-        return CompletionClient(model="test-model", cache_control_injection_points=[])
+        # Anthropic model: the parts form is used only for Anthropic; non-Anthropic
+        # marks at the message level (see test_anthropic_detection.py).
+        return CompletionClient(
+            model="anthropic/claude-sonnet-4-5", cache_control_injection_points=[]
+        )
 
     def test_last_assistant_marked(self, client):
         """position='last' marks only the last message of the specified role (content-block level)."""


### PR DESCRIPTION
## What does this PR do?
Cache-control injection converted the last tool-role message's content to the Anthropic parts-array form for every provider. OpenAI-compatible gateways (e.g. NVIDIA vLLM/NIM) reject a content list on non-user roles, so every request ending in a tool result failed there, and structured-output correction retries could never recover. The litellm patch strips the marker for non-Anthropic models but leaves the list shape behind, so stripping alone didn't fix it.

Gate the parts-array conversion on _is_anthropic_model(): non-Anthropic providers get cache_control at the message level instead. Adds a regression test and points the position-injection fixture at an Anthropic model (that suite asserts the content-block form, now Anthropic-specific).

## Related issues

No related issue

## Checklist

- [x ] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [ x] Tests added/updated and passing (`uv run pytest`)
- [ ] Docs updated if behavior or public APIs changed
- [ ] New source files carry an SPDX license header
