### PR TITLE
feat(strategy): allow a callable for @strategy(llm=...) 

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -557,6 +557,22 @@ class MyAgent(Agent, llm=default_llm):              # 1. class default
         ...
 
 agent = MyAgent(llm=different_llm)                  # 4. instance override
+await agent.complex_task(llm=one_off_llm)           # 5. call override
+```
+
+A method override can also be a callable taking the agent and returning a
+client. It is resolved on each call, so the per-method model can be chosen at
+agent-construction time (or vary with instance state) instead of being fixed
+when the module is imported:
+
+```python
+class MyAgent(Agent, llm=default_llm):
+    @strategy(CodeActStrategy(), llm=lambda self: self.big_model)
+    async def complex_task(self) -> str:
+        ...
+
+alice = MyAgent(); alice.big_model = strong_llm     # same method, different
+bob = MyAgent();   bob.big_model = cheap_llm        # model per instance
 ```
 
 ### Event-driven history

--- a/skills/nooa-agent-authoring/SKILL.md
+++ b/skills/nooa-agent-authoring/SKILL.md
@@ -58,10 +58,31 @@ Keys come from `.env` (library use) or `~/.config/nooa/secrets.yaml`.
 
 **Resolution cascade** for which LLM a method uses — first match wins:
 
-1. `@strategy(..., llm=special_llm)` — method override
-2. `agent = MyAgent(llm=other)` — instance override
-3. `class MyAgent(Agent, llm=default)` — class default
-4. **Parent inheritance** — a subagent with no `llm=` of its own inherits from the agent that calls it
+1. `await agent.method(..., llm=special_llm)` — call override
+2. `@strategy(..., llm=special_llm)` — method override
+3. `agent = MyAgent(llm=other)` — instance override
+4. `class MyAgent(Agent, llm=default)` — class default
+5. **Parent inheritance** — a subagent with no `llm=` of its own inherits from the agent that calls it
+
+The method override also accepts a **callable** taking the agent and returning
+a client, resolved on each call. Use it when the per-method model has to be
+chosen per instance (or per call) rather than fixed at import time:
+
+```python
+class Researcher(Agent, llm=fast):
+    def __init__(self, big, **kw):
+        super().__init__(**kw)
+        self.big = big
+
+    @strategy(llm=lambda self: self.big)          # differs per instance
+    async def analyze(self, doc: str) -> str: ...
+
+    @strategy(llm=lambda self: self.big if self.retries > 2 else fast)
+    async def solve(self, problem: str) -> str: ...   # differs per call
+```
+
+Standalone `@strategy` functions must pass a client, not a callable — they
+have no instance to resolve against.
 
 Child agents inherit the parent's LLM by default. Any explicit `llm=` on the child overrides it — that's how you run a cheap model for one phase:
 

--- a/src/nooa/decorators.py
+++ b/src/nooa/decorators.py
@@ -15,8 +15,8 @@ from nooa.ellipsis_detection import has_ellipsis_body
 
 if TYPE_CHECKING:
     from nooa.config.truncation_config import TruncationConfig
-    from nooa.method_llm import MethodLLM
     from nooa.strategies import GenerationStrategy as GenerationStrategyABC
+    from nooa.unifiedllm import UnifiedLLM
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -26,7 +26,7 @@ def strategy(
     strategy_instance: "GenerationStrategyABC | None" = None,
     context: "ScopedContext | dict[str, Any] | None" = None,
     *,
-    llm: "MethodLLM | None" = None,
+    llm: "UnifiedLLM | Callable[[Any], UnifiedLLM] | None" = None,
     truncation: "TruncationConfig | None" = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Strategy decorator for agent methods.

--- a/src/nooa/decorators.py
+++ b/src/nooa/decorators.py
@@ -15,8 +15,8 @@ from nooa.ellipsis_detection import has_ellipsis_body
 
 if TYPE_CHECKING:
     from nooa.config.truncation_config import TruncationConfig
+    from nooa.method_llm import MethodLLM
     from nooa.strategies import GenerationStrategy as GenerationStrategyABC
-    from nooa.unifiedllm import UnifiedLLM
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -26,7 +26,7 @@ def strategy(
     strategy_instance: "GenerationStrategyABC | None" = None,
     context: "ScopedContext | dict[str, Any] | None" = None,
     *,
-    llm: "UnifiedLLM | None" = None,
+    llm: "MethodLLM | None" = None,
     truncation: "TruncationConfig | None" = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Strategy decorator for agent methods.
@@ -41,7 +41,12 @@ def strategy(
             - A plain dict ``{key: str | Context | DynamicContext | None}`` for context-only overrides.
             - A ``ScopedContext`` instance when you also need event filtering.
             Applied in _prepare_context() between strategy overrides and scoped blocks.
-        llm: Optional LLM override for this method
+        llm: Optional LLM override for this method. Either a ``UnifiedLLM``
+            instance (fixed at import time, shared by every instance of the
+            class) or a callable taking the agent instance and returning one
+            (resolved on each generation call, so it can vary per instance or
+            per call). Standalone functions must pass a ``UnifiedLLM`` — they
+            have no instance for a callable to bind against.
         truncation: Optional TruncationConfig override for this method. Fields set
             here take precedence over the agent-level truncation config. Unset fields
             inherit from the agent-level config.
@@ -99,6 +104,18 @@ def strategy(
 
         needs_gen = has_ellipsis_body(func)
 
+        # Detect standalone functions (no 'self' as first parameter).
+        # Each call creates a fresh agent stub — no state, no history.
+        _params = list(inspect.signature(func).parameters)
+        is_standalone = not _params or _params[0] != "self"
+
+        # Validate the llm spec now so a bad value points at the @strategy
+        # line rather than failing mid-generation.
+        if llm is not None:
+            from nooa.method_llm import validate_method_llm_spec
+
+            validate_method_llm_spec(llm, func.__name__, standalone=is_standalone)
+
         strat = None
         if needs_gen:
             if strategy_instance is not None:
@@ -108,10 +125,7 @@ def strategy(
 
                 strat = get_default_strategy()
 
-        # Detect standalone functions (no 'self' as first parameter).
-        # Each call creates a fresh agent stub — no state, no history.
-        _params = list(inspect.signature(func).parameters)
-        if not _params or _params[0] != "self":
+        if is_standalone:
             if needs_gen:
                 from nooa.standalone import create_standalone_wrapper
 

--- a/src/nooa/method_llm.py
+++ b/src/nooa/method_llm.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Late-bound per-method LLM overrides for ``@strategy(llm=...)``.
+
+``@strategy(llm=my_client)`` pins a method to a concrete client at import
+time, so every instance of the class shares it forever. Passing a
+**callable** instead defers the choice to generation time, where the agent
+instance is in hand::
+
+    class Researcher(Agent, llm=fast):
+        @strategy(llm=lambda self: self.big_model)
+        async def analyze(self, doc: str) -> str: ...
+
+        @strategy(llm=lambda self: self.big if self.retries > 2 else self.fast)
+        async def solve(self, problem: str) -> str: ...
+
+The callable receives the agent instance and must return a
+:class:`~nooa.unifiedllm.UnifiedLLM`. It is invoked on **every** generation
+call for that method — so return an existing client, don't construct one.
+Re-resolving per call is what makes the second example above work.
+
+Standalone ``@strategy`` functions (no ``self`` parameter) have no instance
+to bind against, so they reject callables at decoration time — see
+:func:`validate_method_llm_spec`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from nooa.unifiedllm import UnifiedLLM
+
+    # A concrete client, or a callable resolving one from the agent instance.
+    MethodLLM = UnifiedLLM | Callable[[Any], UnifiedLLM]
+
+
+def _is_llm_client(spec: Any) -> bool:
+    """True if *spec* is an LLM client rather than a resolver callable.
+
+    Subclassing :class:`~nooa.unifiedllm.UnifiedLLM` is the normal case, but
+    the framework has never *required* it — ``Agent(llm=...)`` accepts any
+    object with the client interface, and several fakes in the test-suite
+    duck-type it. Narrowing to a strict ``isinstance`` here would break them,
+    so fall back to probing for ``acall`` (one of the two abstract methods on
+    ``UnifiedLLM``; ``call`` is the sync twin, but generation is async).
+
+    The ``isinstance`` check runs first so that a ``UnifiedLLM`` subclass
+    which also defines ``__call__`` is still classified as a client, never as
+    a resolver. Resolvers are plain functions and have no ``acall``, so the
+    two categories don't overlap in practice.
+
+    Classes are excluded before the probe: ``hasattr(MyLLMClass, "acall")`` is
+    True for the *unbound* function on the class, so passing the class itself
+    (a plausible "factory" spelling) would sail through validation and then
+    fail on an unbound-method call deep inside generation — exactly the late
+    failure this module exists to prevent. A class is not a client; if it's
+    meant as a resolver it will be treated as one and called, which is the
+    behaviour a factory spelling implies anyway.
+    """
+    import inspect
+
+    from nooa.unifiedllm import UnifiedLLM
+
+    if isinstance(spec, UnifiedLLM):
+        return True
+    if inspect.isclass(spec):
+        return False
+    return hasattr(spec, "acall")
+
+
+def validate_method_llm_spec(spec: Any, func_name: str, *, standalone: bool = False) -> None:
+    """Validate an ``@strategy(llm=...)`` value at decoration time.
+
+    Catches the two mistakes that would otherwise surface much later, in
+    the middle of a generation call:
+
+    - a value that is neither a ``UnifiedLLM`` nor callable (e.g. a model
+      name string — there is no alias registry; pass a client or a callable)
+    - a callable on a standalone function, which has no instance to bind to
+
+    Args:
+        spec: The value passed as ``@strategy(llm=...)``.
+        func_name: Decorated function name, for the error message.
+        standalone: True if the decorated function has no ``self`` parameter.
+
+    Raises:
+        TypeError: If *spec* is unusable. Raised at decoration time, so the
+            failure points at the offending ``@strategy`` line.
+    """
+    if _is_llm_client(spec):
+        return
+
+    if callable(spec):
+        if standalone:
+            raise TypeError(
+                f"@strategy(llm=...) on standalone function '{func_name}' must be a "
+                f"UnifiedLLM instance, not a callable. Callables resolve against an "
+                f"agent instance, and standalone functions have none. Pass a client "
+                f"directly, or make '{func_name}' a method on an Agent subclass."
+            )
+        return
+
+    raise TypeError(
+        f"@strategy(llm=...) on '{func_name}' must be a UnifiedLLM instance or a "
+        f"callable taking the agent and returning one, got {type(spec).__name__}. "
+        f"For a per-instance model, use llm=lambda self: self.my_client."
+    )
+
+
+def resolve_method_llm(spec: Any, agent: Any, method_name: str) -> UnifiedLLM:
+    """Resolve a ``@strategy(llm=...)`` value against an agent instance.
+
+    Args:
+        spec: A ``UnifiedLLM``, or a callable taking the agent instance.
+        agent: The agent the method is executing on.
+        method_name: Method name, for error messages.
+
+    Returns:
+        The resolved ``UnifiedLLM``.
+
+    Raises:
+        TypeError: If *spec* is not a client or callable, or if a callable
+            returns something that is not a ``UnifiedLLM``.
+        RuntimeError: If the callable itself raises. The original exception
+            is chained, but the message names the method and makes clear the
+            failure came from the ``llm=`` callable rather than from
+            generation — a bare AttributeError from a typo'd attribute is
+            otherwise very hard to place.
+    """
+    if _is_llm_client(spec):
+        return cast("UnifiedLLM", spec)
+
+    if not callable(spec):
+        raise TypeError(
+            f"@strategy(llm=...) for '{method_name}' must be a UnifiedLLM instance or "
+            f"a callable returning one, got {type(spec).__name__}."
+        )
+
+    try:
+        resolved = spec(agent)
+    except Exception as exc:
+        raise RuntimeError(
+            f"The @strategy(llm=...) callable for '{method_name}' raised "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+
+    if not _is_llm_client(resolved):
+        raise TypeError(
+            f"The @strategy(llm=...) callable for '{method_name}' must return a "
+            f"UnifiedLLM instance, got {type(resolved).__name__}."
+        )
+
+    return cast("UnifiedLLM", resolved)
+
+
+__all__ = ["resolve_method_llm", "validate_method_llm_spec"]

--- a/src/nooa/method_llm.py
+++ b/src/nooa/method_llm.py
@@ -29,12 +29,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from nooa.unifiedllm import UnifiedLLM
-
-    # A concrete client, or a callable resolving one from the agent instance.
-    MethodLLM = UnifiedLLM | Callable[[Any], UnifiedLLM]
 
 
 def _is_llm_client(spec: Any) -> bool:

--- a/src/nooa/runtime/actor.py
+++ b/src/nooa/runtime/actor.py
@@ -2557,9 +2557,19 @@ class ActorRuntime:
 
         strategy = call_strategy or decorator_strategy or get_default_strategy()
 
-        # Resolve LLM client with priority: call-level > @strategy decorator > agent's default
-        plan_llm = getattr(base_method, "_plan_llm", None)
-        llm_client = call_llm or plan_llm or getattr(self.agent, "_llm", None)
+        # Resolve LLM client with priority: call-level > @strategy decorator > agent's default.
+        # A @strategy(llm=...) value may be a callable resolved against the agent
+        # instance; only invoke it when it would actually be used, so a call-level
+        # override doesn't trigger someone else's resolver side effects.
+        if call_llm is not None:
+            llm_client = call_llm
+        else:
+            plan_llm = getattr(base_method, "_plan_llm", None)
+            if plan_llm is not None:
+                from nooa.method_llm import resolve_method_llm
+
+                plan_llm = resolve_method_llm(plan_llm, self.agent, method_name)
+            llm_client = plan_llm or getattr(self.agent, "_llm", None)
         if llm_client is None:
             raise RuntimeError(f"No LLM client available for {method_name}")
 

--- a/src/nooa/runtime/method_wrapper.py
+++ b/src/nooa/runtime/method_wrapper.py
@@ -115,14 +115,26 @@ def create_agent_method_wrapper(
                 _tc = DEFAULT_TRUNCATION_CONFIG
 
             # Strip framework kwargs before validation — they're consumed by
-            # _execute_with_generation, not the user's method signature.
-            _fw_session_locals = kwargs.pop("_session_locals", None)
+            # _execute_with_generation, not the user's method signature. Must
+            # cover every name that _execute_with_generation pops, or the call
+            # is rejected here before it can ever get there.
+            #
+            # Only on the agent path: the strategy-helper path below routes to
+            # execute_nested(), which pops nothing, so stripping there would
+            # drop these names silently into CurrentCall's prompt arguments
+            # instead of rejecting them as the unexpected kwargs they are.
+            _fw_kwargs: dict[str, Any] = {}
+            if hasattr(self, "runtime"):
+                _fw_kwargs = {
+                    _name: kwargs.pop(_name)
+                    for _name in ("_session_locals", "_strategy", "llm")
+                    if _name in kwargs
+                }
             try:
                 ArgumentValidator().validate(original_func, args, kwargs, _tc)
             finally:
                 # Restore so _execute_with_generation can pop them
-                if _fw_session_locals is not None:
-                    kwargs["_session_locals"] = _fw_session_locals
+                kwargs.update(_fw_kwargs)
 
             # Strategy resolution if not provided
             if resolved_strategy is None:

--- a/src/nooa/standalone.py
+++ b/src/nooa/standalone.py
@@ -163,7 +163,10 @@ def create_standalone_wrapper(
     Args:
         func: Original async function with an ellipsis body.
         strategy: GenerationStrategy instance resolved from the decorator.
-        llm: Optional explicit LLM from ``@strategy(..., llm=...)``.
+        llm: Optional explicit LLM client from ``@strategy(..., llm=...)``.
+            Always a client, never a resolver callable: standalone functions
+            have no agent instance to bind one against, so ``@strategy``
+            rejects callables here at decoration time.
 
     Returns:
         Async callable with the same signature as *func*.

--- a/tests/test_method_llm_callable.py
+++ b/tests/test_method_llm_callable.py
@@ -1,0 +1,364 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for callable ``@strategy(llm=...)`` overrides.
+
+A callable defers the per-method LLM choice from import time to generation
+time, where the agent instance is available — so two instances of the same
+class can run the same method on different models.
+"""
+
+import json
+
+import pytest
+
+from nooa import Agent, strategy
+from nooa.method_llm import resolve_method_llm, validate_method_llm_spec
+from nooa.strategies.predict import PredictStrategy
+from nooa.unifiedllm import FakeLLMClient, LLMResponse
+
+
+def _fake(answer: str = "") -> FakeLLMClient:
+    """A FakeLLMClient whose single PredictStrategy answer is *answer*.
+
+    PredictStrategy wraps a plain ``-> str`` return in ``{"value": ...}``.
+    """
+    content = json.dumps({"value": answer})
+    return FakeLLMClient(
+        scripted_responses=[
+            LLMResponse(
+                raw_response=None,
+                content=content,
+                tool_calls=[],
+                finish_reason="stop",
+                assistant_message={"role": "assistant", "content": content},
+            )
+        ]
+    )
+
+
+class TestValidation:
+    """Decoration-time validation of the llm= value."""
+
+    def test_client_accepted(self) -> None:
+        client = _fake("ok")
+
+        @strategy(PredictStrategy(), llm=client)
+        async def method(self) -> str: ...
+
+        assert method._plan_llm is client  # type: ignore[attr-defined]
+
+    def test_callable_accepted_and_stored_unresolved(self) -> None:
+        """The callable is stored as-is — not invoked at decoration time."""
+        calls = []
+
+        def resolver(agent):
+            calls.append(agent)
+            return _fake("ok")
+
+        @strategy(PredictStrategy(), llm=resolver)
+        async def method(self) -> str: ...
+
+        assert method._plan_llm is resolver  # type: ignore[attr-defined]
+        assert calls == [], "resolver must not run until generation time"
+
+    def test_string_rejected_at_decoration_time(self) -> None:
+        """There is no alias registry — a model name string is a mistake."""
+        with pytest.raises(TypeError, match="must be a UnifiedLLM instance or a callable"):
+
+            @strategy(PredictStrategy(), llm="gpt-4")  # type: ignore[arg-type]
+            async def method(self) -> str: ...
+
+    def test_arbitrary_object_rejected(self) -> None:
+        with pytest.raises(TypeError, match="got int"):
+
+            @strategy(PredictStrategy(), llm=42)  # type: ignore[arg-type]
+            async def method(self) -> str: ...
+
+    def test_callable_rejected_on_standalone_function(self) -> None:
+        """No 'self' parameter means no instance to resolve against."""
+        with pytest.raises(TypeError, match="standalone function"):
+
+            @strategy(PredictStrategy(), llm=lambda agent: _fake("ok"))
+            async def standalone(x: int) -> str: ...
+
+    def test_client_still_allowed_on_standalone_function(self) -> None:
+        client = _fake("ok")
+
+        @strategy(PredictStrategy(), llm=client)
+        async def standalone(x: int) -> str: ...
+
+        assert standalone._plan_llm is client  # type: ignore[attr-defined]
+
+    def test_duck_typed_client_accepted(self) -> None:
+        """Clients have never been required to subclass UnifiedLLM."""
+
+        class DuckLLM:
+            async def acall(self, messages, tools=None, **kwargs):  # noqa: ANN001, ANN003
+                raise NotImplementedError
+
+        duck = DuckLLM()
+        validate_method_llm_spec(duck, "method")  # must not raise
+        assert resolve_method_llm(duck, object(), "method") is duck
+
+    def test_client_subclass_defining_call_is_not_treated_as_resolver(self) -> None:
+        """isinstance runs before the callable check, so a client stays a client."""
+
+        class CallableClient(FakeLLMClient):
+            def __call__(self, agent):  # noqa: ANN001, ANN204
+                raise AssertionError("must not be invoked as a resolver")
+
+        client = CallableClient()
+        assert resolve_method_llm(client, object(), "method") is client
+
+    def test_class_object_is_treated_as_factory_not_client(self) -> None:
+        """``hasattr(SomeClass, 'acall')`` is True for the unbound function.
+
+        Without the isclass guard the class would pass validation as a client
+        and then fail on an unbound-method call inside generation. It is a
+        callable, so it is treated as a resolver and constructed instead.
+        """
+        built = _fake("from-factory")
+
+        class Factory:
+            async def acall(self, messages, tools=None, **kwargs):  # noqa: ANN001, ANN003
+                raise NotImplementedError
+
+            def __new__(cls, agent):  # noqa: ANN001, ANN204
+                return built
+
+        validate_method_llm_spec(Factory, "method")  # must not raise
+        assert resolve_method_llm(Factory, object(), "method") is built
+
+
+class TestResolution:
+    """resolve_method_llm behaviour against an agent instance."""
+
+    def test_callable_receives_agent_and_returns_client(self) -> None:
+        client = _fake("ok")
+        sentinel = object()
+        seen = []
+
+        def resolver(agent):
+            seen.append(agent)
+            return client
+
+        assert resolve_method_llm(resolver, sentinel, "method") is client
+        assert seen == [sentinel]
+
+    def test_callable_exception_is_wrapped_with_method_name(self) -> None:
+        """A typo'd attribute must not surface as a bare AttributeError."""
+
+        def resolver(agent):
+            return agent.does_not_exist
+
+        with pytest.raises(RuntimeError, match=r"callable for 'analyze' raised AttributeError"):
+            resolve_method_llm(resolver, object(), "analyze")
+
+    def test_callable_exception_chains_original(self) -> None:
+        def resolver(agent):
+            raise ValueError("boom")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            resolve_method_llm(resolver, object(), "analyze")
+        assert isinstance(exc_info.value.__cause__, ValueError)
+
+    def test_callable_returning_non_client_rejected(self) -> None:
+        with pytest.raises(TypeError, match="must return a UnifiedLLM instance, got str"):
+            resolve_method_llm(lambda agent: "not-a-client", object(), "analyze")
+
+    def test_client_passed_through_untouched(self) -> None:
+        client = _fake("ok")
+        assert resolve_method_llm(client, object(), "method") is client
+
+
+class TestStrategyHelperPath:
+    """Framework kwargs are only stripped where something pops them back."""
+
+    @pytest.mark.asyncio
+    async def test_llm_kwarg_still_rejected_on_strategy_helper(self) -> None:
+        """The strategy-helper path routes to execute_nested(), which pops nothing.
+
+        Stripping ``llm`` there would let it slip past validation and into
+        CurrentCall's prompt arguments instead of being rejected.
+        """
+        from unittest.mock import MagicMock
+
+        from nooa.runtime.method_wrapper import create_agent_method_wrapper
+        from nooa.strategies.base import RuntimeServices
+
+        async def helper(self, runtime: RuntimeServices, x: int) -> int:
+            """Do something with {x}."""
+            ...
+
+        wrapper = create_agent_method_wrapper(
+            helper, needs_generation=True, needs_tracing=False, strategy=PredictStrategy()
+        )
+
+        class _Bare:  # no 'runtime' attribute → strategy-helper branch
+            pass
+
+        with pytest.raises(TypeError, match="unexpected keyword argument 'llm'"):
+            await wrapper(_Bare(), MagicMock(spec=RuntimeServices), 42, llm=_fake("x"))
+
+
+class TestEndToEnd:
+    """The callable actually drives which model a generation call uses."""
+
+    @pytest.mark.asyncio
+    async def test_two_instances_same_method_different_llms(self) -> None:
+        """The whole point: per-method LLM chosen at object creation time."""
+        default = _fake("default")
+
+        class Researcher(Agent, llm=default):
+            """A researcher."""
+
+            def __init__(self, big, **kwargs):  # noqa: ANN001, ANN003
+                super().__init__(**kwargs)
+                self.big = big
+
+            @strategy(PredictStrategy(), llm=lambda self: self.big)
+            async def analyze(self, doc: str) -> str:
+                """Return the analysis of {doc}."""
+                ...
+
+        alice = Researcher(big=_fake("alice-model"))
+        bob = Researcher(big=_fake("bob-model"))
+
+        assert await alice.analyze("x") == "alice-model"
+        assert await bob.analyze("x") == "bob-model"
+
+    @pytest.mark.asyncio
+    async def test_resolver_runs_per_call_not_once(self) -> None:
+        """Re-resolving each call is what lets the choice depend on state."""
+        first = _fake("first")
+        second = _fake("second")
+
+        # Class default is a third client, so *both* assertions below fail if
+        # the resolver is ignored — not just the second.
+        class Switcher(Agent, llm=_fake("class-default")):
+            """A switcher."""
+
+            def __init__(self, **kwargs):  # noqa: ANN003
+                super().__init__(**kwargs)
+                self.calls = 0
+
+            @strategy(PredictStrategy(), llm=lambda self: first if self.calls == 0 else second)
+            async def run(self) -> str:
+                """Return a word."""
+                ...
+
+        agent = Switcher()
+        assert await agent.run() == "first"
+        agent.calls = 1
+        assert await agent.run() == "second"
+
+    @pytest.mark.asyncio
+    async def test_call_level_llm_wins_and_skips_resolver(self) -> None:
+        """A call-level override must not invoke the resolver at all."""
+        invocations = []
+
+        def resolver(agent):
+            invocations.append(agent)
+            return _fake("from-resolver")
+
+        class Agent1(Agent, llm=_fake("from-agent")):
+            """An agent."""
+
+            @strategy(PredictStrategy(), llm=resolver)
+            async def run(self) -> str:
+                """Return a word."""
+                ...
+
+        agent = Agent1()
+        assert await agent.run(llm=_fake("from-call")) == "from-call"
+        assert invocations == [], "resolver ran despite a call-level override"
+
+    @pytest.mark.asyncio
+    async def test_call_level_llm_survives_argument_validation(self) -> None:
+        """``llm=`` is a framework kwarg, not part of the method signature.
+
+        Regression: the argument validator stripped ``_session_locals`` but
+        not ``llm``, so a call-level override was rejected as an unexpected
+        keyword argument before ever reaching the LLM-resolution code.
+        """
+
+        class Sig(Agent, llm=_fake("from-agent")):
+            """An agent."""
+
+            @strategy(PredictStrategy())
+            async def run(self, topic: str, depth: int = 1) -> str:
+                """Return a word about {topic} at depth {depth}."""
+                ...
+
+        agent = Sig()
+        assert await agent.run("physics", depth=2, llm=_fake("from-call")) == "from-call"
+
+    @pytest.mark.asyncio
+    async def test_unexpected_kwarg_still_rejected(self) -> None:
+        """Stripping framework kwargs must not weaken signature validation."""
+
+        class Sig(Agent, llm=_fake("x")):
+            """An agent."""
+
+            @strategy(PredictStrategy())
+            async def run(self, topic: str) -> str:
+                """Return a word about {topic}."""
+                ...
+
+        with pytest.raises(TypeError, match="unexpected keyword argument 'bogus'"):
+            await Sig().run("physics", bogus=1)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_agent_llm_without_decorator_override(self) -> None:
+        class Plain(Agent, llm=_fake("from-agent")):
+            """An agent."""
+
+            @strategy(PredictStrategy())
+            async def run(self) -> str:
+                """Return a word."""
+                ...
+
+        assert await Plain().run() == "from-agent"
+
+    @pytest.mark.asyncio
+    async def test_resolver_beats_instance_level_llm(self) -> None:
+        """A per-method resolver outranks the agent-wide instance override."""
+
+        class Researcher(Agent, llm=_fake("class-default")):
+            """A researcher."""
+
+            @strategy(PredictStrategy(), llm=lambda self: self.big)
+            async def analyze(self) -> str:
+                """Return a word."""
+                ...
+
+        agent = Researcher(llm=_fake("instance-level"))
+        agent.big = _fake("from-resolver")
+        assert await agent.analyze() == "from-resolver"
+
+    @pytest.mark.asyncio
+    async def test_call_level_strategy_survives_argument_validation(self) -> None:
+        """Same regression as ``llm=``, for the ``_strategy`` framework kwarg."""
+
+        class Sig(Agent, llm=_fake("ok")):
+            """An agent."""
+
+            @strategy(PredictStrategy())
+            async def run(self, topic: str) -> str:
+                """Return a word about {topic}."""
+                ...
+
+        assert await Sig().run("physics", _strategy=PredictStrategy()) == "ok"
+
+    @pytest.mark.asyncio
+    async def test_resolver_failure_surfaces_at_call_time(self) -> None:
+        class Broken(Agent, llm=_fake("unused")):
+            """An agent."""
+
+            @strategy(PredictStrategy(), llm=lambda self: self.missing_attr)
+            async def run(self) -> str:
+                """Return a word."""
+                ...
+
+        with pytest.raises(RuntimeError, match=r"callable for 'run' raised AttributeError"):
+            await Broken().run()


### PR DESCRIPTION
## Motivation

There was no way to choose a **per-method** LLM at **agent-construction time**. `MyAgent(llm=...)` is per-instance but hits every method; `@strategy(llm=client)` is per-method but is baked onto the function at import time, so every instance shares it.

## What changed

`@strategy(llm=...)` now also accepts a callable taking the agent and returning a client, resolved on each generation call:

```python
class Researcher(Agent, llm=fast):
    @strategy(llm=lambda self: self.big)              # varies per instance
    async def analyze(self, doc: str) -> str: ...

    @strategy(llm=lambda self: self.big if self.retries > 2 else fast)
    async def solve(self, problem: str) -> str: ...   # varies per call
```

A string alias (`llm="reasoner"`) was considered and rejected: it needs a role map with its own MRO cascade, and is a static special case of a callable — it can't express the second example. Cost is that typos fail at first call, so resolver failures are wrapped to name the method.

## Adjacent bug fix (worth reviewing separately)

`ArgumentValidator` stripped `_session_locals` from call kwargs but not `llm` or `_strategy`, though `_execute_with_generation` pops all three — so `await agent.method(x, llm=other)` was rejected as an unexpected kwarg before reaching the resolution code. The precedence `actor.py` documents was unreachable for direct calls.

The strip is scoped to the agent path only; the strategy-helper path routes to `execute_nested()`, which pops nothing.

## Reviewer notes

- **Duck-typed clients still work** — detection probes for `acall` rather than requiring a `UnifiedLLM` subclass, which several fakes rely on. Classes are excluded from the probe first, since `hasattr(SomeClass, "acall")` is True for the unbound function.
- **Known gap, not fixed:** a method declaring its own `llm` parameter loses that argument. Broken on `main` too; nothing in the repo declares one. Fixing it means implementing the "Reserved Parameters" check `AGENTS.md` describes but no code enforces — happy to do a follow-up.
- **Pre-commit `pyright`** fails on a pre-existing error at `actor.py:1509`, surfaced only because this PR touches that file. CI runs ruff + pytest, so the PR should be green.

## Testing

24 new tests in `tests/test_method_llm_callable.py`. Full suite: 6531 passed — the `test_nemo_relay_middleware.py` failures reproduce identically on `main`. `ruff` clean; `pyright` clean on all changed files. Subagent-reviewed; findings folded in.

Docs updated in `skills/nooa-agent-authoring/SKILL.md` and `examples/README.md`, which also omitted the call-level override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)