### PR TITLE
feat(agentdoc): shape-aware pformat previews for numpy and pandas

### DIFF
--- a/src/nooa/agentdoc/_docs.py
+++ b/src/nooa/agentdoc/_docs.py
@@ -262,6 +262,31 @@ class Spec:
 
         return register_type_info_extractor(target)
 
+    def define_preview(self, target: type) -> Any:
+        """Define a custom value preview for *target* in ``pformat``/``pprint``.
+
+        Replaces the truncated-``repr`` fallback for instances of *target*
+        (and subclasses) with a structural, bounded preview. The extractor
+        receives the instance and the active ``PreviewBudget``; returning
+        ``None`` declines, falling back to the default repr rendering —
+        return ``None`` whenever the plain repr fits the budget, so complete
+        values keep rendering as plain literals::
+
+            from nooa.agentdoc.ext import PreviewBudget
+
+            @spec.define_preview(np.ndarray)
+            def _(arr, budget: PreviewBudget) -> str | None:
+                r = repr(arr)
+                if budget.max_string is None or len(r) <= budget.max_string:
+                    return None
+                return f"ndarray(shape={arr.shape}, dtype={arr.dtype}, ...)"
+
+        ``doc()`` rendering is unaffected — use :meth:`define_doc` for that.
+        """
+        from nooa.agentdoc.registry import register_preview_extractor
+
+        return register_preview_extractor(target)
+
 
 spec = Spec()
 

--- a/src/nooa/agentdoc/_pformat.py
+++ b/src/nooa/agentdoc/_pformat.py
@@ -1402,6 +1402,23 @@ def _format_value(
         )
         return
 
+    # Registered value previews (numpy arrays, pandas frames, …): a preview
+    # extractor renders a structural, bounded preview instead of the truncated
+    # repr below. Returning None (or raising) declines and falls through.
+    from nooa.agentdoc.registry import PreviewBudget, get_preview_extractor
+
+    preview_extractor = get_preview_extractor(_object)
+    if preview_extractor is not None:
+        try:
+            preview = preview_extractor(
+                _object, PreviewBudget(max_length=max_length, max_string=max_string)
+            )
+        except Exception:
+            preview = None
+        if preview is not None:
+            _stream.write(preview)
+            return
+
     # Fallback to repr for other types (numpy arrays, pandas frames, custom classes, …).
     # When the repr is over budget, emit the truncation 3.0 marker family —
     # same shape as the rest of the renderer, prefixed with the actual type
@@ -1526,6 +1543,21 @@ def _format_shallow(_object: Any, max_string: int | None) -> str:
         return f"{brackets[0]}{type_name}: {len(_object)} items{brackets[1]}"
     if isinstance(_object, str):
         return _format_string(_object, max_string)
+
+    # Registered value previews apply at the depth limit too: without this, a
+    # large array/frame nested at max_depth would dump its full repr.
+    from nooa.agentdoc.registry import PreviewBudget, get_preview_extractor
+
+    preview_extractor = get_preview_extractor(_object)
+    if preview_extractor is not None:
+        try:
+            preview = preview_extractor(
+                _object, PreviewBudget(max_length=None, max_string=max_string)
+            )
+        except Exception:
+            preview = None
+        if preview is not None:
+            return preview
 
     try:
         return repr(_object)

--- a/src/nooa/agentdoc/adapters/__init__.py
+++ b/src/nooa/agentdoc/adapters/__init__.py
@@ -17,7 +17,8 @@ Or register all adapters for installed libraries at once:
 
 Available adapters:
     plotly — plotly, plotly.express, plotly.graph_objects
-    pandas — pandas.DataFrame, pandas.Series
+    pandas — pandas.DataFrame, pandas.Series (doc + pformat previews)
+    numpy — numpy.ndarray (pformat previews)
 """
 
 
@@ -42,6 +43,13 @@ def register_all():
         import nooa.agentdoc.adapters.pandas as _  # noqa: F401
 
         registered.append("pandas")
+    except ImportError:
+        pass
+
+    try:
+        import nooa.agentdoc.adapters.numpy as _  # noqa: F401
+
+        registered.append("numpy")
     except ImportError:
         pass
 

--- a/src/nooa/agentdoc/adapters/numpy.py
+++ b/src/nooa/agentdoc/adapters/numpy.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""agentdoc adapter for numpy — shape-aware pformat previews for ndarray.
+
+Import to register:
+
+    import nooa.agentdoc.adapters.numpy
+
+Without this adapter, a large array renders as a truncated repr slice —
+``ndarray(repr_len=10250, [:100]='array([[   0. , ...')`` — escaped newlines
+and all, with the shape and dtype invisible. With it, the preview leads with
+the structural facts and anchors a bounded head/tail sample to axis 0:
+
+    ndarray(shape=(250, 4), dtype=float64, [:2]=[[0.0, 1.5, 3.0, 4.5], …], [-2:]=[…])
+
+Small arrays (repr within budget) are unaffected: the extractor declines and
+the plain repr renders, keeping the marker-presence-signals-truncation rule.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from nooa.agentdoc import spec
+from nooa.agentdoc.ext import PreviewBudget
+
+# Row/column sample budget for >=2-D arrays. Rows repeat per line, so the
+# 1-D rule of "show max_length items" would be token-hungry; six per axis
+# keeps the preview a few hundred characters no matter the array's size.
+_MATRIX_SAMPLE = 6
+
+
+def _one_line(text: str) -> str:
+    """Collapse numpy's multi-line array text to a single normalized line."""
+    return " ".join(text.split()).replace(" ,", ",")
+
+
+def _subarray_str(elem: np.ndarray, inner_budget: int) -> str:
+    """Bounded one-line rendering of one axis-0 element (itself an array).
+
+    Deeper subarrays (>= 2-D) get one edge item per axis: their rendered
+    size grows multiplicatively with each axis, so anything wider explodes
+    the preview for 3-D+ arrays.
+    """
+    edgeitems = max(1, inner_budget // 2) if elem.ndim == 1 else 1
+    text = np.array2string(
+        elem,
+        threshold=inner_budget,
+        edgeitems=edgeitems,
+        separator=", ",
+    )
+    return _one_line(text)
+
+
+def _scalar_str(elem: object) -> str:
+    """Render one axis-0 element of a 1-D array as a Python literal.
+
+    Iterating a 1-D array yields numpy scalars (``np.float64`` …) for
+    numeric dtypes but raw Python objects for ``dtype=object``; unwrap only
+    the former so strings keep their quotes.
+    """
+    if isinstance(elem, np.generic):
+        try:
+            elem = elem.item()
+        except Exception:
+            pass
+    return repr(elem)
+
+
+def _sample(rows: np.ndarray, inner_budget: int) -> str:
+    """Render a head or tail slice as a bracketed, comma-separated sample."""
+    if rows.ndim == 1:
+        parts = [_scalar_str(x) for x in rows]
+    else:
+        parts = [_subarray_str(x, inner_budget) for x in rows]
+    return "[" + ", ".join(parts) + "]"
+
+
+@spec.define_preview(np.ndarray)
+def _ndarray_preview(arr: np.ndarray, budget: PreviewBudget) -> str | None:
+    if arr.ndim == 0:
+        return None  # scalars: repr is already compact
+
+    max_length, max_string = budget
+    n = arr.shape[0]
+
+    # Decline when the value renders completely within budget — mirrors the
+    # sequence rule (count over max_length OR repr over max_string triggers
+    # the marker; otherwise the plain repr is the complete value). Element
+    # count uses arr.size: numpy's own repr elides with '...' past its print
+    # threshold, so a short repr is not evidence of a complete value.
+    over_count = max_length is not None and arr.size > max_length
+    if not over_count:
+        r = repr(arr)
+        if max_string is None or len(r) <= max_string:
+            return None
+
+    if arr.ndim == 1:
+        k = max_length if max_length is not None else 10
+    else:
+        k = min(max_length if max_length is not None else _MATRIX_SAMPLE, _MATRIX_SAMPLE)
+    k = max(1, min(k, n))
+    inner_budget = _MATRIX_SAMPLE if max_length is None else min(max_length, _MATRIX_SAMPLE)
+
+    header = f"ndarray(shape={arr.shape!r}, dtype={arr.dtype}"
+
+    if n <= k:
+        return f"{header}, values={_sample(arr, inner_budget)})"
+
+    n_head = (k + 1) // 2
+    n_tail = k - n_head
+    head = _sample(arr[:n_head], inner_budget)
+    if n_tail > 0:
+        tail = _sample(arr[-n_tail:], inner_budget)
+        return f"{header}, [:{n_head}]={head}, [-{n_tail}:]={tail})"
+    return f"{header}, [:{n_head}]={head})"

--- a/src/nooa/agentdoc/adapters/pandas.py
+++ b/src/nooa/agentdoc/adapters/pandas.py
@@ -14,8 +14,8 @@ back to an ``Any`` tool schema, so the model has nothing structural to go on oth
 
 import pandas as pd
 
-from nooa.agentdoc import spec
-from nooa.agentdoc.ext import CallableInfo, TypeInfo
+from nooa.agentdoc import pformat, spec
+from nooa.agentdoc.ext import CallableInfo, PreviewBudget, TypeInfo
 
 _DATAFRAME_DOC = (
     "pandas DataFrame — 2-D labelled, column-oriented tabular data.\n\n"
@@ -77,3 +77,90 @@ def _series_doc(cls_or_instance) -> TypeInfo:
         ],
         docstring=_SERIES_DOC,
     )
+
+
+# --- pformat value previews -------------------------------------------------
+#
+# Large frames otherwise render as a truncated repr slice full of escaped
+# newlines with the shape invisible; these previews lead with the structural
+# facts (shape, column dtypes) and anchor a bounded row sample to the ends,
+# reusing pformat itself so nested values inherit the marker family.
+
+# Row sample budget: rows repeat every column name, so even a handful of
+# records dominates the preview's size. Five rows split head/tail.
+_ROW_SAMPLE = 5
+# Column-dtype entries shown before the dict marker elides the rest.
+_COL_SAMPLE = 10
+# Per-cell string budget inside row samples: keeps one pathological cell
+# (a long document in a column) from consuming the whole preview.
+_CELL_STRING = 80
+
+
+def _complete_within_budget(value, n_items: int, budget: PreviewBudget) -> bool:
+    """True when the plain repr is a complete rendering within budget.
+
+    Mirrors the sequence rule: an item count over ``max_length`` triggers the
+    marker even when the repr text is short — pandas elides rows and columns
+    with ``...`` in its own repr, so a short repr is not evidence of a
+    complete value. ``n_items`` is the total cell count for a DataFrame and
+    the length for a Series.
+    """
+    if budget.max_length is not None and n_items > budget.max_length:
+        return False
+    if budget.max_string is None:
+        return True
+    try:
+        return len(repr(value)) <= budget.max_string
+    except Exception:
+        return False
+
+
+def _bounded(value, budget: PreviewBudget, *, max_length: int) -> str:
+    """Render a nested sample through pformat with a tightened budget."""
+    max_string = _CELL_STRING if budget.max_string is None else min(budget.max_string, _CELL_STRING)
+    return pformat(value, max_length=max_length, max_string=max_string, max_depth=3)
+
+
+def _sample_split(n: int, budget: PreviewBudget) -> tuple[int, int]:
+    """Head/tail row counts: ceiling half and floor half of the row budget."""
+    k = _ROW_SAMPLE if budget.max_length is None else min(budget.max_length, _ROW_SAMPLE)
+    k = max(1, min(k, n))
+    n_head = (k + 1) // 2
+    return n_head, k - n_head
+
+
+@spec.define_preview(pd.DataFrame)
+def _dataframe_preview(df: pd.DataFrame, budget: PreviewBudget) -> str | None:
+    n = len(df)
+    if df.empty or _complete_within_budget(df, df.size, budget):
+        return None
+    cols = {str(name): str(dtype) for name, dtype in df.dtypes.items()}
+    header = (
+        f"DataFrame(shape={df.shape!r}, columns={_bounded(cols, budget, max_length=_COL_SAMPLE)}"
+    )
+
+    n_head, n_tail = _sample_split(n, budget)
+    head = _bounded(df.head(n_head).to_dict("records"), budget, max_length=_COL_SAMPLE)
+    if n_tail > 0:
+        tail = _bounded(df.tail(n_tail).to_dict("records"), budget, max_length=_COL_SAMPLE)
+        return f"{header}, [:{n_head}]={head}, [-{n_tail}:]={tail})"
+    return f"{header}, [:{n_head}]={head})"
+
+
+@spec.define_preview(pd.Series)
+def _series_preview(s: pd.Series, budget: PreviewBudget) -> str | None:
+    n = len(s)
+    if s.empty or _complete_within_budget(s, n, budget):
+        return None
+    header = f"Series(len={n}, dtype={s.dtype}"
+    if s.name is not None:
+        header += f", name={s.name!r}"
+    if not isinstance(s.index, pd.RangeIndex):
+        header += f", index={type(s.index).__name__}"
+
+    n_head, n_tail = _sample_split(n, budget)
+    head = _bounded(s.head(n_head).to_list(), budget, max_length=_ROW_SAMPLE)
+    if n_tail > 0:
+        tail = _bounded(s.tail(n_tail).to_list(), budget, max_length=_ROW_SAMPLE)
+        return f"{header}, [:{n_head}]={head}, [-{n_tail}:]={tail})"
+    return f"{header}, [:{n_head}]={head})"

--- a/src/nooa/agentdoc/ext.py
+++ b/src/nooa/agentdoc/ext.py
@@ -48,9 +48,13 @@ from nooa.agentdoc.protocols import (
     SupportsTypeInfo,
 )
 from nooa.agentdoc.registry import (
+    PreviewBudget,
     clear_registry,
+    get_preview_extractor,
     get_type_info_extractor,
+    register_preview_extractor,
     register_type_info_extractor,
+    unregister_preview_extractor,
     unregister_type_info_extractor,
 )
 
@@ -83,6 +87,11 @@ __all__ = [
     "get_type_info_extractor",
     "unregister_type_info_extractor",
     "clear_registry",
+    # Value previews
+    "PreviewBudget",
+    "register_preview_extractor",
+    "get_preview_extractor",
+    "unregister_preview_extractor",
     # Helpers
     "has_type_info",
 ]

--- a/src/nooa/agentdoc/registry.py
+++ b/src/nooa/agentdoc/registry.py
@@ -10,11 +10,25 @@ This is the recommended approach for third-party library integration.
 
 import threading
 from collections.abc import Callable
-from typing import Any
+from typing import Any, NamedTuple
 
 from nooa.agentdoc._info import ModuleInfo, TypeInfo
 
 _registry_lock = threading.RLock()
+
+
+class PreviewBudget(NamedTuple):
+    """Truncation budget handed to a value-preview extractor.
+
+    Mirrors the ``pformat`` knobs active at the call site. Budgets are
+    advisory: an extractor interprets them sensibly for its type (e.g. a
+    DataFrame preview treats ``max_length`` as a row/column sample budget),
+    but the result must stay bounded regardless of the value's size.
+    """
+
+    max_length: int | None
+    max_string: int | None
+
 
 # Type for extractor functions
 # Returns TypeInfo for types, or (TypeInfo, dict) for instances
@@ -23,11 +37,18 @@ TypeInfoExtractorFunc = Callable[[Any], TypeInfo | tuple[TypeInfo, dict[str, Any
 # Module extractor: receives the module object, returns ModuleInfo
 ModuleInfoExtractorFunc = Callable[[Any], ModuleInfo]
 
+# Value-preview extractor: receives the value and the active truncation budget,
+# returns a bounded one-line preview string, or None to fall back to repr.
+PreviewExtractorFunc = Callable[[Any, PreviewBudget], "str | None"]
+
 # Global registry: type -> extractor function
 _extractor_registry: dict[type, TypeInfoExtractorFunc] = {}
 
 # Global registry: module qualified name -> extractor function
 _module_extractor_registry: dict[str, ModuleInfoExtractorFunc] = {}
+
+# Global registry: type -> value-preview extractor function
+_preview_registry: dict[type, PreviewExtractorFunc] = {}
 
 
 def register_type_info_extractor(
@@ -182,6 +203,76 @@ def unregister_module_info_extractor(target_module: Any) -> None:
         _module_extractor_registry.pop(target_module.__name__, None)
 
 
+def register_preview_extractor(
+    target_type: type,
+) -> Callable[[PreviewExtractorFunc], PreviewExtractorFunc]:
+    """Decorator to register a value-preview extractor for a type.
+
+    Preview extractors give ``pformat``/``pprint`` a structural, bounded
+    preview for opaque third-party values (numpy arrays, DataFrames, …) that
+    would otherwise fall back to a truncated ``repr``. The extractor receives
+    the instance and the active :class:`PreviewBudget`, and returns the
+    preview string — or ``None`` to decline (e.g. when the plain repr already
+    fits the budget), which falls through to the default repr rendering.
+
+    Extractors must never raise for values of their type; a raising extractor
+    is treated as declining.
+
+    Args:
+        target_type: The type to register the extractor for. Lookup follows
+            the value's MRO, so subclasses are covered too.
+
+    Returns:
+        Decorator function
+
+    Example:
+        @register_preview_extractor(np.ndarray)
+        def _ndarray_preview(arr, budget) -> str | None:
+            if fits_budget(repr(arr), budget):
+                return None  # complete values render as plain repr
+            return f"ndarray(shape={arr.shape}, dtype={arr.dtype}, ...)"
+    """
+
+    def decorator(func: PreviewExtractorFunc) -> PreviewExtractorFunc:
+        with _registry_lock:
+            _preview_registry[target_type] = func
+        return func
+
+    return decorator
+
+
+def get_preview_extractor(obj: Any) -> PreviewExtractorFunc | None:
+    """Get the registered value-preview extractor for an object's type.
+
+    Checks the object's type and all base classes (MRO order) for a
+    registered extractor.
+
+    Args:
+        obj: Instance to get the extractor for
+
+    Returns:
+        Extractor function if registered, None otherwise
+    """
+    with _registry_lock:
+        for base_type in type(obj).__mro__:
+            if base_type in _preview_registry:
+                return _preview_registry[base_type]
+
+    return None
+
+
+def unregister_preview_extractor(target_type: type) -> None:
+    """Remove a type from the value-preview registry.
+
+    Mainly useful for testing.
+
+    Args:
+        target_type: Type to unregister
+    """
+    with _registry_lock:
+        _preview_registry.pop(target_type, None)
+
+
 def clear_registry() -> None:
     """Clear all registered extractors.
 
@@ -190,3 +281,4 @@ def clear_registry() -> None:
     with _registry_lock:
         _extractor_registry.clear()
         _module_extractor_registry.clear()
+        _preview_registry.clear()

--- a/src/nooa/strategies/codeact.py
+++ b/src/nooa/strategies/codeact.py
@@ -752,6 +752,16 @@ Standard Python builtins and agent instance (`self`) are available."""
         session_holder: dict[str, Any],
     ) -> Any:
         """Body of :meth:`execute`; ``session_holder`` receives the session for teardown."""
+        # Activate doc()/preview adapters for installed libs (pandas, numpy, …) so
+        # argument inspection and pprint() in cells render structural, bounded
+        # previews instead of truncated reprs. Idempotent and installed-gated.
+        try:
+            from nooa.agentdoc.adapters import register_all
+
+            register_all()
+        except Exception:  # noqa: BLE001 — adapters are advisory; never block execution
+            pass
+
         # Return type is pre-resolved by _execute_with_generation (handles PEP 563).
         return_type = call.return_type
         if return_type is None:

--- a/tests/agentdoc/test_numpy_preview.py
+++ b/tests/agentdoc/test_numpy_preview.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The numpy adapter gives shape-aware pformat previews for large ndarrays.
+
+Large arrays lead with shape/dtype and anchor a bounded head/tail sample to
+axis 0; small arrays keep their plain repr (marker presence = truncation).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from nooa.agentdoc import pformat  # noqa: E402
+from nooa.agentdoc.adapters import register_all  # noqa: E402
+
+# FormatConfig defaults used by the runtime's context rendering.
+KW = {"max_length": 50, "max_string": 500}
+
+
+@pytest.fixture(autouse=True)
+def _register():
+    # Reload to re-run the @spec.define_preview decorators even if a sibling
+    # agentdoc test cleared the registry (register_all() alone is a no-op once
+    # the module is imported).
+    import importlib
+
+    import nooa.agentdoc.adapters.numpy as _numpy_adapter
+
+    importlib.reload(_numpy_adapter)
+
+
+class TestRegistration:
+    def test_register_all_includes_numpy(self):
+        assert "numpy" in register_all()
+
+
+class TestSmallArraysUnchanged:
+    def test_small_array_is_plain_repr(self):
+        assert pformat(np.array([1, 2, 3]), **KW) == "array([1, 2, 3])"
+
+    def test_zero_d_array_is_plain_repr(self):
+        assert pformat(np.array(7), **KW) == "array(7)"
+
+    def test_unbudgeted_call_is_plain_repr(self):
+        # No truncation budget → no preview, matching list behavior.
+        assert pformat(np.arange(3)) == "array([0, 1, 2])"
+
+
+class TestOneDim:
+    def test_marker_leads_with_shape_and_dtype(self):
+        result = pformat(np.arange(100) * 0.5, max_length=10, max_string=500)
+        assert result.startswith("ndarray(shape=(100,), dtype=float64,")
+
+    def test_head_tail_slice_keys(self):
+        result = pformat(np.arange(100), max_length=10, max_string=500)
+        assert "[:5]=[0, 1, 2, 3, 4]" in result
+        assert "[-5:]=[95, 96, 97, 98, 99]" in result
+
+    def test_middle_is_elided(self):
+        result = pformat(np.arange(100), max_length=10, max_string=500)
+        assert "42" not in result
+
+    def test_object_dtype_keeps_quotes(self):
+        result = pformat(np.array(["word"] * 5000, dtype=object), max_length=6, max_string=500)
+        assert "'word'" in result
+        assert "dtype=object" in result
+
+
+class TestMultiDim:
+    def test_2d_marker_and_row_sample(self):
+        a = np.arange(1000).reshape(250, 4) * 1.5
+        result = pformat(a, **KW)
+        assert result.startswith("ndarray(shape=(250, 4), dtype=float64,")
+        assert "[:3]=" in result and "[-3:]=" in result
+        assert "1.5" in result and "1498.5" in result
+        assert "\n" not in result
+
+    def test_wide_2d_triggers_by_total_size(self):
+        # 2 rows but 1M cells: numpy's own repr elides columns, so the
+        # count trigger must use arr.size, not just axis-0 length.
+        a = np.zeros((2, 1_000_000))
+        result = pformat(a, **KW)
+        assert result.startswith("ndarray(shape=(2, 1000000),")
+
+    def test_3d_preview_stays_bounded(self):
+        result = pformat(np.zeros((10, 20, 30)), **KW)
+        assert result.startswith("ndarray(shape=(10, 20, 30), dtype=float64,")
+        assert len(result) < 800
+
+    def test_preview_never_materializes_huge_output(self):
+        a = np.arange(3_000_000, dtype=np.int64).reshape(1000, 3000)
+        result = pformat(a, **KW)
+        assert result.startswith("ndarray(shape=(1000, 3000),")
+        assert len(result) < 800

--- a/tests/agentdoc/test_pandas_preview.py
+++ b/tests/agentdoc/test_pandas_preview.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The pandas adapter gives shape-aware pformat previews for DataFrame/Series.
+
+Large frames lead with shape and column dtypes and anchor a bounded record
+sample to the ends; small frames keep their plain repr.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from nooa.agentdoc import pformat  # noqa: E402
+
+# FormatConfig defaults used by the runtime's context rendering.
+KW = {"max_length": 50, "max_string": 500}
+
+
+@pytest.fixture(autouse=True)
+def _register():
+    # Reload to re-run the @spec.define_preview decorators even if a sibling
+    # agentdoc test cleared the registry (register_all() alone is a no-op once
+    # the module is imported).
+    import importlib
+
+    import nooa.agentdoc.adapters.pandas as _pandas_adapter
+
+    importlib.reload(_pandas_adapter)
+
+
+def _big_df(n: int = 500) -> pd.DataFrame:
+    return pd.DataFrame({"price": [i / n for i in range(n)], "qty": range(n), "label": ["x"] * n})
+
+
+class TestSmallValuesUnchanged:
+    def test_small_dataframe_is_plain_repr(self):
+        df = pd.DataFrame({"a": [1, 2]})
+        assert pformat(df, **KW) == repr(df)
+
+    def test_small_series_is_plain_repr(self):
+        s = pd.Series([1, 2, 3])
+        assert pformat(s, **KW) == repr(s)
+
+    def test_unbudgeted_call_is_plain_repr(self):
+        df = _big_df()
+        assert pformat(df) == repr(df)
+
+    def test_empty_dataframe_is_plain_repr(self):
+        df = pd.DataFrame()
+        assert pformat(df, **KW) == repr(df)
+
+
+class TestDataFrame:
+    def test_marker_leads_with_shape_and_column_dtypes(self):
+        result = pformat(_big_df(), **KW)
+        assert result.startswith("DataFrame(shape=(500, 3), columns=")
+        assert "'price': 'float64'" in result
+        assert "'qty': 'int64'" in result
+
+    def test_head_tail_record_sample(self):
+        result = pformat(_big_df(), **KW)
+        assert "[:3]=" in result and "[-2:]=" in result
+        assert "'qty': 0" in result  # first record
+        assert "'qty': 499" in result  # last record
+
+    def test_middle_rows_are_elided(self):
+        result = pformat(_big_df(), **KW)
+        assert "'qty': 250" not in result
+
+    def test_wide_frame_triggers_by_cell_count(self):
+        # 2 rows × 100 columns: pandas' own repr elides columns, so the
+        # count trigger must use df.size, not just row count.
+        df = pd.DataFrame([[0] * 100, [1] * 100])
+        result = pformat(df, **KW)
+        assert result.startswith("DataFrame(shape=(2, 100),")
+
+    def test_preview_stays_bounded_for_huge_frames(self):
+        df = pd.DataFrame({f"c{i}": range(10_000) for i in range(50)})
+        result = pformat(df, **KW)
+        assert result.startswith("DataFrame(shape=(10000, 50),")
+        assert len(result) < 3000
+
+    def test_long_cell_strings_are_truncated(self):
+        df = pd.DataFrame({"doc": ["long text " * 100] * 200})
+        result = pformat(df, **KW)
+        assert result.startswith("DataFrame(shape=(200, 1),")
+        assert len(result) < 1500
+
+
+class TestSeries:
+    def test_marker_leads_with_len_dtype_name(self):
+        s = _big_df()["price"]
+        result = pformat(s, **KW)
+        assert result.startswith("Series(len=500, dtype=float64, name='price',")
+
+    def test_head_tail_value_sample(self):
+        s = pd.Series(range(300))
+        result = pformat(s, **KW)
+        assert "[:3]=[0, 1, 2]" in result
+        assert "[-2:]=[298, 299]" in result
+
+    def test_non_range_index_is_named(self):
+        s = pd.Series(range(300), index=pd.date_range("2026-01-01", periods=300), name="hits")
+        result = pformat(s, **KW)
+        assert "index=DatetimeIndex" in result
+
+    def test_range_index_is_not_named(self):
+        result = pformat(pd.Series(range(300)), **KW)
+        assert "index=" not in result

--- a/tests/agentdoc/test_preview_registry.py
+++ b/tests/agentdoc/test_preview_registry.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the value-preview extractor registry.
+
+Preview extractors let ``pformat`` render structural, bounded previews for
+opaque third-party values (numpy arrays, DataFrames, …) in place of the
+truncated-repr fallback. These tests cover the registry mechanics with plain
+Python types; the numpy/pandas adapters have their own test modules.
+"""
+
+import pytest
+
+from nooa.agentdoc import pformat, spec
+from nooa.agentdoc.ext import (
+    PreviewBudget,
+    clear_registry,
+    get_preview_extractor,
+    register_preview_extractor,
+    unregister_preview_extractor,
+)
+
+
+class Blob:
+    """Opaque sample type with a deliberately long repr."""
+
+    def __init__(self, size: int = 1000):
+        self.size = size
+
+    def __repr__(self) -> str:
+        return "Blob<" + "x" * self.size + ">"
+
+
+class SubBlob(Blob):
+    """Subclass of Blob."""
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Clear registry before and after each test."""
+    clear_registry()
+    yield
+    clear_registry()
+
+
+class TestRegistryMechanics:
+    def test_register_and_get(self):
+        @register_preview_extractor(Blob)
+        def blob_preview(obj, budget):
+            return f"Blob(size={obj.size})"
+
+        assert get_preview_extractor(Blob()) is blob_preview
+
+    def test_get_returns_none_if_not_registered(self):
+        assert get_preview_extractor(Blob()) is None
+
+    def test_mro_lookup_covers_subclasses(self):
+        @register_preview_extractor(Blob)
+        def blob_preview(obj, budget):
+            return f"Blob(size={obj.size})"
+
+        assert get_preview_extractor(SubBlob()) is blob_preview
+
+    def test_unregister(self):
+        @register_preview_extractor(Blob)
+        def blob_preview(obj, budget):
+            return "preview"
+
+        unregister_preview_extractor(Blob)
+        assert get_preview_extractor(Blob()) is None
+
+    def test_clear_registry_clears_previews(self):
+        @register_preview_extractor(Blob)
+        def blob_preview(obj, budget):
+            return "preview"
+
+        clear_registry()
+        assert get_preview_extractor(Blob()) is None
+
+    def test_spec_define_preview_registers(self):
+        @spec.define_preview(Blob)
+        def blob_preview(obj, budget):
+            return f"Blob(size={obj.size})"
+
+        assert get_preview_extractor(Blob()) is blob_preview
+
+
+class TestPformatIntegration:
+    def test_preview_replaces_repr_fallback(self):
+        @register_preview_extractor(Blob)
+        def blob_preview(obj, budget):
+            return f"Blob(size={obj.size})"
+
+        assert pformat(Blob(1000), max_string=100) == "Blob(size=1000)"
+
+    def test_budget_reflects_call_site(self):
+        seen: list[PreviewBudget] = []
+
+        @register_preview_extractor(Blob)
+        def blob_preview(obj, budget):
+            seen.append(budget)
+            return "preview"
+
+        pformat(Blob(), max_length=7, max_string=42)
+        assert seen == [PreviewBudget(max_length=7, max_string=42)]
+
+    def test_declining_falls_back_to_repr_marker(self):
+        @register_preview_extractor(Blob)
+        def blob_preview(obj, budget):
+            return None
+
+        result = pformat(Blob(1000), max_string=100)
+        # the truncated-repr fallback marker, unchanged
+        assert result.startswith("Blob(repr_len=")
+
+    def test_raising_extractor_falls_back_to_repr_marker(self):
+        @register_preview_extractor(Blob)
+        def blob_preview(obj, budget):
+            raise RuntimeError("boom")
+
+        result = pformat(Blob(1000), max_string=100)
+        assert result.startswith("Blob(repr_len=")
+
+    def test_preview_applies_inside_containers(self):
+        @register_preview_extractor(Blob)
+        def blob_preview(obj, budget):
+            return f"Blob(size={obj.size})"
+
+        result = pformat({"blob": Blob(1000)}, max_string=100)
+        assert "Blob(size=1000)" in result
+
+    def test_preview_applies_at_depth_limit(self):
+        @register_preview_extractor(Blob)
+        def blob_preview(obj, budget):
+            return f"Blob(size={obj.size})"
+
+        # Blob sits at max_depth, where the shallow formatter would
+        # otherwise dump the full 1000-char repr.
+        nested = {"a": {"b": Blob(1000)}}
+        result = pformat(nested, max_string=100, max_depth=2)
+        assert "Blob(size=1000)" in result
+        assert "xxx" not in result
+
+    def test_unregistered_types_unaffected(self):
+        result = pformat(Blob(1000), max_string=100)
+        assert result.startswith("Blob(repr_len=")

--- a/tests/strategies/test_codeact_preview_adapters.py
+++ b/tests/strategies/test_codeact_preview_adapters.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""CodeAct execution registers the pformat preview adapters.
+
+Regression test for the adapter-registration gap: register_all() used to run
+only on the opaque-return-type path (_render_return_type_doc), so a method
+with a JSON-schemable return type (-> str) never activated the numpy/pandas
+previews and argument inspection fell back to truncated reprs. Found live —
+the first end-to-end run showed `ndarray(repr_len=...)` in the prefill
+PythonOutput instead of the structural preview.
+"""
+
+import json
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from nooa import Agent, strategy  # noqa: E402
+from nooa.strategies.codeact import CodeActStrategy  # noqa: E402
+from nooa.unifiedllm import FakeLLMClient, LLMResponse, ToolCall  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _register():
+    # Reload to re-run the @spec.define_preview decorators even if a sibling
+    # agentdoc test cleared the registry (register_all() alone is a no-op once
+    # the module is imported).
+    import importlib
+
+    import nooa.agentdoc.adapters.pandas as _pandas_adapter
+
+    importlib.reload(_pandas_adapter)
+
+
+def _return_result(result, call_id: str = "call_return") -> ToolCall:
+    return ToolCall(id=call_id, name="return_result", arguments=json.dumps({"result": result}))
+
+
+def _resp(tool_calls: list) -> LLMResponse:
+    return LLMResponse(
+        raw_response=None,
+        content="",
+        tool_calls=tool_calls,
+        finish_reason="tool_calls",
+        assistant_message={"role": "assistant", "content": ""},
+    )
+
+
+@pytest.mark.asyncio
+async def test_prefill_inspection_uses_structural_preview_for_dataframe():
+    """A schemable return type (-> str) must still activate preview adapters."""
+
+    class FrameAgent(Agent, llm=FakeLLMClient()):
+        @strategy(CodeActStrategy())
+        async def summarize(self, table: pd.DataFrame) -> str:
+            """Summarize the table."""
+            ...
+
+    fake_llm = FakeLLMClient(scripted_responses=[_resp([_return_result("ok")])])
+    agent = FrameAgent(llm=fake_llm)
+
+    big = pd.DataFrame({"a": range(500), "b": [str(i) for i in range(500)]})
+    result = await agent.summarize(big)
+    assert result == "ok"
+
+    outputs = agent.events.query(type="PythonOutput")
+    assert outputs, "expected the prefill input-inspection PythonOutput event"
+    stdout = getattr(outputs[0], "stdout", "") or ""
+    assert "DataFrame(shape=(500, 2)" in stdout
+    # the old fallback marker must be gone
+    assert "repr_len=" not in stdout


### PR DESCRIPTION
## Motivation

Section 3.2 of the paper calls bounded-preview coverage open work: *"Finding even better formats that are obvious to LLMs, and supporting more types, remains open work."* Today, numpy arrays and pandas frames — the two types a data-touching CodeAct agent handles most — fall through to the truncated-repr fallback, which slices the repr text mid-escape and hides the structural facts:

```
ndarray(repr_len=10250, [:100]='array([[   0. ,    1.5,    3. ,    4.5],\n       [   6. , ...')
DataFrame(repr_len=323, [:100]='        price  qty label\n0    0.000000    0     x\n1  ...')
```

The shape, dtype, and column schema — exactly what the model needs to write its next cell — are invisible or accidental.

## What this PR does

**1. A value-preview extension point mirroring the existing `doc()` adapter architecture.** `spec.define_preview(SomeType)` registers an extractor (MRO-aware, thread-safe, cleared by `clear_registry()`) that `pformat`/`pprint` consults before the repr fallback. Extractors receive the instance plus the active truncation budget and may decline by returning `None` (raising also declines), so behavior is unchanged for every unregistered type and for complete-within-budget values — the marker-presence-signals-truncation rule is preserved.

**2. numpy + pandas adapters** (`agentdoc/adapters/numpy.py`, additions to `adapters/pandas.py`), registered via `register_all()` so CodeAct rendering picks them up automatically. Neither library becomes a dependency. With the runtime's default budgets:

```
ndarray(shape=(250, 4), dtype=float64, [:3]=[[0., 1.5, 3., 4.5], ...], [-3:]=[..., [1494., 1495.5, 1497., 1498.5]])
DataFrame(shape=(500, 3), columns={'price': 'float64', 'qty': 'int64', 'label': 'str'}, [:3]=[{'price': 0.0, 'qty': 0, 'label': 'x'}, ...], [-2:]=[...])
Series(len=500, dtype=float64, name='price', [:3]=[0.0, 0.002, 0.004], [-2:]=[0.998, 1.0])
```

Formats stay inside the truncation 3.0 marker family (`[:H]=` / `[-T:]=` slice keys). Details worth reviewing:

- The count trigger uses **total element counts** (`arr.size`, `df.size`): numpy and pandas elide their own reprs with `...`, so a short repr is not evidence of a complete value (a 2×1M array's repr is short but far from complete).
- Row/column samples are bounded per axis (≥2-D arrays get one edge item per deep axis; frames cap row records and per-cell strings), so previews stay a few hundred characters no matter the value's size, and nothing over-materializes (the 1000×3000 test asserts this).
- Previews also apply at the `max_depth` shallow path, which previously wrote **full untruncated reprs** for values nested at the depth limit.

**3. Adapter activation at CodeAct execution start** (`codeact.py`). Live end-to-end testing (Ollama `qwen3:1.7b`, a real CodeAct run over a 500-row DataFrame + 250×4 ndarray) caught that `register_all()` previously ran only on the opaque-return-type path (`_render_return_type_doc`), so a method with a schemable return type (`-> str`) never activated the adapters and argument inspection fell back to truncated reprs. `_run_generation` now registers adapters up front (idempotent, installed-gated, exception-guarded).

**4. Tests** — 40 new tests in four files: registry mechanics with plain Python types (no numpy needed), per-adapter suites using the repo's `importorskip` + adapter-reload pattern, and an end-to-end regression test asserting a CodeAct run's prefill inspection renders `DataFrame(shape=...)` rather than `repr_len=...`.

## Validation

- `pytest tests/agentdoc tests/strategies` — 1641 passed (40 new)
- Full `-m "not integration and not stress"` suite green
- `ruff check`, `ruff format --check`, SPDX header check green
- Verified live: a CodeAct agent on Ollama `qwen3:1.7b` received the structural previews in its first `PythonOutput` event

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes the design discussion in #86.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bounded value previews for large NumPy arrays, pandas DataFrames, and Series.
  - Added preview registration APIs with configurable formatting budgets.
  - Large values now show structural details and head/tail samples instead of excessively long representations.
  - Added automatic adapter registration when supported libraries are installed.
- **Bug Fixes**
  - Improved CodeAct inspections to display useful previews for large tabular values.
  - Preview failures safely fall back to standard rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->