### PR TITLE
Add GitHub Copilot SDK benchmark agent

### DIFF
--- a/examples/benchmarks/README.md
+++ b/examples/benchmarks/README.md
@@ -9,6 +9,7 @@ Terminal-Bench 2.0 results).
 |------|------|
 | `harbor_adapter.py` | Harbor "installed agent" adapter: clones this repo into the trial container, installs `packages/nooa-bench`, and invokes the `nemo-harbor` CLI |
 | `harbor_minimal.yaml` | Minimal Harbor config wiring the adapter to a model and dataset |
+| `harbor_copilot_minimal.yaml` | Minimal Harbor config for the GitHub Copilot SDK-backed agent |
 | `bench_agent.py` | Standalone 35-line minimal agent, for reading — the real BenchAgent lives in [`packages/nooa-bench`](../../packages/nooa-bench/) |
 
 ## Run
@@ -36,3 +37,33 @@ nemo-harbor --instruction '...' --model '...' --agent-type bench
 which runs the BenchAgent and writes `result.json` (success, response, token
 counts) to `/logs/agent/` — token usage is surfaced back into Harbor's
 per-trial context for cost analysis.
+
+## Copilot SDK agent
+
+Direct local runs reuse the signed-in GitHub Copilot CLI account:
+
+```bash
+uv run --package nooa-bench nemo-harbor \
+  --instruction '...' \
+  --agent-type copilot \
+  --model gpt-5.6-sol \
+  --reasoning-effort xhigh \
+  --context-tier long_context
+```
+
+`xhigh` is the highest reasoning-effort literal supported by the Python
+`github-copilot-sdk` version used here; `long_context` requests the SDK's
+largest context tier.
+
+For Harbor containers, use `harbor_copilot_minimal.yaml`. The Copilot path
+approves tool permissions non-interactively because each task runs in an
+isolated benchmark container. Containerized runs do not automatically inherit
+your host login: forward `COPILOT_GITHUB_TOKEN`, or mount supported Copilot
+state into the container. Do not copy secrets into this repo or commit them.
+The adapter pre-downloads the Copilot runtime during install with
+`COPILOT_CLI_EXTRACT_DIR=/opt/nooa-copilot-runtime`, and sets
+`COPILOT_HOME=/logs/artifacts/copilot-home` so runtime/session state is written
+to a container-writable artifact path.
+
+Future Pareto-loop orchestration and GPU allocation should stay outside this
+agent boundary; this agent only adapts Harbor tasks to the Copilot SDK runtime.

--- a/examples/benchmarks/README.md
+++ b/examples/benchmarks/README.md
@@ -61,9 +61,10 @@ isolated benchmark container. Containerized runs do not automatically inherit
 your host login: forward `COPILOT_GITHUB_TOKEN`, or mount supported Copilot
 state into the container. Do not copy secrets into this repo or commit them.
 The adapter pre-downloads the Copilot runtime during install with
-`COPILOT_CLI_EXTRACT_DIR=/opt/nooa-copilot-runtime`, and sets
-`COPILOT_HOME=/logs/artifacts/copilot-home` so runtime/session state is written
-to a container-writable artifact path.
+`COPILOT_CLI_EXTRACT_DIR=/opt/nooa-copilot-runtime`. It keeps Copilot
+runtime/session state in the private, container-local
+`COPILOT_HOME=/tmp/nooa-copilot-home`; that state is not persisted with Harbor
+artifacts.
 
 Future Pareto-loop orchestration and GPU allocation should stay outside this
 agent boundary; this agent only adapts Harbor tasks to the Copilot SDK runtime.

--- a/examples/benchmarks/harbor_adapter.py
+++ b/examples/benchmarks/harbor_adapter.py
@@ -17,8 +17,9 @@ Credentials: set ``NVIDIA_INFERENCE_API_KEY`` (inference.nvidia.com gateway)
 or ``NVIDIA_API_KEY`` (public NIM endpoint) on the host — it is forwarded
 into the agent process. The NVIDIA endpoints are OpenAI-compatible, so the
 key is also exposed as ``OPENAI_API_KEY`` for litellm when you point
-``api_base`` at them. To use another provider directly, add its key to
-``FORWARDED_ENV_VARS`` below.
+``api_base`` at them. The Copilot SDK path can use a forwarded
+``COPILOT_GITHUB_TOKEN``; direct local runs normally reuse the signed-in
+Copilot CLI account.
 
 Note: the container needs network access during :meth:`install` (git clone +
 dependency download). For air-gapped task containers, pre-stage the repo and
@@ -37,12 +38,15 @@ from harbor.models.agent.context import AgentContext
 
 REPO_DIR = "/installed-agent/nooa"
 VENV = "/opt/nooa-venv"
+COPILOT_RUNTIME_DIR = "/opt/nooa-copilot-runtime"
+COPILOT_HOME = "/logs/artifacts/copilot-home"
 
 # Credentials forwarded from the host into the agent process. The NVIDIA
 # inference endpoints are public; add other provider keys here if needed.
 FORWARDED_ENV_VARS = (
     "NVIDIA_INFERENCE_API_KEY",  # inference.nvidia.com gateway
     "NVIDIA_API_KEY",  # public NIM endpoint
+    "COPILOT_GITHUB_TOKEN",  # optional Copilot SDK token auth
 )
 
 
@@ -54,6 +58,9 @@ class NooaBenchAgent(BaseInstalledAgent):
         git_ref:    optional branch/tag/SHA (or env ``NOOA_GIT_REF``)
         agent_type: registry key passed to ``nemo-harbor`` (default ``bench``)
         api_base:   optional OpenAI-compatible endpoint override
+        reasoning_effort: optional Copilot SDK reasoning effort
+        context_tier: optional Copilot SDK context tier
+        timeout_seconds: optional Copilot SDK session timeout
     """
 
     def __init__(
@@ -63,6 +70,9 @@ class NooaBenchAgent(BaseInstalledAgent):
         git_ref: str | None = None,
         agent_type: str = "bench",
         api_base: str | None = None,
+        reasoning_effort: str | None = None,
+        context_tier: str | None = None,
+        timeout_seconds: float | None = None,
         *args,
         **kwargs,
     ) -> None:
@@ -76,6 +86,9 @@ class NooaBenchAgent(BaseInstalledAgent):
         self._git_ref = git_ref or os.environ.get("NOOA_GIT_REF")
         self._agent_type = agent_type
         self._api_base = api_base
+        self._reasoning_effort = reasoning_effort
+        self._context_tier = context_tier
+        self._timeout_seconds = timeout_seconds
 
     @staticmethod
     def name() -> str:
@@ -84,6 +97,14 @@ class NooaBenchAgent(BaseInstalledAgent):
     async def install(self, environment: BaseEnvironment) -> None:
         """Clone the repo and install core + cli + bench into a fresh venv."""
         branch = f"--branch {shlex.quote(self._git_ref)} " if self._git_ref else ""
+        copilot_runtime_install = (
+            f"mkdir -p {COPILOT_RUNTIME_DIR} && chmod -R a+rwx {COPILOT_RUNTIME_DIR} && "
+            f"COPILOT_CLI_EXTRACT_DIR={COPILOT_RUNTIME_DIR} "
+            f"{VENV}/bin/python3 -m copilot download-runtime && "
+            f"chmod -R a+rwx {COPILOT_RUNTIME_DIR} && "
+            if self._agent_type == "copilot"
+            else ""
+        )
         await self.exec_as_root(
             environment,
             command=(
@@ -98,6 +119,7 @@ class NooaBenchAgent(BaseInstalledAgent):
                 f"uv venv {VENV} && "
                 f"uv pip install --python {VENV}/bin/python3 "
                 f"{REPO_DIR} {REPO_DIR}/packages/nooa-cli {REPO_DIR}/packages/nooa-bench && "
+                f"{copilot_runtime_install}"
                 f"{VENV}/bin/python3 -c \"from nooa_bench.runner import main; print('nooa-bench installed OK')\""
             ),
         )
@@ -109,14 +131,31 @@ class NooaBenchAgent(BaseInstalledAgent):
         context: AgentContext,
     ) -> None:
         api_base = f"--api-base {shlex.quote(self._api_base)} " if self._api_base else ""
+        reasoning_effort = (
+            f"--reasoning-effort {shlex.quote(self._reasoning_effort)} "
+            if self._reasoning_effort
+            else ""
+        )
+        context_tier = (
+            f"--context-tier {shlex.quote(self._context_tier)} " if self._context_tier else ""
+        )
+        timeout_seconds = (
+            f"--timeout-seconds {self._timeout_seconds:g} "
+            if self._timeout_seconds is not None
+            else ""
+        )
         # Exit code 1 means the agent reported task failure: map it to exit 0 so
         # the verifier scores reward=0 instead of raising a harness error.
+        prefix = f"mkdir -p {shlex.quote(COPILOT_HOME)} && " if self._agent_type == "copilot" else ""
         command = (
-            f"({VENV}/bin/nemo-harbor "
+            f"({prefix}{VENV}/bin/nemo-harbor "
             f"--instruction {shlex.quote(instruction)} "
             f"--model {shlex.quote(self.model_name or '')} "
             f"--agent-type {shlex.quote(self._agent_type)} "
             f"{api_base}"
+            f"{reasoning_effort}"
+            f"{context_tier}"
+            f"{timeout_seconds}"
             f"; EC=$?; [ $EC -eq 1 ] && exit 0 || exit $EC) "
             f"2>&1 | tee /logs/agent/nooa_bench.log"
         )
@@ -126,6 +165,9 @@ class NooaBenchAgent(BaseInstalledAgent):
         nvidia_key = env.get("NVIDIA_INFERENCE_API_KEY") or env.get("NVIDIA_API_KEY")
         if nvidia_key:
             env.setdefault("OPENAI_API_KEY", nvidia_key)
+        if self._agent_type == "copilot":
+            env.setdefault("COPILOT_CLI_EXTRACT_DIR", COPILOT_RUNTIME_DIR)
+            env.setdefault("COPILOT_HOME", COPILOT_HOME)
         await self.exec_as_agent(environment, command=command, env=env, cwd=REPO_DIR)
 
     def populate_context_post_run(self, context: AgentContext) -> None:

--- a/examples/benchmarks/harbor_adapter.py
+++ b/examples/benchmarks/harbor_adapter.py
@@ -39,14 +39,13 @@ from harbor.models.agent.context import AgentContext
 REPO_DIR = "/installed-agent/nooa"
 VENV = "/opt/nooa-venv"
 COPILOT_RUNTIME_DIR = "/opt/nooa-copilot-runtime"
-COPILOT_HOME = "/logs/artifacts/copilot-home"
+COPILOT_HOME = "/tmp/nooa-copilot-home"
 
 # Credentials forwarded from the host into the agent process. The NVIDIA
 # inference endpoints are public; add other provider keys here if needed.
 FORWARDED_ENV_VARS = (
     "NVIDIA_INFERENCE_API_KEY",  # inference.nvidia.com gateway
     "NVIDIA_API_KEY",  # public NIM endpoint
-    "COPILOT_GITHUB_TOKEN",  # optional Copilot SDK token auth
 )
 
 
@@ -146,7 +145,12 @@ class NooaBenchAgent(BaseInstalledAgent):
         )
         # Exit code 1 means the agent reported task failure: map it to exit 0 so
         # the verifier scores reward=0 instead of raising a harness error.
-        prefix = f"mkdir -p {shlex.quote(COPILOT_HOME)} && " if self._agent_type == "copilot" else ""
+        prefix = (
+            f"umask 077; mkdir -p {shlex.quote(COPILOT_HOME)} && "
+            f"chmod 700 {shlex.quote(COPILOT_HOME)} && "
+            if self._agent_type == "copilot"
+            else ""
+        )
         command = (
             f"({prefix}{VENV}/bin/nemo-harbor "
             f"--instruction {shlex.quote(instruction)} "
@@ -166,6 +170,8 @@ class NooaBenchAgent(BaseInstalledAgent):
         if nvidia_key:
             env.setdefault("OPENAI_API_KEY", nvidia_key)
         if self._agent_type == "copilot":
+            if copilot_token := os.environ.get("COPILOT_GITHUB_TOKEN"):
+                env["COPILOT_GITHUB_TOKEN"] = copilot_token
             env.setdefault("COPILOT_CLI_EXTRACT_DIR", COPILOT_RUNTIME_DIR)
             env.setdefault("COPILOT_HOME", COPILOT_HOME)
         await self.exec_as_agent(environment, command=command, env=env, cwd=REPO_DIR)

--- a/examples/benchmarks/harbor_adapter.py
+++ b/examples/benchmarks/harbor_adapter.py
@@ -97,10 +97,10 @@ class NooaBenchAgent(BaseInstalledAgent):
         """Clone the repo and install core + cli + bench into a fresh venv."""
         branch = f"--branch {shlex.quote(self._git_ref)} " if self._git_ref else ""
         copilot_runtime_install = (
-            f"mkdir -p {COPILOT_RUNTIME_DIR} && chmod -R a+rwx {COPILOT_RUNTIME_DIR} && "
+            f"mkdir -p {COPILOT_RUNTIME_DIR} && chmod -R a+rX {COPILOT_RUNTIME_DIR} && "
             f"COPILOT_CLI_EXTRACT_DIR={COPILOT_RUNTIME_DIR} "
             f"{VENV}/bin/python3 -m copilot download-runtime && "
-            f"chmod -R a+rwx {COPILOT_RUNTIME_DIR} && "
+            f"chmod -R a+rX {COPILOT_RUNTIME_DIR} && "
             if self._agent_type == "copilot"
             else ""
         )
@@ -145,14 +145,8 @@ class NooaBenchAgent(BaseInstalledAgent):
         )
         # Exit code 1 means the agent reported task failure: map it to exit 0 so
         # the verifier scores reward=0 instead of raising a harness error.
-        prefix = (
-            f"umask 077; mkdir -p {shlex.quote(COPILOT_HOME)} && "
-            f"chmod 700 {shlex.quote(COPILOT_HOME)} && "
-            if self._agent_type == "copilot"
-            else ""
-        )
         command = (
-            f"({prefix}{VENV}/bin/nemo-harbor "
+            f"({VENV}/bin/nemo-harbor "
             f"--instruction {shlex.quote(instruction)} "
             f"--model {shlex.quote(self.model_name or '')} "
             f"--agent-type {shlex.quote(self._agent_type)} "

--- a/examples/benchmarks/harbor_adapter.py
+++ b/examples/benchmarks/harbor_adapter.py
@@ -97,10 +97,11 @@ class NooaBenchAgent(BaseInstalledAgent):
         """Clone the repo and install core + cli + bench into a fresh venv."""
         branch = f"--branch {shlex.quote(self._git_ref)} " if self._git_ref else ""
         copilot_runtime_install = (
-            f"mkdir -p {COPILOT_RUNTIME_DIR} && chmod -R a+rX {COPILOT_RUNTIME_DIR} && "
+            f"mkdir -p {COPILOT_RUNTIME_DIR} && "
+            f"chmod -R u=rwX,go=rX {COPILOT_RUNTIME_DIR} && "
             f"COPILOT_CLI_EXTRACT_DIR={COPILOT_RUNTIME_DIR} "
             f"{VENV}/bin/python3 -m copilot download-runtime && "
-            f"chmod -R a+rX {COPILOT_RUNTIME_DIR} && "
+            f"chmod -R u=rwX,go=rX {COPILOT_RUNTIME_DIR} && "
             if self._agent_type == "copilot"
             else ""
         )

--- a/examples/benchmarks/harbor_copilot_minimal.yaml
+++ b/examples/benchmarks/harbor_copilot_minimal.yaml
@@ -1,0 +1,25 @@
+# Minimal Harbor configuration for the NOOA Copilot SDK bench agent.
+# Run from the repo root:
+#   export COPILOT_GITHUB_TOKEN=...
+#   PYTHONPATH=examples/benchmarks harbor run --config examples/benchmarks/harbor_copilot_minimal.yaml
+jobs_dir: ./harbor_jobs
+n_attempts: 1
+orchestrator:
+  type: local
+  n_concurrent_trials: 1
+environment:
+  type: apptainer
+  kwargs:
+    apptainer_binary: apptainer
+agents:
+  - import_path: harbor_adapter:NooaBenchAgent
+    model_name: gpt-5.6-sol
+    kwargs:
+      git_url: https://github.com/NVIDIA-NeMo/labs-OO-Agents.git
+      agent_type: copilot
+      reasoning_effort: xhigh
+      context_tier: long_context
+      # git_ref: main          # optional branch/tag/SHA
+      # timeout_seconds: 3600  # optional per-task session timeout
+datasets:
+  - path: /path/to/your/tasks/

--- a/packages/nooa-bench/pyproject.toml
+++ b/packages/nooa-bench/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "nooa",
     "nooa-cli",
     "click>=8.1",
+    "github-copilot-sdk>=1.0.5",
 ]
 
 [project.scripts]

--- a/packages/nooa-bench/src/nooa_bench/__init__.py
+++ b/packages/nooa-bench/src/nooa_bench/__init__.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 AGENT_CLASSES: dict[str, str] = {
     # Unified SWE-bench + Terminal-Bench agent (the tech report's BenchAgent)
     "bench": "nooa_bench.bench_agent:BenchAgent",
+    # Official GitHub Copilot SDK-backed runtime.
+    "copilot": "nooa_bench.copilot_agent:CopilotBenchAgent",
 }
 
 __all__ = ["AGENT_CLASSES"]

--- a/packages/nooa-bench/src/nooa_bench/copilot_agent.py
+++ b/packages/nooa-bench/src/nooa_bench/copilot_agent.py
@@ -1,0 +1,439 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Copilot SDK-backed benchmark agent.
+
+This agent preserves the Harbor runner's ``_run_evaluation(dict) -> dict``
+contract while delegating execution to the official GitHub Copilot SDK runtime.
+It intentionally does not subclass ``nooa.Agent``: Copilot SDK already provides
+the agent loop, built-in coding tools, permissions, and session lifecycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+from copilot import CopilotClient, ToolInvocation, ToolResult, define_tool
+from copilot.session import PermissionHandler
+from copilot.session_events import (
+    AssistantMessageData,
+    AssistantUsageData,
+    SessionErrorData,
+    SessionEvent,
+    SessionIdleData,
+)
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+_logger = logging.getLogger(__name__)
+
+ReasoningEffort = Literal["low", "medium", "high", "xhigh"]
+ContextTier = Literal["default", "long_context"]
+
+DEFAULT_COPILOT_MODEL = "gpt-5.6-sol"
+DEFAULT_REASONING_EFFORT: ReasoningEffort = "xhigh"
+DEFAULT_CONTEXT_TIER: ContextTier = "long_context"
+DEFAULT_TIMEOUT_SECONDS = 3600.0
+_CLEANUP_TIMEOUT_SECONDS = 10.0
+
+_SDK_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+_SDK_CONTEXT_TIERS = {"default", "long_context"}
+
+_SYSTEM_MESSAGE_APPEND = """\
+You are running as the NOOA benchmark agent inside an isolated benchmark
+container or worktree. Use the SDK-provided coding tools to inspect, edit, and
+verify the task autonomously. Non-interactive tool permission approval is enabled
+only for this isolated benchmark environment.
+
+Do not ask the user for clarification; make reasonable assumptions and proceed.
+Before finishing, run the most targeted verification command that demonstrates
+the task is solved.
+
+When the task is complete, call the return_task_result tool exactly once with:
+- solution_description: what changed and why it solves the task
+- evidence: commands run and concrete observed output
+- command_to_verify: one shell command a verifier can run
+
+Do not finish by printing JSON text; the benchmark runner only accepts the
+return_task_result tool call as completion.
+"""
+
+
+class TaskResult(BaseModel):
+    """Strict structured result for the Copilot-backed benchmark agent."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    solution_description: str = Field(
+        description="What changed and why it solves the benchmark task."
+    )
+    evidence: str = Field(description="Concrete commands/output observed during verification.")
+    command_to_verify: str = Field(description="Verifier command expected to exit 0 on success.")
+
+    @field_validator("solution_description", "evidence", "command_to_verify")
+    @classmethod
+    def _non_blank(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("field must be a non-blank string")
+        return stripped
+
+
+def _problem_statement(task_input: dict) -> str:
+    """Extract the task text from supported Harbor/benchmark field names."""
+    for key in ("user_message", "problem_statement", "task_description"):
+        value = task_input.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise ValueError(
+        "task_input must include a non-empty user_message, problem_statement, or task_description"
+    )
+
+
+class _CopilotSessionProtocol(Protocol):
+    def on(self, handler: Any) -> Any: ...
+
+    async def send(self, prompt: str, **kwargs: Any) -> str: ...
+
+    async def disconnect(self) -> None: ...
+
+
+class _CopilotClientProtocol(Protocol):
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+    async def force_stop(self) -> None: ...
+
+    async def list_models(self) -> list[Any]: ...
+
+    async def create_session(self, **kwargs: Any) -> _CopilotSessionProtocol: ...
+
+
+@dataclass
+class _UsageAccumulator:
+    n_input_tokens: int = 0
+    n_output_tokens: int = 0
+    _seen_api_call_ids: set[str] = field(default_factory=set)
+
+    def add(self, data: AssistantUsageData) -> None:
+        api_call_id = data.api_call_id
+        if api_call_id:
+            if api_call_id in self._seen_api_call_ids:
+                return
+            self._seen_api_call_ids.add(api_call_id)
+
+        self.n_input_tokens += data.input_tokens or 0
+        self.n_output_tokens += data.output_tokens or 0
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "n_input_tokens": self.n_input_tokens,
+            "n_output_tokens": self.n_output_tokens,
+        }
+
+
+@dataclass
+class _CopilotRunOutcome:
+    final_response: str
+    usage: _UsageAccumulator
+    task_result: TaskResult | None = None
+    error: str | None = None
+
+
+def _prompt_for_task(description: str, instructions: str, initial_observation: str) -> str:
+    parts = [
+        "Solve this benchmark task end-to-end.",
+        "",
+        "Task:",
+        description,
+    ]
+    if instructions.strip():
+        parts.extend(["", "Additional instructions:", instructions.strip()])
+    if initial_observation.strip():
+        parts.extend(["", "Initial observation:", initial_observation.strip()])
+    parts.extend(
+        [
+            "",
+            "Finish by calling the return_task_result tool.",
+        ]
+    )
+    return "\n".join(parts)
+
+
+class CopilotBenchAgent:
+    """Benchmark agent implemented with the official GitHub Copilot SDK."""
+
+    def __init__(
+        self,
+        *,
+        model: str = DEFAULT_COPILOT_MODEL,
+        reasoning_effort: ReasoningEffort | None = DEFAULT_REASONING_EFFORT,
+        context_tier: ContextTier | None = DEFAULT_CONTEXT_TIER,
+        timeout_seconds: float | None = DEFAULT_TIMEOUT_SECONDS,
+        github_token: str | None = None,
+        client_factory: Any = CopilotClient,
+    ) -> None:
+        self.model = model
+        self.reasoning_effort = (
+            DEFAULT_REASONING_EFFORT if reasoning_effort is None else reasoning_effort
+        )
+        self.context_tier = DEFAULT_CONTEXT_TIER if context_tier is None else context_tier
+        self.timeout_seconds = DEFAULT_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds
+        self.github_token = github_token or os.environ.get("COPILOT_GITHUB_TOKEN")
+        self._client_factory = client_factory
+
+    async def _run_evaluation(self, task_input: dict) -> dict:
+        """Entry point called by the Harbor runner."""
+        description = _problem_statement(task_input)
+        working_dir = self._working_dir(task_input.get("working_dir"))
+        instructions = task_input.get("system_prompt") or task_input.get("instructions") or ""
+        initial_observation = task_input.get("initial_observation") or ""
+
+        prompt = _prompt_for_task(description, instructions, initial_observation)
+        usage = _UsageAccumulator()
+        try:
+            if self.timeout_seconds is None:
+                outcome = await self._run_copilot_session(
+                    prompt=prompt, working_dir=working_dir, usage=usage
+                )
+            else:
+                outcome = await asyncio.wait_for(
+                    self._run_copilot_session(prompt=prompt, working_dir=working_dir, usage=usage),
+                    timeout=self.timeout_seconds,
+                )
+        except TimeoutError:
+            error = f"Copilot session timed out after {self.timeout_seconds:g} seconds"
+            _logger.error(error)
+            return {
+                "response": "",
+                "success": False,
+                "error": error,
+                **usage.as_dict(),
+            }
+        except asyncio.CancelledError:
+            raise
+        except ValueError as exc:
+            _logger.exception("CopilotBenchAgent configuration failed: %s", exc)
+            return {
+                "response": "",
+                "success": False,
+                "error": str(exc),
+                **usage.as_dict(),
+            }
+        except Exception as exc:
+            _logger.exception("CopilotBenchAgent failed: %s", exc)
+            return {
+                "response": "",
+                "success": False,
+                "error": str(exc),
+                **usage.as_dict(),
+            }
+        usage = outcome.usage.as_dict()
+
+        if outcome.error:
+            return {
+                "response": outcome.final_response,
+                "success": False,
+                "error": outcome.error,
+                **usage,
+            }
+
+        if outcome.task_result is None:
+            return {
+                "response": outcome.final_response,
+                "success": False,
+                "error": "Copilot session went idle before return_task_result was called",
+                **usage,
+            }
+
+        result = outcome.task_result
+        success = all(getattr(result, field_name) for field_name in TaskResult.model_fields)
+        return {
+            "response": result.command_to_verify,
+            "success": success,
+            "result": result.model_dump(),
+            "copilot_response": outcome.final_response,
+            **usage,
+        }
+
+    def _working_dir(self, configured: Any) -> str:
+        if isinstance(configured, str) and configured.strip():
+            path = Path(configured)
+        else:
+            path = next((Path(d) for d in ("/testbed", "/app") if Path(d).is_dir()), Path.cwd())
+
+        if not path.is_dir():
+            raise ValueError(f"working_dir does not exist: {str(path)!r}")
+        return str(path)
+
+    async def _run_copilot_session(
+        self, *, prompt: str, working_dir: str, usage: _UsageAccumulator
+    ) -> _CopilotRunOutcome:
+        done = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        final_messages: list[str] = []
+        errors: list[str] = []
+
+        def mark_done() -> None:
+            if not done.is_set():
+                done.set()
+
+        def on_event(event: SessionEvent) -> None:
+            data = event.data
+            match data:
+                case AssistantMessageData() as message:
+                    final_messages.append(message.content)
+                case AssistantUsageData() as usage_data:
+                    usage.add(usage_data)
+                case SessionErrorData() as error_data:
+                    errors.append(error_data.message)
+                    loop.call_soon_threadsafe(mark_done)
+                case SessionIdleData() as idle_data:
+                    if idle_data.aborted:
+                        errors.append("Copilot session aborted")
+                    loop.call_soon_threadsafe(mark_done)
+
+        client_kwargs: dict[str, Any] = {"working_directory": working_dir}
+        if self.github_token:
+            client_kwargs["github_token"] = self.github_token
+            client_kwargs["use_logged_in_user"] = False
+        else:
+            client_kwargs["use_logged_in_user"] = True
+
+        client: _CopilotClientProtocol = self._client_factory(**client_kwargs)
+        session: _CopilotSessionProtocol | None = None
+        unsubscribe: Any = None
+        try:
+            await client.start()
+            model_info = await self._find_model(client)
+            completed_result: TaskResult | None = None
+
+            async def return_task_result(
+                params: TaskResult, invocation: ToolInvocation
+            ) -> ToolResult:
+                nonlocal completed_result
+                completed_result = params
+                return ToolResult(
+                    text_result_for_llm="TaskResult recorded. Stop now.",
+                    result_type="success",
+                    session_log="TaskResult recorded",
+                )
+
+            return_tool = define_tool(
+                "return_task_result",
+                description="Record the final benchmark TaskResult. Call exactly once when done.",
+                params_type=TaskResult,
+                handler=return_task_result,
+                skip_permission=True,
+                defer="never",
+            )
+            session_kwargs: dict[str, Any] = {
+                "model": self.model,
+                "on_permission_request": PermissionHandler.approve_all,
+                "system_message": {"mode": "append", "content": _SYSTEM_MESSAGE_APPEND},
+                "tools": [return_tool],
+                "working_directory": working_dir,
+            }
+            session_kwargs.update(self._supported_model_options(model_info))
+
+            session = await client.create_session(**session_kwargs)
+            unsubscribe = session.on(on_event)
+            await session.send(prompt, agent_mode="autopilot")
+            await done.wait()
+        finally:
+            if callable(unsubscribe):
+                unsubscribe()
+            if session is not None:
+                await _bounded_cleanup("Copilot session", session.disconnect())
+            await _cleanup_client(client)
+
+        return _CopilotRunOutcome(
+            final_response=final_messages[-1] if final_messages else "",
+            usage=usage,
+            task_result=completed_result,
+            error=errors[-1] if errors else None,
+        )
+
+    async def _find_model(self, client: _CopilotClientProtocol) -> Any:
+        models = await client.list_models()
+        model = next((candidate for candidate in models if candidate.id == self.model), None)
+        if model is None:
+            available = ", ".join(sorted(candidate.id for candidate in models))
+            raise ValueError(
+                f"Copilot model {self.model!r} is not available. Available models: {available}"
+            )
+        return model
+
+    def _supported_model_options(self, model_info: Any) -> dict[str, str]:
+        options: dict[str, str] = {}
+
+        if self.reasoning_effort is not None:
+            if self.reasoning_effort not in _SDK_REASONING_EFFORTS:
+                raise ValueError(
+                    f"Unsupported Copilot SDK reasoning effort: {self.reasoning_effort!r}"
+                )
+
+            supported = model_info.supported_reasoning_efforts
+            supports_reasoning = model_info.capabilities.supports.reasoning_effort
+            if supported is not None:
+                if self.reasoning_effort not in supported:
+                    raise ValueError(
+                        f"Model {self.model!r} does not support reasoning effort "
+                        f"{self.reasoning_effort!r}. Supported: {supported}"
+                    )
+            elif not supports_reasoning:
+                raise ValueError(f"Model {self.model!r} does not support reasoning_effort")
+            options["reasoning_effort"] = self.reasoning_effort
+
+        if self.context_tier is not None:
+            if self.context_tier not in _SDK_CONTEXT_TIERS:
+                raise ValueError(f"Unsupported Copilot SDK context tier: {self.context_tier!r}")
+            options["context_tier"] = self.context_tier
+
+        return options
+
+
+async def _bounded_cleanup(label: str, awaitable: Any) -> None:
+    try:
+        await asyncio.wait_for(awaitable, timeout=_CLEANUP_TIMEOUT_SECONDS)
+    except TimeoutError:
+        _logger.error("%s cleanup timed out after %s seconds", label, _CLEANUP_TIMEOUT_SECONDS)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        _logger.exception("%s cleanup failed: %s", label, exc)
+
+
+async def _cleanup_client(client: _CopilotClientProtocol) -> None:
+    try:
+        await asyncio.wait_for(client.stop(), timeout=_CLEANUP_TIMEOUT_SECONDS)
+        return
+    except TimeoutError:
+        _logger.error(
+            "Copilot client stop timed out after %s seconds; forcing runtime termination",
+            _CLEANUP_TIMEOUT_SECONDS,
+        )
+    except asyncio.CancelledError:
+        await _force_stop_client(client)
+        raise
+    except Exception as exc:
+        _logger.exception("Copilot client stop failed; forcing runtime termination: %s", exc)
+
+    await _force_stop_client(client)
+
+
+async def _force_stop_client(client: _CopilotClientProtocol) -> None:
+    try:
+        await asyncio.wait_for(client.force_stop(), timeout=_CLEANUP_TIMEOUT_SECONDS)
+    except TimeoutError:
+        _logger.error(
+            "Copilot client force_stop timed out after %s seconds", _CLEANUP_TIMEOUT_SECONDS
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        _logger.exception("Copilot client force_stop failed: %s", exc)

--- a/packages/nooa-bench/src/nooa_bench/copilot_agent.py
+++ b/packages/nooa-bench/src/nooa_bench/copilot_agent.py
@@ -273,6 +273,7 @@ class CopilotBenchAgent:
     async def _run_copilot_session(
         self, *, prompt: str, working_dir: str, usage: _UsageAccumulator
     ) -> _CopilotRunOutcome:
+        _prepare_copilot_home()
         done = asyncio.Event()
         loop = asyncio.get_running_loop()
         final_messages: list[str] = []
@@ -345,14 +346,16 @@ class CopilotBenchAgent:
             await session.send(prompt, agent_mode="autopilot")
             await done.wait()
         finally:
-            if callable(unsubscribe):
-                try:
-                    unsubscribe()
-                except Exception as exc:
-                    _logger.exception("Copilot session unsubscribe failed: %s", exc)
-            if session is not None:
-                await _bounded_cleanup("Copilot session", session.disconnect())
-            await _cleanup_client(client)
+            try:
+                if callable(unsubscribe):
+                    try:
+                        unsubscribe()
+                    except Exception as exc:
+                        _logger.exception("Copilot session unsubscribe failed: %s", exc)
+                if session is not None:
+                    await _bounded_cleanup("Copilot session", session.disconnect())
+            finally:
+                await _cleanup_client(client)
 
         return _CopilotRunOutcome(
             final_response=final_messages[-1] if final_messages else "",
@@ -398,6 +401,15 @@ class CopilotBenchAgent:
             options["context_tier"] = self.context_tier
 
         return options
+
+
+def _prepare_copilot_home() -> None:
+    configured = os.environ.get("COPILOT_HOME")
+    if not configured:
+        return
+    path = Path(configured).expanduser()
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    path.chmod(0o700)
 
 
 async def _bounded_cleanup(label: str, awaitable: Any) -> None:

--- a/packages/nooa-bench/src/nooa_bench/copilot_agent.py
+++ b/packages/nooa-bench/src/nooa_bench/copilot_agent.py
@@ -346,7 +346,10 @@ class CopilotBenchAgent:
             await done.wait()
         finally:
             if callable(unsubscribe):
-                unsubscribe()
+                try:
+                    unsubscribe()
+                except Exception as exc:
+                    _logger.exception("Copilot session unsubscribe failed: %s", exc)
             if session is not None:
                 await _bounded_cleanup("Copilot session", session.disconnect())
             await _cleanup_client(client)

--- a/packages/nooa-bench/src/nooa_bench/copilot_agent.py
+++ b/packages/nooa-bench/src/nooa_bench/copilot_agent.py
@@ -182,7 +182,9 @@ class CopilotBenchAgent:
             DEFAULT_REASONING_EFFORT if reasoning_effort is None else reasoning_effort
         )
         self.context_tier = DEFAULT_CONTEXT_TIER if context_tier is None else context_tier
-        self.timeout_seconds = DEFAULT_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds
+        self.timeout_seconds = (
+            DEFAULT_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds
+        )
         self.github_token = github_token or os.environ.get("COPILOT_GITHUB_TOKEN")
         self._client_factory = client_factory
 

--- a/packages/nooa-bench/src/nooa_bench/runner.py
+++ b/packages/nooa-bench/src/nooa_bench/runner.py
@@ -212,6 +212,9 @@ async def _run(
         except Exception as e:
             logger.exception("Agent evaluation failed with unhandled exception: %s", e)
             result = {"response": "", "success": False, "error": str(e)}
+    if result is None:
+        logger.error("Agent returned no result")
+        result = {"response": "", "success": False, "error": "Agent returned no result"}
     if get_token_counts is not None:
         result.update(get_token_counts())
     _write_result(result, model, agent_type)

--- a/packages/nooa-bench/src/nooa_bench/runner.py
+++ b/packages/nooa-bench/src/nooa_bench/runner.py
@@ -159,23 +159,31 @@ async def _run(
     # inside the agent's _run_evaluation method.
     logger.info("Running agent %s (model=%s)...", agent_type, model)
     get_token_counts: Any | None = None
+    result: dict[str, Any] | None = None
+    agent: Any = None
     task_input: dict[str, Any] = {"user_message": instruction}
     if working_dir:
         task_input["working_dir"] = working_dir
 
     if agent_type in COPILOT_AGENT_TYPES:
-        if api_base:
-            raise ValueError(
-                "--api-base is not supported for --agent-type copilot; "
-                "BYOK provider wiring is not implemented"
+        try:
+            if api_base:
+                raise ValueError(
+                    "--api-base is not supported for --agent-type copilot; "
+                    "BYOK provider wiring is not implemented"
+                )
+            AgentClass = _import_agent_class(agent_type)
+            agent = AgentClass(
+                model=model,
+                reasoning_effort=reasoning_effort,
+                context_tier=context_tier,
+                timeout_seconds=timeout_seconds,
             )
-        AgentClass = _import_agent_class(agent_type)
-        agent: Any = AgentClass(
-            model=model,
-            reasoning_effort=reasoning_effort,
-            context_tier=context_tier,
-            timeout_seconds=timeout_seconds,
-        )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.exception("Copilot agent setup failed: %s", e)
+            result = {"response": "", "success": False, "error": str(e)}
     else:
         from nooa.runtime.token_usage import get_task_tokens, start_task_tokens
         from nooa.unifiedllm import get_llm_client
@@ -196,13 +204,14 @@ async def _run(
         start_task_tokens()
         get_token_counts = get_task_tokens
 
-    try:
-        result = await agent._run_evaluation(task_input)
-    except asyncio.CancelledError:
-        raise
-    except Exception as e:
-        logger.exception("Agent evaluation failed with unhandled exception: %s", e)
-        result = {"response": "", "success": False, "error": str(e)}
+    if result is None:
+        try:
+            result = await agent._run_evaluation(task_input)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.exception("Agent evaluation failed with unhandled exception: %s", e)
+            result = {"response": "", "success": False, "error": str(e)}
     if get_token_counts is not None:
         result.update(get_token_counts())
     _write_result(result, model, agent_type)

--- a/packages/nooa-bench/src/nooa_bench/runner.py
+++ b/packages/nooa-bench/src/nooa_bench/runner.py
@@ -40,6 +40,7 @@ LOGS_DIR = Path("/logs/agent")
 ARTIFACTS_DIR = Path("/logs/artifacts")
 TRACES_DIR = ARTIFACTS_DIR / "traces"
 ANSWER_FILE = Path("/app/answer.txt")
+COPILOT_AGENT_TYPES = {"copilot"}
 
 
 def _setup_logging() -> None:
@@ -148,37 +149,62 @@ async def _run(
     agent_type: str,
     api_base: str | None,
     working_dir: str | None = None,
+    reasoning_effort: str | None = None,
+    context_tier: str | None = None,
+    timeout_seconds: float | None = None,
 ) -> int:
     """Async main: instantiate, wire, run.  Returns exit code (0 = success)."""
-    from nooa.unifiedllm import get_llm_client
-
-    # Build LLM client — honour env-var overrides for local vLLM deployments.
-    llm_overrides: dict[str, str] = {}
-    if api_base:
-        llm_overrides["api_base"] = api_base
-    elif base_url := os.environ.get("OPENAI_BASE_URL"):
-        llm_overrides["api_base"] = base_url
-    if api_key := os.environ.get("OPENAI_API_KEY"):
-        llm_overrides["api_key"] = api_key
-
-    llm_client = get_llm_client(model, **llm_overrides)
-
-    # Instantiate agent.
-    AgentClass = _import_agent_class(agent_type)
-    agent: Any = AgentClass(llm=llm_client)
-
     # All agents share the same interface: {"user_message": instruction}.
     # Benchmark-specific parsing (system prompts, data paths, etc.) happens
     # inside the agent's _run_evaluation method.
-    from nooa.runtime.token_usage import get_task_tokens, start_task_tokens
-
     logger.info("Running agent %s (model=%s)...", agent_type, model)
-    start_task_tokens()
+    get_token_counts: Any | None = None
     task_input: dict[str, Any] = {"user_message": instruction}
     if working_dir:
         task_input["working_dir"] = working_dir
-    result = await agent._run_evaluation(task_input)
-    result.update(get_task_tokens())
+
+    if agent_type in COPILOT_AGENT_TYPES:
+        if api_base:
+            raise ValueError(
+                "--api-base is not supported for --agent-type copilot; "
+                "BYOK provider wiring is not implemented"
+            )
+        AgentClass = _import_agent_class(agent_type)
+        agent: Any = AgentClass(
+            model=model,
+            reasoning_effort=reasoning_effort,
+            context_tier=context_tier,
+            timeout_seconds=timeout_seconds,
+        )
+    else:
+        from nooa.runtime.token_usage import get_task_tokens, start_task_tokens
+        from nooa.unifiedllm import get_llm_client
+
+        AgentClass = _import_agent_class(agent_type)
+
+        # Build LLM client — honour env-var overrides for local vLLM deployments.
+        llm_overrides: dict[str, str] = {}
+        if api_base:
+            llm_overrides["api_base"] = api_base
+        elif base_url := os.environ.get("OPENAI_BASE_URL"):
+            llm_overrides["api_base"] = base_url
+        if api_key := os.environ.get("OPENAI_API_KEY"):
+            llm_overrides["api_key"] = api_key
+
+        llm_client = get_llm_client(model, **llm_overrides)
+        agent = AgentClass(llm=llm_client)
+        start_task_tokens()
+        get_token_counts = get_task_tokens
+
+    try:
+        result = await agent._run_evaluation(task_input)
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.exception("Agent evaluation failed with unhandled exception: %s", e)
+        result = {"response": "", "success": False, "error": str(e)}
+    if get_token_counts is not None:
+        result.update(get_token_counts())
     _write_result(result, model, agent_type)
     _write_answer(result)
 
@@ -196,12 +222,33 @@ async def _run(
 @click.option("--agent-type", default="bench", show_default=True, help="Agent variant to run")
 @click.option("--working-dir", default=None, help="Working directory for the agent shell session")
 @click.option("--api-base", default=None, help="Override API base URL")
+@click.option(
+    "--reasoning-effort",
+    type=click.Choice(["low", "medium", "high", "xhigh"]),
+    default=None,
+    help="Copilot SDK reasoning effort for --agent-type copilot (highest supported: xhigh)",
+)
+@click.option(
+    "--context-tier",
+    type=click.Choice(["default", "long_context"]),
+    default=None,
+    help="Copilot SDK context tier for --agent-type copilot",
+)
+@click.option(
+    "--timeout-seconds",
+    type=float,
+    default=None,
+    help="Copilot SDK session timeout for --agent-type copilot",
+)
 def main(
     instruction: str,
     model: str,
     agent_type: str,
     working_dir: str | None,
     api_base: str | None,
+    reasoning_effort: str | None,
+    context_tier: str | None,
+    timeout_seconds: float | None,
 ) -> None:
     """Run a NOOA agent on a task inside a Harbor container."""
     _setup_logging()
@@ -223,7 +270,18 @@ def main(
     _setup_tracing(model=model, agent_type=agent_type)
 
     try:
-        exit_code = asyncio.run(_run(instruction, model, agent_type, api_base, working_dir))
+        exit_code = asyncio.run(
+            _run(
+                instruction,
+                model,
+                agent_type,
+                api_base,
+                working_dir,
+                reasoning_effort,
+                context_tier,
+                timeout_seconds,
+            )
+        )
     except Exception as e:
         logger.exception("Runner failed with unhandled exception: %s", e)
         exit_code = 1
@@ -232,4 +290,4 @@ def main(
 
 
 if __name__ == "__main__":
-    main()
+    main()  # type: ignore[call-arg]

--- a/packages/nooa-bench/src/nooa_bench/runner.py
+++ b/packages/nooa-bench/src/nooa_bench/runner.py
@@ -158,9 +158,6 @@ async def _run(
     # Benchmark-specific parsing (system prompts, data paths, etc.) happens
     # inside the agent's _run_evaluation method.
     logger.info("Running agent %s (model=%s)...", agent_type, model)
-    get_token_counts: Any | None = None
-    result: dict[str, Any] | None = None
-    agent: Any = None
     task_input: dict[str, Any] = {"user_message": instruction}
     if working_dir:
         task_input["working_dir"] = working_dir
@@ -173,17 +170,21 @@ async def _run(
                     "BYOK provider wiring is not implemented"
                 )
             AgentClass = _import_agent_class(agent_type)
-            agent = AgentClass(
+            agent: Any = AgentClass(
                 model=model,
                 reasoning_effort=reasoning_effort,
                 context_tier=context_tier,
                 timeout_seconds=timeout_seconds,
             )
+            result = await agent._run_evaluation(task_input)
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            logger.exception("Copilot agent setup failed: %s", e)
+            logger.exception("Copilot agent failed: %s", e)
             result = {"response": "", "success": False, "error": str(e)}
+        if result is None:
+            logger.error("Copilot agent returned no result")
+            result = {"response": "", "success": False, "error": "Agent returned no result"}
     else:
         from nooa.runtime.token_usage import get_task_tokens, start_task_tokens
         from nooa.unifiedllm import get_llm_client
@@ -202,21 +203,9 @@ async def _run(
         llm_client = get_llm_client(model, **llm_overrides)
         agent = AgentClass(llm=llm_client)
         start_task_tokens()
-        get_token_counts = get_task_tokens
+        result = await agent._run_evaluation(task_input)
+        result.update(get_task_tokens())
 
-    if result is None:
-        try:
-            result = await agent._run_evaluation(task_input)
-        except asyncio.CancelledError:
-            raise
-        except Exception as e:
-            logger.exception("Agent evaluation failed with unhandled exception: %s", e)
-            result = {"response": "", "success": False, "error": str(e)}
-    if result is None:
-        logger.error("Agent returned no result")
-        result = {"response": "", "success": False, "error": "Agent returned no result"}
-    if get_token_counts is not None:
-        result.update(get_token_counts())
     _write_result(result, model, agent_type)
     _write_answer(result)
 

--- a/packages/nooa-bench/tests/test_copilot_agent.py
+++ b/packages/nooa-bench/tests/test_copilot_agent.py
@@ -37,9 +37,7 @@ def _model(
 ) -> SimpleNamespace:
     return SimpleNamespace(
         id=model_id,
-        capabilities=SimpleNamespace(
-            supports=SimpleNamespace(reasoning_effort=supports_reasoning)
-        ),
+        capabilities=SimpleNamespace(supports=SimpleNamespace(reasoning_effort=supports_reasoning)),
         supported_reasoning_efforts=supported_reasoning_efforts
         or ["low", "medium", "high", "xhigh"],
     )
@@ -296,7 +294,10 @@ async def test_copilot_agent_reports_idle_without_return_tool(monkeypatch):
     monkeypatch.delenv("GITHUB_COPILOT_TOKEN", raising=False)
     monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
     factory = _ClientFactory(
-        [AssistantMessageData(content='{"solution_description":"text only"}', message_id="m1"), SessionIdleData()]
+        [
+            AssistantMessageData(content='{"solution_description":"text only"}', message_id="m1"),
+            SessionIdleData(),
+        ]
     )
     agent = CopilotBenchAgent(timeout_seconds=1, client_factory=factory)
 
@@ -528,9 +529,7 @@ async def test_copilot_agent_stops_client_when_disconnect_is_cancelled(monkeypat
     monkeypatch.setattr(factory.session, "disconnect", disconnect)
     agent = CopilotBenchAgent(timeout_seconds=1, client_factory=factory)
     task = asyncio.create_task(
-        agent._run_evaluation(
-            {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
-        )
+        agent._run_evaluation({"user_message": "fix the bug", "working_dir": str(Path.cwd())})
     )
 
     await asyncio.wait_for(disconnect_started.wait(), timeout=1)

--- a/packages/nooa-bench/tests/test_copilot_agent.py
+++ b/packages/nooa-bench/tests/test_copilot_agent.py
@@ -467,6 +467,42 @@ async def test_copilot_agent_force_stops_client_when_stop_hangs(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_copilot_agent_cleans_up_when_unsubscribe_fails(monkeypatch):
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory(
+        [
+            _CallReturnTool(
+                {
+                    "solution_description": "fixed it",
+                    "evidence": "pytest passed",
+                    "command_to_verify": "pytest -q",
+                }
+            ),
+            SessionIdleData(),
+        ]
+    )
+
+    def on(handler: Any) -> Any:
+        factory.session.handlers.append(handler)
+
+        def unsubscribe() -> None:
+            raise RuntimeError("unsubscribe failed")
+
+        return unsubscribe
+
+    monkeypatch.setattr(factory.session, "on", on)
+    agent = CopilotBenchAgent(timeout_seconds=1, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result["success"] is True
+    assert factory.session.disconnected is True
+    assert factory.clients[-1].stopped is True
+
+
+@pytest.mark.asyncio
 async def test_copilot_agent_returns_failure_for_send_exception(monkeypatch):
     monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
     factory = _ClientFactory([], send_error=RuntimeError("send failed"))

--- a/packages/nooa-bench/tests/test_copilot_agent.py
+++ b/packages/nooa-bench/tests/test_copilot_agent.py
@@ -1,0 +1,595 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Copilot SDK-backed benchmark agent."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from copilot import ToolInvocation
+from copilot.session_events import (
+    AssistantMessageData,
+    AssistantUsageData,
+    SessionErrorData,
+    SessionIdleData,
+)
+from nooa_bench import copilot_agent as copilot_agent_module
+from nooa_bench.copilot_agent import CopilotBenchAgent, TaskResult
+from pydantic import ValidationError
+
+
+class _CallReturnTool:
+    def __init__(self, arguments: dict[str, Any]) -> None:
+        self.arguments = arguments
+
+
+def _model(
+    model_id: str = "gpt-5.6-sol",
+    *,
+    supports_reasoning: bool = True,
+    supported_reasoning_efforts: list[str] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=model_id,
+        capabilities=SimpleNamespace(
+            supports=SimpleNamespace(reasoning_effort=supports_reasoning)
+        ),
+        supported_reasoning_efforts=supported_reasoning_efforts
+        or ["low", "medium", "high", "xhigh"],
+    )
+
+
+class _FakeSession:
+    def __init__(
+        self,
+        events: list[Any],
+        *,
+        hang_send: bool = False,
+        send_error: Exception | None = None,
+    ) -> None:
+        self.events = events
+        self.hang_send = hang_send
+        self.send_error = send_error
+        self.handlers: list[Any] = []
+        self.sent: list[tuple[str, dict[str, Any]]] = []
+        self.disconnected = False
+        self.unsubscribed = False
+        self.tools: list[Any] = []
+
+    async def __aenter__(self) -> _FakeSession:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        await self.disconnect()
+
+    async def disconnect(self) -> None:
+        self.disconnected = True
+
+    def on(self, handler: Any) -> Any:
+        self.handlers.append(handler)
+
+        def unsubscribe() -> None:
+            self.unsubscribed = True
+
+        return unsubscribe
+
+    async def send(self, prompt: str, **kwargs: Any) -> str:
+        if self.hang_send:
+            await asyncio.Event().wait()
+        if self.send_error is not None:
+            raise self.send_error
+        self.sent.append((prompt, kwargs))
+        for data in self.events:
+            if isinstance(data, _CallReturnTool):
+                tool = next(tool for tool in self.tools if tool.name == "return_task_result")
+                await tool.handler(ToolInvocation(arguments=data.arguments))
+                continue
+            for handler in list(self.handlers):
+                handler(SimpleNamespace(data=data))
+        return "message-id"
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        session: _FakeSession,
+        models: list[Any],
+        list_models_error: Exception | None,
+        create_session_error: Exception | None,
+        hang_start: bool,
+        hang_stop: bool,
+        **kwargs: Any,
+    ) -> None:
+        self.session = session
+        self.models = models
+        self.list_models_error = list_models_error
+        self.create_session_error = create_session_error
+        self.hang_start = hang_start
+        self.hang_stop = hang_stop
+        self.kwargs = kwargs
+        self.create_session_kwargs: dict[str, Any] | None = None
+        self.started = False
+        self.stopped = False
+        self.force_stopped = False
+        self.list_models_calls = 0
+
+    async def __aenter__(self) -> _FakeClient:
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        await self.stop()
+
+    async def start(self) -> None:
+        if self.hang_start:
+            await asyncio.Event().wait()
+        self.started = True
+
+    async def stop(self) -> None:
+        if self.hang_stop:
+            await asyncio.Event().wait()
+        self.stopped = True
+
+    async def force_stop(self) -> None:
+        self.force_stopped = True
+
+    async def list_models(self) -> list[Any]:
+        self.list_models_calls += 1
+        if self.list_models_error is not None:
+            raise self.list_models_error
+        return self.models
+
+    async def create_session(self, **kwargs: Any) -> _FakeSession:
+        if self.create_session_error is not None:
+            raise self.create_session_error
+        self.create_session_kwargs = kwargs
+        self.session.tools = kwargs["tools"]
+        return self.session
+
+
+class _ClientFactory:
+    def __init__(
+        self,
+        events: list[Any],
+        models: list[Any] | None = None,
+        *,
+        hang_send: bool = False,
+        send_error: Exception | None = None,
+        list_models_error: Exception | None = None,
+        create_session_error: Exception | None = None,
+        hang_start: bool = False,
+        hang_stop: bool = False,
+    ) -> None:
+        self.session = _FakeSession(events, hang_send=hang_send, send_error=send_error)
+        self.models = models or [_model()]
+        self.list_models_error = list_models_error
+        self.create_session_error = create_session_error
+        self.hang_start = hang_start
+        self.hang_stop = hang_stop
+        self.clients: list[_FakeClient] = []
+
+    def __call__(self, **kwargs: Any) -> _FakeClient:
+        client = _FakeClient(
+            self.session,
+            self.models,
+            self.list_models_error,
+            self.create_session_error,
+            self.hang_start,
+            self.hang_stop,
+            **kwargs,
+        )
+        self.clients.append(client)
+        return client
+
+
+def test_task_result_rejects_blank_fields_and_extras():
+    with pytest.raises(ValidationError, match="non-blank"):
+        TaskResult(
+            solution_description="fixed it",
+            evidence="   ",
+            command_to_verify="pytest -q",
+        )
+
+    with pytest.raises(ValidationError, match="Extra inputs"):
+        TaskResult(
+            solution_description="fixed it",
+            evidence="pytest passed",
+            command_to_verify="pytest -q",
+            extra="not allowed",
+        )
+
+    with pytest.raises(ValidationError, match="string_type"):
+        TaskResult(
+            solution_description=123,
+            evidence="pytest passed",
+            command_to_verify="pytest -q",
+        )
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_returns_structured_result_and_usage(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_TOKEN", raising=False)
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory(
+        [
+            AssistantUsageData(
+                model="gpt-5.6-sol",
+                api_call_id="call-1",
+                input_tokens=11,
+                output_tokens=3,
+            ),
+            AssistantUsageData(
+                model="gpt-5.6-sol",
+                api_call_id="call-2",
+                input_tokens=7,
+                output_tokens=5,
+            ),
+            AssistantUsageData(
+                model="gpt-5.6-sol",
+                api_call_id="call-1",
+                input_tokens=1000,
+                output_tokens=1000,
+            ),
+            SimpleNamespace(input_tokens=1000, output_tokens=1000),
+            AssistantMessageData(
+                content="I verified the task and will return the structured result.",
+                message_id="m1",
+                output_tokens=1000,
+            ),
+            _CallReturnTool(
+                {
+                    "solution_description": "fixed it",
+                    "evidence": "pytest -q passed",
+                    "command_to_verify": "pytest -q",
+                }
+            ),
+            SessionIdleData(),
+        ]
+    )
+    agent = CopilotBenchAgent(
+        model="gpt-5.6-sol",
+        reasoning_effort="xhigh",
+        context_tier="long_context",
+        timeout_seconds=1,
+        client_factory=factory,
+    )
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "pytest -q"
+    assert result["result"] == {
+        "solution_description": "fixed it",
+        "evidence": "pytest -q passed",
+        "command_to_verify": "pytest -q",
+    }
+    assert result["n_input_tokens"] == 18
+    assert result["n_output_tokens"] == 8
+
+    client = factory.clients[-1]
+    assert client.list_models_calls == 1
+    assert client.kwargs == {"working_directory": str(Path.cwd()), "use_logged_in_user": True}
+    assert client.create_session_kwargs is not None
+    assert client.create_session_kwargs["model"] == "gpt-5.6-sol"
+    assert client.create_session_kwargs["reasoning_effort"] == "xhigh"
+    assert client.create_session_kwargs["context_tier"] == "long_context"
+    assert client.create_session_kwargs["system_message"]["mode"] == "append"
+    assert client.create_session_kwargs["on_permission_request"] is not None
+    assert [tool.name for tool in client.create_session_kwargs["tools"]] == ["return_task_result"]
+    assert factory.session.sent[-1][1] == {"agent_mode": "autopilot"}
+    assert factory.session.disconnected is True
+    assert client.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_reports_idle_without_return_tool(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_TOKEN", raising=False)
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory(
+        [AssistantMessageData(content='{"solution_description":"text only"}', message_id="m1"), SessionIdleData()]
+    )
+    agent = CopilotBenchAgent(timeout_seconds=1, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"problem_statement": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result["success"] is False
+    assert result["response"] == '{"solution_description":"text only"}'
+    assert "return_task_result" in result["error"]
+    assert result["n_input_tokens"] == 0
+    assert result["n_output_tokens"] == 0
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_reports_session_error(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_TOKEN", raising=False)
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory(
+        [
+            AssistantUsageData(
+                model="gpt-5.6-sol",
+                api_call_id="call-1",
+                input_tokens=4,
+                output_tokens=1,
+            ),
+            SessionErrorData(error_type="provider", message="provider failed"),
+        ]
+    )
+    agent = CopilotBenchAgent(timeout_seconds=1, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"task_description": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result == {
+        "response": "",
+        "success": False,
+        "error": "provider failed",
+        "n_input_tokens": 4,
+        "n_output_tokens": 1,
+    }
+    assert factory.session.disconnected is True
+    assert factory.clients[-1].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_reports_timeout_and_cleans_up(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_TOKEN", raising=False)
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory([])
+    agent = CopilotBenchAgent(timeout_seconds=0.01, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result["success"] is False
+    assert "timed out" in result["error"]
+    assert factory.session.disconnected is True
+    assert factory.clients[-1].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_times_out_hanging_send_and_cleans_up(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_TOKEN", raising=False)
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory([], hang_send=True)
+    agent = CopilotBenchAgent(timeout_seconds=0.01, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result == {
+        "response": "",
+        "success": False,
+        "error": "Copilot session timed out after 0.01 seconds",
+        "n_input_tokens": 0,
+        "n_output_tokens": 0,
+    }
+    assert factory.session.disconnected is True
+    assert factory.clients[-1].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_timeout_preserves_partial_usage(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_TOKEN", raising=False)
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory(
+        [
+            AssistantUsageData(
+                model="gpt-5.6-sol",
+                api_call_id="call-before-stall",
+                input_tokens=13,
+                output_tokens=8,
+            )
+        ]
+    )
+    agent = CopilotBenchAgent(timeout_seconds=0.01, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result == {
+        "response": "",
+        "success": False,
+        "error": "Copilot session timed out after 0.01 seconds",
+        "n_input_tokens": 13,
+        "n_output_tokens": 8,
+    }
+    assert factory.session.disconnected is True
+    assert factory.clients[-1].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_timeout_during_start_stops_client(monkeypatch):
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory([], hang_start=True)
+    agent = CopilotBenchAgent(timeout_seconds=0.01, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result == {
+        "response": "",
+        "success": False,
+        "error": "Copilot session timed out after 0.01 seconds",
+        "n_input_tokens": 0,
+        "n_output_tokens": 0,
+    }
+    assert factory.clients[-1].started is False
+    assert factory.clients[-1].stopped is True
+    assert factory.session.disconnected is False
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_force_stops_client_when_stop_hangs(monkeypatch):
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(copilot_agent_module, "_CLEANUP_TIMEOUT_SECONDS", 0.01)
+    factory = _ClientFactory(
+        [
+            _CallReturnTool(
+                {
+                    "solution_description": "fixed it",
+                    "evidence": "pytest passed",
+                    "command_to_verify": "pytest -q",
+                }
+            ),
+            SessionIdleData(),
+        ],
+        hang_stop=True,
+    )
+    agent = CopilotBenchAgent(timeout_seconds=1, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result["success"] is True
+    assert factory.session.disconnected is True
+    assert factory.clients[-1].stopped is False
+    assert factory.clients[-1].force_stopped is True
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_returns_failure_for_send_exception(monkeypatch):
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory([], send_error=RuntimeError("send failed"))
+    agent = CopilotBenchAgent(timeout_seconds=1, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result == {
+        "response": "",
+        "success": False,
+        "error": "send failed",
+        "n_input_tokens": 0,
+        "n_output_tokens": 0,
+    }
+    assert factory.session.disconnected is True
+    assert factory.clients[-1].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_returns_failure_for_create_session_exception(monkeypatch):
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory([], create_session_error=RuntimeError("session failed"))
+    agent = CopilotBenchAgent(timeout_seconds=1, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result == {
+        "response": "",
+        "success": False,
+        "error": "session failed",
+        "n_input_tokens": 0,
+        "n_output_tokens": 0,
+    }
+    assert factory.clients[-1].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_uses_explicit_container_token(monkeypatch):
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "token-value")
+    factory = _ClientFactory(
+        [
+            _CallReturnTool(
+                {
+                    "solution_description": "fixed it",
+                    "evidence": "pytest passed",
+                    "command_to_verify": "pytest -q",
+                }
+            ),
+            SessionIdleData(),
+        ]
+    )
+    agent = CopilotBenchAgent(timeout_seconds=1, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result["success"] is True
+    assert factory.clients[-1].kwargs == {
+        "working_directory": str(Path.cwd()),
+        "github_token": "token-value",
+        "use_logged_in_user": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_fails_when_model_unavailable(monkeypatch):
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory([], models=[_model("gpt-5")])
+    agent = CopilotBenchAgent(model="gpt-5.6-sol", timeout_seconds=1, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result["success"] is False
+    assert "not available" in result["error"]
+    assert factory.clients[-1].create_session_kwargs is None
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_returns_failure_for_list_models_exception(monkeypatch):
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory([], list_models_error=RuntimeError("not authenticated"))
+    agent = CopilotBenchAgent(timeout_seconds=1, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result == {
+        "response": "",
+        "success": False,
+        "error": "not authenticated",
+        "n_input_tokens": 0,
+        "n_output_tokens": 0,
+    }
+    assert factory.clients[-1].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_fails_for_unsupported_reasoning_effort(monkeypatch):
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory(
+        [],
+        models=[
+            _model(
+                "gpt-5.6-sol",
+                supports_reasoning=True,
+                supported_reasoning_efforts=["low", "medium", "high"],
+            )
+        ],
+    )
+    agent = CopilotBenchAgent(reasoning_effort="xhigh", timeout_seconds=1, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result["success"] is False
+    assert "does not support reasoning effort" in result["error"]
+    assert factory.clients[-1].create_session_kwargs is None

--- a/packages/nooa-bench/tests/test_copilot_agent.py
+++ b/packages/nooa-bench/tests/test_copilot_agent.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import stat
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -500,6 +502,71 @@ async def test_copilot_agent_cleans_up_when_unsubscribe_fails(monkeypatch):
     assert result["success"] is True
     assert factory.session.disconnected is True
     assert factory.clients[-1].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_stops_client_when_disconnect_is_cancelled(monkeypatch):
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    factory = _ClientFactory(
+        [
+            _CallReturnTool(
+                {
+                    "solution_description": "fixed it",
+                    "evidence": "pytest passed",
+                    "command_to_verify": "pytest -q",
+                }
+            ),
+            SessionIdleData(),
+        ]
+    )
+    disconnect_started = asyncio.Event()
+
+    async def disconnect() -> None:
+        disconnect_started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(factory.session, "disconnect", disconnect)
+    agent = CopilotBenchAgent(timeout_seconds=1, client_factory=factory)
+    task = asyncio.create_task(
+        agent._run_evaluation(
+            {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+        )
+    )
+
+    await asyncio.wait_for(disconnect_started.wait(), timeout=1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert factory.clients[-1].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_copilot_agent_prepares_private_home(monkeypatch, tmp_path):
+    home = tmp_path / "copilot-home"
+    monkeypatch.setenv("COPILOT_HOME", str(home))
+    factory = _ClientFactory(
+        [
+            _CallReturnTool(
+                {
+                    "solution_description": "fixed it",
+                    "evidence": "pytest passed",
+                    "command_to_verify": "pytest -q",
+                }
+            ),
+            SessionIdleData(),
+        ]
+    )
+    agent = CopilotBenchAgent(timeout_seconds=1, client_factory=factory)
+
+    result = await agent._run_evaluation(
+        {"user_message": "fix the bug", "working_dir": str(Path.cwd())}
+    )
+
+    assert result["success"] is True
+    assert home.is_dir()
+    if os.name != "nt":
+        assert stat.S_IMODE(home.stat().st_mode) == 0o700
 
 
 @pytest.mark.asyncio

--- a/packages/nooa-bench/tests/test_harbor_adapter.py
+++ b/packages/nooa-bench/tests/test_harbor_adapter.py
@@ -83,7 +83,7 @@ async def test_copilot_install_downloads_runtime(monkeypatch):
     command = agent.root_commands[-1]
     assert "python3 -m copilot download-runtime" in command
     assert "COPILOT_CLI_EXTRACT_DIR=/opt/nooa-copilot-runtime" in command
-    assert "chmod -R a+rX /opt/nooa-copilot-runtime" in command
+    assert "chmod -R u=rwX,go=rX /opt/nooa-copilot-runtime" in command
     assert "a+rwx" not in command
 
 

--- a/packages/nooa-bench/tests/test_harbor_adapter.py
+++ b/packages/nooa-bench/tests/test_harbor_adapter.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Focused tests for the example Harbor adapter command construction."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+class _FakeBaseInstalledAgent:
+    def __init__(self, logs_dir: Path, *args: Any, **kwargs: Any) -> None:
+        self.logs_dir = logs_dir
+        self.model_name = "gpt-5.6-sol"
+        self.root_commands: list[str] = []
+        self.agent_commands: list[tuple[str, dict[str, str]]] = []
+
+    async def exec_as_root(self, environment: Any, command: str) -> None:
+        self.root_commands.append(command)
+
+    async def exec_as_agent(
+        self, environment: Any, command: str, env: dict[str, str], cwd: str
+    ) -> None:
+        self.agent_commands.append((command, env))
+
+
+def _install_harbor_fakes(monkeypatch: pytest.MonkeyPatch) -> None:
+    modules = {
+        "harbor": types.ModuleType("harbor"),
+        "harbor.agents": types.ModuleType("harbor.agents"),
+        "harbor.agents.installed": types.ModuleType("harbor.agents.installed"),
+        "harbor.agents.installed.base": types.ModuleType("harbor.agents.installed.base"),
+        "harbor.environments": types.ModuleType("harbor.environments"),
+        "harbor.environments.base": types.ModuleType("harbor.environments.base"),
+        "harbor.models": types.ModuleType("harbor.models"),
+        "harbor.models.agent": types.ModuleType("harbor.models.agent"),
+        "harbor.models.agent.context": types.ModuleType("harbor.models.agent.context"),
+    }
+    modules["harbor.agents.installed.base"].BaseInstalledAgent = _FakeBaseInstalledAgent
+    modules["harbor.environments.base"].BaseEnvironment = object
+    modules["harbor.models.agent.context"].AgentContext = object
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+def _load_adapter(monkeypatch: pytest.MonkeyPatch) -> Any:
+    _install_harbor_fakes(monkeypatch)
+    module_path = Path("examples/benchmarks/harbor_adapter.py").resolve()
+    spec = importlib.util.spec_from_file_location("harbor_adapter_under_test", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_bench_install_does_not_download_copilot_runtime(monkeypatch):
+    adapter = _load_adapter(monkeypatch)
+    agent = adapter.NooaBenchAgent(Path.cwd(), git_url="https://example.test/repo.git")
+
+    await agent.install(object())
+
+    command = agent.root_commands[-1]
+    assert "download-runtime" not in command
+    assert "COPILOT_CLI_EXTRACT_DIR" not in command
+
+
+@pytest.mark.asyncio
+async def test_copilot_install_downloads_runtime(monkeypatch):
+    adapter = _load_adapter(monkeypatch)
+    agent = adapter.NooaBenchAgent(
+        Path.cwd(), git_url="https://example.test/repo.git", agent_type="copilot"
+    )
+
+    await agent.install(object())
+
+    command = agent.root_commands[-1]
+    assert "python3 -m copilot download-runtime" in command
+    assert "COPILOT_CLI_EXTRACT_DIR=/opt/nooa-copilot-runtime" in command

--- a/packages/nooa-bench/tests/test_harbor_adapter.py
+++ b/packages/nooa-bench/tests/test_harbor_adapter.py
@@ -83,6 +83,8 @@ async def test_copilot_install_downloads_runtime(monkeypatch):
     command = agent.root_commands[-1]
     assert "python3 -m copilot download-runtime" in command
     assert "COPILOT_CLI_EXTRACT_DIR=/opt/nooa-copilot-runtime" in command
+    assert "chmod -R a+rX /opt/nooa-copilot-runtime" in command
+    assert "a+rwx" not in command
 
 
 @pytest.mark.asyncio
@@ -111,6 +113,5 @@ async def test_copilot_run_uses_private_ephemeral_home(monkeypatch):
     command, env = agent.agent_commands[-1]
     assert env["COPILOT_GITHUB_TOKEN"] == "secret-token"
     assert env["COPILOT_HOME"] == "/tmp/nooa-copilot-home"
-    assert "umask 077" in command
-    assert "chmod 700 /tmp/nooa-copilot-home" in command
+    assert "nooa-copilot-home" not in command
     assert "/logs/artifacts/copilot-home" not in command

--- a/packages/nooa-bench/tests/test_harbor_adapter.py
+++ b/packages/nooa-bench/tests/test_harbor_adapter.py
@@ -83,3 +83,34 @@ async def test_copilot_install_downloads_runtime(monkeypatch):
     command = agent.root_commands[-1]
     assert "python3 -m copilot download-runtime" in command
     assert "COPILOT_CLI_EXTRACT_DIR=/opt/nooa-copilot-runtime" in command
+
+
+@pytest.mark.asyncio
+async def test_bench_run_does_not_forward_copilot_credentials(monkeypatch):
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "secret-token")
+    adapter = _load_adapter(monkeypatch)
+    agent = adapter.NooaBenchAgent(Path.cwd(), git_url="https://example.test/repo.git")
+
+    await agent.run("fix it", object(), object())
+
+    command, env = agent.agent_commands[-1]
+    assert "COPILOT_GITHUB_TOKEN" not in env
+    assert "nooa-copilot-home" not in command
+
+
+@pytest.mark.asyncio
+async def test_copilot_run_uses_private_ephemeral_home(monkeypatch):
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "secret-token")
+    adapter = _load_adapter(monkeypatch)
+    agent = adapter.NooaBenchAgent(
+        Path.cwd(), git_url="https://example.test/repo.git", agent_type="copilot"
+    )
+
+    await agent.run("fix it", object(), object())
+
+    command, env = agent.agent_commands[-1]
+    assert env["COPILOT_GITHUB_TOKEN"] == "secret-token"
+    assert env["COPILOT_HOME"] == "/tmp/nooa-copilot-home"
+    assert "umask 077" in command
+    assert "chmod 700 /tmp/nooa-copilot-home" in command
+    assert "/logs/artifacts/copilot-home" not in command

--- a/packages/nooa-bench/tests/test_runner.py
+++ b/packages/nooa-bench/tests/test_runner.py
@@ -34,7 +34,9 @@ async def test_runner_copilot_dispatch_does_not_construct_litellm(monkeypatch):
     written: dict[str, Any] = {}
 
     monkeypatch.setattr(runner, "_import_agent_class", lambda agent_type: FakeCopilotAgent)
-    monkeypatch.setattr(runner, "_write_result", lambda result, model, agent_type: written.update(result))
+    monkeypatch.setattr(
+        runner, "_write_result", lambda result, model, agent_type: written.update(result)
+    )
     monkeypatch.setattr(runner, "_write_answer", lambda result: None)
 
     exit_code = await runner._run(
@@ -85,7 +87,9 @@ async def test_runner_legacy_dispatch_preserves_token_accounting(monkeypatch):
         "get_task_tokens",
         lambda: {"n_input_tokens": 11, "n_output_tokens": 7},
     )
-    monkeypatch.setattr(runner, "_write_result", lambda result, model, agent_type: written.update(result))
+    monkeypatch.setattr(
+        runner, "_write_result", lambda result, model, agent_type: written.update(result)
+    )
     monkeypatch.setattr(runner, "_write_answer", lambda result: None)
 
     exit_code = await runner._run(
@@ -114,7 +118,9 @@ async def test_runner_writes_failure_result_when_agent_raises(monkeypatch):
     written: dict[str, Any] = {}
 
     monkeypatch.setattr(runner, "_import_agent_class", lambda agent_type: BrokenAgent)
-    monkeypatch.setattr(runner, "_write_result", lambda result, model, agent_type: written.update(result))
+    monkeypatch.setattr(
+        runner, "_write_result", lambda result, model, agent_type: written.update(result)
+    )
     monkeypatch.setattr(runner, "_write_answer", lambda result: None)
 
     exit_code = await runner._run(
@@ -141,7 +147,9 @@ async def test_runner_writes_failure_result_when_agent_returns_none(monkeypatch)
     written: dict[str, Any] = {}
 
     monkeypatch.setattr(runner, "_import_agent_class", lambda agent_type: EmptyAgent)
-    monkeypatch.setattr(runner, "_write_result", lambda result, model, agent_type: written.update(result))
+    monkeypatch.setattr(
+        runner, "_write_result", lambda result, model, agent_type: written.update(result)
+    )
     monkeypatch.setattr(runner, "_write_answer", lambda result: None)
 
     exit_code = await runner._run(
@@ -168,7 +176,9 @@ async def test_runner_copilot_rejects_api_base_before_agent_construction(monkeyp
     written: dict[str, Any] = {}
 
     monkeypatch.setattr(runner, "_import_agent_class", fail_import)
-    monkeypatch.setattr(runner, "_write_result", lambda result, model, agent_type: written.update(result))
+    monkeypatch.setattr(
+        runner, "_write_result", lambda result, model, agent_type: written.update(result)
+    )
     monkeypatch.setattr(runner, "_write_answer", lambda result: None)
 
     exit_code = await runner._run(
@@ -201,7 +211,9 @@ async def test_runner_writes_failure_result_when_copilot_setup_fails(monkeypatch
     written: dict[str, Any] = {}
 
     monkeypatch.setattr(runner, "_import_agent_class", fail_import)
-    monkeypatch.setattr(runner, "_write_result", lambda result, model, agent_type: written.update(result))
+    monkeypatch.setattr(
+        runner, "_write_result", lambda result, model, agent_type: written.update(result)
+    )
     monkeypatch.setattr(runner, "_write_answer", lambda result: None)
 
     exit_code = await runner._run(

--- a/packages/nooa-bench/tests/test_runner.py
+++ b/packages/nooa-bench/tests/test_runner.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Harbor runner dispatch paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nooa_bench import runner
+
+
+@pytest.mark.asyncio
+async def test_runner_copilot_dispatch_does_not_construct_litellm(monkeypatch):
+    constructed: dict[str, Any] = {}
+
+    class FakeCopilotAgent:
+        def __init__(self, **kwargs: Any) -> None:
+            constructed.update(kwargs)
+
+        async def _run_evaluation(self, task_input: dict[str, Any]) -> dict[str, Any]:
+            assert task_input == {"user_message": "fix it", "working_dir": str(Path.cwd())}
+            return {
+                "response": "pytest -q",
+                "success": True,
+                "n_input_tokens": 2,
+                "n_output_tokens": 3,
+            }
+
+    written: dict[str, Any] = {}
+
+    monkeypatch.setattr(runner, "_import_agent_class", lambda agent_type: FakeCopilotAgent)
+    monkeypatch.setattr(runner, "_write_result", lambda result, model, agent_type: written.update(result))
+    monkeypatch.setattr(runner, "_write_answer", lambda result: None)
+
+    exit_code = await runner._run(
+        "fix it",
+        "gpt-5.6-sol",
+        "copilot",
+        api_base=None,
+        working_dir=str(Path.cwd()),
+        reasoning_effort="xhigh",
+        context_tier="long_context",
+        timeout_seconds=10,
+    )
+
+    assert exit_code == 0
+    assert constructed == {
+        "model": "gpt-5.6-sol",
+        "reasoning_effort": "xhigh",
+        "context_tier": "long_context",
+        "timeout_seconds": 10,
+    }
+    assert written["n_input_tokens"] == 2
+    assert written["n_output_tokens"] == 3
+
+
+@pytest.mark.asyncio
+async def test_runner_writes_failure_result_when_agent_raises(monkeypatch):
+    class BrokenAgent:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def _run_evaluation(self, task_input: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("sdk exploded")
+
+    written: dict[str, Any] = {}
+
+    monkeypatch.setattr(runner, "_import_agent_class", lambda agent_type: BrokenAgent)
+    monkeypatch.setattr(runner, "_write_result", lambda result, model, agent_type: written.update(result))
+    monkeypatch.setattr(runner, "_write_answer", lambda result: None)
+
+    exit_code = await runner._run(
+        "fix it",
+        "gpt-5.6-sol",
+        "copilot",
+        api_base=None,
+        working_dir=str(Path.cwd()),
+    )
+
+    assert exit_code == 1
+    assert written == {"response": "", "success": False, "error": "sdk exploded"}
+
+
+@pytest.mark.asyncio
+async def test_runner_copilot_rejects_api_base_before_agent_construction(monkeypatch):
+    def fail_import(agent_type: str) -> Any:
+        raise AssertionError("agent should not be imported when --api-base is rejected")
+
+    monkeypatch.setattr(runner, "_import_agent_class", fail_import)
+
+    with pytest.raises(ValueError, match="BYOK provider wiring is not implemented"):
+        await runner._run(
+            "fix it",
+            "gpt-5.6-sol",
+            "copilot",
+            api_base="https://example.test/v1",
+            working_dir=str(Path.cwd()),
+            reasoning_effort="xhigh",
+            context_tier="long_context",
+            timeout_seconds=10,
+        )

--- a/packages/nooa-bench/tests/test_runner.py
+++ b/packages/nooa-bench/tests/test_runner.py
@@ -84,6 +84,37 @@ async def test_runner_writes_failure_result_when_agent_raises(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_runner_writes_failure_result_when_agent_returns_none(monkeypatch):
+    class EmptyAgent:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def _run_evaluation(self, task_input: dict[str, Any]) -> None:
+            return None
+
+    written: dict[str, Any] = {}
+
+    monkeypatch.setattr(runner, "_import_agent_class", lambda agent_type: EmptyAgent)
+    monkeypatch.setattr(runner, "_write_result", lambda result, model, agent_type: written.update(result))
+    monkeypatch.setattr(runner, "_write_answer", lambda result: None)
+
+    exit_code = await runner._run(
+        "fix it",
+        "gpt-5.6-sol",
+        "copilot",
+        api_base=None,
+        working_dir=str(Path.cwd()),
+    )
+
+    assert exit_code == 1
+    assert written == {
+        "response": "",
+        "success": False,
+        "error": "Agent returned no result",
+    }
+
+
+@pytest.mark.asyncio
 async def test_runner_copilot_rejects_api_base_before_agent_construction(monkeypatch):
     def fail_import(agent_type: str) -> Any:
         raise AssertionError("agent should not be imported when --api-base is rejected")

--- a/packages/nooa-bench/tests/test_runner.py
+++ b/packages/nooa-bench/tests/test_runner.py
@@ -10,6 +10,9 @@ from typing import Any
 import pytest
 from nooa_bench import runner
 
+import nooa.runtime.token_usage as token_usage
+import nooa.unifiedllm as unifiedllm
+
 
 @pytest.mark.asyncio
 async def test_runner_copilot_dispatch_does_not_construct_litellm(monkeypatch):
@@ -54,6 +57,49 @@ async def test_runner_copilot_dispatch_does_not_construct_litellm(monkeypatch):
     }
     assert written["n_input_tokens"] == 2
     assert written["n_output_tokens"] == 3
+
+
+@pytest.mark.asyncio
+async def test_runner_legacy_dispatch_preserves_token_accounting(monkeypatch):
+    started = False
+    llm_client = object()
+    written: dict[str, Any] = {}
+
+    class FakeBenchAgent:
+        def __init__(self, *, llm: Any) -> None:
+            assert llm is llm_client
+
+        async def _run_evaluation(self, task_input: dict[str, Any]) -> dict[str, Any]:
+            assert task_input == {"user_message": "fix it", "working_dir": str(Path.cwd())}
+            return {"response": "pytest -q", "success": True}
+
+    def start_task_tokens() -> None:
+        nonlocal started
+        started = True
+
+    monkeypatch.setattr(runner, "_import_agent_class", lambda agent_type: FakeBenchAgent)
+    monkeypatch.setattr(unifiedllm, "get_llm_client", lambda model, **kwargs: llm_client)
+    monkeypatch.setattr(token_usage, "start_task_tokens", start_task_tokens)
+    monkeypatch.setattr(
+        token_usage,
+        "get_task_tokens",
+        lambda: {"n_input_tokens": 11, "n_output_tokens": 7},
+    )
+    monkeypatch.setattr(runner, "_write_result", lambda result, model, agent_type: written.update(result))
+    monkeypatch.setattr(runner, "_write_answer", lambda result: None)
+
+    exit_code = await runner._run(
+        "fix it",
+        "openai/test-model",
+        "bench",
+        api_base=None,
+        working_dir=str(Path.cwd()),
+    )
+
+    assert exit_code == 0
+    assert started is True
+    assert written["n_input_tokens"] == 11
+    assert written["n_output_tokens"] == 7
 
 
 @pytest.mark.asyncio

--- a/packages/nooa-bench/tests/test_runner.py
+++ b/packages/nooa-bench/tests/test_runner.py
@@ -88,16 +88,56 @@ async def test_runner_copilot_rejects_api_base_before_agent_construction(monkeyp
     def fail_import(agent_type: str) -> Any:
         raise AssertionError("agent should not be imported when --api-base is rejected")
 
-    monkeypatch.setattr(runner, "_import_agent_class", fail_import)
+    written: dict[str, Any] = {}
 
-    with pytest.raises(ValueError, match="BYOK provider wiring is not implemented"):
-        await runner._run(
-            "fix it",
-            "gpt-5.6-sol",
-            "copilot",
-            api_base="https://example.test/v1",
-            working_dir=str(Path.cwd()),
-            reasoning_effort="xhigh",
-            context_tier="long_context",
-            timeout_seconds=10,
-        )
+    monkeypatch.setattr(runner, "_import_agent_class", fail_import)
+    monkeypatch.setattr(runner, "_write_result", lambda result, model, agent_type: written.update(result))
+    monkeypatch.setattr(runner, "_write_answer", lambda result: None)
+
+    exit_code = await runner._run(
+        "fix it",
+        "gpt-5.6-sol",
+        "copilot",
+        api_base="https://example.test/v1",
+        working_dir=str(Path.cwd()),
+        reasoning_effort="xhigh",
+        context_tier="long_context",
+        timeout_seconds=10,
+    )
+
+    assert exit_code == 1
+    assert written == {
+        "response": "",
+        "success": False,
+        "error": (
+            "--api-base is not supported for --agent-type copilot; "
+            "BYOK provider wiring is not implemented"
+        ),
+    }
+
+
+@pytest.mark.asyncio
+async def test_runner_writes_failure_result_when_copilot_setup_fails(monkeypatch):
+    def fail_import(agent_type: str) -> Any:
+        raise RuntimeError("copilot import failed")
+
+    written: dict[str, Any] = {}
+
+    monkeypatch.setattr(runner, "_import_agent_class", fail_import)
+    monkeypatch.setattr(runner, "_write_result", lambda result, model, agent_type: written.update(result))
+    monkeypatch.setattr(runner, "_write_answer", lambda result: None)
+
+    exit_code = await runner._run(
+        "fix it",
+        "gpt-5.6-sol",
+        "copilot",
+        api_base=None,
+        working_dir=str(Path.cwd()),
+    )
+
+    assert exit_code == 1
+    assert written == {
+        "response": "",
+        "success": False,
+        "error": "copilot import failed",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -668,6 +668,19 @@ wheels = [
 ]
 
 [[package]]
+name = "github-copilot-sdk"
+version = "1.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/c7/152a5e87528a3960886bf8d6af8cd1c32437367d2c40725b51da428fdaca/github_copilot_sdk-1.0.5-py3-none-any.whl", hash = "sha256:4f4715553dfab863ffdbff250fc245fb484577e2a16c9cbaab3cf43bb69c4ca7", size = 375876, upload-time = "2026-07-01T15:11:57.92Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1476,6 +1489,7 @@ name = "nooa-bench"
 source = { editable = "packages/nooa-bench" }
 dependencies = [
     { name = "click" },
+    { name = "github-copilot-sdk" },
     { name = "nooa" },
     { name = "nooa-cli" },
 ]
@@ -1483,6 +1497,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
+    { name = "github-copilot-sdk", specifier = ">=1.0.5" },
     { name = "nooa", editable = "." },
     { name = "nooa-cli", editable = "packages/nooa-cli" },
 ]


### PR DESCRIPTION
## What does this PR do?

Adds an additive GitHub Copilot SDK execution path to `nooa-bench` so evaluations can use a signed-in Copilot account and models such as `gpt-5.6-sol` without replacing the existing NOOA/LiteLLM benchmark agent.

The new `CopilotBenchAgent` owns the SDK session directly, enforces structured task results, captures deduplicated usage events, and bounds startup, execution, and teardown. Runner and Harbor dispatch select this path with `agent_type=copilot`, scope credentials to Copilot runs, keep `COPILOT_HOME` private and ephemeral, and install the SDK runtime with read-only group/other permissions. Documentation, a minimal Harbor configuration, and lifecycle/contract regression coverage are included.

`CopilotBenchAgent` intentionally does not subclass `nooa.Agent`: both NOOA CodeAct and the Copilot SDK are agent runtimes that own their tool loop and session lifecycle. The existing `BenchAgent` remains unchanged from `main`.

Validation includes 45 `nooa-bench` tests on Python 3.12 and 3.13, five-repeat lifecycle and runner/Harbor stress runs, Ruff, Pyright with zero errors, wheel installation/import, permission semantics, and a live signed-in `gpt-5.6-sol` structured-completion smoke using `xhigh` and `long_context`.

## Related issues

N/A

## Checklist

- [x] Code follows the project style (Ruff lint passes repo-wide; changed Python files pass `ruff format --check`)
- [x] Tests added/updated and passing (`uv run pytest`)
- [x] Docs updated if behavior or public APIs changed
- [x] New source files carry an SPDX license header