### PR TITLE
docs(nooa_memory): fixed broken tests/memory/ link in README

### DIFF
--- a/packages/nooa-memory/src/nooa_memory/README.md
+++ b/packages/nooa-memory/src/nooa_memory/README.md
@@ -431,7 +431,7 @@ fit the budget, and *hurts* pinpoint lookups.
 | `monitoring.py` | `MemoryStats` + runtime memory events |
 | `manager.py` | `MemoryManager` (install/hooks/ops) + `MemoryToolsMixin` + `MEMORY_SCHEMA_GUIDE` |
 
-Tests: [`tests/memory/`](../../../tests/memory/).
+Tests: [`tests/memory/`](../../tests/memory/).
 
 ---
 


### PR DESCRIPTION
## Summary

`packages/nooa-memory/src/nooa_memory/README.md` linked to `tests/memory/`
with one extra `../`, so the link resolved to a nonexistent top-level
`tests/memory/` instead of the actual `packages/nooa-memory/tests/memory/`.

## What does this PR do?

Fixes the relative path so the link resolves correctly from the file's
location (`packages/nooa-memory/src/nooa_memory/`).

## What changed

- `packages/nooa-memory/src/nooa_memory/README.md`: `../../../tests/memory/` → `../../tests/memory/`

## Related issues

None — found by reading through the README and checking that its links resolve.
