### PR TITLE
Add optional ACP coding-agent package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build all packages
         run: |
           rm -rf dist
-          for pkg in nooa nooa-cli nooa-memory nooa-bench; do
+          for pkg in nooa nooa-cli nooa-acp nooa-memory nooa-bench; do
             uv build --no-sources --package "$pkg" --out-dir dist
           done
       - name: Upload wheels

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-# Publishes the four workspace packages to PyPI.
+# Publishes the five workspace packages to PyPI.
 #
 # Trigger: a GitHub Release is *published* (the release's tag `vX.Y.Z` is what
 # uv-dynamic-versioning turns into the package version — see RELEASING.md).
@@ -51,7 +51,7 @@ jobs:
       - name: Build all packages
         run: |
           rm -rf dist
-          for pkg in nooa nooa-cli nooa-memory nooa-bench; do
+          for pkg in nooa nooa-cli nooa-acp nooa-memory nooa-bench; do
             uv build --no-sources --package "$pkg" --out-dir dist
           done
           ls -l dist
@@ -71,14 +71,14 @@ jobs:
 
           expected = Version(os.environ["TAG"].removeprefix("v"))
           wheels = sorted(pathlib.Path("dist").glob("*.whl"))
-          assert len(wheels) == 4, f"expected 4 wheels, got {[w.name for w in wheels]}"
+          assert len(wheels) == 5, f"expected 5 wheels, got {[w.name for w in wheels]}"
           for whl in wheels:
               _, version, _, _ = parse_wheel_filename(whl.name)
               if version.is_devrelease:
                   sys.exit(f"{whl.name}: dev version — the tag is not reachable from HEAD")
               if version != expected:
                   sys.exit(f"{whl.name}: built {version}, but the tag says {expected}")
-          print(f"OK — all four packages built as {expected}")
+          print(f"OK — all five packages built as {expected}")
           PY
 
       # Catches a broken wheel before it is on PyPI forever.
@@ -86,9 +86,12 @@ jobs:
         run: |
           uv venv /tmp/smoke --python 3.12
           VIRTUAL_ENV=/tmp/smoke uv pip install \
-            dist/nooa-*.whl dist/nooa_cli-*.whl dist/nooa_memory-*.whl dist/nooa_bench-*.whl
-          /tmp/smoke/bin/python -c "import nooa, nooa_cli, nooa_memory, nooa_bench; print(nooa.__version__)"
+            dist/nooa-*.whl dist/nooa_cli-*.whl dist/nooa_acp-*.whl \
+            dist/nooa_memory-*.whl dist/nooa_bench-*.whl
+          /tmp/smoke/bin/python -c "import nooa, nooa_cli, nooa_acp, nooa_memory, nooa_bench; print(nooa.__version__)"
           /tmp/smoke/bin/nooa --version
+          /tmp/smoke/bin/nooa --help
+          /tmp/smoke/bin/nooa-acp --help
 
       - uses: actions/upload-artifact@v4
         with:
@@ -98,7 +101,7 @@ jobs:
   # One job per package, each in its OWN environment (`pypi-<package>`).
   #
   # PyPI keys a *pending* trusted publisher on
-  # (owner, repo, workflow filename, environment). Four packages sharing one
+  # (owner, repo, workflow filename, environment). Five packages sharing one
   # environment collide: PyPI rejects the 2nd registration with "a pending
   # trusted publisher matching this configuration has already been registered
   # for a different project name", because it cannot tell which project to
@@ -112,7 +115,7 @@ jobs:
     strategy:
       fail-fast: false  # a partial publish is recoverable; a cancelled one is messier
       matrix:
-        package: [nooa, nooa-cli, nooa-memory, nooa-bench]
+        package: [nooa, nooa-cli, nooa-acp, nooa-memory, nooa-bench]
     environment:
       name: testpypi-${{ matrix.package }}
       url: https://test.pypi.org/p/${{ matrix.package }}
@@ -158,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [nooa, nooa-cli, nooa-memory, nooa-bench]
+        package: [nooa, nooa-cli, nooa-acp, nooa-memory, nooa-bench]
     environment:
       name: pypi-${{ matrix.package }}
       url: https://pypi.org/p/${{ matrix.package }}

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ them by name, or pull them in as extras of the core package:
 
 ```bash
 uv add nooa-cli                 # or: uv add "nooa[cli]"
+uv add nooa-acp                 # or: uv add "nooa[acp]"
 uv add nooa-memory              # or: uv add "nooa[memory]"
 uv add nooa-bench               # or: uv add "nooa[bench]"
 
@@ -98,6 +99,7 @@ uv add "nooa[cli,memory]"       # several at once
 | Package | Extra | What it adds |
 |---|---|---|
 | `nooa-cli` | `nooa[cli]` | the `nooa` command, trace viewer, eval runner |
+| `nooa-acp` | `nooa[acp]` | coding agent for Agent Client Protocol hosts |
 | `nooa-memory` | `nooa[memory]` | long-term memory subsystem (`MemoryManager`) |
 | `nooa-bench` | `nooa[bench]` | `BenchAgent` and the Harbor benchmark runner |
 
@@ -192,6 +194,31 @@ uv run nooa start-dev        # trace viewer on http://localhost:5001
 ```
 
 If the viewer isn't running, tracing is silently disabled — no configuration needed either way.
+
+### 4. Work in a repository interactively
+
+Install `nooa-acp`, select any LiteLLM model or configured NOOA alias, then
+configure an ACP-compatible client to launch the agent with the repository as
+its working directory:
+
+```bash
+uv add nooa-acp
+export NOOA_MODEL=gpt-5-mini
+
+# Agent command for the ACP client
+uv run nooa-acp
+```
+
+`nooa-acp` runs NOOA's `InteractiveAgent`, CodeAct strategy, repository tools,
+and persistent shell over the standard Agent Client Protocol on stdin/stdout.
+The adapter also registers `nooa acp` when both `nooa-cli` and `nooa-acp` are
+installed.
+
+Because the agent executes generated code and shell commands, use an OS-level
+sandbox for untrusted tasks. `cwd` scopes the working session but is not a
+security boundary. Generated code shares the agent's process environment,
+including model credentials, so launch it with only the credentials and network
+access that the session may use.
 
 ## Learn more
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ its working directory:
 
 ```bash
 uv add nooa-acp
-export NOOA_MODEL=gpt-5.6-luna
+export NVIDIA_API_KEY=nvapi-...
 
 # Agent command for the ACP client
 uv run nooa-acp

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ its working directory:
 
 ```bash
 uv add nooa-acp
-export NOOA_MODEL=gpt-5-mini
+export NOOA_MODEL=gpt-5.6-luna
 
 # Agent command for the ACP client
 uv run nooa-acp

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,10 @@
 # Releasing
 
-Four workspace packages release together from the same git commit:
+Five workspace packages release together from the same git commit:
 
 - **`nooa`** — the core framework
 - **`nooa-cli`** — the `nooa` command and REPL
+- **`nooa-acp`** — the ACP coding agent
 - **`nooa-memory`** — the long-term memory subsystem
 - **`nooa-bench`** — the benchmark agent and Harbor runner
 
@@ -47,7 +48,7 @@ gh release edit v0.0.7 --draft=false
 
 Publishing the release triggers the workflow, which:
 
-1. Builds all four packages from the tagged commit.
+1. Builds all five packages from the tagged commit.
 2. Fails the run if the built version does not match the tag, or is a `.devN`
    version (which means the tag was not reachable from the checked-out commit).
 3. Smoke-tests the wheels in a clean venv (imports + `nooa --version`).
@@ -88,14 +89,16 @@ builds.
 
 ```bash
 rm -rf dist
-for p in nooa nooa-cli nooa-memory nooa-bench; do
+for p in nooa nooa-cli nooa-acp nooa-memory nooa-bench; do
   uv build --no-sources --package "$p" --out-dir dist
 done
 uvx twine check dist/*
 uv venv /tmp/nooa-smoke --python 3.12
 VIRTUAL_ENV=/tmp/nooa-smoke uv pip install dist/nooa-*.whl dist/nooa_cli-*.whl \
-  dist/nooa_memory-*.whl dist/nooa_bench-*.whl
-/tmp/nooa-smoke/bin/python -c "import nooa, nooa_cli, nooa_memory, nooa_bench; print(nooa.__version__)"
+  dist/nooa_acp-*.whl dist/nooa_memory-*.whl dist/nooa_bench-*.whl
+/tmp/nooa-smoke/bin/python -c "import nooa, nooa_cli, nooa_acp, nooa_memory, nooa_bench; print(nooa.__version__)"
+/tmp/nooa-smoke/bin/nooa --help
+/tmp/nooa-smoke/bin/nooa-acp --help
 ```
 
 ### Pre-release tags
@@ -106,20 +109,21 @@ the GitHub Release as a pre-release; PyPI will not serve it to plain
 
 ## One-time PyPI setup
 
-Each of the four project names needs a **pending publisher** registered at
+Each of the five project names needs a **pending publisher** registered at
 <https://pypi.org/manage/account/publishing/> before its first upload. Owner
-`NVIDIA-NeMo`, repository `labs-OO-Agents`, workflow `publish.yml` for all four
+`NVIDIA-NeMo`, repository `labs-OO-Agents`, workflow `publish.yml` for all five
 — but the **environment name differs per package**:
 
 | PyPI Project Name | Environment name |
 |---|---|
 | `nooa` | `pypi-nooa` |
 | `nooa-cli` | `pypi-nooa-cli` |
+| `nooa-acp` | `pypi-nooa-acp` |
 | `nooa-memory` | `pypi-nooa-memory` |
 | `nooa-bench` | `pypi-nooa-bench` |
 
 > **Why one environment per package.** PyPI keys a *pending* publisher on
-> (owner, repo, workflow filename, environment). If all four shared one
+> (owner, repo, workflow filename, environment). If all five shared one
 > environment, the second registration fails with *"a pending trusted publisher
 > matching this configuration has already been registered for a different
 > project name"* — PyPI cannot tell which project to create on first upload.
@@ -131,13 +135,13 @@ for dry runs. After the first successful upload each pending publisher becomes
 a normal one.
 
 The matching **GitHub Environments** must exist too (Settings → Environments):
-`pypi-nooa`, `pypi-nooa-cli`, `pypi-nooa-memory`, `pypi-nooa-bench`, and the
-four `testpypi-*` equivalents.
+`pypi-nooa`, `pypi-nooa-cli`, `pypi-nooa-acp`, `pypi-nooa-memory`,
+`pypi-nooa-bench`, and the five `testpypi-*` equivalents.
 
 ## Distribution
 
 ```bash
-uv add nooa nooa-cli
+uv add nooa nooa-cli nooa-acp
 ```
 
 Installing straight from a tag also works, and does not require a release:
@@ -148,6 +152,7 @@ uv add "nooa @ git+https://github.com/NVIDIA-NeMo/labs-OO-Agents.git@v0.0.7"
 
 ## Cross-package dependencies
 
-`nooa-cli`, `nooa-memory`, and `nooa-bench` depend on the core `nooa` package.
-They are always released together at the same derived version, so their
-dependency on `nooa` carries **no version floor** — CI never rewrites it.
+`nooa-cli`, `nooa-acp`, `nooa-memory`, and `nooa-bench` depend on the core
+`nooa` package. They are always released together at the same derived version,
+so their dependency on `nooa` carries **no version floor** — CI never rewrites
+it.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -62,6 +62,35 @@ Source/Homepage: https://github.com/yaml/pyyaml
 
 ---
 
+## `nooa-acp`
+
+agent-client-protocol - Apache License 2.0
+Attribution Statements: NVIDIA includes `agent-client-protocol` under the Apache License 2.0 for use with NVIDIA OO Agents.
+License Text(https://spdx.org/licenses/Apache-2.0.html)
+Source/Homepage: https://github.com/agentclientprotocol/python-sdk
+
+click - BSD 3-Clause License
+Attribution Statements: NVIDIA includes `click` under the BSD 3-Clause License for use with NVIDIA OO Agents.
+License Text(https://spdx.org/licenses/BSD-3-Clause.html)
+Source/Homepage: https://github.com/pallets/click
+
+litellm - MIT License
+Attribution Statements: NVIDIA includes `litellm` under the MIT License for use with NVIDIA OO Agents.
+License Text(https://spdx.org/licenses/MIT.html)
+Source/Homepage: https://github.com/BerriAI/litellm
+
+nooa - Apache License 2.0
+Attribution Statements: NVIDIA includes `nooa` under the Apache License 2.0 for use with NVIDIA OO Agents.
+License Text(https://spdx.org/licenses/Apache-2.0.html)
+Source/Homepage: https://github.com/NVIDIA-NeMo/labs-OO-Agents
+
+nooa-cli - Apache License 2.0
+Attribution Statements: NVIDIA includes `nooa-cli` under the Apache License 2.0 for use with NVIDIA OO Agents.
+License Text(https://spdx.org/licenses/Apache-2.0.html)
+Source/Homepage: https://github.com/NVIDIA-NeMo/labs-OO-Agents
+
+---
+
 ## `nemo-oo-agents-benchmarks`
 
 click - BSD 3-Clause License

--- a/packages/nooa-acp/README.md
+++ b/packages/nooa-acp/README.md
@@ -8,7 +8,7 @@ Set the model and its provider credentials, then configure the client to launch
 this command with the repository as its working directory:
 
 ```bash
-export NOOA_MODEL=gpt-5-mini
+export NOOA_MODEL=gpt-5.6-luna
 uvx nooa-acp
 ```
 
@@ -29,7 +29,7 @@ finish in the background when its client does not support transport-level aborts
 ## Standalone server
 
 ```bash
-nooa-acp --model gpt-5-mini
+nooa-acp --model gpt-5.6-luna
 ```
 
 The process waits for an ACP client on standard input. `--model` accepts any

--- a/packages/nooa-acp/README.md
+++ b/packages/nooa-acp/README.md
@@ -8,7 +8,7 @@ Set the model and its provider credentials, then configure the client to launch
 this command with the repository as its working directory:
 
 ```bash
-export NOOA_MODEL=gpt-5.6-luna
+export NVIDIA_API_KEY=nvapi-...
 uvx nooa-acp
 ```
 
@@ -29,7 +29,7 @@ finish in the background when its client does not support transport-level aborts
 ## Standalone server
 
 ```bash
-nooa-acp --model gpt-5.6-luna
+nooa-acp --model nvidia_nim/nvidia/nemotron-3-super-120b-a12b
 ```
 
 The process waits for an ACP client on standard input. `--model` accepts any

--- a/packages/nooa-acp/README.md
+++ b/packages/nooa-acp/README.md
@@ -1,0 +1,36 @@
+# nooa-acp
+
+ACP adapter for running the NOOA coding agent from compatible clients.
+
+## Connect an ACP client
+
+Set the model and its provider credentials, then configure the client to launch
+this command with the repository as its working directory:
+
+```bash
+export NOOA_MODEL=gpt-5-mini
+uvx nooa-acp
+```
+
+From this repository, use the workspace package as the client command:
+
+```bash
+uv run --project "$PWD" --package nooa-acp -- nooa-acp
+```
+
+ACP uses standard input and output for JSON-RPC. Diagnostics are written to
+standard error. The agent can execute generated Python and shell commands, so
+use an OS-level sandbox for untrusted tasks. Generated code shares the agent's
+process environment, including model credentials; launch it with only the
+credentials and network access that the session may use.
+Cancellation stops local work immediately. An in-flight provider request may
+finish in the background when its client does not support transport-level aborts.
+
+## Standalone server
+
+```bash
+nooa-acp --model gpt-5-mini
+```
+
+The process waits for an ACP client on standard input. `--model` accepts any
+LiteLLM model name or configured NOOA model alias.

--- a/packages/nooa-acp/pyproject.toml
+++ b/packages/nooa-acp/pyproject.toml
@@ -1,0 +1,47 @@
+[project]
+name = "nooa-acp"
+dynamic = ["version"]
+description = "Agent Client Protocol adapter for the NOOA coding agent"
+license = {text = "Apache-2.0"}
+readme = "README.md"
+requires-python = ">=3.12,<3.14"
+dependencies = [
+    "nooa[mcp]",
+    "nooa-cli",
+    # 1.95.0 has no macOS wheels and requires a newer Rust than common toolchains.
+    "litellm!=1.95.0",
+    "agent-client-protocol>=0.11,<0.12",
+    "click>=8.1.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/NVIDIA-NeMo/labs-OO-Agents"
+Repository = "https://github.com/NVIDIA-NeMo/labs-OO-Agents"
+Issues = "https://github.com/NVIDIA-NeMo/labs-OO-Agents/issues"
+
+[project.scripts]
+nooa-acp = "nooa_acp.cli:main"
+
+[project.entry-points."nooa_cli.commands"]
+acp = "nooa_acp.cli:command"
+
+[tool.uv.sources]
+nooa = { workspace = true }
+nooa-cli = { workspace = true }
+
+[build-system]
+requires = ["hatchling>=1.26.0", "uv-dynamic-versioning>=0.14.0"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
+metadata = false
+fallback-version = "0.0.6"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/nooa_acp"]

--- a/packages/nooa-acp/src/nooa_acp/__init__.py
+++ b/packages/nooa-acp/src/nooa_acp/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Agent Client Protocol adapter for the NOOA coding agent."""

--- a/packages/nooa-acp/src/nooa_acp/cli.py
+++ b/packages/nooa-acp/src/nooa_acp/cli.py
@@ -3,6 +3,7 @@
 """Command-line entry points for the NOOA ACP agent."""
 
 import asyncio
+import os
 from typing import TYPE_CHECKING
 
 import click
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
 @click.option(
     "--model",
     envvar="NOOA_MODEL",
-    default="gpt-5.6-luna",
+    default="nvidia_nim/nvidia/nemotron-3-super-120b-a12b",
     show_default=True,
     help="LiteLLM model name or configured NOOA model alias.",
 )
@@ -32,9 +33,11 @@ def command(model: str, client_type: str | None) -> None:
     from nooa_acp.server import serve
 
     load_secrets_into_env()
+    nvidia_api_key = os.getenv("NVIDIA_API_KEY") if model.startswith("nvidia_nim/") else None
 
     def llm_factory() -> "UnifiedLLM":
-        return get_llm_client(model, client_type=client_type)
+        overrides = {"api_key": nvidia_api_key} if nvidia_api_key else {}
+        return get_llm_client(model, client_type=client_type, **overrides)
 
     asyncio.run(serve(llm_factory))
 

--- a/packages/nooa-acp/src/nooa_acp/cli.py
+++ b/packages/nooa-acp/src/nooa_acp/cli.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Command-line entry points for the NOOA ACP agent."""
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from nooa.unifiedllm import UnifiedLLM
+
+
+@click.command()
+@click.option(
+    "--model",
+    envvar="NOOA_MODEL",
+    default="gpt-5-mini",
+    show_default=True,
+    help="LiteLLM model name or configured NOOA model alias.",
+)
+@click.option(
+    "--client-type",
+    type=click.Choice(("completion", "responses")),
+    default=None,
+    help="Override the configured NOOA LLM client type.",
+)
+def command(model: str, client_type: str | None) -> None:
+    """Serve the NOOA coding agent over ACP on standard input/output."""
+    from nooa.secrets import load_secrets_into_env
+    from nooa.unifiedllm import get_llm_client
+    from nooa_acp.server import serve
+
+    load_secrets_into_env()
+
+    def llm_factory() -> "UnifiedLLM":
+        return get_llm_client(model, client_type=client_type)
+
+    asyncio.run(serve(llm_factory))
+
+
+def main() -> None:
+    command()

--- a/packages/nooa-acp/src/nooa_acp/cli.py
+++ b/packages/nooa-acp/src/nooa_acp/cli.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 @click.option(
     "--model",
     envvar="NOOA_MODEL",
-    default="gpt-5-mini",
+    default="gpt-5.6-luna",
     show_default=True,
     help="LiteLLM model name or configured NOOA model alias.",
 )

--- a/packages/nooa-acp/src/nooa_acp/coding_agent.py
+++ b/packages/nooa-acp/src/nooa_acp/coding_agent.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""NOOA coding agent hosted by the ACP adapter."""
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from nooa_cli.tools.repo_tools import RepoTools
+
+from nooa import Context, hidden
+from nooa.agentdoc import doc
+from nooa.interactive import (
+    InteractiveAgent,
+    RespondReason,
+    RespondResult,
+    SummarizationConfig,
+    install_summarizer,
+)
+from nooa.mcp import MCPTool
+from nooa.tools import ShellTools, TodoManager
+
+if TYPE_CHECKING:
+    from nooa.unifiedllm import UnifiedLLM
+
+__all__ = ["CodingInteractiveAgent", "RespondReason"]
+
+
+class CodingInteractiveAgent(InteractiveAgent):
+    """A careful coding agent working in one local repository."""
+
+    cwd: Path
+    shell: ShellTools
+    repo: RepoTools
+    todo: TodoManager
+    mcp: dict[str, MCPTool]
+
+    def __init__(
+        self,
+        llm: "UnifiedLLM",
+        cwd: Path,
+        mcp: dict[str, MCPTool] | None = None,
+    ) -> None:
+        super().__init__(llm=llm)  # type: ignore[no-untyped-call]
+        self.cwd = cwd.resolve()
+        self.shell = ShellTools(cwd=str(self.cwd))
+        self.repo = RepoTools(root=str(self.cwd), session=self.shell.session)
+        self.todo = TodoManager()
+        self.mcp = mcp or {}
+        self.context_manager["python_tools"] = Context(doc(RepoTools, ShellTools), prefix=True)
+        self.context_manager["todo"] = Context(doc(TodoManager), prefix=True)
+        self.context_manager["todo_status"] = Context(expr="self.todo.status()")
+        if self.mcp:
+            mcp_docs = "\n\n".join(
+                f"self.mcp[{name!r}]:\n{doc(tool)}" for name, tool in self.mcp.items()
+            )
+            self.context_manager["mcp"] = Context(mcp_docs, prefix=True)
+        install_summarizer(SummarizationConfig(), self)
+
+    @hidden
+    async def handle(self, notification: dict[str, list[Any]]) -> RespondResult:
+        """Fulfill the newest software-engineering request in the working directory.
+
+        Inspect repository instructions and relevant code before editing. Use
+        ``self.shell`` for files and commands, ``self.repo`` for definitions and
+        references, ``self.todo`` for multi-step work, and ``self.mcp`` for MCP
+        servers supplied by the client. Preserve unrelated worktree changes and
+        avoid destructive commands.
+
+        Complete and verify the work before returning ``RespondReason.DONE``.
+        Send each user-facing answer or question through ``self.message()`` as a
+        complete Markdown document. Return ``RespondReason.NEED_INPUT`` only when
+        human input is required, and ``RespondReason.WAIT`` only for an active
+        background job. Always provide a concrete explanation to
+        ``return_result()``.
+        """
+        ...
+
+    @hidden
+    async def close(self) -> None:
+        await self.queue_manager.shutdown()
+        await self.shell.close()
+        await self.llm.aclose()

--- a/packages/nooa-acp/src/nooa_acp/dispatcher.py
+++ b/packages/nooa-acp/src/nooa_acp/dispatcher.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Host-side dispatcher for a NOOA interactive agent."""
+
+import asyncio
+from contextlib import suppress
+from typing import Any, cast
+
+from nooa.interactive import RespondReason, RespondResult
+from nooa_acp.coding_agent import CodingInteractiveAgent
+
+
+class InteractiveSessionDispatcher:
+    def __init__(self, agent: CodingInteractiveAgent) -> None:
+        self.agent = agent
+        self._active_task: asyncio.Task[RespondResult] | None = None
+        self._cancel_requested = False
+        self._cancelling = False
+
+    @property
+    def active(self) -> bool:
+        return self._cancelling or (self._active_task is not None and not self._active_task.done())
+
+    async def submit(self, text: str) -> RespondResult | None:
+        if self.active:
+            raise RuntimeError("A prompt is already running")
+
+        self._cancel_requested = False
+        self.agent.queue_manager.get_channel("user_messages").put(text)
+        task = asyncio.create_task(self._dispatch(), name="nooa-acp-dispatch")
+        self._active_task = task
+        try:
+            return await task
+        except asyncio.CancelledError:
+            if self._cancel_requested:
+                return None
+            raise
+        finally:
+            if self._active_task is task:
+                self._active_task = None
+
+    async def _dispatch(self) -> RespondResult:
+        while True:
+            wins = await self.agent.queue_manager.race()
+            notification: dict[str, list[Any]] = {}
+            for name, item in wins:
+                notification.setdefault(name, []).append(item)
+            for name, channel in self.agent.queue_manager.channels().items():
+                if drained := channel.drain():
+                    notification.setdefault(name, []).extend(drained)
+
+            result = cast(RespondResult, await self.agent.handle(notification))
+            if result.kind is not RespondReason.WAIT:
+                return result
+
+    async def cancel(self) -> bool:
+        task = self._active_task
+        if task is None or task.done():
+            return False
+
+        self._cancelling = True
+        self._cancel_requested = True
+        try:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+            self.agent.queue_manager.get_channel("user_messages").flush()
+            await self.agent.queue_manager.shutdown()
+            await self.agent.shell.close()
+            return True
+        finally:
+            self._cancelling = False
+
+    async def close(self) -> None:
+        await self.cancel()
+        await self.agent.close()

--- a/packages/nooa-acp/src/nooa_acp/event_bridge.py
+++ b/packages/nooa-acp/src/nooa_acp/event_bridge.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Translate observational NOOA events into ACP session updates."""
+
+import asyncio
+from collections.abc import Callable
+from contextlib import suppress
+from typing import Any, Literal
+
+from acp import start_tool_call, text_block, tool_content, update_agent_message, update_tool_call
+from acp.interfaces import Client
+from acp.schema import Cost, UsageUpdate
+
+from nooa.context_blocks.events import EventBase, ResultStatus, ToolCallEvent
+from nooa.events import LLMComplete, PythonOutput
+from nooa.interactive import AgentMessage
+from nooa_acp.coding_agent import CodingInteractiveAgent
+
+_STOP = object()
+
+
+class ACPEventBridge:
+    def __init__(self, agent: CodingInteractiveAgent, client: Client, session_id: str) -> None:
+        self.agent = agent
+        self.client = client
+        self.session_id = session_id
+        self._queue: asyncio.Queue[Any] = asyncio.Queue()
+        self._error: Exception | None = None
+        self._closed = False
+        self._open_tools: set[str] = set()
+        self._cost_usd = 0.0
+        self._unsubscribers: list[Callable[[], None]] = [
+            agent.event_manager.on("AgentMessage", self._on_agent_message),
+            agent.event_manager.on("ToolCallEvent", self._on_tool_call),
+            agent.event_manager.on("PythonOutput", self._on_python_output),
+            agent.event_manager.on("LLMComplete", self._on_llm_complete),
+        ]
+        self._pump_task = asyncio.create_task(self._pump(), name="nooa-acp-events")
+
+    def _enqueue(self, update: Any) -> None:
+        if not self._closed:
+            self._queue.put_nowait(update)
+
+    def _on_agent_message(self, event: EventBase) -> None:
+        if not isinstance(event, AgentMessage):
+            return
+        self._enqueue(update_agent_message(text_block(event.content)))
+
+    def _on_tool_call(self, event: EventBase) -> None:
+        if (
+            not isinstance(event, ToolCallEvent)
+            or event.name != "execute_python"
+            or event.metadata.get("prefill") is True
+        ):
+            return
+        self._open_tools.add(event.tool_call_id)
+        self._enqueue(
+            start_tool_call(
+                event.tool_call_id,
+                "Running Python",
+                kind="execute",
+                status="in_progress",
+                raw_input=event.arguments,
+            )
+        )
+
+    def _on_python_output(self, event: EventBase) -> None:
+        if not isinstance(event, PythonOutput) or event.tool_call_id not in self._open_tools:
+            return
+        self._open_tools.discard(event.tool_call_id)
+        parts = [
+            part.rstrip() for part in (event.stdout, event.stderr, event.error) if part.strip()
+        ]
+        output = "\n".join(parts) or "Completed."
+        status: Literal["failed", "completed"] = (
+            "failed" if event.execution_status is ResultStatus.ERROR else "completed"
+        )
+        self._enqueue(
+            update_tool_call(
+                event.tool_call_id,
+                status=status,
+                content=[tool_content(text_block(output))],
+            )
+        )
+
+    def _on_llm_complete(self, event: EventBase) -> None:
+        if not isinstance(event, LLMComplete):
+            return
+        self._cost_usd += event.cost_usd
+        context_window = getattr(self.agent.llm, "context_window", None)
+        if context_window is None:
+            return
+        self._enqueue(
+            UsageUpdate(
+                session_update="usage_update",
+                used=event.prompt_tokens,
+                size=max(context_window, event.prompt_tokens),
+                cost=Cost(amount=self._cost_usd, currency="USD"),
+            )
+        )
+
+    async def _pump(self) -> None:
+        while True:
+            item = await self._queue.get()
+            try:
+                if item is _STOP:
+                    return
+                if isinstance(item, asyncio.Future):
+                    if not item.done():
+                        if self._error is None:
+                            item.set_result(None)
+                        else:
+                            item.set_exception(self._error)
+                    continue
+                if self._error is None:
+                    try:
+                        await self.client.session_update(self.session_id, item)
+                    except Exception as exc:
+                        self._error = exc
+            finally:
+                self._queue.task_done()
+
+    async def flush(self) -> None:
+        if self._closed:
+            return
+        future = asyncio.get_running_loop().create_future()
+        self._queue.put_nowait(future)
+        await asyncio.shield(future)
+
+    async def fail_open_tools(self, reason: str) -> None:
+        for tool_call_id in tuple(self._open_tools):
+            self._enqueue(
+                update_tool_call(
+                    tool_call_id,
+                    status="failed",
+                    content=[tool_content(text_block(reason))],
+                )
+            )
+        self._open_tools.clear()
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        for unsubscribe in self._unsubscribers:
+            unsubscribe()
+        with suppress(Exception):
+            await self.flush()
+        self._closed = True
+        self._queue.put_nowait(_STOP)
+        await self._pump_task

--- a/packages/nooa-acp/src/nooa_acp/server.py
+++ b/packages/nooa-acp/src/nooa_acp/server.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""ACP server for the NOOA coding agent."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from contextlib import suppress
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, cast
+from uuid import uuid4
+
+from acp import (
+    PROTOCOL_VERSION,
+    InitializeResponse,
+    NewSessionResponse,
+    PromptResponse,
+    RequestError,
+    run_agent,
+)
+from acp.interfaces import Agent, Client
+from acp.schema import AgentCapabilities, Implementation, McpServerStdio
+
+from nooa.errors import GenerationError
+from nooa.mcp import MCPManager, MCPTool
+from nooa.unifiedllm import UnifiedLLM
+from nooa_acp.coding_agent import CodingInteractiveAgent
+from nooa_acp.dispatcher import InteractiveSessionDispatcher
+from nooa_acp.event_bridge import ACPEventBridge
+
+
+class CodingACPAdapter:
+    def __init__(self, llm_factory: Callable[[], UnifiedLLM]) -> None:
+        self._llm_factory = llm_factory
+        self._client: Client | None = None
+        self._session_id: str | None = None
+        self._dispatcher: InteractiveSessionDispatcher | None = None
+        self._bridge: ACPEventBridge | None = None
+        self._creating_session = False
+        self._prompt_lock = asyncio.Lock()
+        self._cancel_lock = asyncio.Lock()
+        self._cancel_complete = asyncio.Event()
+        self._cancel_complete.set()
+
+    def on_connect(self, conn: Client) -> None:
+        self._client = conn
+
+    async def initialize(
+        self,
+        protocol_version: int,
+        client_capabilities: Any = None,
+        client_info: Implementation | None = None,
+        **kwargs: Any,
+    ) -> InitializeResponse:
+        del protocol_version, client_capabilities, client_info, kwargs
+        try:
+            package_version = version("nooa-acp")
+        except PackageNotFoundError:
+            package_version = "0.0.0"
+        return InitializeResponse(
+            protocol_version=PROTOCOL_VERSION,
+            agent_capabilities=AgentCapabilities(),
+            auth_methods=[],
+            agent_info=Implementation(
+                name="nooa-acp",
+                title="NVIDIA OO Agents",
+                version=package_version,
+            ),
+        )
+
+    async def new_session(
+        self,
+        cwd: str,
+        additional_directories: list[str] | None = None,
+        mcp_servers: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> NewSessionResponse:
+        del kwargs
+        if self._session_id is not None or self._creating_session:
+            raise RequestError.invalid_request({"reason": "Only one session is supported"})
+        if additional_directories:
+            raise RequestError.invalid_params(
+                {"reason": "Additional directories are not supported"}
+            )
+        unsupported_mcp = [
+            type(server).__name__
+            for server in mcp_servers or []
+            if not isinstance(server, McpServerStdio)
+        ]
+        if unsupported_mcp:
+            raise RequestError.invalid_params(
+                {"reason": f"Unsupported MCP server type(s): {', '.join(unsupported_mcp)}"}
+            )
+
+        root = Path(cwd).expanduser()
+        if not root.is_absolute() or not root.is_dir():
+            raise RequestError.invalid_params(
+                {"cwd": cwd, "reason": "cwd must be an existing absolute directory"}
+            )
+        if self._client is None:
+            raise RequestError.internal_error({"reason": "ACP client is not connected"})
+
+        session_id = str(uuid4())
+        self._creating_session = True
+        try:
+            stdio_servers = [
+                server for server in mcp_servers or [] if isinstance(server, McpServerStdio)
+            ]
+            server_names = [server.name for server in stdio_servers]
+            duplicate_names = sorted(
+                name for name in set(server_names) if server_names.count(name) > 1
+            )
+            if duplicate_names:
+                raise RequestError.invalid_params(
+                    {"reason": f"Duplicate MCP server name(s): {', '.join(duplicate_names)}"}
+                )
+            mcp: dict[str, MCPTool] = {}
+            for server in stdio_servers:
+                env = {item.name: item.value for item in server.env}
+                mcp[server.name] = await MCPManager.create_stdio_server(
+                    server.name,
+                    command=server.command,
+                    args=server.args,
+                    env=env,
+                )
+
+            agent = CodingInteractiveAgent(llm=self._llm_factory(), cwd=root, mcp=mcp)
+            self._session_id = session_id
+            self._dispatcher = InteractiveSessionDispatcher(agent)
+            self._bridge = ACPEventBridge(agent, self._client, session_id)
+            return NewSessionResponse(session_id=session_id)
+        finally:
+            self._creating_session = False
+
+    async def prompt(self, session_id: str, prompt: list[Any], **kwargs: Any) -> PromptResponse:
+        del kwargs
+        dispatcher, bridge = self._get_session(session_id)
+        if self._prompt_lock.locked():
+            raise RequestError.invalid_request({"reason": "A prompt is already running"})
+        text_parts: list[str] = []
+        for block in prompt:
+            block_type = getattr(block, "type", None)
+            if block_type == "text":
+                text_parts.append(block.text)
+            elif block_type == "resource_link":
+                text_parts.append(f"Resource {block.name}: {block.uri}")
+            else:
+                raise RequestError.invalid_params(
+                    {"reason": f"Unsupported prompt content type: {block_type!r}"}
+                )
+        text = "\n\n".join(text_parts)
+        if not text.strip():
+            raise RequestError.invalid_params({"reason": "Prompt text must not be empty"})
+
+        async with self._prompt_lock:
+            self._cancel_complete.clear()
+            try:
+                result = await dispatcher.submit(text)
+            except RuntimeError as exc:
+                raise RequestError.invalid_request({"reason": str(exc)}) from None
+            except GenerationError as exc:
+                await bridge.flush()
+                message = str(exc)
+                if message.startswith("Empty response: the model used all available output tokens"):
+                    return PromptResponse(stop_reason="max_tokens")
+                if message.startswith("Generation failed after ") and (
+                    "max_iterations=" in message or "max_retries=" in message
+                ):
+                    return PromptResponse(stop_reason="max_turn_requests")
+                raise
+            if result is None:
+                await self._cancel_complete.wait()
+                return PromptResponse(stop_reason="cancelled")
+            await bridge.flush()
+            return PromptResponse(stop_reason="end_turn")
+
+    async def cancel(self, session_id: str, **kwargs: Any) -> None:
+        del kwargs
+        dispatcher, bridge = self._get_session(session_id)
+        async with self._cancel_lock:
+            try:
+                if await dispatcher.cancel():
+                    await bridge.fail_open_tools("Cancelled by user.")
+                    await bridge.flush()
+            finally:
+                self._cancel_complete.set()
+
+    def _get_session(self, session_id: str) -> tuple[InteractiveSessionDispatcher, ACPEventBridge]:
+        if session_id != self._session_id or self._dispatcher is None or self._bridge is None:
+            raise RequestError.resource_not_found(session_id)
+        return self._dispatcher, self._bridge
+
+    async def close(self) -> None:
+        if (
+            self._session_id is not None
+            and self._dispatcher is not None
+            and self._bridge is not None
+        ):
+            with suppress(Exception):
+                await self.cancel(self._session_id)
+        self._cancel_complete.set()
+        if self._bridge is not None:
+            await self._bridge.close()
+            self._bridge = None
+        if self._dispatcher is not None:
+            await self._dispatcher.close()
+            self._dispatcher = None
+        self._session_id = None
+
+
+async def serve(llm_factory: Callable[[], UnifiedLLM]) -> None:
+    adapter = CodingACPAdapter(llm_factory)
+    try:
+        await run_agent(cast(Agent, adapter))
+    finally:
+        with suppress(Exception):
+            await adapter.close()

--- a/packages/nooa-acp/tests/fixtures/fake_agent.py
+++ b/packages/nooa-acp/tests/fixtures/fake_agent.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic ACP subprocess used by protocol smoke tests."""
+
+import asyncio
+import sys
+
+from nooa_acp.server import serve
+
+from nooa.unifiedllm import FakeLLMClient
+
+
+def llm_factory() -> FakeLLMClient:
+    if "--blocking" in sys.argv:
+        return FakeLLMClient.with_tool_call(
+            "execute_python",
+            {"code": "await asyncio.Event().wait()"},
+        )
+    return FakeLLMClient.with_tool_call(
+        "execute_python",
+        {
+            "code": (
+                "self.message('NOOA ACP smoke test passed.')\n"
+                "return_result(RespondReason.DONE, explanation='smoke test complete')"
+            )
+        },
+    )
+
+
+asyncio.run(serve(llm_factory))

--- a/packages/nooa-acp/tests/test_coding_agent.py
+++ b/packages/nooa-acp/tests/test_coding_agent.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the NOOA coding agent and dispatcher."""
+
+import asyncio
+from typing import Any
+
+from nooa_acp.coding_agent import CodingInteractiveAgent
+from nooa_acp.dispatcher import InteractiveSessionDispatcher
+
+from nooa.context_blocks.events import ToolCallEvent
+from nooa.events import PythonOutput
+from nooa.interactive import AgentMessage, RespondReason, RespondResult
+from nooa.unifiedllm import FakeLLMClient, LLMResponse
+
+
+def _completed_llm(message: str = "Finished **successfully**.") -> FakeLLMClient:
+    return FakeLLMClient.with_tool_call(
+        "execute_python",
+        {
+            "code": (
+                f"self.message({message!r})\n"
+                "return_result(RespondReason.DONE, explanation='completed and verified')"
+            )
+        },
+    )
+
+
+async def test_coding_agent_runs_through_nooa_codeact(tmp_path):
+    agent = CodingInteractiveAgent(llm=_completed_llm(), cwd=tmp_path)
+    dispatcher = InteractiveSessionDispatcher(agent)
+
+    result = await dispatcher.submit("inspect the repository")
+
+    assert result is not None
+    assert result.kind is RespondReason.DONE
+    assert agent.cwd == tmp_path.resolve()
+    assert agent.shell.session is agent.repo.session
+    events = agent.event_manager.values()
+    assert any(isinstance(event, AgentMessage) for event in events)
+    assert any(isinstance(event, ToolCallEvent) for event in events)
+    assert any(isinstance(event, PythonOutput) for event in events)
+    await dispatcher.close()
+
+
+class _BlockingLLM(FakeLLMClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = asyncio.Event()
+
+    async def acall(self, *args, **kwargs) -> LLMResponse:
+        self.started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+
+class _WaitingAgent(CodingInteractiveAgent):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.handle_calls = 0
+
+    async def handle(self, notification: dict[str, list[Any]]) -> RespondResult:
+        self.handle_calls += 1
+        if self.handle_calls == 1:
+            self.queue_manager.get_channel("system_messages").put("job finished")
+            return RespondResult(kind=RespondReason.WAIT, explanation="waiting for job")
+        assert notification == {"system_messages": ["job finished"]}
+        return RespondResult(kind=RespondReason.DONE, explanation="job finished")
+
+
+class _BackgroundAgent(CodingInteractiveAgent):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.job_started = asyncio.Event()
+        self.job: Any = None
+
+    async def handle(self, notification: dict[str, list[Any]]) -> RespondResult:
+        async def background_job() -> None:
+            self.job_started.set()
+            await asyncio.Event().wait()
+
+        self.job = self.queue_manager.spawn(background_job(), channel="system_messages")
+        return RespondResult(kind=RespondReason.WAIT, explanation="waiting for job")
+
+
+async def test_dispatcher_cancels_active_nooa_turn(tmp_path):
+    llm = _BlockingLLM()
+    agent = CodingInteractiveAgent(llm=llm, cwd=tmp_path)
+    dispatcher = InteractiveSessionDispatcher(agent)
+    prompt_task = asyncio.create_task(dispatcher.submit("wait forever"))
+    await asyncio.wait_for(llm.started.wait(), timeout=2)
+
+    assert await dispatcher.cancel() is True
+    assert await asyncio.wait_for(prompt_task, timeout=2) is None
+    assert dispatcher.active is False
+    await dispatcher.close()
+
+
+async def test_dispatcher_resumes_after_wait_notification(tmp_path):
+    agent = _WaitingAgent(llm=FakeLLMClient(), cwd=tmp_path)
+    dispatcher = InteractiveSessionDispatcher(agent)
+
+    result = await dispatcher.submit("wait for the job")
+
+    assert result is not None
+    assert result.kind is RespondReason.DONE
+    assert agent.handle_calls == 2
+    await dispatcher.close()
+
+
+async def test_dispatcher_cancels_background_jobs(tmp_path):
+    agent = _BackgroundAgent(llm=FakeLLMClient(), cwd=tmp_path)
+    dispatcher = InteractiveSessionDispatcher(agent)
+    prompt_task = asyncio.create_task(dispatcher.submit("start a background job"))
+    await asyncio.wait_for(agent.job_started.wait(), timeout=1)
+
+    assert await dispatcher.cancel() is True
+    assert await asyncio.wait_for(prompt_task, timeout=1) is None
+    assert agent.job is not None
+    assert agent.job.state == "cancelled"
+    await dispatcher.close()

--- a/packages/nooa-acp/tests/test_event_bridge.py
+++ b/packages/nooa-acp/tests/test_event_bridge.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for translating NOOA events into ACP updates."""
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+from acp.schema import AgentMessageChunk, ToolCallProgress, ToolCallStart, UsageUpdate
+from nooa_acp.coding_agent import CodingInteractiveAgent
+from nooa_acp.event_bridge import ACPEventBridge
+
+from nooa.context_blocks.events import ResultStatus, ToolCallEvent
+from nooa.events import LLMComplete, PythonOutput
+from nooa.interactive import AgentMessage
+from nooa.unifiedllm import FakeLLMClient
+
+
+class _RecordingClient:
+    def __init__(self) -> None:
+        self.updates: list[tuple[str, object]] = []
+
+    async def session_update(self, session_id: str, update: object, **kwargs) -> None:
+        self.updates.append((session_id, update))
+
+
+async def test_bridge_preserves_message_tool_and_usage_order(tmp_path):
+    agent = CodingInteractiveAgent(llm=FakeLLMClient(), cwd=tmp_path)
+    client = _RecordingClient()
+    bridge = ACPEventBridge(agent, client, "session-1")  # type: ignore[arg-type]
+
+    agent.event_manager.add(AgentMessage(content="Final answer"))
+    agent.event_manager.add(
+        ToolCallEvent(
+            tool_call_id="prefill-1",
+            name="execute_python",
+            arguments={"code": "print('internal setup')"},
+            metadata={"prefill": True},
+        )
+    )
+    agent.event_manager.add(
+        PythonOutput(
+            tool_call_id="prefill-1",
+            execution_status=ResultStatus.COMPLETE,
+            execution_count=1,
+            stdout="internal setup\n",
+        )
+    )
+    agent.event_manager.add(
+        ToolCallEvent(
+            tool_call_id="call-1",
+            name="execute_python",
+            arguments={"code": "print('hello')"},
+        )
+    )
+    agent.event_manager.add(
+        PythonOutput(
+            tool_call_id="call-1",
+            execution_status=ResultStatus.COMPLETE,
+            execution_count=1,
+            stdout="hello\n",
+        )
+    )
+    agent.event_manager.add(LLMComplete(prompt_tokens=40, completion_tokens=10, cost_usd=0.25))
+    await bridge.flush()
+
+    updates = [update for _, update in client.updates]
+    assert {session_id for session_id, _ in client.updates} == {"session-1"}
+    assert [type(update) for update in updates] == [
+        AgentMessageChunk,
+        ToolCallStart,
+        ToolCallProgress,
+        UsageUpdate,
+    ]
+    assert cast(AgentMessageChunk, updates[0]).content.text == "Final answer"
+    assert cast(ToolCallProgress, updates[2]).status == "completed"
+    usage = cast(UsageUpdate, updates[3])
+    assert usage.cost is not None
+    assert usage.cost.amount == 0.25
+    await bridge.close()
+    await agent.close()
+
+
+async def test_bridge_marks_failed_python_output(tmp_path):
+    agent = CodingInteractiveAgent(llm=FakeLLMClient(), cwd=tmp_path)
+    client = _RecordingClient()
+    bridge = ACPEventBridge(agent, client, "session-1")  # type: ignore[arg-type]
+
+    agent.event_manager.add(
+        ToolCallEvent(
+            tool_call_id="call-1",
+            name="execute_python",
+            arguments={"code": "raise RuntimeError('boom')"},
+        )
+    )
+    agent.event_manager.add(
+        PythonOutput(
+            tool_call_id="call-1",
+            execution_status=ResultStatus.ERROR,
+            execution_count=1,
+            stderr="Execution error: RuntimeError: boom",
+        )
+    )
+    await bridge.flush()
+
+    progress = next(
+        cast(ToolCallProgress, update)
+        for _, update in client.updates
+        if isinstance(update, ToolCallProgress)
+    )
+    assert progress.status == "failed"
+    assert "Execution error: RuntimeError: boom" in str(progress.content)
+    await bridge.close()
+    await agent.close()
+
+
+async def test_bridge_omits_usage_when_context_window_is_unknown(tmp_path):
+    llm = FakeLLMClient()
+    cast(Any, llm)._context_window = None
+    agent = CodingInteractiveAgent(llm=llm, cwd=tmp_path)
+    client = _RecordingClient()
+    bridge = ACPEventBridge(agent, client, "session-1")  # type: ignore[arg-type]
+
+    agent.event_manager.add(LLMComplete(prompt_tokens=40, completion_tokens=10, cost_usd=0.25))
+    await bridge.flush()
+
+    assert not any(isinstance(update, UsageUpdate) for _, update in client.updates)
+    await bridge.close()
+    await agent.close()
+
+
+class _BlockingClient(_RecordingClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def session_update(self, session_id: str, update: object, **kwargs) -> None:
+        self.started.set()
+        await self.release.wait()
+        await super().session_update(session_id, update, **kwargs)
+
+
+async def test_cancelled_flush_does_not_stop_update_pump(tmp_path):
+    agent = CodingInteractiveAgent(llm=FakeLLMClient(), cwd=tmp_path)
+    client = _BlockingClient()
+    bridge = ACPEventBridge(agent, client, "session-1")  # type: ignore[arg-type]
+    agent.event_manager.add(AgentMessage(content="First"))
+    flush_task = asyncio.create_task(bridge.flush())
+    await asyncio.wait_for(client.started.wait(), timeout=1)
+
+    flush_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await flush_task
+    client.release.set()
+    agent.event_manager.add(AgentMessage(content="Second"))
+    await asyncio.wait_for(bridge.flush(), timeout=1)
+
+    messages = [
+        update.content.text for _, update in client.updates if isinstance(update, AgentMessageChunk)
+    ]
+    assert messages == ["First", "Second"]
+    await bridge.close()
+    await agent.close()

--- a/packages/nooa-acp/tests/test_protocol.py
+++ b/packages/nooa-acp/tests/test_protocol.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end ACP JSON-RPC subprocess test."""
+
+import asyncio
+import sys
+from pathlib import Path
+
+from acp import PROTOCOL_VERSION, spawn_agent_process, text_block
+from acp.schema import AgentMessageChunk, ToolCallProgress, ToolCallStart
+
+
+class _RecordingClient:
+    def __init__(self) -> None:
+        self.updates: list[tuple[str, object]] = []
+        self.tool_started = asyncio.Event()
+
+    async def session_update(self, session_id: str, update: object, **kwargs) -> None:
+        self.updates.append((session_id, update))
+        if isinstance(update, ToolCallStart):
+            self.tool_started.set()
+
+
+async def test_acp_subprocess_transcript(tmp_path):
+    client = _RecordingClient()
+    fixture = Path(__file__).parent / "fixtures" / "fake_agent.py"
+
+    async with spawn_agent_process(
+        client,  # type: ignore[arg-type]
+        sys.executable,
+        str(fixture),
+        cwd=tmp_path,
+    ) as (connection, _process):
+        initialized = await connection.initialize(PROTOCOL_VERSION)
+        session = await connection.new_session(str(tmp_path))
+        response = await connection.prompt(session.session_id, [text_block("run smoke test")])
+
+    assert initialized.agent_info is not None
+    assert initialized.agent_info.name == "nooa-acp"
+    assert response.stop_reason == "end_turn"
+    assert {update_session for update_session, _ in client.updates} == {session.session_id}
+    assert any(isinstance(update, ToolCallStart) for _, update in client.updates)
+    assert any(isinstance(update, ToolCallProgress) for _, update in client.updates)
+    assert any(
+        isinstance(update, AgentMessageChunk)
+        and update.content.text == "NOOA ACP smoke test passed."
+        for _, update in client.updates
+    )
+
+
+async def test_acp_subprocess_cancellation_finishes_open_tools(tmp_path):
+    client = _RecordingClient()
+    fixture = Path(__file__).parent / "fixtures" / "fake_agent.py"
+
+    async with spawn_agent_process(
+        client,  # type: ignore[arg-type]
+        sys.executable,
+        str(fixture),
+        "--blocking",
+        cwd=tmp_path,
+    ) as (connection, _process):
+        await connection.initialize(PROTOCOL_VERSION)
+        session = await connection.new_session(str(tmp_path))
+        prompt_task = asyncio.create_task(
+            connection.prompt(session.session_id, [text_block("wait forever")])
+        )
+        await asyncio.wait_for(client.tool_started.wait(), timeout=5)
+        await connection.cancel(session.session_id)
+        response = await asyncio.wait_for(prompt_task, timeout=5)
+
+    assert response.stop_reason == "cancelled"
+    started = next(update for _, update in client.updates if isinstance(update, ToolCallStart))
+    failed = next(
+        update
+        for _, update in client.updates
+        if isinstance(update, ToolCallProgress) and update.status == "failed"
+    )
+    assert failed.tool_call_id == started.tool_call_id

--- a/packages/nooa-acp/tests/test_server.py
+++ b/packages/nooa-acp/tests/test_server.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ACP server surface."""
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from acp import PROTOCOL_VERSION, RequestError, resource_link_block, text_block
+from acp.schema import AgentMessageChunk, EnvVariable, McpServerStdio
+from nooa_acp.cli import command
+from nooa_acp.server import CodingACPAdapter
+from nooa_cli.commands import discover_commands
+
+from nooa.errors import GenerationError
+from nooa.interactive import RespondReason, RespondResult
+from nooa.unifiedllm import FakeLLMClient
+
+
+def _completed_llm() -> FakeLLMClient:
+    return FakeLLMClient.with_tool_call(
+        "execute_python",
+        {
+            "code": (
+                "self.message('ACP response')\n"
+                "return_result(RespondReason.DONE, explanation='request complete')"
+            )
+        },
+    )
+
+
+class _RecordingClient:
+    def __init__(self) -> None:
+        self.updates: list[object] = []
+
+    async def session_update(self, session_id: str, update: object, **kwargs) -> None:
+        self.updates.append(update)
+
+
+def test_acp_command_is_discovered_as_cli_plugin():
+    assert dict(discover_commands())["acp"] is command
+
+
+class _MCPTools:
+    async def lookup(self, query: str) -> str:
+        """Look up a value in the test MCP server."""
+        return query
+
+
+async def test_adapter_completes_one_session_prompt(tmp_path):
+    client = _RecordingClient()
+    adapter = CodingACPAdapter(_completed_llm)
+    adapter.on_connect(client)  # type: ignore[arg-type]
+
+    initialized = await adapter.initialize(PROTOCOL_VERSION)
+    session = await adapter.new_session(str(tmp_path))
+    response = await adapter.prompt(session.session_id, [text_block("do the work")])
+
+    assert initialized.protocol_version == PROTOCOL_VERSION
+    assert initialized.agent_info is not None
+    assert initialized.agent_info.name == "nooa-acp"
+    assert response.stop_reason == "end_turn"
+    assert any(
+        isinstance(update, AgentMessageChunk) and update.content.text == "ACP response"
+        for update in client.updates
+    )
+    await adapter.close()
+
+
+async def test_adapter_includes_resource_links_in_prompt(tmp_path):
+    llm = _completed_llm()
+    client = _RecordingClient()
+    adapter = CodingACPAdapter(lambda: llm)
+    adapter.on_connect(client)  # type: ignore[arg-type]
+
+    session = await adapter.new_session(str(tmp_path))
+    await adapter.prompt(
+        session.session_id,
+        [resource_link_block("README", "file:///workspace/README.md")],
+    )
+
+    assert "Resource README: file:///workspace/README.md" in str(llm.last_messages)
+    await adapter.close()
+
+
+async def test_adapter_preserves_prompt_whitespace(tmp_path):
+    client = _RecordingClient()
+    adapter = CodingACPAdapter(_completed_llm)
+    adapter.on_connect(client)  # type: ignore[arg-type]
+
+    session = await adapter.new_session(str(tmp_path))
+    assert adapter._dispatcher is not None
+    result = RespondResult(kind=RespondReason.DONE, explanation="done")
+    submit = AsyncMock(return_value=result)
+    with patch.object(adapter._dispatcher, "submit", submit):
+        await adapter.prompt(session.session_id, [text_block("  indented\n")])
+
+    submit.assert_awaited_once_with("  indented\n")
+    await adapter.close()
+
+
+async def test_adapter_connects_baseline_stdio_mcp_servers(tmp_path):
+    client = _RecordingClient()
+    adapter = CodingACPAdapter(_completed_llm)
+    adapter.on_connect(client)  # type: ignore[arg-type]
+    server = McpServerStdio(
+        name="lookup",
+        command="lookup-server",
+        args=["--stdio"],
+        env=[EnvVariable(name="TOKEN", value="test")],
+    )
+
+    with patch(
+        "nooa_acp.server.MCPManager.create_stdio_server",
+        new=AsyncMock(return_value=_MCPTools()),
+    ) as create:
+        await adapter.new_session(str(tmp_path), mcp_servers=[server])
+
+    create.assert_awaited_once_with(
+        "lookup",
+        command="lookup-server",
+        args=["--stdio"],
+        env={"TOKEN": "test"},
+    )
+    await adapter.close()
+
+
+async def test_adapter_rejects_concurrent_session_creation(tmp_path):
+    client = _RecordingClient()
+    adapter = CodingACPAdapter(_completed_llm)
+    adapter.on_connect(client)  # type: ignore[arg-type]
+    server = McpServerStdio(name="lookup", command="lookup-server", args=[], env=[])
+    started = threading.Event()
+    release = threading.Event()
+
+    async def create_mcp(*args, **kwargs):
+        started.set()
+        await asyncio.to_thread(release.wait, 2)
+        return _MCPTools()
+
+    with patch("nooa_acp.server.MCPManager.create_stdio_server", side_effect=create_mcp):
+        first_session = asyncio.create_task(
+            adapter.new_session(str(tmp_path), mcp_servers=[server])
+        )
+        await asyncio.to_thread(started.wait, 1)
+        with pytest.raises(RequestError):
+            await adapter.new_session(str(tmp_path))
+        release.set()
+        await first_session
+
+    await adapter.close()
+
+
+async def test_adapter_rejects_duplicate_mcp_names_before_startup(tmp_path):
+    client = _RecordingClient()
+    adapter = CodingACPAdapter(_completed_llm)
+    adapter.on_connect(client)  # type: ignore[arg-type]
+    servers = [
+        McpServerStdio(name="lookup", command="first", args=[], env=[]),
+        McpServerStdio(name="lookup", command="second", args=[], env=[]),
+    ]
+
+    with patch(
+        "nooa_acp.server.MCPManager.create_stdio_server",
+        new=AsyncMock(return_value=_MCPTools()),
+    ) as create:
+        with pytest.raises(RequestError):
+            await adapter.new_session(str(tmp_path), mcp_servers=servers)
+
+    create.assert_not_awaited()
+    await adapter.close()
+
+
+@pytest.mark.parametrize(
+    ("message", "stop_reason"),
+    [
+        (
+            "Empty response: the model used all available output tokens on reasoning; "
+            "increase `max_tokens`.",
+            "max_tokens",
+        ),
+        (
+            "Generation failed after 10 iterations (max_iterations=10).",
+            "max_turn_requests",
+        ),
+    ],
+)
+async def test_adapter_maps_generation_limits_to_stop_reasons(
+    tmp_path, message: str, stop_reason: str
+):
+    client = _RecordingClient()
+    adapter = CodingACPAdapter(_completed_llm)
+    adapter.on_connect(client)  # type: ignore[arg-type]
+    session = await adapter.new_session(str(tmp_path))
+    assert adapter._dispatcher is not None
+
+    with patch.object(adapter._dispatcher, "submit", side_effect=GenerationError(message)):
+        response = await adapter.prompt(session.session_id, [text_block("do the work")])
+
+    assert response.stop_reason == stop_reason
+    await adapter.close()
+
+
+async def test_adapter_propagates_unrelated_generation_errors(tmp_path):
+    client = _RecordingClient()
+    adapter = CodingACPAdapter(_completed_llm)
+    adapter.on_connect(client)  # type: ignore[arg-type]
+    session = await adapter.new_session(str(tmp_path))
+    assert adapter._dispatcher is not None
+
+    with (
+        patch.object(
+            adapter._dispatcher,
+            "submit",
+            side_effect=GenerationError("LLM API error after retries"),
+        ),
+        pytest.raises(GenerationError, match="LLM API error"),
+    ):
+        await adapter.prompt(session.session_id, [text_block("do the work")])
+
+    await adapter.close()

--- a/packages/nooa-acp/tests/test_server.py
+++ b/packages/nooa-acp/tests/test_server.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from acp import PROTOCOL_VERSION, RequestError, resource_link_block, text_block
 from acp.schema import AgentMessageChunk, EnvVariable, McpServerStdio
+from click.testing import CliRunner
 from nooa_acp.cli import command
 from nooa_acp.server import CodingACPAdapter
 from nooa_cli.commands import discover_commands
@@ -40,6 +41,26 @@ class _RecordingClient:
 
 def test_acp_command_is_discovered_as_cli_plugin():
     assert dict(discover_commands())["acp"] is command
+
+
+def test_acp_command_defaults_to_public_nvidia_model():
+    runner = CliRunner()
+    with (
+        patch("nooa.secrets.load_secrets_into_env"),
+        patch("nooa.unifiedllm.get_llm_client") as get_llm_client,
+        patch("nooa_acp.server.serve") as serve,
+        patch("nooa_acp.cli.asyncio.run"),
+    ):
+        result = runner.invoke(command, env={"NVIDIA_API_KEY": "nvapi-test"})
+
+    assert result.exit_code == 0
+    llm_factory = serve.call_args.args[0]
+    llm_factory()
+    get_llm_client.assert_called_once_with(
+        "nvidia_nim/nvidia/nemotron-3-super-120b-a12b",
+        client_type=None,
+        api_key="nvapi-test",
+    )
 
 
 class _MCPTools:

--- a/packages/nooa-cli/README.md
+++ b/packages/nooa-cli/README.md
@@ -27,7 +27,7 @@ run the NOOA coding agent from an ACP-compatible client:
 
 ```bash
 uv add nooa-acp
-export NOOA_MODEL=gpt-5.6-luna
+export NVIDIA_API_KEY=nvapi-...
 uv run nooa-acp
 ```
 

--- a/packages/nooa-cli/README.md
+++ b/packages/nooa-cli/README.md
@@ -27,7 +27,7 @@ run the NOOA coding agent from an ACP-compatible client:
 
 ```bash
 uv add nooa-acp
-export NOOA_MODEL=gpt-5-mini
+export NOOA_MODEL=gpt-5.6-luna
 uv run nooa-acp
 ```
 

--- a/packages/nooa-cli/README.md
+++ b/packages/nooa-cli/README.md
@@ -17,9 +17,18 @@ uv add "nooa-cli[datascience]"
 
 ```bash
 nooa --help
-nooa start-dev            # launch the trace viewer
-nooa eval ...             # eval pipeline runner
-nooa traces ...           # inspect/manage trace files
+nooa start-dev        # launch the trace viewer
+nooa eval ...         # eval pipeline runner
+nooa traces ...       # inspect/manage trace files
+```
+
+Install the separate `nooa-acp` package to add the `nooa acp` plugin command and
+run the NOOA coding agent from an ACP-compatible client:
+
+```bash
+uv add nooa-acp
+export NOOA_MODEL=gpt-5-mini
+uv run nooa-acp
 ```
 
 See the main repo [README](https://github.com/NVIDIA-NeMo/labs-OO-Agents/blob/main/README.md) for the framework documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ trace-explorer = "nooa.trace_explorer:main"
 [tool.uv.sources]
 eval_pipeline = { workspace = true }
 nooa-cli = { workspace = true }
+nooa-acp = { workspace = true }
 nooa-memory = { workspace = true }
 nooa-bench = { workspace = true }
 
@@ -62,15 +63,12 @@ nooa-bench = { workspace = true }
 # Extra index URLs to search for packages (in addition to PyPI)
 # Ignore packages uploaded less than 7 days ago to mitigate supply-chain attacks
 exclude-newer = "2026-07-23T00:00:00Z"
-# Match the package's supported Python range and LiteLLM's stable releases.
-environments = [
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
-]
 
 [tool.uv.workspace]
 members = [
     "util/eval_pipeline",
     "packages/nooa-cli",
+    "packages/nooa-acp",
     "packages/nooa-memory",
     "packages/nooa-bench",
 ]
@@ -89,6 +87,7 @@ members = [
 cli = ["nooa-cli"]
 memory = ["nooa-memory"]
 bench = ["nooa-bench"]
+acp = ["nooa-acp"]
 # ARC-AGI-3 example agent (examples/arc_agi_3): the public ARC-AGI-3 SDK + deps.
 # Install with `pip install "nemo-oo-agents[arc]"` (or `uv sync --extra arc`).
 arc = [
@@ -189,8 +188,9 @@ dev = [
     "httpx[socks]>=0.28.1",
     "opentelemetry-exporter-otlp-proto-http>=1.39.1",
     "eval_pipeline",
-    # Workspace packages — keep bench + cli + memory installed/editable in dev sync
+    # Workspace packages — keep acp + bench + cli + memory installed/editable in dev sync
     "nooa-cli",
+    "nooa-acp",
     "nooa-memory",
     "nooa-bench",
     "pre-commit>=4.5.0",
@@ -214,6 +214,7 @@ testpaths = [
     "tests/tracing",
     "tests/test_mcp",
     "packages/nooa-cli/tests",
+    "packages/nooa-acp/tests",
     "packages/nooa-bench/tests",
     "tests/trace_explorer",
 ]

--- a/src/nooa/mcp/tool.py
+++ b/src/nooa/mcp/tool.py
@@ -710,6 +710,30 @@ class MCPTool:
             return False
 
 
+def _create_tool_instance(
+    server_name: str,
+    client: Any,
+    tools_result: Any,
+    refresh_ctx: dict[str, Any] | None = None,
+) -> MCPTool:
+    tool_specs = []
+    for tool in tools_result.tools:
+        input_schema = tool.inputSchema if isinstance(tool.inputSchema, dict) else {}
+        tool_specs.append(
+            MCPToolSpec(
+                name=tool.name,
+                description=tool.description or "",
+                input_schema=input_schema,
+                required=set(input_schema.get("required", [])),
+            )
+        )
+
+    dynamic_class = _make_dynamic_class(server_name, tool_specs, MCPTool)
+    instance = object.__new__(dynamic_class)
+    instance.__init__(client, server_name, refresh_ctx=refresh_ctx)
+    return instance
+
+
 class MCPManager:
     """Manager for creating and connecting to MCP server tool instances.
 
@@ -748,6 +772,33 @@ class MCPManager:
         config = _load_mcp_config(mcp_file)
         config.update(servers or {})
         return list(config.keys())
+
+    @staticmethod
+    async def create_stdio_server(
+        server_name: str,
+        command: str,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        tool_call_timeout: timedelta = timedelta(seconds=60),
+    ) -> MCPTool:
+        """Create an MCP tool from explicit stdio configuration without blocking the event loop."""
+        client = create_mcp_client(
+            transport="stdio",
+            command=command,
+            args=args,
+            env=env,
+            tool_call_timeout=tool_call_timeout,
+        )
+        async with client.connect_to_server() as session:
+            tools_result = await session.list_tools()
+        refresh_ctx = {
+            "server_url": "",
+            "transport": "stdio",
+            "command": command,
+            "args": args,
+            "env": env,
+        }
+        return _create_tool_instance(server_name, client, tools_result, refresh_ctx)
 
     @staticmethod
     def create_from_server(
@@ -920,22 +971,6 @@ class MCPManager:
 
         # Parse tools
         assert tools_result is not None, "tools_result must be set by connect or OAuth retry"
-        tool_specs = []
-        for tool in tools_result.tools:
-            input_schema = tool.inputSchema if isinstance(tool.inputSchema, dict) else {}
-            required = set(input_schema.get("required", []))
-            tool_specs.append(
-                MCPToolSpec(
-                    name=tool.name,
-                    description=tool.description or "",
-                    input_schema=input_schema,
-                    required=required,
-                )
-            )
-
-        # Generate dynamic class and create instance. Stash a refresh context so
-        # _call_tool can transparently refresh the OAuth token + retry once on a
-        # 401 mid-session (cached access tokens expire between connect and call).
         refresh_ctx = {
             "server_url": url or config_server.get("url") or "",
             "redirect_uri": oauth_redirect_uri,
@@ -947,7 +982,4 @@ class MCPManager:
             "args": args,
             "env": env,
         }
-        dynamic_class = _make_dynamic_class(server_name, tool_specs, MCPTool)
-        instance = object.__new__(dynamic_class)
-        instance.__init__(client, server_name, refresh_ctx=refresh_ctx)
-        return instance
+        return _create_tool_instance(server_name, client, tools_result, refresh_ctx)

--- a/tests/test_mcp/test_client.py
+++ b/tests/test_mcp/test_client.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for mcp_nooa module."""
 
+import asyncio
+
 import httpx
 import pytest
 
@@ -19,7 +21,7 @@ from nooa.mcp.client import (  # noqa: E402
     MCPStreamableHTTPClient,
     create_mcp_client,
 )
-from nooa.mcp.tool import MCPTool, MCPToolSpec, _make_dynamic_class  # noqa: E402
+from nooa.mcp.tool import MCPManager, MCPTool, MCPToolSpec, _make_dynamic_class  # noqa: E402
 
 
 # Fixtures
@@ -638,3 +640,76 @@ def test_create_from_server_caller_headers_override_config():
     assert captured_headers["Authorization"] == "Bearer caller-token"
     # ...and config-only headers are still merged in.
     assert captured_headers["X-Config-Only"] == "keep"
+
+
+@pytest.mark.asyncio
+async def test_create_stdio_server_builds_tool_without_blocking_wrapper():
+    session = AsyncMock()
+    schema = {
+        "type": "object",
+        "properties": {"query": {"type": "string"}},
+        "required": ["query"],
+    }
+    remote_tool = MagicMock()
+    remote_tool.name = "lookup"
+    remote_tool.description = "Look up a value"
+    remote_tool.inputSchema = schema
+    session.list_tools.return_value.tools = [remote_tool]
+    client = MagicMock()
+
+    class Context:
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    client.connect_to_server.return_value = Context()
+
+    with patch("nooa.mcp.tool.create_mcp_client", return_value=client) as create:
+        tool = await MCPManager.create_stdio_server(
+            "lookup", "lookup-server", args=["--stdio"], env={"TOKEN": "test"}
+        )
+
+    assert isinstance(tool, MCPTool)
+    assert callable(tool.lookup)  # type: ignore[attr-defined]
+    create.assert_called_once_with(
+        transport="stdio",
+        command="lookup-server",
+        args=["--stdio"],
+        env={"TOKEN": "test"},
+        tool_call_timeout=timedelta(seconds=60),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_stdio_server_closes_connection_on_cancellation():
+    started = asyncio.Event()
+    closed = asyncio.Event()
+    session = AsyncMock()
+
+    async def list_tools():
+        started.set()
+        await asyncio.Event().wait()
+
+    session.list_tools.side_effect = list_tools
+    client = MagicMock()
+
+    class Context:
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, exc_type, exc, tb):
+            closed.set()
+            return False
+
+    client.connect_to_server.return_value = Context()
+
+    with patch("nooa.mcp.tool.create_mcp_client", return_value=client):
+        task = asyncio.create_task(MCPManager.create_stdio_server("lookup", "lookup-server"))
+        await asyncio.wait_for(started.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert closed.is_set()

--- a/uv.lock
+++ b/uv.lock
@@ -6,8 +6,6 @@ resolution-markers = [
     "sys_platform == 'emscripten'",
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
-supported-markers = [
-]
 
 [options]
 exclude-newer = "2026-07-23T00:00:00Z"
@@ -16,9 +14,22 @@ exclude-newer = "2026-07-23T00:00:00Z"
 members = [
     "eval-pipeline",
     "nooa",
+    "nooa-acp",
     "nooa-bench",
     "nooa-cli",
     "nooa-memory",
+]
+
+[[package]]
+name = "agent-client-protocol"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/93/396d02c91b387b2678f23081869ca47bd495fc6c78789022c683180cf5f1/agent_client_protocol-0.11.0.tar.gz", hash = "sha256:8920a3b27bdcc852fd7c73066f47ab53257dbfbe57b505e20a40c69f80a5391c", size = 87402, upload-time = "2026-07-05T17:07:56.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/48/a1367dded7765f5489f9840389949d5aeac53a73aeb1b4e6c0ab61e1617a/agent_client_protocol-0.11.0-py3-none-any.whl", hash = "sha256:2d8570cd4911f8af9fbab4808f7b05f09204a756f346c7409ecdcae3f37cdb2f", size = 68089, upload-time = "2026-07-05T17:07:55.518Z" },
 ]
 
 [[package]]
@@ -1348,6 +1359,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+acp = [
+    { name = "nooa-acp" },
+]
 arc = [
     { name = "arc-agi" },
     { name = "arcengine" },
@@ -1393,6 +1407,7 @@ dev = [
     { name = "httpx", extra = ["socks"] },
     { name = "matplotlib" },
     { name = "mypy" },
+    { name = "nooa-acp" },
     { name = "nooa-bench" },
     { name = "nooa-cli" },
     { name = "nooa-memory" },
@@ -1429,6 +1444,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.84.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "nemo-relay", marker = "extra == 'nemo-relay'", specifier = ">=0.6,<0.7" },
+    { name = "nooa-acp", marker = "extra == 'acp'", editable = "packages/nooa-acp" },
     { name = "nooa-bench", marker = "extra == 'bench'", editable = "packages/nooa-bench" },
     { name = "nooa-cli", marker = "extra == 'cli'", editable = "packages/nooa-cli" },
     { name = "nooa-memory", marker = "extra == 'memory'", editable = "packages/nooa-memory" },
@@ -1446,7 +1462,7 @@ requires-dist = [
     { name = "rich", marker = "extra == 'arc'", specifier = ">=13.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'viewer'", specifier = ">=0.20.0" },
 ]
-provides-extras = ["arc", "bench", "cli", "mcp", "memory", "nemo-relay", "sandbox", "tracing", "viewer"]
+provides-extras = ["acp", "arc", "bench", "cli", "mcp", "memory", "nemo-relay", "sandbox", "tracing", "viewer"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1455,6 +1471,7 @@ dev = [
     { name = "httpx", extras = ["socks"], specifier = ">=0.28.1" },
     { name = "matplotlib", specifier = ">=3.8.0" },
     { name = "mypy", specifier = ">=1.7.0" },
+    { name = "nooa-acp", editable = "packages/nooa-acp" },
     { name = "nooa-bench", editable = "packages/nooa-bench" },
     { name = "nooa-cli", editable = "packages/nooa-cli" },
     { name = "nooa-memory", editable = "packages/nooa-memory" },
@@ -1481,6 +1498,26 @@ trace-viewer = [
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "uvicorn", specifier = ">=0.38.0" },
     { name = "watchfiles", specifier = ">=1.0.0" },
+]
+
+[[package]]
+name = "nooa-acp"
+source = { editable = "packages/nooa-acp" }
+dependencies = [
+    { name = "agent-client-protocol" },
+    { name = "click" },
+    { name = "litellm" },
+    { name = "nooa", extra = ["mcp"] },
+    { name = "nooa-cli" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agent-client-protocol", specifier = ">=0.11,<0.12" },
+    { name = "click", specifier = ">=8.1.0" },
+    { name = "litellm", specifier = "!=1.95.0" },
+    { name = "nooa", extras = ["mcp"], editable = "." },
+    { name = "nooa-cli", editable = "packages/nooa-cli" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add an optional `nooa-acp` distribution that serves a NOOA coding agent over ACP on stdin/stdout
- translate agent messages, tool progress, usage, resource links, cancellation, and stdio MCP servers into ACP protocol behavior
- register both the standalone `nooa-acp` executable and the `nooa acp` plugin command
- include the package in workspace, CI, release, smoke-test, and third-party notice flows

## Verification

- `uv run pytest -q -m "not integration and not stress"`: 6526 passed, 6 skipped, 282 deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- SPDX/license checks and `uv lock --check`
- built all five wheels and source distributions with `--no-sources`; all passed `twine check`
- installed all five wheels in a clean Python 3.12 environment and verified imports, `nooa --help`, and `nooa-acp --help`
- independent pre-landing and Codex reviews: no unresolved findings

## Release Setup

Before first publication, maintainers must create the `pypi-nooa-acp` and `testpypi-nooa-acp` GitHub environments and matching trusted publishers.

Closes #76
