### PR TITLE
feat(cli): let external packages add nooa subcommands via entry points

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/AGENTS.md
+++ b/packages/nooa-cli/src/nooa_cli/AGENTS.md
@@ -101,6 +101,35 @@ def command(args: tuple[str, ...]):
     subprocess.run([sys.executable, "-m", "some_other_tool", *args])
 ```
 
+## Commands From Another Package
+
+If your command lives in a *different* installed package (not in this repo),
+register it in the `nooa_cli.commands` entry-point group instead of dropping a
+file here. The entry-point name becomes the subcommand name:
+
+```toml
+# pyproject.toml of your package
+[project.entry-points."nooa_cli.commands"]
+tui  = "my_package.cli.tui:command"
+term = "my_package.cli.term:command"
+```
+
+`my_package.cli.tui:command` must be a `click.Command` or `click.Group` — the
+same contract as an in-repo command module.
+
+- **Built-ins win name collisions.** A plugin can't shadow `eval`, `config`,
+  or anything else shipped here; it's logged and skipped.
+- **A broken plugin is skipped, not fatal.** An entry point that fails to
+  import, or that resolves to a non-`click.Command`, logs a warning and is
+  left out. `nooa` keeps working.
+- Plugins register in entry-point-name order, so `nooa --help` is stable
+  regardless of install order.
+- The **Performance Rule** below applies with extra force: every registered
+  entry point is loaded on *every* `nooa` invocation, including `nooa --help`.
+  Keep heavy imports inside the handler.
+
+This mirrors the existing `nooa.skills` and `nooa.bundled_configs` groups.
+
 ## Shared Utilities
 
 Common helpers live in `src/nooa_cli/_common.py`:

--- a/packages/nooa-cli/src/nooa_cli/__init__.py
+++ b/packages/nooa-cli/src/nooa_cli/__init__.py
@@ -9,7 +9,10 @@ Usage:
     nooa completion install         # Set up shell completions
 
 Adding new commands:
-    Drop a .py file in nooa_cli/commands/ — see commands/_template.py
+    In this package: drop a .py file in nooa_cli/commands/ — see
+    commands/_template.py
+    From another package: register an entry point in the
+    "nooa_cli.commands" group — see nooa_cli/commands/__init__.py
 
 Shell completion:
     eval "$(_NOOA_COMPLETE=bash_source nooa)"    # bash
@@ -36,7 +39,8 @@ def oo(ctx):
     """OO Agents — agent toolkit.
 
     Extensible CLI for running agents, evaluations, and trace management.
-    Add new commands by dropping a .py file in nooa_cli/commands/.
+    Add new commands by dropping a .py file in nooa_cli/commands/, or from
+    another package via the "nooa_cli.commands" entry-point group.
     """
     if ctx.invoked_subcommand in _SKIP_SECRETS_PRELOAD:
         return
@@ -57,11 +61,14 @@ def oo(ctx):
         )
 
 
-# -- Auto-discover and register all commands from commands/ -----------------
+# -- Auto-discover and register all commands (built-ins + entry-point plugins) --
 for _name, _cmd in discover_commands():
     oo.add_command(_cmd, name=_name)
 
 # -- Built-in infrastructure commands (not in commands/ because they're meta) -
+# Registered *after* discovery on purpose: `completion` is not part of
+# discover_commands(), so this ordering is what stops a third-party plugin
+# named "completion" from taking the name.
 oo.add_command(completion)
 
 

--- a/packages/nooa-cli/src/nooa_cli/commands/__init__.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/__init__.py
@@ -13,6 +13,9 @@
 ║                                                                      ║
 ║  See _template.py for a copy-paste starter.                          ║
 ║                                                                      ║
+║  From *another* package? Register an entry point instead —           ║
+║  see "Commands from other packages" below.                           ║
+║                                                                      ║
 ╚══════════════════════════════════════════════════════════════════════╝
 
 Convention
@@ -62,22 +65,58 @@ Full example with a group (commands/things.py)::
     def create(name):
         \"\"\"Create a new thing.\"\"\"
         click.echo(f"Created {name}")
+
+Commands from other packages
+----------------------------
+
+A package installed alongside ``nooa-cli`` can contribute top-level
+subcommands through the ``nooa_cli.commands`` entry-point group. The
+entry-point name is the subcommand name; the object it points at must be a
+``click.Command``::
+
+    # pyproject.toml of the contributing package
+    [project.entry-points."nooa_cli.commands"]
+    tui  = "my_package.cli.tui:command"
+    term = "my_package.cli.term:command"
+
+Rules:
+
+* **Built-ins win name collisions.** A plugin cannot shadow ``eval``,
+  ``config`` or any other command shipped here — it is logged and skipped.
+* **Broken plugins are skipped, not fatal.** An entry point that fails to
+  import, or that resolves to something other than a ``click.Command``, logs a
+  warning and is left out; ``nooa`` keeps working.
+* Plugins are registered in entry-point-name order, so ``nooa --help`` is
+  stable regardless of install order.
+* **Keep imports lazy**, exactly as for in-repo commands: every registered
+  entry point is loaded on *every* ``nooa`` invocation, including
+  ``nooa --help``, so heavy imports belong inside the command handler.
 """
 
 import importlib
+import logging
 import pkgutil
 from collections.abc import Iterator
+from importlib import metadata
 
 import click
 
+logger = logging.getLogger(__name__)
 
-def discover_commands() -> Iterator[tuple[str, click.Command]]:
-    """Yield (name, command) pairs from all command modules in this package.
+#: Entry-point group external packages use to contribute subcommands.
+PLUGIN_ENTRY_POINT_GROUP = "nooa_cli.commands"
+
+
+def _builtin_commands() -> Iterator[tuple[str, click.Command]]:
+    """Yield (name, command) pairs from the command modules in this package.
 
     Scans this directory for Python modules, imports each one, and looks
     for a ``command`` attribute that is a ``click.Command`` or ``click.Group``.
 
     Modules starting with ``_`` are skipped (private / template files).
+
+    Unlike the plugin pass, a malformed module here raises: it is a bug in
+    this repository and should be loud.
     """
     package_path = __path__
     package_name = __name__
@@ -103,4 +142,67 @@ def discover_commands() -> Iterator[tuple[str, click.Command]]:
         # Allow overriding the command name
         name = getattr(module, "NAME", module_info.name)
 
+        yield name, cmd
+
+
+def _plugin_commands() -> Iterator[tuple[str, click.Command]]:
+    """Yield (name, command) pairs contributed by other installed packages.
+
+    Reads the ``nooa_cli.commands`` entry-point group. The entry-point name
+    becomes the subcommand name, and ``ep.load()`` must return a
+    ``click.Command``.
+
+    Entry points are sorted by name so the command list does not depend on
+    install order. Every failure is logged at WARNING and skipped: these are
+    arbitrary third-party imports, and a broken one must never make ``nooa``
+    unusable.
+    """
+    try:
+        eps = metadata.entry_points(group=PLUGIN_ENTRY_POINT_GROUP)
+    except Exception:  # noqa: BLE001 — importlib.metadata can raise on broken installs
+        logger.warning(
+            "Failed to enumerate %r entry points", PLUGIN_ENTRY_POINT_GROUP, exc_info=True
+        )
+        return
+
+    for ep in sorted(eps, key=lambda e: e.name):
+        try:
+            cmd = ep.load()
+        except Exception:  # noqa: BLE001 — third-party entry-point code, be defensive
+            logger.warning("CLI plugin entry-point %r failed to load", ep.name, exc_info=True)
+            continue
+
+        if not isinstance(cmd, click.Command):
+            logger.warning(
+                "CLI plugin entry-point %r resolved to %s, not a click.Command; skipping",
+                ep.name,
+                type(cmd).__name__,
+            )
+            continue
+
+        yield ep.name, cmd
+
+
+def discover_commands() -> Iterator[tuple[str, click.Command]]:
+    """Yield (name, command) pairs for every subcommand of ``nooa``.
+
+    Built-in commands from this package come first, then commands contributed
+    by other packages through the ``nooa_cli.commands`` entry-point group.
+    A plugin whose name is already taken is logged and skipped, so built-ins
+    always win and each name is yielded exactly once.
+    """
+    seen: set[str] = set()
+
+    for name, cmd in _builtin_commands():
+        seen.add(name)
+        yield name, cmd
+
+    for name, cmd in _plugin_commands():
+        if name in seen:
+            logger.warning(
+                "CLI plugin entry-point %r shadows an existing command; ignoring the plugin",
+                name,
+            )
+            continue
+        seen.add(name)
         yield name, cmd

--- a/packages/nooa-cli/tests/test_command_plugins.py
+++ b/packages/nooa-cli/tests/test_command_plugins.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for third-party subcommands contributed via the entry-point group.
+
+Fake entry points (only ``.name`` and ``.load()`` are used) are injected by
+rebinding the ``metadata`` global of ``nooa_cli.commands`` — no real
+distribution needs to be installed, and the real ``importlib.metadata`` is
+left alone for every other caller.
+"""
+
+import importlib
+import logging
+import sys
+import types
+
+import click
+import pytest
+from nooa_cli import commands as commands_pkg
+from nooa_cli.commands import PLUGIN_ENTRY_POINT_GROUP, discover_commands
+
+BUILTIN_NAMES = {"eval", "config", "start-dev"}
+
+
+class FakeEntryPoint:
+    """Minimal stand-in for ``importlib.metadata.EntryPoint``."""
+
+    def __init__(self, name: str, value=None, error: Exception | None = None):
+        self.name = name
+        self._value = value
+        self._error = error
+
+    def load(self):
+        if self._error is not None:
+            raise self._error
+        return self._value
+
+
+def make_command(help_text: str = "A plugin command.") -> click.Command:
+    @click.command(name="name-from-the-command-object")
+    def _cmd():
+        click.echo(help_text)
+
+    return _cmd
+
+
+def _install(monkeypatch, fake) -> None:
+    """Rebind the module's ``metadata`` global rather than patching the real
+    ``importlib.metadata``, so the fake is invisible to unrelated callers."""
+    monkeypatch.setattr(commands_pkg, "metadata", types.SimpleNamespace(entry_points=fake))
+
+
+def patch_entry_points(monkeypatch, eps) -> None:
+    """Install a fake ``entry_points`` that returns ``eps``.
+
+    The replacement asserts the group it is queried with. That assertion is
+    load-bearing: the real call sits inside a ``try/except Exception``, so a
+    fake with the wrong signature would raise ``TypeError``, get swallowed,
+    and make the "plugin skipped" tests pass against a completely broken
+    call path.
+    """
+
+    def _fake_entry_points(*, group):
+        assert group == PLUGIN_ENTRY_POINT_GROUP
+        return eps
+
+    _install(monkeypatch, _fake_entry_points)
+
+
+def patch_entry_points_raising(monkeypatch, error: Exception) -> None:
+    def _fake_entry_points(*, group):
+        assert group == PLUGIN_ENTRY_POINT_GROUP
+        raise error
+
+    _install(monkeypatch, _fake_entry_points)
+
+
+def test_group_name_is_stable():
+    """Third parties hard-code this string in pyproject.toml — pin it.
+
+    Every other test fakes ``entry_points``, so a typo here would otherwise
+    pass the whole suite while breaking the only thing consumers depend on.
+    """
+    assert PLUGIN_ENTRY_POINT_GROUP == "nooa_cli.commands"
+
+
+def test_plugin_command_is_registered_alongside_builtins(monkeypatch):
+    plugin = make_command()
+    patch_entry_points(monkeypatch, [FakeEntryPoint("tui", plugin)])
+
+    found = dict(discover_commands())
+
+    assert found["tui"] is plugin
+    assert BUILTIN_NAMES <= set(found)
+
+
+def test_entry_point_name_becomes_the_subcommand_name(monkeypatch):
+    plugin = make_command()
+    patch_entry_points(monkeypatch, [FakeEntryPoint("term", plugin)])
+
+    found = dict(discover_commands())
+
+    assert "term" in found
+    # The command object's own name is ignored, just like NAME/filename for
+    # built-ins — the entry-point name wins.
+    assert plugin.name == "name-from-the-command-object"
+    assert "name-from-the-command-object" not in found
+
+
+def test_plugins_are_sorted_by_entry_point_name(monkeypatch):
+    patch_entry_points(
+        monkeypatch,
+        [
+            FakeEntryPoint("zeta", make_command()),
+            FakeEntryPoint("alpha", make_command()),
+            FakeEntryPoint("mid", make_command()),
+        ],
+    )
+
+    names = [name for name, _ in discover_commands()]
+    plugin_order = [n for n in names if n in {"zeta", "alpha", "mid"}]
+
+    assert plugin_order == ["alpha", "mid", "zeta"]
+
+
+def test_plugin_cannot_shadow_a_builtin(monkeypatch, caplog):
+    builtin_config = importlib.import_module("nooa_cli.commands.config").command
+    patch_entry_points(monkeypatch, [FakeEntryPoint("config", make_command())])
+
+    with caplog.at_level(logging.WARNING, logger="nooa_cli.commands"):
+        pairs = list(discover_commands())
+
+    names = [name for name, _ in pairs]
+    assert names.count("config") == 1
+    assert dict(pairs)["config"] is builtin_config
+    assert any(
+        "shadows" in record.getMessage() and "config" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_two_plugins_with_the_same_name_yield_one_command(monkeypatch, caplog):
+    """Two installed distributions can register the same entry-point name.
+
+    Without deduping, ``add_command`` would be called twice and whichever
+    distribution sorts later would silently win — the install-order
+    instability that sorting exists to prevent.
+    """
+    first, second = make_command(), make_command()
+    patch_entry_points(
+        monkeypatch,
+        [FakeEntryPoint("tui", first), FakeEntryPoint("tui", second)],
+    )
+
+    with caplog.at_level(logging.WARNING, logger="nooa_cli.commands"):
+        pairs = list(discover_commands())
+
+    names = [name for name, _ in pairs]
+    assert names.count("tui") == 1
+    assert dict(pairs)["tui"] is first
+    assert any(
+        "shadows" in record.getMessage() and "tui" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_plugin_that_fails_to_load_is_skipped(monkeypatch, caplog):
+    healthy = make_command()
+    patch_entry_points(
+        monkeypatch,
+        [
+            FakeEntryPoint("broken", error=ImportError("no such module")),
+            FakeEntryPoint("healthy", healthy),
+        ],
+    )
+
+    with caplog.at_level(logging.WARNING, logger="nooa_cli.commands"):
+        found = dict(discover_commands())
+
+    assert "broken" not in found
+    assert found["healthy"] is healthy
+    assert BUILTIN_NAMES <= set(found)
+    assert any("broken" in record.getMessage() for record in caplog.records)
+
+
+def test_plugin_that_is_not_a_click_command_is_skipped(monkeypatch, caplog):
+    patch_entry_points(monkeypatch, [FakeEntryPoint("bogus", value="not a command")])
+
+    with caplog.at_level(logging.WARNING, logger="nooa_cli.commands"):
+        found = dict(discover_commands())
+
+    assert "bogus" not in found
+    assert BUILTIN_NAMES <= set(found)
+    assert any("bogus" in record.getMessage() for record in caplog.records)
+
+
+def test_broken_distribution_metadata_is_not_fatal(monkeypatch, caplog):
+    patch_entry_points_raising(monkeypatch, RuntimeError("corrupt metadata"))
+
+    with caplog.at_level(logging.WARNING, logger="nooa_cli.commands"):
+        found = dict(discover_commands())
+
+    assert BUILTIN_NAMES <= set(found)
+    assert any("Failed to enumerate" in record.getMessage() for record in caplog.records)
+
+
+def test_no_plugins_installed_yields_the_builtins(monkeypatch):
+    patch_entry_points(monkeypatch, [])
+
+    found = dict(discover_commands())
+
+    assert BUILTIN_NAMES <= set(found)
+
+
+def test_builtin_scan_still_raises_on_a_bad_command_attribute(monkeypatch):
+    """The built-in path is deliberately *not* forgiving.
+
+    A malformed module in this repo is a bug and must stay loud, unlike a
+    malformed third-party plugin. Extracting the scan into
+    ``_builtin_commands()`` is exactly the refactor that could silently lose
+    this, so pin it.
+    """
+    # Seed the import cache instead of stubbing importlib.import_module, so
+    # the fake is only visible to this one lookup and not to pytest itself.
+    monkeypatch.setitem(
+        sys.modules,
+        "nooa_cli.commands.bogus_builtin",
+        types.SimpleNamespace(command="not a click.Command"),
+    )
+    monkeypatch.setattr(
+        commands_pkg,
+        "pkgutil",
+        types.SimpleNamespace(
+            iter_modules=lambda *_args: [types.SimpleNamespace(name="bogus_builtin")]
+        ),
+    )
+
+    with pytest.raises(TypeError, match="must be a click.Command"):
+        list(discover_commands())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,8 +202,7 @@ testpaths = [
     "tests/unifiedllm",
     "tests/tracing",
     "tests/test_mcp",
-    "packages/nooa-cli/tests/cli",
-    "packages/nooa-cli/tests/integration",
+    "packages/nooa-cli/tests",
     "packages/nooa-bench/tests",
     "tests/trace_explorer",
 ]


### PR DESCRIPTION
Adds a `nooa_cli.commands` entry-point group so packages outside this repo can contribute `nooa` subcommands, instead of shipping standalone console scripts.

```toml
[project.entry-points."nooa_cli.commands"]
tui = "my_package.cli.tui:command"
```

`discover_commands()` is now the existing built-in scan plus an entry-point pass. Built-ins are yielded first and win name collisions; each name is yielded once. Plugin failures (broken metadata, failing import, non-`click.Command`) are logged and skipped — the built-in scan still raises, since that's a bug in this repo. Plugins are sorted by entry-point name so `--help` doesn't depend on install order.

Mirrors the existing `nooa.skills` and `nooa.bundled_configs` groups.

### Also included

The new tests wouldn't have run: `testpaths` pointed at `packages/nooa-cli/tests/{cli,integration}`, neither of which exists, so nothing under `packages/nooa-cli/tests` was collected in CI — `test_cli_smoke.py` included. Pointing it at the parent exposed a collision: the empty `packages/nooa-cli/tests/__init__.py` made that a package named `tests`, shadowing the root `tests` package. Deleted it; `packages/nooa-bench/tests` already ships without one.

### Verification

11 new tests. Full suite 6385 passed / 5 skipped; ruff clean; `nooa --help` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
