### PR TITLE
ci: run sandbox containment tests, split off the sandbox marker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,15 @@ jobs:
       - name: Sync
         run: uv sync --all-extras --no-extra sandbox
       - name: Unit tests (no live API calls)
-        run: uv run pytest -q -m "not integration and not stress"
+        run: uv run pytest -q -m "not integration and not stress and not sandbox"
+      # Sandbox containment tests fork a real worker to exercise the OS-level
+      # sandbox (Landlock, seccomp, RLIMIT, cell timeouts, broker-pipe
+      # boundary). They need no credentials and skipif-degrade on kernels
+      # without the relevant capabilities, so ubuntu-latest runs them for
+      # real. Kept out of the unit-test step because forking a worker is
+      # heavier than a unit test. See #78.
+      - name: Sandbox containment tests
+        run: uv run pytest -q -m sandbox
 
   build:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,11 +221,12 @@ pythonpath = [
     "src",
     "packages/nooa-cli/src",
 ]
-addopts = "-v --tb=short --import-mode=importlib -m 'not integration and not stress'"
+addopts = "-v --tb=short --import-mode=importlib -m 'not integration and not stress and not sandbox'"
 markers = [
     "integration: marks tests as integration tests that make real API calls (run with '-m integration')",
     "provider_compat_ollama: marks live Ollama provider compatibility tests",
     "provider_compat_vllm: marks live vLLM provider compatibility tests",
+    "sandbox: marks tests that fork a real sandbox worker to exercise OS-level containment (run with '-m sandbox'); no credentials needed, but heavier than unit tests",
     "stress: marks tests as stress/load tests that simulate high concurrency (run with '-m stress')",
 ]
 filterwarnings = [

--- a/tests/runtime/sandbox/test_broker_deadline.py
+++ b/tests/runtime/sandbox/test_broker_deadline.py
@@ -25,7 +25,7 @@ from nooa.runtime.sandbox.config import SandboxConfig
 from nooa.runtime.sandbox.executor import SandboxedExecutor
 from nooa.unifiedllm import FakeLLMClient
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.sandbox
 
 # cell_timeout=1.0 + timeout_grace_s=2.0 -> hard deadline 3.0s.
 _CELL_TIMEOUT = 1.0

--- a/tests/runtime/sandbox/test_codeact_sandbox.py
+++ b/tests/runtime/sandbox/test_codeact_sandbox.py
@@ -22,7 +22,7 @@ from nooa.runtime.sandbox.guards import probe_capabilities
 from nooa.strategies.codeact import CodeActStrategy
 from nooa.unifiedllm import FakeLLMClient, LLMResponse, ToolCall
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.sandbox
 
 CAPS = probe_capabilities()
 

--- a/tests/runtime/sandbox/test_executor.py
+++ b/tests/runtime/sandbox/test_executor.py
@@ -22,7 +22,7 @@ from nooa.runtime.sandbox.executor import SandboxedExecutor
 from nooa.runtime.sandbox.guards import probe_capabilities
 from nooa.unifiedllm.fake import FakeLLMClient
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.sandbox
 
 CAPS = probe_capabilities()
 

--- a/tests/runtime/sandbox/test_guards.py
+++ b/tests/runtime/sandbox/test_guards.py
@@ -27,7 +27,7 @@ from nooa.runtime.sandbox.guards import (
     probe_capabilities,
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.sandbox
 
 CAPS = probe_capabilities()
 

--- a/tests/runtime/sandbox/test_nested_async_proxy.py
+++ b/tests/runtime/sandbox/test_nested_async_proxy.py
@@ -24,7 +24,7 @@ from nooa.runtime.sandbox.config import SandboxConfig
 from nooa.runtime.sandbox.executor import SandboxedExecutor
 from nooa.unifiedllm import FakeLLMClient
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.sandbox
 
 
 class _AsyncTool:

--- a/tests/runtime/sandbox/test_readonly_module_state.py
+++ b/tests/runtime/sandbox/test_readonly_module_state.py
@@ -124,7 +124,7 @@ def _executor() -> SandboxedExecutor:
     )
 
 
-@pytest.mark.integration
+@pytest.mark.sandbox
 @pytest.mark.asyncio
 async def test_cell_mutating_module_dict_fails_loud():
     ex = _executor()
@@ -137,7 +137,7 @@ async def test_cell_mutating_module_dict_fails_loud():
         await ex.aclose()
 
 
-@pytest.mark.integration
+@pytest.mark.sandbox
 @pytest.mark.asyncio
 async def test_cell_mutating_module_list_fails_loud():
     ex = _executor()
@@ -148,7 +148,7 @@ async def test_cell_mutating_module_list_fails_loud():
         await ex.aclose()
 
 
-@pytest.mark.integration
+@pytest.mark.sandbox
 @pytest.mark.asyncio
 async def test_cell_reading_module_state_still_works():
     ex = _executor()


### PR DESCRIPTION
Fixes #78.

## Problem
`ci.yml` only pytest step ran `-m "not integration and not stress"`. The `integration` marker was overloaded — it meant "needs live credentials" (6 files) *and* "forks a real sandbox worker" (6 files under `tests/runtime/sandbox/`). The blanket exclusion dropped both, so the 46-test sandbox containment suite — Landlock, seccomp, RLIMIT, cell timeouts, broker-pipe boundary.

## Fix
Split the marker:
- `integration` — unchanged, still means "needs live credentials."
- `sandbox` — new, means "forks a real worker for OS-level containment." No credentials needed; `skipif`-degrades on kernels without the relevant capabilities.

CI `test` job gains a second step:

```yaml
- run: uv run pytest -q -m "not integration and not stress and not sandbox"
- run: uv run pytest -q -m sandbox
```

Verification

- pytest -m sandbox --collect-only → 48 selected under tests/runtime/sandbox/.
- Default addopts → same 48 deselected; the 25 unmarked helper tests in that directory still run in the unit-test step.
- Ran locally on Darwin: 39 pass / 7 skip / 2 fail (the failures are
macOS-specific RLIMIT_AS behavior; the sandbox is Linux-only and the
executor already logs sandbox requires Linux). ubuntu-latest should
match the reporter's clean run.
