### PR TITLE
ci: publish to PyPI via Trusted Publishing on GitHub Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,13 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
+      # Mirrors the publish workflow's build exactly (--no-sources included) so
+      # this job stays a real canary for release-build breakage.
       - name: Build all packages
         run: |
           rm -rf dist
           for pkg in nooa nooa-cli nooa-memory nooa-bench; do
-            uv build --package "$pkg" --out-dir dist
+            uv build --no-sources --package "$pkg" --out-dir dist
           done
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,13 +17,10 @@ name: Publish
 on:
   release:
     types: [published]
+  # Manual runs are ALWAYS a TestPyPI dry run. There is deliberately no input
+  # to select the index: real PyPI is reachable only by publishing a GitHub
+  # Release, so a mis-click here cannot burn a version number on PyPI.
   workflow_dispatch:
-    inputs:
-      target:
-        description: "Index to upload to"
-        type: choice
-        options: [testpypi, pypi]
-        default: testpypi
 
 permissions: {}
 
@@ -110,7 +107,7 @@ jobs:
   # but a distinct environment is also what gives per-package approval gates.)
   publish-testpypi:
     needs: build
-    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # a partial publish is recoverable; a cancelled one is messier
@@ -155,7 +152,8 @@ jobs:
 
   publish-pypi:
     needs: build
-    if: github.event_name == 'release' || inputs.target == 'pypi'
+    # Real PyPI is reachable ONLY from a published GitHub Release.
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -214,6 +212,13 @@ jobs:
         with:
           name: dist
           path: dist/
-      - env:
+      # The tag name goes through `env:`, not `${{ }}` inside the script.
+      # GitHub expands `${{ }}` textually *before* bash parses the line, so a
+      # tag containing `$(...)` or backticks would execute — double quotes do
+      # not help, because the substitution happens before quoting is applied.
+      # This job holds `contents: write`. Via env, bash sees the value as data.
+      - name: Attach artifacts to the release
+        env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --repo "$GITHUB_REPOSITORY"
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" dist/* --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,13 @@
 # Auth: PyPI Trusted Publishing (OIDC). No API tokens, no repo secrets.
 #
 # `workflow_dispatch` runs the same build against TestPyPI for a dry run.
+#
+# Every `uses:` here is an `actions/*` action, i.e. GitHub-created. That is
+# deliberate: this org enforces an Actions allowlist, and a disallowed action
+# fails the *entire workflow* at startup (see PR #50 — one blocked action left
+# CI dead for 8 days). A publish workflow that cannot start is a publish
+# workflow that silently never ships. uv is installed from a pinned, versioned
+# install script and does the upload itself via `uv publish`.
 name: Publish
 
 on:
@@ -20,6 +27,11 @@ on:
 
 permissions: {}
 
+env:
+  # Pinned: the install script is fetched at runtime, so an unversioned URL
+  # would make every run depend on whatever uv ships that day.
+  UV_VERSION: "0.11.4"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,9 +41,10 @@ jobs:
           fetch-depth: 0  # tags needed for uv-dynamic-versioning
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
+        run: |
+          set -euo pipefail
+          curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       # --no-sources: build with `tool.uv.sources` disabled, so the build is
       # exercised the way a non-uv consumer's build backend would see it. Without
@@ -125,10 +138,20 @@ jobs:
           cp dist/"${PKG//-/_}"-* upload/
           test "$(ls upload | wc -l)" -eq 2  # exactly one wheel + one sdist
           ls -l upload
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: upload/
-          repository-url: https://test.pypi.org/legacy/
+      - name: Install uv
+        run: |
+          set -euo pipefail
+          curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      # --trusted-publishing always: never silently fall back to looking for a
+      # token if the OIDC exchange fails. Fail instead, so a broken publisher
+      # config surfaces as an error rather than an auth prompt.
+      - name: Publish to TestPyPI
+        run: |
+          uv publish --trusted-publishing always \
+            --publish-url https://test.pypi.org/legacy/ \
+            --check-url https://test.pypi.org/simple/ \
+            upload/*
 
   publish-pypi:
     needs: build
@@ -160,9 +183,23 @@ jobs:
           cp dist/"${PKG//-/_}"-* upload/
           test "$(ls upload | wc -l)" -eq 2  # exactly one wheel + one sdist
           ls -l upload
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: upload/
+      - name: Install uv
+        run: |
+          set -euo pipefail
+          curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      # --trusted-publishing always: never silently fall back to looking for a
+      # token if the OIDC exchange fails. Fail instead, so a broken publisher
+      # config surfaces as an error rather than an auth prompt.
+      #
+      # --check-url makes a re-run idempotent: already-uploaded files are
+      # skipped rather than erroring. Matters because `fail-fast: false` means
+      # a partial publish is a state you can land in and need to resume from.
+      - name: Publish to PyPI
+        run: |
+          uv publish --trusted-publishing always \
+            --check-url https://pypi.org/simple/ \
+            upload/*
 
   # Attach the built wheels to the GitHub Release so `pip install <url>` and
   # air-gapped consumers get the exact artifacts that went to PyPI.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,182 @@
+# Publishes the four workspace packages to PyPI.
+#
+# Trigger: a GitHub Release is *published* (the release's tag `vX.Y.Z` is what
+# uv-dynamic-versioning turns into the package version — see RELEASING.md).
+# Auth: PyPI Trusted Publishing (OIDC). No API tokens, no repo secrets.
+#
+# `workflow_dispatch` runs the same build against TestPyPI for a dry run.
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Index to upload to"
+        type: choice
+        options: [testpypi, pypi]
+        default: testpypi
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags needed for uv-dynamic-versioning
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      # --no-sources: build with `tool.uv.sources` disabled, so the build is
+      # exercised the way a non-uv consumer's build backend would see it. Without
+      # it, a workspace source could paper over a dependency that is unresolvable
+      # off this machine. Recommended by
+      # https://docs.astral.sh/uv/guides/package/
+      - name: Build all packages
+        run: |
+          rm -rf dist
+          for pkg in nooa nooa-cli nooa-memory nooa-bench; do
+            uv build --no-sources --package "$pkg" --out-dir dist
+          done
+          ls -l dist
+
+      # Guards the two ways a release can silently ship the wrong version:
+      # a shallow checkout (no tag reachable -> `.devN`), or a Release created
+      # from a commit that is not the tagged one.
+      - name: Check built version matches the release tag
+        if: github.event_name == 'release'
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          uv run --no-project --with packaging python - <<'PY'
+          import os, pathlib, sys
+          from packaging.utils import parse_wheel_filename
+          from packaging.version import Version
+
+          expected = Version(os.environ["TAG"].removeprefix("v"))
+          wheels = sorted(pathlib.Path("dist").glob("*.whl"))
+          assert len(wheels) == 4, f"expected 4 wheels, got {[w.name for w in wheels]}"
+          for whl in wheels:
+              _, version, _, _ = parse_wheel_filename(whl.name)
+              if version.is_devrelease:
+                  sys.exit(f"{whl.name}: dev version — the tag is not reachable from HEAD")
+              if version != expected:
+                  sys.exit(f"{whl.name}: built {version}, but the tag says {expected}")
+          print(f"OK — all four packages built as {expected}")
+          PY
+
+      # Catches a broken wheel before it is on PyPI forever.
+      - name: Smoke-test the wheels in a clean environment
+        run: |
+          uv venv /tmp/smoke --python 3.12
+          VIRTUAL_ENV=/tmp/smoke uv pip install \
+            dist/nooa-*.whl dist/nooa_cli-*.whl dist/nooa_memory-*.whl dist/nooa_bench-*.whl
+          /tmp/smoke/bin/python -c "import nooa, nooa_cli, nooa_memory, nooa_bench; print(nooa.__version__)"
+          /tmp/smoke/bin/nooa --version
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  # One job per package, each in its OWN environment (`pypi-<package>`).
+  #
+  # PyPI keys a *pending* trusted publisher on
+  # (owner, repo, workflow filename, environment). Four packages sharing one
+  # environment collide: PyPI rejects the 2nd registration with "a pending
+  # trusted publisher matching this configuration has already been registered
+  # for a different project name", because it cannot tell which project to
+  # create on first upload. A distinct environment per package makes each
+  # tuple unique. (The constraint applies only while a publisher is pending —
+  # but a distinct environment is also what gives per-package approval gates.)
+  publish-testpypi:
+    needs: build
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false  # a partial publish is recoverable; a cancelled one is messier
+      matrix:
+        package: [nooa, nooa-cli, nooa-memory, nooa-bench]
+    environment:
+      name: testpypi-${{ matrix.package }}
+      url: https://test.pypi.org/p/${{ matrix.package }}
+    permissions:
+      id-token: write  # required for Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      # Upload only this package's files. Distribution filenames normalise `-`
+      # to `_`, and the glob anchors on the `-` before the version, so
+      # `nooa-*` matches nooa's own files and never `nooa_cli-*`.
+      - name: Isolate this package's artifacts
+        env:
+          PKG: ${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          mkdir upload
+          cp dist/"${PKG//-/_}"-* upload/
+          test "$(ls upload | wc -l)" -eq 2  # exactly one wheel + one sdist
+          ls -l upload
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: upload/
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    needs: build
+    if: github.event_name == 'release' || inputs.target == 'pypi'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [nooa, nooa-cli, nooa-memory, nooa-bench]
+    environment:
+      name: pypi-${{ matrix.package }}
+      url: https://pypi.org/p/${{ matrix.package }}
+    permissions:
+      id-token: write  # required for Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      # Upload only this package's files. Distribution filenames normalise `-`
+      # to `_`, and the glob anchors on the `-` before the version, so
+      # `nooa-*` matches nooa's own files and never `nooa_cli-*`.
+      - name: Isolate this package's artifacts
+        env:
+          PKG: ${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          mkdir upload
+          cp dist/"${PKG//-/_}"-* upload/
+          test "$(ls upload | wc -l)" -eq 2  # exactly one wheel + one sdist
+          ls -l upload
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: upload/
+
+  # Attach the built wheels to the GitHub Release so `pip install <url>` and
+  # air-gapped consumers get the exact artifacts that went to PyPI.
+  attach-to-release:
+    needs: publish-pypi
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --repo "$GITHUB_REPOSITORY"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,50 +33,101 @@ initial development).
 
 ## Cutting a release
 
+Publishing to PyPI is automated by
+[`.github/workflows/publish.yml`](.github/workflows/publish.yml). **Publishing a
+GitHub Release is the release ceremony** — the release's tag is what
+`uv-dynamic-versioning` turns into the version.
+
 ```bash
 git checkout main && git pull
-git tag -a v0.0.6 -m "NOOA 0.0.6 — research preview"
-git push origin v0.0.6
+gh release create v0.0.7 --title "NOOA 0.0.7" --generate-notes --draft
+# review the draft notes, then publish it:
+gh release edit v0.0.7 --draft=false
 ```
 
-Build the four packages from the tagged commit:
+Publishing the release triggers the workflow, which:
+
+1. Builds all four packages from the tagged commit.
+2. Fails the run if the built version does not match the tag, or is a `.devN`
+   version (which means the tag was not reachable from the checked-out commit).
+3. Smoke-tests the wheels in a clean venv (imports + `nooa --version`).
+4. Uploads to PyPI via **Trusted Publishing** — no API tokens.
+5. Attaches the wheels and sdists to the GitHub Release.
+
+The upload waits on the `pypi` GitHub Environment, so you can require a manual
+approval there if you want a second pair of eyes before the irreversible step.
+
+### Dry run against TestPyPI
+
+Run the **Publish** workflow manually (Actions → Publish → Run workflow) with
+target `testpypi`. This exercises the identical build and smoke test.
+
+### Doing it by hand
+
+`--no-sources` disables `tool.uv.sources` so the build is exercised the way a
+non-uv consumer sees it — the [uv packaging
+guide](https://docs.astral.sh/uv/guides/package/) recommends it for release
+builds.
 
 ```bash
 rm -rf dist
 for p in nooa nooa-cli nooa-memory nooa-bench; do
-  uv build --package "$p" --out-dir dist
+  uv build --no-sources --package "$p" --out-dir dist
 done
-```
-
-**Smoke-test the wheels in a clean environment** before publishing:
-
-```bash
-python3.12 -m venv /tmp/nooa-smoke && . /tmp/nooa-smoke/bin/activate
-pip install dist/nooa-*.whl dist/nooa_cli-*.whl dist/nooa_memory-*.whl dist/nooa_bench-*.whl
-python -c "import nooa, nooa_cli, nooa_memory, nooa_bench; print(nooa.__version__)"
-nooa --version
-deactivate
+uvx twine check dist/*
+uv venv /tmp/nooa-smoke --python 3.12
+VIRTUAL_ENV=/tmp/nooa-smoke uv pip install dist/nooa-*.whl dist/nooa_cli-*.whl \
+  dist/nooa_memory-*.whl dist/nooa_bench-*.whl
+/tmp/nooa-smoke/bin/python -c "import nooa, nooa_cli, nooa_memory, nooa_bench; print(nooa.__version__)"
 ```
 
 ### Pre-release tags
 
-Annotated tags like `v0.0.6-rc1` build as `0.0.6rc1` (PEP 440 normalized).
+Annotated tags like `v0.0.6-rc1` build as `0.0.6rc1` (PEP 440 normalized). Mark
+the GitHub Release as a pre-release; PyPI will not serve it to plain
+`pip install nooa`.
+
+## One-time PyPI setup
+
+Each of the four project names needs a **pending publisher** registered at
+<https://pypi.org/manage/account/publishing/> before its first upload. Owner
+`NVIDIA-NeMo`, repository `labs-OO-Agents`, workflow `publish.yml` for all four
+— but the **environment name differs per package**:
+
+| PyPI Project Name | Environment name |
+|---|---|
+| `nooa` | `pypi-nooa` |
+| `nooa-cli` | `pypi-nooa-cli` |
+| `nooa-memory` | `pypi-nooa-memory` |
+| `nooa-bench` | `pypi-nooa-bench` |
+
+> **Why one environment per package.** PyPI keys a *pending* publisher on
+> (owner, repo, workflow filename, environment). If all four shared one
+> environment, the second registration fails with *"a pending trusted publisher
+> matching this configuration has already been registered for a different
+> project name"* — PyPI cannot tell which project to create on first upload.
+> The restriction lifts once a project exists, but the per-package environment
+> is kept because it also gives per-package approval gates.
+
+Repeat on <https://test.pypi.org> using `testpypi-<package>` environment names
+for dry runs. After the first successful upload each pending publisher becomes
+a normal one.
+
+The matching **GitHub Environments** must exist too (Settings → Environments):
+`pypi-nooa`, `pypi-nooa-cli`, `pypi-nooa-memory`, `pypi-nooa-bench`, and the
+four `testpypi-*` equivalents.
 
 ## Distribution
 
-The packages are currently distributed as **source** — install directly from
-GitHub at a tag:
-
 ```bash
-uv add "nooa @ git+https://github.com/NVIDIA-NeMo/labs-OO-Agents.git@v0.0.6"
+uv add nooa nooa-cli
 ```
 
-Optionally attach the built wheels to a **GitHub Release** for the tag.
+Installing straight from a tag also works, and does not require a release:
 
-> **PyPI publishing is not yet enabled.** When it is, a GitHub Actions workflow
-> (PyPI Trusted Publishing) will build and upload all four packages on each
-> `vX.Y.Z` tag. The names `nooa`, `nooa-cli`, `nooa-memory`, and `nooa-bench`
-> are available on PyPI and can be reserved ahead of the first publish.
+```bash
+uv add "nooa @ git+https://github.com/NVIDIA-NeMo/labs-OO-Agents.git@v0.0.7"
+```
 
 ## Cross-package dependencies
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,11 +51,24 @@ Publishing the release triggers the workflow, which:
 2. Fails the run if the built version does not match the tag, or is a `.devN`
    version (which means the tag was not reachable from the checked-out commit).
 3. Smoke-tests the wheels in a clean venv (imports + `nooa --version`).
-4. Uploads to PyPI via **Trusted Publishing** — no API tokens.
+4. Uploads to PyPI via **Trusted Publishing** (`uv publish`) — no API tokens.
 5. Attaches the wheels and sdists to the GitHub Release.
 
-The upload waits on the `pypi` GitHub Environment, so you can require a manual
-approval there if you want a second pair of eyes before the irreversible step.
+Each upload waits on its `pypi-<package>` GitHub Environment, so a required
+reviewer there gives a second pair of eyes before the irreversible step.
+
+> **Why no third-party actions.** Every `uses:` in `publish.yml` is an
+> `actions/*` action. This org enforces a GitHub Actions allowlist, and a
+> disallowed action fails the *entire workflow* at startup — that is what left
+> CI dead for eight days (PR #50). A publish workflow that cannot start is one
+> that silently never ships, so uv is installed from a pinned install script
+> and does the upload itself.
+>
+> The tradeoff is **no PEP 740 attestations**: `uv publish` uploads them but
+> [does not generate them](https://docs.astral.sh/uv/guides/package/), and the
+> action that does (`pypa/gh-action-pypi-publish`) may not be allowlisted.
+> Worth revisiting if it is added to the allowlist, or once uv can generate
+> them. Trusted Publishing itself is unaffected.
 
 ### Dry run against TestPyPI
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,8 +72,12 @@ reviewer there gives a second pair of eyes before the irreversible step.
 
 ### Dry run against TestPyPI
 
-Run the **Publish** workflow manually (Actions → Publish → Run workflow) with
-target `testpypi`. This exercises the identical build and smoke test.
+Run the **Publish** workflow manually (Actions → Publish → Run workflow). This
+exercises the identical build, version check, and smoke test.
+
+A manual run always targets TestPyPI — there is no index selector. Real PyPI is
+reachable only by publishing a GitHub Release, so a mis-click here cannot burn
+a version number on PyPI.
 
 ### Doing it by hand
 

--- a/packages/nooa-bench/README.md
+++ b/packages/nooa-bench/README.md
@@ -1,0 +1,15 @@
+# nooa-bench
+
+Benchmark agent (`BenchAgent`) and Harbor runner for
+[NOOA](https://github.com/NVIDIA-NeMo/labs-OO-Agents). Reproduces the SWE-bench
+and Terminal-Bench results from the NOOA tech report.
+
+```bash
+uv add nooa-bench
+nemo-harbor --help
+```
+
+See the [main repository](https://github.com/NVIDIA-NeMo/labs-OO-Agents) for
+documentation.
+
+Apache-2.0 licensed.

--- a/packages/nooa-bench/pyproject.toml
+++ b/packages/nooa-bench/pyproject.toml
@@ -5,7 +5,11 @@ dynamic = ["version"]
 description = "Benchmark agent (BenchAgent) and Harbor runner for the NOOA framework — reproduces the tech report's SWE-bench and Terminal-Bench results"
 license = {text = "Apache-2.0"}
 readme = "README.md"
-requires-python = ">=3.12"
+# Matches nooa and nooa-cli (both >=3.12,<3.14), which this depends on.
+# Without the upper bound, installing on 3.14 fails with a confusing
+# "could not find a version that satisfies nooa" instead of a clean
+# "requires a different Python".
+requires-python = ">=3.12,<3.14"
 dependencies = [
     "nooa",
     "nooa-cli",

--- a/packages/nooa-bench/pyproject.toml
+++ b/packages/nooa-bench/pyproject.toml
@@ -4,12 +4,18 @@ name = "nooa-bench"
 dynamic = ["version"]
 description = "Benchmark agent (BenchAgent) and Harbor runner for the NOOA framework — reproduces the tech report's SWE-bench and Terminal-Bench results"
 license = {text = "Apache-2.0"}
+readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "nooa",
     "nooa-cli",
     "click>=8.1",
 ]
+
+[project.urls]
+Homepage = "https://github.com/NVIDIA-NeMo/labs-OO-Agents"
+Repository = "https://github.com/NVIDIA-NeMo/labs-OO-Agents"
+Issues = "https://github.com/NVIDIA-NeMo/labs-OO-Agents/issues"
 
 [project.scripts]
 nemo-harbor = "nooa_bench.runner:main"

--- a/packages/nooa-cli/pyproject.toml
+++ b/packages/nooa-cli/pyproject.toml
@@ -16,6 +16,11 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/NVIDIA-NeMo/labs-OO-Agents"
+Repository = "https://github.com/NVIDIA-NeMo/labs-OO-Agents"
+Issues = "https://github.com/NVIDIA-NeMo/labs-OO-Agents/issues"
+
 [project.scripts]
 nooa = "nooa_cli:main"
 
@@ -64,4 +69,3 @@ fallback-version = "0.0.6"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nooa_cli"]
-

--- a/packages/nooa-memory/README.md
+++ b/packages/nooa-memory/README.md
@@ -1,0 +1,17 @@
+# nooa-memory
+
+Long-term memory subsystem for [NOOA](https://github.com/NVIDIA-NeMo/labs-OO-Agents)
+agents. Installs the `nemo.memory` skill, which gives an agent persistent recall
+across sessions backed by vector search.
+
+```bash
+uv add nooa-memory
+```
+
+The default vector backend is numpy-only (no extra dependencies). `sqlite-vec`
+and `chromadb` backends are imported lazily if you install them yourself.
+
+See the [main repository](https://github.com/NVIDIA-NeMo/labs-OO-Agents) for
+documentation, and `examples/arc_agi_3` for a worked usage example.
+
+Apache-2.0 licensed.

--- a/packages/nooa-memory/pyproject.toml
+++ b/packages/nooa-memory/pyproject.toml
@@ -2,8 +2,9 @@
 name = "nooa-memory"
 # Version is derived from git tags at build time by uv-dynamic-versioning.
 dynamic = ["version"]
-description = "Long-term memory system for nooa agents (ships with the ARC-AGI-3 example; not yet published)"
+description = "Long-term memory system for NOOA agents — persistent recall backed by vector search"
 license = {text = "Apache-2.0"}
+readme = "README.md"
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "nooa",
@@ -15,6 +16,11 @@ dependencies = [
 # vector_backends.py and deliberately NOT declared as an extra: `uv sync
 # --all-extras` in CI would otherwise install the heavy chromadb stack that
 # the numpy default backend makes unnecessary.
+
+[project.urls]
+Homepage = "https://github.com/NVIDIA-NeMo/labs-OO-Agents"
+Repository = "https://github.com/NVIDIA-NeMo/labs-OO-Agents"
+Issues = "https://github.com/NVIDIA-NeMo/labs-OO-Agents/issues"
 
 [project.entry-points."nooa.skills"]
 "nemo.memory" = "nooa_memory.memory_skill:MemorySkill"
@@ -38,4 +44,3 @@ fallback-version = "0.0.6"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nooa_memory"]
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,18 @@ members = [
 
 
 [project.optional-dependencies]
+# Convenience aliases for the sibling distributions, so `pip install
+# nooa[cli]` does what a user reasonably expects. Without these, that command
+# *succeeds* with only a warning and silently installs no CLI.
+#
+# These are deliberately circular (nooa[cli] -> nooa-cli -> nooa); pip and uv
+# both resolve that fine, and it is the standard pattern for a split
+# core/plugin distribution. No version floor, matching the existing policy in
+# packages/*/pyproject.toml: published wheels declare what they actually need
+# rather than being locked to their co-released version.
+cli = ["nooa-cli"]
+memory = ["nooa-memory"]
+bench = ["nooa-bench"]
 # ARC-AGI-3 example agent (examples/arc_agi_3): the public ARC-AGI-3 SDK + deps.
 # Install with `pip install "nemo-oo-agents[arc]"` (or `uv sync --extra arc`).
 arc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,15 @@ authors = [
     {name = "NVIDIA NeMo Team"}
 ]
 requires-python = ">=3.12,<3.14"
+keywords = ["agents", "llm", "codeact", "event-sourcing", "orchestration", "nemo"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 dependencies = [
     "pydantic>=2.5.0",
     # context_blocks + unifiedllm now ship as nooa.context_blocks /
@@ -23,6 +32,12 @@ dependencies = [
     "httpx>=0.27.0",
     "openinference-instrumentation-litellm>=0.1.30",
 ]
+
+[project.urls]
+Homepage = "https://github.com/NVIDIA-NeMo/labs-OO-Agents"
+Repository = "https://github.com/NVIDIA-NeMo/labs-OO-Agents"
+Changelog = "https://github.com/NVIDIA-NeMo/labs-OO-Agents/blob/main/CHANGELOG.md"
+Issues = "https://github.com/NVIDIA-NeMo/labs-OO-Agents/issues"
 
 [project.scripts]
 trace-explorer = "nooa.trace_explorer:main"

--- a/uv.lock
+++ b/uv.lock
@@ -1354,8 +1354,17 @@ arc = [
     { name = "pillow" },
     { name = "rich" },
 ]
+bench = [
+    { name = "nooa-bench" },
+]
+cli = [
+    { name = "nooa-cli" },
+]
 mcp = [
     { name = "mcp" },
+]
+memory = [
+    { name = "nooa-memory" },
 ]
 nemo-relay = [
     { name = "nemo-relay" },
@@ -1420,6 +1429,9 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.84.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "nemo-relay", marker = "extra == 'nemo-relay'", specifier = ">=0.4.0" },
+    { name = "nooa-bench", marker = "extra == 'bench'", editable = "packages/nooa-bench" },
+    { name = "nooa-cli", marker = "extra == 'cli'", editable = "packages/nooa-cli" },
+    { name = "nooa-memory", marker = "extra == 'memory'", editable = "packages/nooa-memory" },
     { name = "openinference-instrumentation", marker = "extra == 'tracing'", specifier = ">=0.1.42" },
     { name = "openinference-instrumentation-litellm", specifier = ">=0.1.30" },
     { name = "openinference-instrumentation-litellm", marker = "extra == 'tracing'", specifier = ">=0.1.28" },
@@ -1434,7 +1446,7 @@ requires-dist = [
     { name = "rich", marker = "extra == 'arc'", specifier = ">=13.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'viewer'", specifier = ">=0.20.0" },
 ]
-provides-extras = ["arc", "mcp", "nemo-relay", "sandbox", "tracing", "viewer"]
+provides-extras = ["arc", "bench", "cli", "mcp", "memory", "nemo-relay", "sandbox", "tracing", "viewer"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Sets up automated PyPI publishing for the four workspace packages. Publishing a **GitHub Release** is the release ceremony — the release's tag is what `uv-dynamic-versioning` turns into the version, exactly as `RELEASING.md` already described.

Nothing here can publish anything on merge. `publish.yml` triggers only on `release: published` and `workflow_dispatch`, and no GitHub Release exists yet.

## Why Releases rather than tag push

A Release *is* a tag, so versioning is unchanged. What it adds: notes live with the artifacts, a draft state to fix mistakes before anything fires, and a human click before an upload that can never be undone — PyPI does not allow reusing a version, even after a delete.

## Safety gates

A bad upload is permanent, so the build job refuses to hand off unless:

- the built version equals the release tag, and is not a `.devN` version (which would mean the tag was not reachable from the checked-out commit — the shallow-clone failure mode);
- all four wheels import cleanly in a fresh venv, and `nooa --version` runs.

## One environment per package

Publishing fans out into a 4-way matrix, each job in its own `pypi-<package>` environment.

PyPI keys a *pending* trusted publisher on (owner, repo, workflow, environment). Four packages sharing one environment collide — the second registration is rejected with *"a pending trusted publisher matching this configuration has already been registered for a different project name"*, because PyPI cannot tell which project to create on first upload. Distinct environments also give per-package approval gates.

Each job uploads only its own artifacts. The glob anchors on the `-` before the version, so `nooa-*` matches the core's files and never `nooa_cli-*`; verified to split the 8 artifacts exactly 2-per-package.

## uv `--no-sources`

Release builds now pass `--no-sources`, [as the uv packaging guide recommends](https://docs.astral.sh/uv/guides/package/) — it disables `tool.uv.sources` so the build is exercised the way a non-uv consumer sees it. Relevant here because all three sub-packages resolve the core via `nooa = { workspace = true }`. The CI build job mirrors the flag so it stays a real canary for release-build breakage.

Verified locally: all four build with `--no-sources`, `twine check` passes on all 8 artifacts, and cross-package deps come out as a plain `Requires-Dist: nooa` with no workspace leakage.

## Packaging metadata

Project URLs on all four; classifiers and keywords on the core; READMEs for `nooa-memory` and `nooa-bench`, which would otherwise have published blank PyPI pages. `nooa-memory`'s description read *"not yet published"* — that string is the one-liner PyPI renders under the package name.

## Before the first release

- [ ] Register pending publishers for all four names (table in `RELEASING.md`) — **environment name differs per package**
- [ ] Admin: add required reviewers to the `pypi-*` environments

The environments themselves do not need pre-creating — GitHub creates them on first workflow reference. But an auto-created environment has no protection rules, so an admin should add reviewers before the first real release. A TestPyPI dry run (Actions → Publish → `testpypi`) is safe unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)