### PR TITLE
test(memory): assert owner gating blocks relay through foreign memories

### DIFF
--- a/packages/nooa-memory/tests/memory/test_memory_owner.py
+++ b/packages/nooa-memory/tests/memory/test_memory_owner.py
@@ -154,3 +154,37 @@ def test_reflection_never_merges_foreign_duplicates(shared_path):
     mgr_b.reflect()  # bob consolidates: now they merge
     bob_active = [m for m in mgr_b.store.all_memories(owner="bob") if m.owner == "bob"]
     assert len(bob_active) == 1
+
+
+def test_spread_does_not_relay_through_foreign_memories(shared_path):
+    """A foreign memory must not relay activation between two visible ones.
+
+    Graph: alice_a -> bob -> alice_c. The only path from alice_a to alice_c
+    runs through bob. The visibility check must drop bob before he enters the
+    next hop's frontier, not merely before the spread write, or alice_c gains
+    activation via a node alice cannot see.
+
+    This asserts on ``_spread`` rather than ``recall`` because the property is
+    not observable at the public API: alice owns alice_c, so she retrieves it
+    directly regardless of the graph. What a relay would change is activation,
+    and therefore ranking.
+    """
+    alice, mgr_a, bob, mgr_b = _pair(shared_path)
+    aid = alice.remember("the ingest pipeline config lives in configs/ingest.yaml", type="info")
+    bid = bob.remember("bob's secret analysis of quarterly numbers", type="info")
+    cid = alice.remember("the office coffee machine needs descaling monthly", type="info")
+
+    mgr_a.store.add_edge(aid, bid)  # alice -> bob
+    mgr_a.store.add_edge(bid, cid)  # bob -> alice, reachable only through bob
+
+    spread = mgr_a.retrieval._spread
+
+    # The two-hop path is live when unscoped: without this the scoped
+    # assertion below would pass simply because nothing was reachable.
+    unscoped = spread({aid: 1.0}, hops=2, owner=None)
+    assert bid in unscoped
+    assert cid in unscoped
+
+    scoped = spread({aid: 1.0}, hops=2, owner=mgr_a.owner)
+    assert bid not in scoped  # bob must not be activated
+    assert cid not in scoped  # ...nor anything reachable only through bob


### PR DESCRIPTION
## What does this PR do?

Adds a regression test for a property that the code delivers but nothing asserts. Test-only; no production code touched.

**Background**

`_spread()` in `packages/nooa-memory/src/nooa_memory/retrieval.py` gates spreading activation by owner. Its docstring claims an edge "must not leak — or amplify through — another agent's memory in an owner-scoped recall."

Both halves hold, because the `continue` on the visibility check fires before `nxt[e.target_id]` is written and not only before the `spread` write. An invisible memory therefore never enters the next hop's frontier and cannot relay activation between two visible ones.

Existing coverage is `test_spread_does_not_leak_foreign_memories` here and `test_spread_confined_to_role` in `test_memory_owner_roles.py`. Both build a single edge across an owner boundary, so they pin the leak half. Neither builds the three-node `own -> foreign -> own` case, which means the position of the `continue` is load-bearing but asserted nowhere. Moving the visibility check to just before the spread write looks harmless and quietly reopens the path.

This gap was identified by @neoneye while reviewing NOOA's memory system for the Agent Memory Atlas: https://neoneye.github.io/agent-memory-atlas/systems/nooa-memory/

**Why it asserts on `_spread` rather than `recall`**

The property is not observable at the public API. A relay target owned by a third party is gated on its own merits; one owned by the reader is retrieved directly regardless of the graph. What a relay changes is activation, and therefore ranking, which only exists inside `_spread`.

The test includes an unscoped positive control asserting the two-hop path is live, so the scoped assertion cannot pass merely because nothing was reachable.

## Related issues

None.

## Validation

```
uv run pytest packages/nooa-memory/ -q          # 265 passed, 13 skipped
uv run ruff format --check / ruff check         # clean
```

Run against `main` at e505bb9.

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [ ] Docs updated if behavior or public APIs changed — no behavior change
- [ ] New source files carry an SPDX license header — no new files