### PR TITLE
feat: support deterministic generator agent methods (fix #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ class SupportAgent(Agent):
 
 - **Agents are Python objects.** Fields are state, methods are capabilities, docstrings are prompts, type annotations are contracts.
 - **`...` bodies are LLM-driven.** A method with `...` becomes an agentic loop; a real body stays deterministic Python.
+- **Generation commits one result.** Deterministic `def` and `async def` generators are supported, but combining `yield` with the `...` generation marker is rejected; generated streaming needs a separate stream contract.
 - **Code as action.** The model acts by writing Python in a Jupyter-style REPL with access to `self`, imports, and helpers — Python methods and type annotations supply the callable interfaces, reducing the need to write separate tool-schema definitions.
 - **Pythonic and agent-ready.** Typed I/O with auto-retry, live-object arguments passed by reference, and model-callable context and event APIs — designed around agent-oriented Python workflows.
 

--- a/src/nooa/decorators.py
+++ b/src/nooa/decorators.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
 from nooa.context_blocks import ScopedContext
-from nooa.ellipsis_detection import has_ellipsis_body
+from nooa.ellipsis_detection import has_ellipsis_body, has_ellipsis_marker
 
 if TYPE_CHECKING:
     from nooa.config.truncation_config import TruncationConfig
@@ -92,6 +92,22 @@ def strategy(
         setattr(func, "_strategy_context", final_context)  # noqa: B010
         setattr(func, "_strategy_events", final_events)  # noqa: B010
         setattr(func, "_strategy_truncation", truncation)  # noqa: B010
+
+        # Strategies currently have a single-result contract. Deterministic
+        # generators do not need @strategy and are handled by AgentMeta; generated
+        # streams need a separate strategy protocol rather than this decorator.
+        if inspect.isasyncgenfunction(func) or inspect.isgeneratorfunction(func):
+            if has_ellipsis_marker(func):
+                raise TypeError(
+                    f"@strategy method '{func.__name__}' is an LLM-generated generator. "
+                    f"Generation methods must produce one final result; streaming "
+                    f"generation is not supported."
+                )
+            raise TypeError(
+                f"@strategy cannot be applied to deterministic generator method "
+                f"'{func.__name__}'. Remove @strategy; deterministic generators are "
+                f"supported directly as agent methods."
+            )
 
         # Also create runtime wrapper for dynamically-defined methods
         if not inspect.iscoroutinefunction(func):

--- a/src/nooa/ellipsis_detection.py
+++ b/src/nooa/ellipsis_detection.py
@@ -7,10 +7,12 @@ that use `...` as a marker for LLM code generation.
 
 Functions:
     has_ellipsis_body: Check if function body ENDS with `...`
+    has_ellipsis_marker: Check if a function body contains a generation ellipsis
     get_pre_ellipsis_code: Extract setup code before `...`
 """
 
 import ast
+import dis
 import inspect
 import textwrap
 import tokenize
@@ -114,6 +116,75 @@ def has_ellipsis_body(func: Callable[..., Any]) -> bool:
 
     # If we can't determine, assume it's not ellipsis (safer default)
     return False
+
+
+def has_ellipsis_marker(func: Callable[..., Any]) -> bool:
+    """Return whether *func* contains an ellipsis generation marker.
+
+    Ordinary generation methods are identified by :func:`has_ellipsis_body`,
+    because their body ends in a bare ``...`` statement. Generator functions
+    need a slightly broader check: ``yield ...`` is also a natural spelling of
+    an attempted generated stream. Generated streams are not currently a
+    supported execution model, so both spellings must be diagnosed rather than
+    accidentally executed as deterministic Python.
+
+    Ellipses inside nested functions or classes do not mark the outer function.
+    """
+    func_def = _get_function_ast(func)
+    if func_def is not None:
+
+        class _MarkerVisitor(ast.NodeVisitor):
+            found = False
+
+            def visit_Expr(self, node: ast.Expr) -> None:
+                if _is_ellipsis_stmt(node):
+                    self.found = True
+                    return
+                self.generic_visit(node)
+
+            def visit_Yield(self, node: ast.Yield) -> None:
+                if isinstance(node.value, ast.Constant) and node.value.value is ...:
+                    self.found = True
+
+            def visit_YieldFrom(self, node: ast.YieldFrom) -> None:
+                if isinstance(node.value, ast.Constant) and node.value.value is ...:
+                    self.found = True
+
+            # Nested definitions have their own generation semantics.
+            def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+                return
+
+            def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+                return
+
+            def visit_ClassDef(self, node: ast.ClassDef) -> None:
+                return
+
+            def visit_Lambda(self, node: ast.Lambda) -> None:
+                return
+
+        visitor = _MarkerVisitor()
+        for stmt in _get_body_without_docstring(func_def.body):
+            visitor.visit(stmt)
+        return visitor.found
+
+    # Dynamically created functions may not have source. Detect the direct
+    # ``LOAD_CONST Ellipsis; YIELD_VALUE`` bytecode shape without treating
+    # ordinary uses such as ``items[...]`` as generation markers. The existing
+    # body detector covers functions carrying ``_generated_source``.
+    try:
+        instructions = list(dis.get_instructions(func))
+        for index, current in enumerate(instructions):
+            if current.opname != "LOAD_CONST" or current.argval is not ...:
+                continue
+            for following in instructions[index + 1 : index + 3]:
+                if following.opname == "YIELD_VALUE":
+                    return True
+                if following.opname not in {"ASYNC_GEN_WRAP", "CALL_INTRINSIC_1"}:
+                    break
+    except Exception:
+        pass
+    return has_ellipsis_body(func)
 
 
 def get_pre_ellipsis_code(func: Callable[..., Any]) -> str | None:

--- a/src/nooa/metaclass.py
+++ b/src/nooa/metaclass.py
@@ -19,7 +19,7 @@ from abc import ABCMeta
 from collections.abc import Callable
 from typing import Any
 
-from nooa.ellipsis_detection import has_ellipsis_body
+from nooa.ellipsis_detection import has_ellipsis_body, has_ellipsis_marker
 
 
 class AgentMeta(ABCMeta):
@@ -31,8 +31,13 @@ class AgentMeta(ABCMeta):
     Auto-wrapping criteria:
     - Generatable: async + ellipsis body (all: public, private, dunder)
     - Traceable (async): all async methods (if class sets _enable_tracing = True)
+    - Traceable (async generator): deterministic async-generator methods
     - Traceable (sync): all sync `def` methods except dunder names
       (if class sets _enable_tracing = True)
+    - Traceable (sync generator): deterministic sync-generator methods except dunders
+
+    Generator methods containing an ellipsis generation marker are rejected:
+    generation strategies commit one final result and do not define a stream protocol.
 
     Sync methods can't generate or run async middleware; they get tracing only.
     Properties, classmethods, and staticmethods are skipped (they aren't plain
@@ -75,21 +80,25 @@ class AgentMeta(ABCMeta):
             if hasattr(attr_value, "_agent_decorator"):
                 continue
 
-            # Async generator functions (async def … yield) are mutually exclusive
-            # with coroutine functions, so this guard must come first.  The sync
-            # wrapper closes its span before the generator body runs; the async
-            # wrapper awaits the whole coroutine, which an async gen is not.
-            # Either way the span would cover no real work and misattribute every
-            # nested LLM call to the consumer rather than the generator.  Reject
-            # loudly at class-creation time instead of emitting a wrong trace.
+            # Async generators are a distinct callable shape: they must preserve
+            # suspension semantics rather than pass through the coroutine or sync
+            # wrappers. Deterministic streams are supported; LLM-generated streams
+            # are not yet a defined generation strategy contract.
             if inspect.isasyncgenfunction(attr_value):
-                raise TypeError(
-                    f"{name}.{attr_name} is an async generator method "
-                    f"(async def with yield).  Generator methods are not supported "
-                    f"as agent methods — the framework cannot correctly scope a "
-                    f"tracing span across yield points.  Use a regular async def "
-                    f"with return instead."
-                )
+                if has_ellipsis_marker(attr_value):
+                    raise TypeError(
+                        f"{name}.{attr_name} is an LLM-generated async generator method. "
+                        f"Generation methods must produce one final result; streaming "
+                        f"generation is not supported. Remove the ellipsis to keep this "
+                        f"as a deterministic async generator, or use a regular async def "
+                        f"that returns a collected result."
+                    )
+
+                should_trace = mcs._should_trace(attr_name, attr_value, should_trace_class)
+                if should_trace:
+                    wrapped = mcs._create_async_generator_wrapper(attr_value)
+                    type.__setattr__(cls, attr_name, wrapped)
+                continue
 
             if inspect.iscoroutinefunction(attr_value):
                 # === Async method path (generation + tracing) ===
@@ -113,25 +122,30 @@ class AgentMeta(ABCMeta):
                 # === Sync method path (tracing only) ===
                 # `inspect.isfunction` is False for property/classmethod/staticmethod
                 # descriptors, so those are naturally skipped.
+                if inspect.isgeneratorfunction(attr_value):
+                    if has_ellipsis_marker(attr_value):
+                        raise TypeError(
+                            f"{name}.{attr_name} is an LLM-generated sync generator method. "
+                            f"Generation methods must be async and produce one final result; "
+                            f"streaming generation is not supported. Remove the ellipsis to "
+                            f"keep this as a deterministic generator, or return a collected "
+                            f"result from a regular async generation method."
+                        )
+
+                    # Sync dunders are intentionally never traced.
+                    if attr_name.startswith("__") and attr_name.endswith("__"):
+                        continue
+                    should_trace = mcs._should_trace(attr_name, attr_value, should_trace_class)
+                    if should_trace:
+                        wrapped = mcs._create_generator_wrapper(attr_value)
+                        type.__setattr__(cls, attr_name, wrapped)
+                    continue
+
                 # Skip dunders to avoid wrapping __init__/__init_subclass__/__setattr__/
                 # __getattribute__ etc. — risk of infinite recursion or running before
                 # the runtime exists. Custom dunders have to be async to be traced.
                 if attr_name.startswith("__") and attr_name.endswith("__"):
                     continue
-
-                # Sync generator functions (def … yield) hit this branch because
-                # inspect.isfunction returns True for them.  The sync wrapper calls
-                # the original once and treats the returned generator object as the
-                # result, closing the span before any body code runs.  Same class
-                # of misattribution as the async generator case above — reject now.
-                if inspect.isgeneratorfunction(attr_value):
-                    raise TypeError(
-                        f"{name}.{attr_name} is a sync generator method "
-                        f"(def with yield).  Generator methods are not supported "
-                        f"as agent methods — the framework cannot correctly scope a "
-                        f"tracing span across yield points.  Use a regular def with "
-                        f"return instead."
-                    )
 
                 should_trace = mcs._should_trace(attr_name, attr_value, should_trace_class)
                 if should_trace:
@@ -222,6 +236,32 @@ class AgentMeta(ABCMeta):
 
         cached_source_code = AgentMeta._extract_source_code(original_func)
         return create_sync_agent_method_wrapper(
+            original_func,
+            needs_tracing=True,
+            cached_source_code=cached_source_code,
+        )
+
+    @staticmethod
+    def _create_async_generator_wrapper(
+        original_func: Callable[..., Any],
+    ) -> Callable[..., Any]:
+        """Create a tracing wrapper for a deterministic async generator."""
+        from nooa.runtime.method_wrapper import create_async_generator_agent_method_wrapper
+
+        cached_source_code = AgentMeta._extract_source_code(original_func)
+        return create_async_generator_agent_method_wrapper(
+            original_func,
+            needs_tracing=True,
+            cached_source_code=cached_source_code,
+        )
+
+    @staticmethod
+    def _create_generator_wrapper(original_func: Callable[..., Any]) -> Callable[..., Any]:
+        """Create a tracing wrapper for a deterministic sync generator."""
+        from nooa.runtime.method_wrapper import create_generator_agent_method_wrapper
+
+        cached_source_code = AgentMeta._extract_source_code(original_func)
+        return create_generator_agent_method_wrapper(
             original_func,
             needs_tracing=True,
             cached_source_code=cached_source_code,

--- a/src/nooa/metaclass.py
+++ b/src/nooa/metaclass.py
@@ -75,6 +75,22 @@ class AgentMeta(ABCMeta):
             if hasattr(attr_value, "_agent_decorator"):
                 continue
 
+            # Async generator functions (async def … yield) are mutually exclusive
+            # with coroutine functions, so this guard must come first.  The sync
+            # wrapper closes its span before the generator body runs; the async
+            # wrapper awaits the whole coroutine, which an async gen is not.
+            # Either way the span would cover no real work and misattribute every
+            # nested LLM call to the consumer rather than the generator.  Reject
+            # loudly at class-creation time instead of emitting a wrong trace.
+            if inspect.isasyncgenfunction(attr_value):
+                raise TypeError(
+                    f"{name}.{attr_name} is an async generator method "
+                    f"(async def with yield).  Generator methods are not supported "
+                    f"as agent methods — the framework cannot correctly scope a "
+                    f"tracing span across yield points.  Use a regular async def "
+                    f"with return instead."
+                )
+
             if inspect.iscoroutinefunction(attr_value):
                 # === Async method path (generation + tracing) ===
                 should_generate = mcs._should_generate(attr_name, attr_value)
@@ -102,6 +118,20 @@ class AgentMeta(ABCMeta):
                 # the runtime exists. Custom dunders have to be async to be traced.
                 if attr_name.startswith("__") and attr_name.endswith("__"):
                     continue
+
+                # Sync generator functions (def … yield) hit this branch because
+                # inspect.isfunction returns True for them.  The sync wrapper calls
+                # the original once and treats the returned generator object as the
+                # result, closing the span before any body code runs.  Same class
+                # of misattribution as the async generator case above — reject now.
+                if inspect.isgeneratorfunction(attr_value):
+                    raise TypeError(
+                        f"{name}.{attr_name} is a sync generator method "
+                        f"(def with yield).  Generator methods are not supported "
+                        f"as agent methods — the framework cannot correctly scope a "
+                        f"tracing span across yield points.  Use a regular def with "
+                        f"return instead."
+                    )
 
                 should_trace = mcs._should_trace(attr_name, attr_value, should_trace_class)
                 if should_trace:

--- a/src/nooa/runtime/hooks.py
+++ b/src/nooa/runtime/hooks.py
@@ -27,11 +27,23 @@ Usage:
 """
 
 import logging
+import sys
 import time
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
 from contextvars import ContextVar
 from typing import Any, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class AgentCallContextActivator(Protocol):
+    """Optional hook extension for methods that suspend and later resume."""
+
+    def activate_agent_call(self, context: Any) -> AbstractContextManager[None]:
+        """Restore the native tracing context represented by ``context``."""
+        ...
 
 
 @runtime_checkable
@@ -412,10 +424,54 @@ def call_after_hook(hook_name: str, context: Any, **kwargs: Any) -> None:
         _record_tracing_overhead(time.perf_counter() - t0)
 
 
+@contextmanager
+def activate_agent_call_context(context: Any) -> Iterator[None]:
+    """Activate an instrumentation call context for suspended-method execution.
+
+    Most methods run continuously between their before/after hooks, so hook
+    implementations can recover parentage from the framework call stack. A
+    generator can instead resume in a different task, where task-local tracing
+    state is intentionally absent. Instrumentation backends may implement
+    ``activate_agent_call(context)`` as a context manager to restore their native
+    context for each resume.
+
+    Activation is optional and defensive: hook failures are logged and never
+    prevent the generator body from running or change exception propagation.
+    """
+    hooks = get_hooks()
+    if not isinstance(hooks, AgentCallContextActivator) or context is None:
+        yield
+        return
+
+    try:
+        manager = hooks.activate_agent_call(context)
+        manager.__enter__()
+    except Exception:
+        logger.warning("Hook activate_agent_call failed", exc_info=True)
+        yield
+        return
+
+    try:
+        yield
+    except BaseException:
+        try:
+            manager.__exit__(*sys.exc_info())
+        except Exception:
+            logger.warning("Hook activate_agent_call cleanup failed", exc_info=True)
+        raise
+    else:
+        try:
+            manager.__exit__(None, None, None)
+        except Exception:
+            logger.warning("Hook activate_agent_call cleanup failed", exc_info=True)
+
+
 __all__ = [
+    "AgentCallContextActivator",
     "InstrumentationHooks",
     "set_hooks",
     "get_hooks",
     "call_before_hook",
     "call_after_hook",
+    "activate_agent_call_context",
 ]

--- a/src/nooa/runtime/method_wrapper.py
+++ b/src/nooa/runtime/method_wrapper.py
@@ -12,7 +12,8 @@ for context variable management, tracing hooks, and execution routing.
 
 import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable, Generator
+from contextlib import contextmanager
 from functools import wraps
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
@@ -27,7 +28,11 @@ from nooa.runtime.context_vars import (
     _pop_agent_call_id,
     _push_agent_call_id,
 )
-from nooa.runtime.hooks import call_after_hook, call_before_hook
+from nooa.runtime.hooks import (
+    activate_agent_call_context,
+    call_after_hook,
+    call_before_hook,
+)
 
 if TYPE_CHECKING:
     from nooa.strategies.base import GenerationStrategy
@@ -49,6 +54,112 @@ async def _flush_litellm_journal() -> None:
         await asyncio.to_thread(flush_pending)
     finally:
         _in_agent_context.reset(token)
+
+
+@contextmanager
+def _generator_resume_context(agent: Any, call_id: str | None) -> Generator[None, None, None]:
+    """Activate agent context only while a generator body is running.
+
+    A generator suspends at every yield. Leaving these ContextVars active while
+    control is in the consumer would incorrectly make consumer work a child of
+    the generator method.
+    """
+    current_parent = _parent_agent_var.get()
+    is_subagent_call = current_parent is not None and current_parent is not agent
+
+    scoped_blocks_token = None
+    scoped_events_token = None
+    if is_subagent_call:
+        scoped_blocks_token = _scoped_blocks_var.set(None)
+        scoped_events_token = _scoped_events_var.set(None)
+
+    _push_agent_call_id(call_id)
+    parent_token = _parent_agent_var.set(agent)
+    try:
+        yield
+    finally:
+        _parent_agent_var.reset(parent_token)
+        if scoped_blocks_token is not None:
+            _scoped_blocks_var.reset(scoped_blocks_token)
+        if scoped_events_token is not None:
+            _scoped_events_var.reset(scoped_events_token)
+        _pop_agent_call_id()
+
+
+def _start_generator_call(
+    agent: Any,
+    original_func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    call_id: str,
+    parent_call_id: str | None,
+    is_top_level: bool,
+    tracing_enabled: bool,
+    trace_attrs: dict[str, Any],
+) -> Any:
+    """Emit lifecycle start signals for a deterministic generator method."""
+    try:
+        agent.event_manager.add(
+            BeforeAgentCall(
+                method_name=original_func.__name__,
+                call_id=call_id,
+                parent_call_id=parent_call_id,
+                is_top_level=is_top_level,
+                needs_generation=False,
+            )
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("agent-call: BeforeAgentCall emission failed (generator)", exc_info=True)
+
+    if not tracing_enabled:
+        return None
+    return call_before_hook(
+        "before_agent_call",
+        agent=agent,
+        method_name=original_func.__name__,
+        args=args,
+        kwargs=kwargs,
+        call_id=call_id,
+        parent_call_id=parent_call_id,
+        **trace_attrs,
+    )
+
+
+def _finish_generator_call(
+    agent: Any,
+    original_func: Callable[..., Any],
+    call_id: str,
+    parent_call_id: str | None,
+    is_top_level: bool,
+    hook_context: Any,
+    result: Any,
+    exception: BaseException | None,
+) -> None:
+    """Emit lifecycle completion signals for a deterministic generator method."""
+    try:
+        agent.event_manager.add(
+            AfterAgentCall(
+                method_name=original_func.__name__,
+                call_id=call_id,
+                parent_call_id=parent_call_id,
+                is_top_level=is_top_level,
+                needs_generation=False,
+                success=exception is None,
+                exception_type=type(exception).__name__ if exception is not None else None,
+            )
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("agent-call: AfterAgentCall emission failed (generator)", exc_info=True)
+
+    if hook_context is not None:
+        call_after_hook(
+            "after_agent_call",
+            hook_context,
+            agent=agent,
+            method_name=original_func.__name__,
+            result=result,
+            exception=exception,
+        )
 
 
 def create_agent_method_wrapper(
@@ -377,6 +488,278 @@ def create_agent_method_wrapper(
     # Expose the mutable flag so @no_trace applied after @strategy can flip it
     setattr(wrapper, "_tracing_enabled", _tracing_enabled)  # noqa: B010
 
+    return wrapper
+
+
+def create_async_generator_agent_method_wrapper(
+    original_func: Callable[..., AsyncGenerator[Any, Any]],
+    *,
+    needs_tracing: bool,
+    cached_source_code: str | None = None,
+) -> Callable[..., AsyncGenerator[Any, Any]]:
+    """Wrap a deterministic async-generator agent method for tracing.
+
+    The method span starts on first iteration and ends on exhaustion, explicit
+    close, cancellation, or failure. Agent ContextVars are active only while the
+    generator body is advancing, never while control is suspended in its consumer.
+
+    ``agent_call`` middleware is intentionally not run: its contract represents
+    one awaited result and cannot model a suspended stream. A stream middleware
+    protocol should be added separately if interception of yielded values is needed.
+    """
+    _tracing_enabled = [needs_tracing]
+    no_send = object()
+
+    @wraps(original_func)
+    async def wrapper(self: Any, *args: Any, **kwargs: Any) -> AsyncGenerator[Any, Any]:
+        if not hasattr(self, "runtime"):
+            inner = original_func(self, *args, **kwargs)
+            send_value: Any = no_send
+            thrown: BaseException | None = None
+            while True:
+                try:
+                    if thrown is not None:
+                        item = await inner.athrow(thrown)
+                        thrown = None
+                    elif send_value is no_send:
+                        item = await anext(inner)
+                    else:
+                        item = await inner.asend(send_value)
+                        send_value = no_send
+                except StopAsyncIteration:
+                    return
+
+                try:
+                    send_value = yield item
+                except GeneratorExit:
+                    await inner.aclose()
+                    return
+                except BaseException as exc:
+                    thrown = exc
+                    send_value = no_send
+
+        runtime = self.runtime
+        call_id = str(uuid4())
+        parent_call_id = runtime._agent_call_id
+        is_top_level = _parent_agent_var.get() is None
+        active_call_id = call_id if _tracing_enabled[0] else parent_call_id
+        trace_attrs = _build_trace_attributes(
+            needs_generation=False,
+            strategy=None,
+            cached_source_code=cached_source_code,
+        )
+
+        inner = original_func(self, *args, **kwargs)
+        hook_context = None
+        result = None
+        exception_caught: BaseException | None = None
+        inner_closed = False
+        send_value: Any = no_send
+        thrown: BaseException | None = None
+
+        try:
+            with _generator_resume_context(self, active_call_id):
+                hook_context = _start_generator_call(
+                    self,
+                    original_func,
+                    args,
+                    kwargs,
+                    call_id,
+                    parent_call_id,
+                    is_top_level,
+                    _tracing_enabled[0],
+                    trace_attrs,
+                )
+
+            while True:
+                try:
+                    with (
+                        _generator_resume_context(self, active_call_id),
+                        activate_agent_call_context(hook_context),
+                    ):
+                        if thrown is not None:
+                            item = await inner.athrow(thrown)
+                            thrown = None
+                        elif send_value is no_send:
+                            item = await anext(inner)
+                        else:
+                            item = await inner.asend(send_value)
+                            send_value = no_send
+                except StopAsyncIteration:
+                    inner_closed = True
+                    return
+
+                try:
+                    send_value = yield item
+                except GeneratorExit:
+                    with (
+                        _generator_resume_context(self, active_call_id),
+                        activate_agent_call_context(hook_context),
+                    ):
+                        await inner.aclose()
+                    inner_closed = True
+                    return
+                except BaseException as exc:
+                    thrown = exc
+                    send_value = no_send
+        except BaseException as exc:
+            exception_caught = exc
+            raise
+        finally:
+            close_error: BaseException | None = None
+            if not inner_closed:
+                try:
+                    with (
+                        _generator_resume_context(self, active_call_id),
+                        activate_agent_call_context(hook_context),
+                    ):
+                        await inner.aclose()
+                except BaseException as close_exc:
+                    if exception_caught is None:
+                        exception_caught = close_exc
+                        close_error = close_exc
+            with activate_agent_call_context(hook_context):
+                _finish_generator_call(
+                    self,
+                    original_func,
+                    call_id,
+                    parent_call_id,
+                    is_top_level,
+                    hook_context,
+                    result,
+                    exception_caught,
+                )
+            if close_error is not None:
+                raise close_error
+
+    setattr(wrapper, "_agent_decorator", "auto")  # noqa: B010
+    setattr(wrapper, "_needs_generation", False)  # noqa: B010
+    setattr(wrapper, "_plan_strategy", None)  # noqa: B010
+    setattr(wrapper, "_tracing_enabled", _tracing_enabled)  # noqa: B010
+    setattr(wrapper, "_original", original_func)  # noqa: B010
+    return wrapper
+
+
+def create_generator_agent_method_wrapper(
+    original_func: Callable[..., Generator[Any, Any, Any]],
+    *,
+    needs_tracing: bool,
+    cached_source_code: str | None = None,
+) -> Callable[..., Generator[Any, Any, Any]]:
+    """Wrap a deterministic sync-generator agent method for tracing.
+
+    As with the async-generator wrapper, call context is active only while the
+    body advances. ``send()``, ``throw()``, ``close()``, and the generator's
+    final return value are forwarded.
+    """
+    _tracing_enabled = [needs_tracing]
+    no_send = object()
+
+    @wraps(original_func)
+    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Generator[Any, Any, Any]:
+        if not hasattr(self, "runtime"):
+            return (yield from original_func(self, *args, **kwargs))
+
+        runtime = self.runtime
+        call_id = str(uuid4())
+        parent_call_id = runtime._agent_call_id
+        is_top_level = _parent_agent_var.get() is None
+        active_call_id = call_id if _tracing_enabled[0] else parent_call_id
+        trace_attrs = _build_trace_attributes(
+            needs_generation=False,
+            strategy=None,
+            cached_source_code=cached_source_code,
+        )
+
+        inner = original_func(self, *args, **kwargs)
+        hook_context = None
+        result = None
+        exception_caught: BaseException | None = None
+        inner_closed = False
+        send_value: Any = no_send
+        thrown: BaseException | None = None
+
+        try:
+            with _generator_resume_context(self, active_call_id):
+                hook_context = _start_generator_call(
+                    self,
+                    original_func,
+                    args,
+                    kwargs,
+                    call_id,
+                    parent_call_id,
+                    is_top_level,
+                    _tracing_enabled[0],
+                    trace_attrs,
+                )
+
+            while True:
+                try:
+                    with (
+                        _generator_resume_context(self, active_call_id),
+                        activate_agent_call_context(hook_context),
+                    ):
+                        if thrown is not None:
+                            item = inner.throw(thrown)
+                            thrown = None
+                        elif send_value is no_send:
+                            item = next(inner)
+                        else:
+                            item = inner.send(send_value)
+                            send_value = no_send
+                except StopIteration as stop:
+                    result = stop.value
+                    inner_closed = True
+                    return result
+
+                try:
+                    send_value = yield item
+                except GeneratorExit:
+                    with (
+                        _generator_resume_context(self, active_call_id),
+                        activate_agent_call_context(hook_context),
+                    ):
+                        inner.close()
+                    inner_closed = True
+                    return
+                except BaseException as exc:
+                    thrown = exc
+                    send_value = no_send
+        except BaseException as exc:
+            exception_caught = exc
+            raise
+        finally:
+            close_error: BaseException | None = None
+            if not inner_closed:
+                try:
+                    with (
+                        _generator_resume_context(self, active_call_id),
+                        activate_agent_call_context(hook_context),
+                    ):
+                        inner.close()
+                except BaseException as close_exc:
+                    if exception_caught is None:
+                        exception_caught = close_exc
+                        close_error = close_exc
+            with activate_agent_call_context(hook_context):
+                _finish_generator_call(
+                    self,
+                    original_func,
+                    call_id,
+                    parent_call_id,
+                    is_top_level,
+                    hook_context,
+                    result,
+                    exception_caught,
+                )
+            if close_error is not None:
+                raise close_error
+
+    setattr(wrapper, "_agent_decorator", "auto")  # noqa: B010
+    setattr(wrapper, "_needs_generation", False)  # noqa: B010
+    setattr(wrapper, "_plan_strategy", None)  # noqa: B010
+    setattr(wrapper, "_tracing_enabled", _tracing_enabled)  # noqa: B010
+    setattr(wrapper, "_original", original_func)  # noqa: B010
     return wrapper
 
 

--- a/src/nooa/tracing/_hooks_impl.py
+++ b/src/nooa/tracing/_hooks_impl.py
@@ -197,6 +197,14 @@ class OpenInferenceHooks:
         # This pattern prevents potential timing issues with ContextVar inheritance in async contexts
         spans_dict = _get_active_spans()
         parent_span = spans_dict.get(parent_call_id) if parent_call_id else None
+        if parent_span is None and parent_call_id:
+            # Suspended methods may resume in a different task, whose task-local
+            # registry intentionally starts empty. Their wrapper explicitly
+            # reactivates the lifecycle span, making the native OTel context the
+            # authoritative fallback for child parentage.
+            current_span = trace.get_current_span()
+            if current_span.get_span_context().is_valid:
+                parent_span = current_span
 
         # If this method was invoked directly from an agent's executing code (e.g.
         # self.submit() inside execute_python), nest it under the active code_execution
@@ -284,9 +292,20 @@ class OpenInferenceHooks:
         return {
             "span": span,
             "call_id": call_id,
+            "_span_registry": spans_dict,
             **extra_kwargs,
             "start_time": time.time(),
         }
+
+    @contextlib.contextmanager
+    def activate_agent_call(self, context: Any):
+        """Make an existing agent-call span current without ending it."""
+        span = context.get("span") if isinstance(context, dict) else None
+        if span is None:
+            yield
+            return
+        with trace.use_span(span, end_on_exit=False):
+            yield
 
     def after_agent_call(
         self,
@@ -328,7 +347,10 @@ class OpenInferenceHooks:
         self._turn_counters.pop(call_id, None)
 
         # Remove from tracking
-        if call_id and call_id in _get_active_spans():
+        registry = context.get("_span_registry")
+        if isinstance(registry, dict):
+            registry.pop(call_id, None)
+        elif call_id and call_id in _get_active_spans():
             del _get_active_spans()[call_id]
 
     def before_generation(

--- a/tests/test_ellipsis_detection_exec.py
+++ b/tests/test_ellipsis_detection_exec.py
@@ -7,7 +7,7 @@ This tests the critical path where PurePythonStrategy generates code with
 """
 
 from nooa.decorators import strategy
-from nooa.ellipsis_detection import has_ellipsis_body
+from nooa.ellipsis_detection import has_ellipsis_body, has_ellipsis_marker
 from nooa.strategies import PredictStrategy
 from nooa.strategies.generated_code import HelperFunctionManager
 
@@ -63,6 +63,22 @@ async def my_method(self, x: int) -> str:
 
         # Should detect ellipsis body via _generated_source
         assert has_ellipsis_body(func) is True
+
+
+class TestHasEllipsisMarkerExec:
+    """Test source-less generator marker detection without false positives."""
+
+    def test_yield_ellipsis_is_detected_from_bytecode(self):
+        namespace = {}
+        exec("async def generated():\n    yield ...", namespace)
+
+        assert has_ellipsis_marker(namespace["generated"]) is True
+
+    def test_ellipsis_index_is_not_a_generation_marker(self):
+        namespace = {}
+        exec("async def deterministic(items):\n    yield items[...]", namespace)
+
+        assert has_ellipsis_marker(namespace["deterministic"]) is False
 
 
 class TestHelperFunctionManagerSourceTracking:

--- a/tests/test_metaclass.py
+++ b/tests/test_metaclass.py
@@ -1395,6 +1395,73 @@ def test_sync_method_calling_sync_method_chains_parent_call_id():
     assert inner_call["parent_call_id"] == outer_call["call_id"]
 
 
+# ============================================================================
+# Regression tests for generator method rejection (issue #38)
+#
+# Previously, async generator methods (async def … yield) were silently
+# mis-dispatched to create_sync_agent_method_wrapper.  That wrapper calls the
+# original once and treats the returned generator *object* as the result,
+# closing the span before any body code runs.  Every nested LLM call was then
+# parented to the consumer, not the generator — the trace asserted a call
+# sequence that never happened.
+#
+# The correct behaviour is an explicit TypeError at class-creation time so
+# the author is told clearly what is wrong, rather than receiving a
+# confidently wrong audit trail.
+# ============================================================================
+
+
+def test_async_generator_method_raises_at_class_creation():
+    """async def methods with yield must be rejected at class creation (issue #38)."""
+    with pytest.raises(TypeError, match="async generator"):
+
+        class BadAgent(Agent, llm=_TEST_LLM):
+            async def review(self, items: list[str]):
+                for item in items:
+                    yield item
+
+
+def test_sync_generator_method_raises_at_class_creation():
+    """def methods with yield must be rejected at class creation (issue #38)."""
+    with pytest.raises(TypeError, match="sync generator"):
+
+        class BadAgent(Agent, llm=_TEST_LLM):
+            def produce(self, items: list[str]):
+                yield from items
+
+
+def test_generator_error_message_names_method():
+    """TypeError must include the method name so authors can find the offender."""
+    with pytest.raises(TypeError, match="review"):
+
+        class BadAgent(Agent, llm=_TEST_LLM):
+            async def review(self, items: list[str]):
+                for item in items:
+                    yield item
+
+
+def test_regular_async_method_unaffected_by_generator_guard():
+    """Regular async def (no yield) must still be accepted after the guard."""
+
+    class GoodAgent(Agent, llm=_TEST_LLM):
+        async def review(self, items: list[str]) -> list[str]:
+            return items
+
+    assert hasattr(GoodAgent.review, "_agent_decorator")
+    assert GoodAgent.review._needs_generation is False
+
+
+def test_regular_sync_method_unaffected_by_generator_guard():
+    """Regular def (no yield) must still be wrapped for tracing after the guard."""
+
+    class GoodAgent(Agent, llm=_TEST_LLM):
+        def produce(self, items: list[str]) -> list[str]:
+            return items
+
+    assert hasattr(GoodAgent.produce, "_agent_decorator")
+    assert GoodAgent.produce._needs_generation is False
+
+
 def test_agent_init_succeeds_with_sync_tracing_active():
     """Agent.__init__ calls sync helpers BEFORE self.runtime exists; must not crash."""
     from unittest.mock import MagicMock

--- a/tests/test_metaclass.py
+++ b/tests/test_metaclass.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for AgentMeta metaclass and auto-wrapping functionality."""
 
+import inspect
+
 import pytest
 
 from nooa.agent import Agent
@@ -1396,7 +1398,7 @@ def test_sync_method_calling_sync_method_chains_parent_call_id():
 
 
 # ============================================================================
-# Regression tests for generator method rejection (issue #38)
+# Regression tests for generator method support (issue #38)
 #
 # Previously, async generator methods (async def … yield) were silently
 # mis-dispatched to create_sync_agent_method_wrapper.  That wrapper calls the
@@ -1405,29 +1407,143 @@ def test_sync_method_calling_sync_method_chains_parent_call_id():
 # parented to the consumer, not the generator — the trace asserted a call
 # sequence that never happened.
 #
-# The correct behaviour is an explicit TypeError at class-creation time so
-# the author is told clearly what is wrong, rather than receiving a
-# confidently wrong audit trail.
+# Deterministic generators remain ordinary Python methods and receive
+# generator-aware tracing. Generators containing the ellipsis generation marker
+# are rejected because generation strategies currently produce one final result.
 # ============================================================================
 
 
-def test_async_generator_method_raises_at_class_creation():
-    """async def methods with yield must be rejected at class creation (issue #38)."""
-    with pytest.raises(TypeError, match="async generator"):
+@pytest.mark.asyncio
+async def test_deterministic_async_generator_method_is_supported():
+    """Implemented async generators retain their native iteration contract."""
+
+    class StreamAgent(Agent, llm=_TEST_LLM):
+        async def review(self, items: list[str]):
+            for item in items:
+                yield item.upper()
+
+    assert inspect.isasyncgenfunction(StreamAgent.review)
+    assert hasattr(StreamAgent.review, "_agent_decorator")
+    assert [item async for item in StreamAgent().review(["a", "b"])] == ["A", "B"]
+
+
+@pytest.mark.asyncio
+async def test_async_generator_forwards_asend_and_athrow():
+    """Tracing does not narrow the native async-generator protocol."""
+
+    class StreamAgent(Agent, llm=_TEST_LLM):
+        async def exchange(self):
+            received = yield "ready"
+            try:
+                yield received
+            except ValueError:
+                yield "handled"
+
+    stream = StreamAgent().exchange()
+    assert await anext(stream) == "ready"
+    assert await stream.asend("sent") == "sent"
+    assert await stream.athrow(ValueError("recover")) == "handled"
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+
+
+@pytest.mark.asyncio
+async def test_deterministic_async_generator_allows_ordinary_ellipsis_expressions():
+    """Only marker syntax is reserved; annotations and indexing remain Python."""
+
+    class EllipsisIndex:
+        def __getitem__(self, key):
+            assert key is ...
+            return 7
+
+    class StreamAgent(Agent, llm=_TEST_LLM):
+        async def values(self):
+            selected = EllipsisIndex()[...]
+            annotated: tuple[int, ...] = (selected,)
+            for value in annotated:
+                yield value
+
+    assert [item async for item in StreamAgent().values()] == [7]
+
+
+@pytest.mark.asyncio
+async def test_async_generator_without_runtime_preserves_native_protocol():
+    """The pre-runtime path forwards asend and athrow instead of narrowing iteration."""
+
+    class StreamAgent(Agent, llm=_TEST_LLM):
+        def __init__(self):
+            pass
+
+        async def exchange(self):
+            received = yield "ready"
+            try:
+                yield received
+            except ValueError:
+                yield "handled"
+
+    stream = StreamAgent().exchange()
+    assert await anext(stream) == "ready"
+    assert await stream.asend("sent") == "sent"
+    assert await stream.athrow(ValueError("recover")) == "handled"
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+
+
+def test_deterministic_sync_generator_method_is_supported():
+    """Implemented sync generators retain yield/send/return behavior."""
+
+    class StreamAgent(Agent, llm=_TEST_LLM):
+        def values(self):
+            received = yield 1
+            yield received
+            return "done"
+
+    assert inspect.isgeneratorfunction(StreamAgent.values)
+    stream = StreamAgent().values()
+    assert next(stream) == 1
+    assert stream.send(2) == 2
+    with pytest.raises(StopIteration, match="done"):
+        next(stream)
+
+
+def test_generated_async_generator_method_raises_at_class_creation():
+    """An async generator with the LLM marker gets a targeted error."""
+    with pytest.raises(TypeError, match="LLM-generated async generator"):
 
         class BadAgent(Agent, llm=_TEST_LLM):
             async def review(self, items: list[str]):
                 for item in items:
                     yield item
+                ...
 
 
-def test_sync_generator_method_raises_at_class_creation():
-    """def methods with yield must be rejected at class creation (issue #38)."""
-    with pytest.raises(TypeError, match="sync generator"):
+def test_yield_ellipsis_async_generator_gets_targeted_error():
+    """``yield ...`` is diagnosed as an attempted generated stream."""
+    with pytest.raises(TypeError, match="streaming generation is not supported"):
+
+        class BadAgent(Agent, llm=_TEST_LLM):
+            async def review(self):
+                yield ...
+
+
+def test_strategy_generator_error_explains_single_result_contract():
+    """@strategy rejects generated streams without claiming they are not async."""
+    with pytest.raises(TypeError, match="must produce one final result"):
+
+        class BadAgent(Agent, llm=_TEST_LLM):
+            @strategy(PurePythonStrategy())
+            async def review(self):
+                yield ...
+
+
+def test_generated_sync_generator_method_raises_at_class_creation():
+    """A sync generator cannot opt into LLM generation either."""
+    with pytest.raises(TypeError, match="LLM-generated sync generator"):
 
         class BadAgent(Agent, llm=_TEST_LLM):
             def produce(self, items: list[str]):
                 yield from items
+                ...
 
 
 def test_generator_error_message_names_method():
@@ -1438,6 +1554,124 @@ def test_generator_error_message_names_method():
             async def review(self, items: list[str]):
                 for item in items:
                     yield item
+                ...
+
+
+@pytest.mark.asyncio
+async def test_async_generator_trace_context_is_active_only_during_resume():
+    """Nested calls belong to the stream; consumer work between yields does not."""
+    from unittest.mock import MagicMock
+
+    from nooa.runtime.hooks import InstrumentationHooks, set_hooks
+
+    before_calls: list[dict] = []
+
+    def before(**kwargs):
+        before_calls.append(kwargs)
+        return {"call_id": kwargs["call_id"]}
+
+    mock_hooks = MagicMock(spec=InstrumentationHooks)
+    mock_hooks.before_agent_call.side_effect = before
+
+    class StreamAgent(Agent, llm=_TEST_LLM):
+        async def classify(self, item: int) -> int:
+            return item * 10
+
+        async def review(self):
+            yield await self.classify(1)
+            yield await self.classify(2)
+
+        async def consumer_work(self) -> None:
+            return None
+
+    try:
+        set_hooks(mock_hooks)
+        agent = StreamAgent()
+        stream = agent.review()
+        assert before_calls == []  # Calling a generator does not execute its body.
+        assert await anext(stream) == 10
+        await agent.consumer_work()
+        assert await anext(stream) == 20
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
+    finally:
+        set_hooks(None)
+
+    review_call = next(c for c in before_calls if c["method_name"] == "review")
+    classify_calls = [c for c in before_calls if c["method_name"] == "classify"]
+    consumer_call = next(c for c in before_calls if c["method_name"] == "consumer_work")
+    assert len(classify_calls) == 2
+    assert all(c["parent_call_id"] == review_call["call_id"] for c in classify_calls)
+    assert consumer_call["parent_call_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_generator_aclose_finishes_body_and_trace():
+    """Explicit close runs generator cleanup and closes its method span."""
+    from unittest.mock import MagicMock
+
+    from nooa.runtime.hooks import InstrumentationHooks, set_hooks
+
+    mock_hooks = MagicMock(spec=InstrumentationHooks)
+    mock_hooks.before_agent_call.return_value = {}
+
+    class StreamAgent(Agent, llm=_TEST_LLM):
+        closed = False
+
+        async def values(self):
+            try:
+                yield 1
+                yield 2
+            finally:
+                self.closed = True
+
+    try:
+        set_hooks(mock_hooks)
+        agent = StreamAgent()
+        stream = agent.values()
+        assert await anext(stream) == 1
+        await stream.aclose()
+        assert agent.closed is True
+    finally:
+        set_hooks(None)
+
+    mock_hooks.before_agent_call.assert_called_once()
+    mock_hooks.after_agent_call.assert_called_once()
+    assert mock_hooks.after_agent_call.call_args.kwargs["exception"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_generator_cancellation_finishes_trace_as_failure():
+    """Cancellation propagates and reports a failed generator lifecycle."""
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from nooa.runtime.hooks import InstrumentationHooks, set_hooks
+
+    mock_hooks = MagicMock(spec=InstrumentationHooks)
+    mock_hooks.before_agent_call.return_value = {}
+
+    class StreamAgent(Agent, llm=_TEST_LLM):
+        async def values(self):
+            yield 1
+            await asyncio.Event().wait()
+
+    try:
+        set_hooks(mock_hooks)
+        stream = StreamAgent().values()
+        assert await anext(stream) == 1
+        resume = asyncio.create_task(anext(stream))
+        await asyncio.sleep(0)
+        resume.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await resume
+    finally:
+        set_hooks(None)
+
+    mock_hooks.after_agent_call.assert_called_once()
+    assert isinstance(
+        mock_hooks.after_agent_call.call_args.kwargs["exception"], asyncio.CancelledError
+    )
 
 
 def test_regular_async_method_unaffected_by_generator_guard():

--- a/tests/tracing/test_generator_spans.py
+++ b/tests/tracing/test_generator_spans.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""OpenTelemetry lifecycle tests for deterministic async-generator methods."""
+
+import asyncio
+from contextlib import aclosing
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+
+from nooa import Agent
+from nooa.runtime.hooks import set_hooks
+from nooa.tracing._hooks_impl import OpenInferenceHooks, end_active_spans
+from nooa.unifiedllm import FakeLLMClient
+
+
+def _install_test_tracing() -> tuple[TracerProvider, InMemorySpanExporter]:
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_hooks(OpenInferenceHooks(provider.get_tracer("async-generator-test")))
+    return provider, exporter
+
+
+@pytest.mark.asyncio
+async def test_async_generator_span_parents_children_across_tasks():
+    """Every resume reactivates the lifecycle span in the task doing the work."""
+
+    class StreamAgent(Agent, llm=FakeLLMClient()):
+        async def child(self, value: int) -> int:
+            return value * 10
+
+        async def values(self):
+            yield await self.child(1)
+            yield await self.child(2)
+
+        async def consumer_work(self) -> None:
+            return None
+
+    agent = StreamAgent()
+    provider, exporter = _install_test_tracing()
+    try:
+        stream = agent.values()
+        first_item_ready = asyncio.Event()
+        check_starting_registry = asyncio.Event()
+
+        async def first_resume():
+            item = await anext(stream)
+            first_item_ready.set()
+            await check_starting_registry.wait()
+            return item, end_active_spans()
+
+        # Each task inherits the consumer's empty tracing registry. The stream
+        # wrapper must carry and reactivate its span explicitly across resumes.
+        starting_task = asyncio.create_task(first_resume())
+        await first_item_ready.wait()
+        assert not trace.get_current_span().get_span_context().is_valid
+        await agent.consumer_work()
+        assert await asyncio.create_task(anext(stream)) == 20
+        with pytest.raises(StopAsyncIteration):
+            await asyncio.create_task(anext(stream))
+
+        # Completion in another task must remove the span from the registry
+        # belonging to the task that started it, rather than leaving stale state.
+        check_starting_registry.set()
+        first_item, remaining_spans = await starting_task
+        assert first_item == 10
+        assert remaining_spans == 0
+
+        spans = exporter.get_finished_spans()
+    finally:
+        set_hooks(None)
+        provider.shutdown()
+
+    stream_span = next(span for span in spans if span.name == "method.values")
+    child_spans = [span for span in spans if span.name == "method.child"]
+    consumer_span = next(span for span in spans if span.name == "method.consumer_work")
+
+    assert len(child_spans) == 2
+    assert all(
+        span.parent is not None and span.parent.span_id == stream_span.context.span_id
+        for span in child_spans
+    )
+    assert consumer_span.parent is None
+    assert stream_span.status.status_code is StatusCode.OK
+
+
+@pytest.mark.asyncio
+async def test_async_generator_aclosing_ends_span_and_runs_cleanup():
+    """Explicit early close completes both Python cleanup and the lifecycle span."""
+
+    class StreamAgent(Agent, llm=FakeLLMClient()):
+        cleaned_up = False
+
+        async def values(self):
+            try:
+                yield 1
+                yield 2
+            finally:
+                self.cleaned_up = True
+
+    agent = StreamAgent()
+    provider, exporter = _install_test_tracing()
+    try:
+        async with aclosing(agent.values()) as stream:
+            async for item in stream:
+                assert item == 1
+                break
+        spans = exporter.get_finished_spans()
+    finally:
+        set_hooks(None)
+        provider.shutdown()
+
+    [stream_span] = [span for span in spans if span.name == "method.values"]
+    assert agent.cleaned_up is True
+    assert stream_span.status.status_code is StatusCode.OK
+
+
+@pytest.mark.asyncio
+async def test_async_generator_aclose_parents_traced_cleanup_across_tasks():
+    """Cleanup executed by aclose remains inside the lifecycle span."""
+
+    class StreamAgent(Agent, llm=FakeLLMClient()):
+        async def cleanup(self) -> None:
+            return None
+
+        async def values(self):
+            try:
+                yield 1
+            finally:
+                await self.cleanup()
+
+    agent = StreamAgent()
+    provider, exporter = _install_test_tracing()
+    try:
+        stream = agent.values()
+        assert await asyncio.create_task(anext(stream)) == 1
+
+        async def close_stream() -> None:
+            await stream.aclose()
+
+        await asyncio.create_task(close_stream())
+        spans = exporter.get_finished_spans()
+    finally:
+        set_hooks(None)
+        provider.shutdown()
+
+    stream_span = next(span for span in spans if span.name == "method.values")
+    cleanup_span = next(span for span in spans if span.name == "method.cleanup")
+    assert cleanup_span.parent is not None
+    assert cleanup_span.parent.span_id == stream_span.context.span_id
+
+
+@pytest.mark.asyncio
+async def test_async_generator_cancellation_ends_span_as_error():
+    """Cancellation in a later task closes and marks the lifecycle span."""
+
+    class StreamAgent(Agent, llm=FakeLLMClient()):
+        async def values(self):
+            yield "ready"
+            await asyncio.Event().wait()
+
+    agent = StreamAgent()
+    provider, exporter = _install_test_tracing()
+    try:
+        stream = agent.values()
+        assert await asyncio.create_task(anext(stream)) == "ready"
+
+        resume = asyncio.create_task(anext(stream))
+        await asyncio.sleep(0)
+        resume.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await resume
+        spans = exporter.get_finished_spans()
+    finally:
+        set_hooks(None)
+        provider.shutdown()
+
+    [stream_span] = [span for span in spans if span.name == "method.values"]
+    assert stream_span.status.status_code is StatusCode.ERROR


### PR DESCRIPTION
## Problem

Fixes #38.

Generator methods were previously sent through regular method wrappers. Those wrappers opened and closed a span around creation of the generator object, before its body ran, so nested calls made while consuming the generator received the wrong trace parent.

## Design

This PR now uses the framework's semantic boundary rather than rejecting all generators:

- Deterministic sync and async generator methods are supported as ordinary Python.
- Generator methods containing the `...` generation marker are rejected at class creation with a clear error.
- Generation strategies retain their existing one-final-result contract. Generated streaming would require a separate contract for yielded item types, completion, retries, partial failure, and backpressure.
- The unary `agent_call` middleware contract does not wrap generator lifecycles. A future generated-stream feature should define stream middleware explicitly rather than overloading unary middleware.

## Implementation

- Adds generator-aware sync and async wrappers that preserve `next`/`anext`, `send`/`asend`, `throw`/`athrow`, close, cancellation, errors, and sync-generator return values.
- Starts the method span on first iteration and ends it on exhaustion, explicit close, cancellation, or failure.
- Activates agent and OpenTelemetry context only while generator code is running, so nested calls are parented to the generator while consumer work between yields remains separate.
- Carries tracing context safely across sequential resumes from different asyncio tasks and cleans up the originating task's span registry.
- Distinguishes actual generation markers from ordinary Python Ellipsis expressions such as `tuple[int, ...]` and `items[...]`, including source-less generated functions.
- Documents the single-result generation contract.

## Testing

The tests cover native generator protocols, generated-generator rejection and diagnostics, explicit close and cancellation, cross-task tracing, consumer isolation, span-registry cleanup, traced cleanup during `aclose()`, ordinary Ellipsis expressions, and source-less bytecode detection. OpenTelemetry assertions use an in-memory exporter with real spans rather than mocks.

```bash
uv run pytest tests/tracing tests/runtime tests/test_metaclass.py tests/test_pre_ellipsis_code.py tests/test_ellipsis_detection_exec.py tests/external/test_decorators.py -q -p no:cacheprovider
# 1369 passed, 6 skipped

PYTHON_DOTENV_DISABLED=1 NOOA_VIEWER_AUTH_TOKEN= uv run pytest -m 'not integration and not stress' --ignore=tests/test_mcp -q -p no:cacheprovider
# 6384 passed, 5 skipped

uv run ruff check ...
uv run ruff format --check ...
uv run pyright ...
# all clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deterministic synchronous and asynchronous generator methods.
  * Preserved native generator controls, including send, throw, close, and cancellation behavior.
  * Improved tracing and span continuity while generators pause and resume across tasks.

* **Bug Fixes**
  * Added validation to reject unsupported generated streaming methods with clear errors.
  * Improved tracing context restoration and cleanup during generator execution and cancellation.

* **Documentation**
  * Documented generator support requirements and streaming generation limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->