### PR TITLE
fix(windows): resolve POSIX-only compatibility issues (#92, #95)

### DIFF
--- a/src/nooa/agentdoc/_truncating_stream.py
+++ b/src/nooa/agentdoc/_truncating_stream.py
@@ -181,7 +181,7 @@ class FileBackedTruncatingStringIO(TruncatingStringIO):
         self._file: io.TextIOWrapper | None = None
         try:
             fd, path = tempfile.mkstemp(dir=dir, prefix=prefix, suffix=suffix)
-            self._file = os.fdopen(fd, "w")
+            self._file = os.fdopen(fd, "w", encoding="utf-8")
             self._file_path = path
         except OSError:
             _log.warning(

--- a/src/nooa/runtime/debug_handler.py
+++ b/src/nooa/runtime/debug_handler.py
@@ -426,8 +426,9 @@ def install_debug_handler(dump_dir: Path | None = None) -> None:
 
     # Install SIGUSR2 handler (less commonly used than SIGUSR1)
     try:
-        signal.signal(signal.SIGUSR2, _debug_signal_handler)
-        _handler_installed = True
+        if hasattr(signal, "SIGUSR2"):
+            signal.signal(signal.SIGUSR2, _debug_signal_handler)
+            _handler_installed = True
     except (ValueError, OSError):
         # Can't set signal handler (not main thread, or platform issue)
         pass

--- a/src/nooa/runtime/sandbox/executor.py
+++ b/src/nooa/runtime/sandbox/executor.py
@@ -409,9 +409,9 @@ class SandboxedExecutor:
     def _classify_worker_death(self, exc: WorkerDiedError) -> Exception:
         proc = self._proc
         code = getattr(proc, "exitcode", None)
-        if code == -signal.SIGXCPU:
+        if hasattr(signal, "SIGXCPU") and code == -signal.SIGXCPU:
             return CellTimeoutError("cell exceeded its CPU-time limit and was killed")
-        if code == -signal.SIGKILL:
+        if hasattr(signal, "SIGKILL") and code == -signal.SIGKILL:
             return CellMemoryError(
                 "worker was killed (out-of-memory or resource limit). "
                 "Reduce the cell's memory use or raise max_memory_mb."

--- a/src/nooa/runtime/sandbox/guards.py
+++ b/src/nooa/runtime/sandbox/guards.py
@@ -178,14 +178,20 @@ class Capabilities:
 
 def probe_capabilities() -> Capabilities:
     """Probe the host once for every enforcement mechanism the sandbox uses."""
-    import resource
-
     is_linux = platform.system() == "Linux"
+    rlimit = False
+    if is_linux:
+        try:
+            import resource
+
+            rlimit = hasattr(resource, "RLIMIT_AS") and hasattr(resource, "RLIMIT_CPU")
+        except ImportError:
+            pass
     return Capabilities(
         linux=is_linux,
         landlock_abi=landlock_abi() if is_linux else 0,
         seccomp=seccomp_supported() if is_linux else False,
-        rlimit=hasattr(resource, "RLIMIT_AS") and hasattr(resource, "RLIMIT_CPU"),
+        rlimit=rlimit,
     )
 
 
@@ -212,7 +218,10 @@ def apply_rlimits(*, max_memory_mb: int = 0, max_cpu_seconds: int = 0) -> None:
     so an absolute cap below that baseline would break it instantly. The cap is
     ``current VmSize + max_memory_mb`` — i.e. how much more the cell may allocate.
     """
-    import resource
+    try:
+        import resource
+    except ImportError:
+        return  # resource module is not available on this platform (e.g. Windows)
 
     if max_memory_mb and max_memory_mb > 0:
         baseline = _self_vmsize_bytes()

--- a/src/nooa/storage/sqlite.py
+++ b/src/nooa/storage/sqlite.py
@@ -7,7 +7,10 @@ Provides persistent storage using stdlib sqlite3 — no new dependencies.
 
 from __future__ import annotations
 
-import fcntl
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 import json
 import logging
 import os
@@ -643,7 +646,8 @@ def _acquire_session_lock(lock_path: str) -> int:
     """
     fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
     try:
-        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:
         os.close(fd)
         owner_pid = _read_lock_pid(lock_path)
@@ -832,7 +836,8 @@ class SQLiteStorageManager:
                     conn.close()
         finally:
             if self._lock_fd is not None:
-                fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
+                if fcntl is not None:
+                    fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
                 os.close(self._lock_fd)
                 self._lock_fd = None
 

--- a/src/nooa/tools/_bash_session.py
+++ b/src/nooa/tools/_bash_session.py
@@ -18,9 +18,11 @@ import logging
 import os
 import secrets
 import signal
+import sys
 import time
 from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -74,10 +76,11 @@ class BashSession:
         proc = self._process
         if proc is not None and proc.returncode is None:
             try:
-                # During interpreter shutdown, module globals (os, signal) may
-                # be None, causing TypeError. Broad except handles all cases.
-                pgid = os.getpgid(proc.pid)
-                os.killpg(pgid, signal.SIGKILL)
+                if hasattr(os, "killpg"):
+                    pgid = os.getpgid(proc.pid)
+                    os.killpg(pgid, signal.SIGKILL)
+                else:
+                    proc.kill()
             except Exception:
                 try:
                     proc.kill()
@@ -159,6 +162,10 @@ class BashSession:
 
         # Create pipe for control channel (fd 3 inside bash).
         ctrl_r, ctrl_w = os.pipe()
+        kwargs: dict[str, Any] = {}
+        if sys.platform != "win32":
+            kwargs["start_new_session"] = True
+            kwargs["pass_fds"] = (ctrl_w,)
         try:
             self._process = await asyncio.create_subprocess_exec(
                 "/bin/bash",
@@ -169,8 +176,7 @@ class BashSession:
                 stderr=asyncio.subprocess.PIPE,
                 cwd=str(self._cwd),
                 env=env,
-                start_new_session=True,
-                pass_fds=(ctrl_w,),
+                **kwargs,
             )
         except Exception:
             os.close(ctrl_r)
@@ -639,9 +645,12 @@ class BashSession:
             if same_loop:
                 # Graceful shutdown: SIGTERM → wait → SIGKILL on timeout
                 try:
-                    pgid = os.getpgid(self._process.pid)
-                    os.killpg(pgid, signal.SIGTERM)
-                except (ProcessLookupError, OSError):
+                    if hasattr(os, "killpg"):
+                        pgid = os.getpgid(self._process.pid)
+                        os.killpg(pgid, signal.SIGTERM)
+                    else:
+                        self._process.terminate()
+                except OSError:
                     try:
                         self._process.kill()
                     except Exception:
@@ -650,16 +659,22 @@ class BashSession:
                     await asyncio.wait_for(self._process.wait(), timeout=3.0)
                 except TimeoutError:
                     try:
-                        pgid = os.getpgid(self._process.pid)
-                        os.killpg(pgid, signal.SIGKILL)
-                    except (ProcessLookupError, OSError):
+                        if hasattr(os, "killpg"):
+                            pgid = os.getpgid(self._process.pid)
+                            os.killpg(pgid, signal.SIGKILL)
+                        else:
+                            self._process.kill()
+                    except OSError:
                         pass
             else:
                 # Cross-loop (gl-212): transport is dead, just kill immediately.
                 try:
-                    pgid = os.getpgid(self._process.pid)
-                    os.killpg(pgid, signal.SIGKILL)
-                except (ProcessLookupError, OSError):
+                    if hasattr(os, "killpg"):
+                        pgid = os.getpgid(self._process.pid)
+                        os.killpg(pgid, signal.SIGKILL)
+                    else:
+                        self._process.kill()
+                except OSError:
                     try:
                         self._process.kill()
                     except Exception:

--- a/tests/agentdoc/test_file_backed_truncating_stream.py
+++ b/tests/agentdoc/test_file_backed_truncating_stream.py
@@ -80,7 +80,7 @@ class TestFileBackedBasicBehavior:
         text = "Hello 世界! 🚀 café"
         buf.write(text)
         assert buf.getvalue() == text
-        with open(buf.file_path) as f:
+        with open(buf.file_path, encoding="utf-8") as f:
             assert f.read() == text
 
 

--- a/tests/runtime/sandbox/test_executor.py
+++ b/tests/runtime/sandbox/test_executor.py
@@ -504,3 +504,85 @@ async def test_require_true_raises_when_unavailable(monkeypatch):
             cell_timeout=5.0,
         )
     ex_mod._CAPS_CACHE = None
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: Windows signal guard in _classify_worker_death (issue #92)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_worker_death_no_sigxcpu_no_sigkill(monkeypatch):
+    """Regression test for #92.
+
+    On platforms where signal.SIGXCPU and signal.SIGKILL don't exist (e.g.
+    Windows), _classify_worker_death() must not raise AttributeError.  It
+    should fall through and return the original WorkerDiedError unchanged.
+    """
+    import signal as signal_mod
+
+    from nooa.runtime.sandbox import executor as ex_mod
+    from nooa.runtime.sandbox.errors import WorkerDiedError
+    from nooa.runtime.sandbox.guards import Capabilities
+
+    # Inject a degraded-mode Windows-like Capabilities so __init__ doesn't crash
+    fake_caps = Capabilities(linux=False, landlock_abi=0, seccomp=False, rlimit=False)
+    monkeypatch.setattr(ex_mod, "_CAPS_CACHE", fake_caps)
+
+    # Mock get_context so instantiating SandboxedExecutor doesn't fail on Windows due to 'fork'
+    import multiprocessing
+
+    monkeypatch.setattr(multiprocessing, "get_context", lambda method: None)
+
+    # Simulate Windows: remove POSIX-only signal constants
+    monkeypatch.delattr(signal_mod, "SIGXCPU", raising=False)
+    monkeypatch.delattr(signal_mod, "SIGKILL", raising=False)
+
+    executor = SandboxedExecutor(
+        _ToolAgent(),
+        SandboxConfig(require=False),
+        cell_timeout=None,
+    )
+
+    # Simulate a dead worker with a generic exit code (e.g. 1)
+    class _FakeProc:
+        exitcode = 1
+
+    executor._proc = _FakeProc()
+    exc = WorkerDiedError("worker died unexpectedly")
+
+    # Before fix: raised AttributeError: module 'signal' has no attribute 'SIGXCPU'
+    # After fix:  falls through and returns the original exception unchanged
+    result = executor._classify_worker_death(exc)
+    assert result is exc
+
+    ex_mod._CAPS_CACHE = None
+
+
+def test_classify_worker_death_sigxcpu_present(monkeypatch):
+    """On Linux where signal.SIGXCPU exists, a SIGXCPU exit should map to CellTimeoutError."""
+    import signal as signal_mod
+
+    from nooa.runtime.sandbox import executor as ex_mod
+    from nooa.runtime.sandbox.errors import CellTimeoutError, WorkerDiedError
+    from nooa.runtime.sandbox.guards import Capabilities
+
+    if not hasattr(signal_mod, "SIGXCPU"):
+        pytest.skip("SIGXCPU not available on this platform")
+
+    fake_caps = Capabilities(linux=False, landlock_abi=0, seccomp=False, rlimit=False)
+    monkeypatch.setattr(ex_mod, "_CAPS_CACHE", fake_caps)
+
+    executor = SandboxedExecutor(
+        _ToolAgent(),
+        SandboxConfig(require=False),
+        cell_timeout=None,
+    )
+
+    class _FakeProc:
+        exitcode = -signal_mod.SIGXCPU
+
+    executor._proc = _FakeProc()
+    result = executor._classify_worker_death(WorkerDiedError("cpu killed"))
+    assert isinstance(result, CellTimeoutError)
+
+    ex_mod._CAPS_CACHE = None

--- a/tests/runtime/sandbox/test_guards.py
+++ b/tests/runtime/sandbox/test_guards.py
@@ -169,3 +169,55 @@ def test_probe_capabilities_reports_mechanisms():
     assert isinstance(caps.landlock_abi, int)
     assert isinstance(caps.seccomp, bool)
     assert isinstance(caps.rlimit, bool)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: Windows platform guards (issue #92)
+# These simulate a platform where POSIX-only modules are absent by patching
+# the import machinery with monkeypatch — no fork required, runs on Linux CI.
+# ---------------------------------------------------------------------------
+
+
+def test_probe_capabilities_returns_rlimit_false_when_resource_unavailable(monkeypatch):
+    """Regression test for #92.
+
+    probe_capabilities() must return Capabilities(rlimit=False) on platforms
+    where the ``resource`` module does not exist (e.g. Windows), instead of
+    raising ModuleNotFoundError.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _import_without_resource(name, *args, **kwargs):
+        if name == "resource":
+            raise ImportError("No module named 'resource'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import_without_resource)
+
+    # Must not raise — should gracefully return rlimit=False
+    caps = guards.probe_capabilities()
+    assert caps.rlimit is False
+
+
+def test_apply_rlimits_returns_early_when_resource_unavailable(monkeypatch):
+    """Regression test for #92 (second site).
+
+    apply_rlimits() must return silently on platforms where the ``resource``
+    module does not exist (e.g. Windows), instead of raising ModuleNotFoundError.
+    The dormant import at guards.py line 215 must never propagate to the caller.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _import_without_resource(name, *args, **kwargs):
+        if name == "resource":
+            raise ImportError("No module named 'resource'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import_without_resource)
+
+    # Must not raise even when args are non-zero
+    apply_rlimits(max_memory_mb=256, max_cpu_seconds=30)

--- a/util/eval_pipeline/src/eval_pipeline/_memory_monitor.py
+++ b/util/eval_pipeline/src/eval_pipeline/_memory_monitor.py
@@ -16,7 +16,11 @@ from __future__ import annotations
 import gc
 import logging
 import platform
-import resource
+
+try:
+    import resource
+except ImportError:
+    resource = None
 import sys
 import threading
 import time
@@ -47,6 +51,8 @@ def get_rss_mb() -> float:
     except FileNotFoundError:
         pass
     # macOS: ru_maxrss is in bytes; Linux: kB
+    if resource is None:
+        return 0.0
     usage = resource.getrusage(resource.RUSAGE_SELF)
     if platform.system() == "Darwin":
         return usage.ru_maxrss / (1024 * 1024)
@@ -84,6 +90,8 @@ def set_hard_limit(limit_mb: int) -> bool:
     """
     current_vas = _get_vas_mb()
     vas_cap_bytes = int((current_vas + limit_mb) * 1024 * 1024)
+    if resource is None:
+        return False
     try:
         _, hard = resource.getrlimit(resource.RLIMIT_AS)
         # Clamp to OS hard ceiling (macOS maps RLIMIT_AS → RLIMIT_RSS and
@@ -99,6 +107,8 @@ def set_hard_limit(limit_mb: int) -> bool:
 
 def clear_hard_limit() -> None:
     """Remove the RLIMIT_AS soft cap (reset to the hard ceiling)."""
+    if resource is None:
+        return
     try:
         _, hard = resource.getrlimit(resource.RLIMIT_AS)
         resource.setrlimit(resource.RLIMIT_AS, (hard, hard))


### PR DESCRIPTION
## What does this PR do?

Resolves unconditional POSIX imports and asserts across the codebase that crash the framework on Windows.

- Add platform guards for sandbox resource limits and executor death classification

- Handle missing fcntl and fallback to SQLite native locking

- Provide graceful fallbacks for resource memory limits in eval pipeline

- Prevent asyncio subprocess failure on missing start_new_session/pass_fds args

- Add regression tests for sandbox guards and executor

## Related issues

Fixes #92 
Fixes #95

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [ ] Docs updated if behavior or public APIs changed
- [ ] New source files carry an SPDX license header
