### PR TITLE
fix(ci) - ripregrep skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
           python-version: "3.12"
       - name: Sync
         run: uv sync --all-extras --no-extra sandbox
+      # tests/tools/test_shell_tools_modern.py skipif-drops 145 tests when `rg`
+      # is not on PATH. ubuntu-latest does not ship ripgrep, so without this
+      # step those tests silently skip and the job passes vacuously. See #65.
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
       - name: Unit tests (no live API calls)
         run: uv run pytest -q -m "not integration and not stress"
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -90,6 +90,14 @@ Viewer main routes, journal and OTLP stores, OTLP ingest, stress coverage, image
 
 ## Running Tests
 
+### Prerequisites
+
+- `ripgrep` (`rg`) and `grep` must be on `PATH`. The 145 tests in
+  `tests/tools/test_shell_tools_modern.py` skipif-away without them, and a
+  clean skip is indistinguishable from a pass in the summary line. Install
+  with `apt install ripgrep` on Debian/Ubuntu or `brew install ripgrep` on
+  macOS.
+
 ```bash
 uv run pytest                          # all tests
 uv run pytest tests/runtime/ -v        # single directory

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Session-start check for shell-tool test prerequisites.
+
+`test_shell_tools_modern.py` skipif-drops 145 tests when `rg` or `grep` is
+missing from `PATH`. A skip is indistinguishable from a pass in the pytest
+summary, so a base image that stops shipping ripgrep would silently erase
+that coverage. Fail loud in CI; warn locally.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import warnings
+
+import pytest
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    missing = [tool for tool in ("rg", "grep") if shutil.which(tool) is None]
+    if not missing:
+        return
+    msg = (
+        f"tests/tools/ prerequisite missing on PATH: {', '.join(missing)}. "
+        "Install ripgrep (`apt install ripgrep` / `brew install ripgrep`); "
+        "see tests/README.md."
+    )
+    # CI must fail loud rather than silently skip 145 tests. Locally, warn
+    # but do not block — a contributor running `pytest tests/agents/` should
+    # not be forced to install a dep for a suite they are not touching.
+    if os.environ.get("CI"):
+        pytest.exit(msg, returncode=1)
+    warnings.warn(msg, UserWarning, stacklevel=1)

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -12,23 +12,34 @@ from __future__ import annotations
 
 import os
 import shutil
-import warnings
 
 import pytest
 
 
-def pytest_sessionstart(session: pytest.Session) -> None:
-    missing = [tool for tool in ("rg", "grep") if shutil.which(tool) is None]
-    if not missing:
-        return
-    msg = (
+def _missing_prereqs() -> list[str]:
+    return [tool for tool in ("rg", "grep") if shutil.which(tool) is None]
+
+
+def _prereq_message(missing: list[str]) -> str:
+    return (
         f"tests/tools/ prerequisite missing on PATH: {', '.join(missing)}. "
         "Install ripgrep (`apt install ripgrep` / `brew install ripgrep`); "
         "see tests/README.md."
     )
-    # CI must fail loud rather than silently skip 145 tests. Locally, warn
-    # but do not block — a contributor running `pytest tests/agents/` should
-    # not be forced to install a dep for a suite they are not touching.
-    if os.environ.get("CI"):
-        pytest.exit(msg, returncode=1)
-    warnings.warn(msg, UserWarning, stacklevel=1)
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    # CI must fail loud rather than silently skip 145 tests. Locally, the
+    # header hook below surfaces a banner but the run continues — a
+    # contributor running `pytest tests/agents/` should not be forced to
+    # install a dep for a suite they are not touching.
+    missing = _missing_prereqs()
+    if missing and os.environ.get("CI"):
+        pytest.exit(_prereq_message(missing), returncode=1)
+
+
+def pytest_report_header(config: pytest.Config) -> str | None:
+    missing = _missing_prereqs()
+    if not missing:
+        return None
+    return f"WARNING: {_prereq_message(missing)}"


### PR DESCRIPTION
Fixes #65.

## Problem
`tests/tools/test_shell_tools_modern.py` skipif-drops all 145 tests when `rg` or `grep` is missing from `PATH`. `ubuntu-latest` does not ship ripgrep, and no workflow installs it — so on every CI run those 145 tests silently skipped and the `test` job passed vacuously.

## Fix
Two layers, so the failure mode can't recur silently:

1. **Install ripgrep in CI** and document it as a test prerequisite in `tests/README.md`. Fixes the current instance.
2. **Session-start check in `tests/tools/conftest.py`** — inspects `PATH`  for `rg`/`grep` at collection start. If either is missing:
   - in CI (`CI=true`): `pytest.exit(...)` → job fails red with a clear
     message rather than passing green with 145 silent skips;
   - locally: emits a `UserWarning` banner but does not block the run.

This closes the underlying "tests silently didn't run" pattern, not just the current instance — a future base-image regression would fail loud instead of erasing coverage.

## Verification
- `pytest tests/tools/test_shell_tools_modern.py --collect-only` → 145 collected with `rg` on `PATH` (matches the reporter's count).
- `CI=true PATH=/usr/bin:/bin pytest ...` → exits red with the prerequisite message. `PATH=/usr/bin:/bin pytest ...` (no CI) → session continues, warning surfaces.