### PR TITLE
fix(nooa-bench): always persist traces and dump a local trajectory

### DIFF
--- a/packages/nooa-bench/src/nooa_bench/runner.py
+++ b/packages/nooa-bench/src/nooa_bench/runner.py
@@ -58,16 +58,17 @@ def _setup_logging() -> None:
 
 
 def _setup_tracing(model: str, agent_type: str) -> None:
-    """Enable OTel tracing, publishing live to the viewer if reachable.
+    """Enable OTel tracing, always on disk and additionally live when reachable.
 
-    Detection order:
-    1. Probe ``OTLP_ENDPOINT`` env var, or ``http://localhost:5001`` by default.
-    2. If reachable → stream spans via the journal exporter with ``eval.model``
-       and ``eval.agent_type`` injected as resource attributes so the viewer can
-       display them without a separate ``import-harbor`` step.
-    3. If unreachable → fall back to JSONL files in the Harbor artifact
-       directory (``/logs/artifacts/traces/``), importable later via
-       ``nemo-oo import-harbor``.
+    JSONL files in the Harbor artifact directory (``/logs/artifacts/traces/``)
+    are written unconditionally — they are the record failure analysis runs on,
+    and they are importable later via ``nemo-oo import-harbor``.  When
+    ``OTLP_ENDPOINT`` (default ``http://localhost:5001``) is reachable the
+    journal exporter is added *alongside* the file exporter so the viewer sees
+    spans live without that becoming the only copy.
+
+    Streaming used to replace the file exporter rather than supplement it, so a
+    run against a reachable viewer left no trajectory on disk at all.
 
     Note: Apptainer containers share the host network namespace, so
     ``localhost:5001`` inside the container resolves to the developer's host.
@@ -85,17 +86,20 @@ def _setup_tracing(model: str, agent_type: str) -> None:
 
     endpoint = os.environ.get("OTLP_ENDPOINT", "http://localhost:5001/v1/traces")
 
+    TRACES_DIR.mkdir(parents=True, exist_ok=True)
+    exporters = [nemo_exporters.jsonl(TRACES_DIR)]
+
     if probe_otlp_endpoint(endpoint):
-        logger.info("OTLP endpoint reachable (%s) — streaming traces live", endpoint)
-        enable_tracing(
-            exporters=[nemo_exporters.journal(endpoint=endpoint)],
-            extra_resource_attrs={"eval.model": model, "eval.agent_type": agent_type},
-        )
-        logger.info("OTel tracing enabled → %s", endpoint)
+        exporters.append(nemo_exporters.journal(endpoint=endpoint))
+        logger.info("OTLP endpoint reachable (%s) — also streaming live", endpoint)
     else:
-        TRACES_DIR.mkdir(parents=True, exist_ok=True)
-        enable_tracing(exporters=[nemo_exporters.jsonl(TRACES_DIR)])
-        logger.info("OTel tracing enabled → %s (OTLP not reachable)", TRACES_DIR)
+        logger.info("OTLP endpoint unreachable (%s) — writing files only", endpoint)
+
+    enable_tracing(
+        exporters=exporters,
+        extra_resource_attrs={"eval.model": model, "eval.agent_type": agent_type},
+    )
+    logger.info("OTel tracing enabled → %s (%d exporter(s))", TRACES_DIR, len(exporters))
 
 
 def _import_agent_class(agent_type: str) -> type:
@@ -126,6 +130,42 @@ def _write_result(result: dict[str, Any], model: str, agent_type: str) -> None:
     out = LOGS_DIR / "result.json"
     out.write_text(json.dumps(payload, indent=2))
     logger.info("Result written → %s", out)
+
+
+def _write_trajectory(agent: Any) -> None:
+    """Dump the agent's full event history to LOGS_DIR/trajectory.json.
+
+    The OTLP spans under ``/logs/artifacts/traces/`` remain the canonical
+    record, but failure analysis starts in the per-task ``agent/`` directory —
+    which otherwise holds only ``nooa_bench.log`` and a ``result.json``
+    carrying just the final response.  Anyone looking there for the turn-by-turn
+    trajectory previously found nothing.
+    """
+    manager = getattr(agent, "event_manager", None)
+    if manager is None:
+        logger.warning("Agent exposes no event_manager — no trajectory written")
+        return
+
+    try:
+        events = [
+            {
+                "event_id": event_id,
+                "event_type": type(event).__name__,
+                **event.model_dump(mode="json"),
+            }
+            for event_id, event in manager.items()
+        ]
+    except Exception as e:  # never fail the task over a debug artifact
+        logger.warning("Could not serialise trajectory: %s", e)
+        return
+
+    out = LOGS_DIR / "trajectory.json"
+    try:
+        out.write_text(json.dumps(events, indent=2, default=str))
+    except OSError as e:
+        logger.warning("Could not write %s: %s", out, e)
+        return
+    logger.info("Trajectory written → %s (%d events)", out, len(events))
 
 
 def _write_answer(result: dict[str, Any]) -> None:
@@ -180,6 +220,7 @@ async def _run(
     result = await agent._run_evaluation(task_input)
     result.update(get_task_tokens())
     _write_result(result, model, agent_type)
+    _write_trajectory(agent)
     _write_answer(result)
 
     if result.get("success"):


### PR DESCRIPTION
## Problem

A Harbor run could finish with **no trajectory stored anywhere on disk**, which blocks post-hoc failure analysis. This was hit in practice — reported as:

> "it appears that nooa does not have locally stored full trajectory? I could not find it in, say, `nooa-base_ultra_on/astropy__astropy-14598__7oCi6qh/agent`"

Two independent causes.

### 1. The exporter choice was mutually exclusive

`_setup_tracing()` installed *either* the streaming journal exporter *or* the JSONL file exporter:

```python
if probe_otlp_endpoint(endpoint):
    enable_tracing(exporters=[nemo_exporters.journal(endpoint=endpoint)])
else:
    enable_tracing(exporters=[nemo_exporters.jsonl(TRACES_DIR)])
```

Benchmark configs set `OTLP_ENDPOINT`, so those runs streamed spans to the viewer and wrote nothing locally. If the viewer was down, restarted, or the network blipped, the trajectory was simply gone.

### 2. Nothing wrote per-turn history where anyone looks for it

The per-task `agent/` directory held only `nooa_bench.log` and `result.json` — and `result.json` carries just the final response. So the directory named in the report above was genuinely empty of trajectory data under *either* branch, since JSONL goes to `/logs/artifacts/traces/`.

## Changes

- The JSONL file exporter is now **unconditional**; the journal exporter is *added* alongside it when `OTLP_ENDPOINT` is reachable. Live viewing no longer costs the durable copy.
- Add `_write_trajectory()`, dumping the agent's full event history to `agent/trajectory.json`.
- `extra_resource_attrs` (`eval.model`, `eval.agent_type`) now apply in both cases, not just the streaming one, so file-only runs stay attributable.

## Notes

Trajectory serialisation failures are logged and swallowed — a debug artifact must never fail a task. The OTLP spans under `/logs/artifacts/traces/` remain the canonical record; `trajectory.json` is the greppable companion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)