### PR TITLE
docs(examples): add Ollama and vLLM to the model selection snippet

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -53,7 +53,18 @@ from nooa.unifiedllm import get_llm_client
 llm = get_llm_client("gpt-4o-mini")                 # OpenAI (needs OPENAI_API_KEY)
 llm = get_llm_client("claude-sonnet-4-5-20250514")  # Anthropic (needs ANTHROPIC_API_KEY)
 llm = get_llm_client("gemini/gemini-2.5-flash")     # Google (needs GEMINI_API_KEY)
+llm = get_llm_client("ollama_chat/qwen3:1.7b",      # Ollama (no key)
+                     api_base="http://localhost:11434")
 ```
+
+The checked-in examples take their model from the environment. Set `NEMO_OO_MODEL` to any litellm name, plus `NEMO_OO_API_BASE` for a local server:
+
+```bash
+NEMO_OO_MODEL="ollama_chat/qwen3:1.7b" NEMO_OO_API_BASE="http://localhost:11434" \
+  uv run python examples/quickstart/01_first_generation_method.py
+```
+
+Without it, the examples select whichever provider credential is present (`NVIDIA_API_KEY`, `OPENAI_API_KEY`, ...).
 
 Provider packages can register bundled model aliases automatically through the `nooa.bundled_configs` entry-point group. To customize the registry, run `nooa config eject`, drop an `llm_config.yaml` in your project's `.nooa/`, or point `NEMO_OO_LLM_CONFIG` at one or more YAML files. See [`src/nooa/unifiedllm/registry.py`](../src/nooa/unifiedllm/registry.py) for the YAML schema.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,16 +55,9 @@ llm = get_llm_client("claude-sonnet-4-5-20250514")  # Anthropic (needs ANTHROPIC
 llm = get_llm_client("gemini/gemini-2.5-flash")     # Google (needs GEMINI_API_KEY)
 llm = get_llm_client("ollama_chat/qwen3:1.7b",      # Ollama (no key)
                      api_base="http://localhost:11434")
+llm = get_llm_client("hosted_vllm/Qwen/Qwen3-1.7B", # vLLM (no key)
+                     api_base="http://localhost:8000/v1")
 ```
-
-The checked-in examples take their model from the environment. Set `NEMO_OO_MODEL` to any litellm name, plus `NEMO_OO_API_BASE` for a local server:
-
-```bash
-NEMO_OO_MODEL="ollama_chat/qwen3:1.7b" NEMO_OO_API_BASE="http://localhost:11434" \
-  uv run python examples/quickstart/01_first_generation_method.py
-```
-
-Without it, the examples select whichever provider credential is present (`NVIDIA_API_KEY`, `OPENAI_API_KEY`, ...).
 
 Provider packages can register bundled model aliases automatically through the `nooa.bundled_configs` entry-point group. To customize the registry, run `nooa config eject`, drop an `llm_config.yaml` in your project's `.nooa/`, or point `NEMO_OO_LLM_CONFIG` at one or more YAML files. See [`src/nooa/unifiedllm/registry.py`](../src/nooa/unifiedllm/registry.py) for the YAML schema.
 

--- a/src/nooa/util/quickstart.py
+++ b/src/nooa/util/quickstart.py
@@ -26,10 +26,18 @@ load_dotenv(override=True)
 #   * OPENAI_API_KEY           -> OpenAI (public)
 #   * NVIDIA_INFERENCE_API_KEY -> NVIDIA internal inference gateway
 #                                 (inference-api.nvidia.com; NVIDIA employees)
-# To use a specific model, set MODEL to any litellm name and provide its key,
-# e.g. MODEL = "claude-haiku-4-5" with ANTHROPIC_API_KEY.
+# To pin a specific model, set NEMO_OO_MODEL to any litellm name and provide its
+# credential, e.g. NEMO_OO_MODEL="claude-haiku-4-5" with ANTHROPIC_API_KEY.
+# For a local server, add NEMO_OO_API_BASE, e.g.
+#   NEMO_OO_MODEL="ollama_chat/qwen3:1.7b" NEMO_OO_API_BASE="http://localhost:11434"
 _internal_key = os.getenv("NVIDIA_INFERENCE_API_KEY") or os.getenv("NVIDIA_INTERNAL_API_KEY")
-if os.getenv("NVIDIA_API_KEY"):
+if os.getenv("NEMO_OO_MODEL"):
+    # Checked first so a local model does not require unsetting provider keys.
+    # api_base is only passed when set, so hosted providers route normally.
+    MODEL = os.environ["NEMO_OO_MODEL"]
+    _api_base = os.getenv("NEMO_OO_API_BASE")
+    llm = get_llm_client(MODEL, **({"api_base": _api_base} if _api_base else {}))
+elif os.getenv("NVIDIA_API_KEY"):
     # build.nvidia.com NIM. litellm routes `nvidia_nim/*` to
     # integrate.api.nvidia.com; it reads the key from NVIDIA_NIM_API_KEY, so
     # pass NVIDIA_API_KEY (the build.nvidia.com convention) explicitly.

--- a/src/nooa/util/quickstart.py
+++ b/src/nooa/util/quickstart.py
@@ -26,18 +26,10 @@ load_dotenv(override=True)
 #   * OPENAI_API_KEY           -> OpenAI (public)
 #   * NVIDIA_INFERENCE_API_KEY -> NVIDIA internal inference gateway
 #                                 (inference-api.nvidia.com; NVIDIA employees)
-# To pin a specific model, set NEMO_OO_MODEL to any litellm name and provide its
-# credential, e.g. NEMO_OO_MODEL="claude-haiku-4-5" with ANTHROPIC_API_KEY.
-# For a local server, add NEMO_OO_API_BASE, e.g.
-#   NEMO_OO_MODEL="ollama_chat/qwen3:1.7b" NEMO_OO_API_BASE="http://localhost:11434"
+# To use a specific model, set MODEL to any litellm name and provide its key,
+# e.g. MODEL = "claude-haiku-4-5" with ANTHROPIC_API_KEY.
 _internal_key = os.getenv("NVIDIA_INFERENCE_API_KEY") or os.getenv("NVIDIA_INTERNAL_API_KEY")
-if os.getenv("NEMO_OO_MODEL"):
-    # Checked first so a local model does not require unsetting provider keys.
-    # api_base is only passed when set, so hosted providers route normally.
-    MODEL = os.environ["NEMO_OO_MODEL"]
-    _api_base = os.getenv("NEMO_OO_API_BASE")
-    llm = get_llm_client(MODEL, **({"api_base": _api_base} if _api_base else {}))
-elif os.getenv("NVIDIA_API_KEY"):
+if os.getenv("NVIDIA_API_KEY"):
     # build.nvidia.com NIM. litellm routes `nvidia_nim/*` to
     # integrate.api.nvidia.com; it reads the key from NVIDIA_NIM_API_KEY, so
     # pass NVIDIA_API_KEY (the build.nvidia.com convention) explicitly.


### PR DESCRIPTION
## What does this PR do?

Adds Ollama and vLLM to the `get_llm_client()` snippet in `examples/README.md`, matching the local-model examples already shown in the main README. Documentation only.

Originally this also proposed a `NEMO_OO_MODEL` / `NEMO_OO_API_BASE` override in `quickstart.py`. Dropped per review: it would have been the only env-driven model selection in the codebase, and `get_llm_client()` plus the `llm_config` registry is the framework's canonical pattern. See the review thread below.

## Related issues

None.

## Validation

Docs only, no code changed.

## Checklist

- [ ] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass) — no code changed
- [ ] Tests added/updated and passing (`uv run pytest`) — no code changed
- [x] Docs updated if behavior or public APIs changed
- [ ] New source files carry an SPDX license header — no new files