### PR TITLE
ci: run gitleaks directly instead of via the blocked action (fixes all CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,29 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # full history so the scan covers all commits
+      # Invokes the gitleaks binary directly rather than gitleaks/gitleaks-action.
+      # That action is not on this org's GitHub Actions allowlist, and a
+      # disallowed action fails the *entire workflow* at startup — which is why
+      # every CI run since 2026-07-21 was a 0-second `startup_failure` and no
+      # lint, test, or build job ran at all.
+      #
+      # Pinned to an exact version and checksum-verified: the binary is fetched
+      # at runtime, so an unpinned tag would be an unreviewed remote dependency.
       - name: Gitleaks
-        uses: gitleaks/gitleaks-action@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          set -euo pipefail
+          curl -sSLo gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar xzf gitleaks.tar.gz gitleaks
+          # `gitleaks git` exits 0 with "no leaks found" when it has no history
+          # to read — a shallow clone scans 1 commit and passes vacuously, and a
+          # non-repo scans 0. Fail loudly instead of reporting a clean scan.
+          test "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" \
+            || { echo "::error::not a git checkout — gitleaks would pass vacuously"; exit 1; }
+          test "$(git rev-parse --is-shallow-repository)" = "false" \
+            || { echo "::error::shallow clone — gitleaks would miss history (need fetch-depth: 0)"; exit 1; }
+          ./gitleaks git --config .gitleaks.toml --redact --no-banner .


### PR DESCRIPTION
## CI has been completely dead for 8 days

Every workflow run since 2026-07-21 is a 0-second `startup_failure` — **69 of them**, against 30 successes before that point. No lint, no tests, no build, no secret scan has run on any branch, including `main`.

```
2026-07-20        1 success
2026-07-21       29 successes   ← then 9c27a8f lands at 15:09:55Z
2026-07-21T15:10:47Z  ─── first startup_failure (52s later) ───
since            69 startup_failures, 0 successes
```

Roughly **13 PRs have merged with zero validation**, several on `security/*` branches.

This is easy to miss: `startup_failure` renders as a grey dot rather than a red X, and the run reports 0s, so it reads as "nothing to do" rather than "everything is broken."

## Cause

`9c27a8f` ("ci: expand GitHub Actions — build, frontend-check, secret-scan") introduced `gitleaks/gitleaks-action@v2`, which is not on the org's Actions allowlist:

> The action `gitleaks/gitleaks-action@v2` is not allowed in `NVIDIA-NeMo/labs-OO-Agents` because all actions must be from a repository owned by your enterprise, created by GitHub, verified in the GitHub Marketplace, or match one of the patterns: […]

The key detail: **a disallowed action fails the entire workflow at startup**, not just its own job. One blocked reference in `secret-scan` took `lint`, `test`, `build`, and `frontend-build` down with it.

## Fix

Invoke the gitleaks binary directly. Same scan, same `.gitleaks.toml`, no third-party action — so no allowlist can block it.

- **Pinned + checksum-verified.** The binary is fetched at runtime; an unpinned tag would be an unreviewed remote dependency.
- **Guards against a vacuous pass.** `gitleaks git` exits 0 with *"no leaks found"* when it has no history to read — a shallow clone scans 1 commit and reports clean. A scan that silently passes is worse than no scan, so both that and a missing checkout now fail loudly.

## Verified locally

| Case | Result |
|---|---|
| Full history | 69 commits scanned, no leaks, exit 0 |
| `--depth 1` clone | rejected by guard, exit 1 |
| Non-repo directory | rejected by guard, exit 1 |
| Checksum | `551f6fc8…70eb` verified against the v8.30.1 release |

## Note for reviewers

This does not prove the *rest* of the allowlist is satisfied. If CI still shows `startup_failure` after merging, the next suspect is `astral-sh/setup-uv@v5` (used by `lint`, `test`, `build`). This PR is deliberately minimal so its result is a clean signal either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)