### PR TITLE
Fix warnings capture, hook-failure tracing, and a class-shadow false positive

### DIFF
--- a/src/nooa/runtime/actor.py
+++ b/src/nooa/runtime/actor.py
@@ -450,6 +450,7 @@ from nooa.runtime.stream_wrappers import (  # noqa: E402
     BlockedStdinWrapper,
     ContextVarStream,
     _block_stdin_var,
+    install_warnings_capture,
 )
 
 # Task-local stack for generation ID tracking.
@@ -1550,6 +1551,10 @@ class ActorRuntime:
                 sys.stderr = ContextVarStream(sys.stderr, _stderr_buffer_var, "stderr")
             if not isinstance(sys.stdin, BlockedStdinWrapper):
                 sys.stdin = BlockedStdinWrapper(sys.stdin)
+            # Re-installed on every call: pytest's warning-capture plugin replaces
+            # warnings.showwarning around each test, which would otherwise swallow
+            # warnings before they reach the (now-wrapped) sys.stderr.
+            install_warnings_capture()
 
             # Parse AST to find method definitions
             try:

--- a/src/nooa/runtime/code_validator.py
+++ b/src/nooa/runtime/code_validator.py
@@ -804,6 +804,10 @@ class _ClassAssignmentVisitor(ast.NodeVisitor):
         self.class_ref_vars: set[str] = set()
         # Track variables assigned from self - type(var) is equivalent to type(self)
         self.self_ref_vars: set[str] = set()
+        # Line of the first top-level `ClassName = <expr>` reassignment, per
+        # class name - top-level only, so a reassignment nested in if/for/try
+        # can't fake a shadow on a branch that never runs.
+        self.shadow_lines: dict[str, int] = {}
 
     def _collect_class_names(self) -> set[str]:
         """Collect names that refer to classes in the execution context."""
@@ -860,6 +864,22 @@ class _ClassAssignmentVisitor(ast.NodeVisitor):
         if arg.id in self.self_ref_vars:
             return True
         return False
+
+    def visit_Module(self, node: ast.Module) -> None:
+        """Precompute top-level class-name shadowing before the recursive walk."""
+        for stmt in node.body:
+            name: str | None = None
+            if isinstance(stmt, ast.Assign):
+                for target in stmt.targets:
+                    if isinstance(target, ast.Name) and target.id in self.known_class_names:
+                        name = target.id
+                        break
+            elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                if stmt.target.id in self.known_class_names:
+                    name = stmt.target.id
+            if name is not None and name not in self.shadow_lines:
+                self.shadow_lines[name] = stmt.lineno
+        self.generic_visit(node)
 
     def visit_Assign(self, node: ast.Assign) -> None:
         """Check for ClassName.attr = value and track self/type(self) assignments."""
@@ -985,7 +1005,11 @@ class _ClassAssignmentVisitor(ast.NodeVisitor):
         if name == "self":
             return
 
-        # Check if name is a known class
+        # Check if name is a known class (unless shadowed by an earlier
+        # top-level reassignment - see shadow_lines above)
+        shadow_line = self.shadow_lines.get(name)
+        if shadow_line is not None and node.lineno > shadow_line:
+            return
         if name in self.known_class_names:
             self.issues.append(
                 ValidationIssue(

--- a/src/nooa/runtime/method_wrapper.py
+++ b/src/nooa/runtime/method_wrapper.py
@@ -157,8 +157,13 @@ def create_agent_method_wrapper(
                 cached_source_code,
             )
 
-            # hook_context is set inside the middleware/fast-path blocks below
+            # hook_context is set inside the middleware/fast-path blocks below.
+            # before_hook_attempted tracks whether before_agent_call actually ran,
+            # since call_before_hook swallows hook exceptions and returns None
+            # on failure - indistinguishable from hook_context legitimately
+            # being None if we only checked that.
             hook_context = None
+            before_hook_attempted = False
 
             # Enforce max nesting depth before pushing the new call ID
             execution_config = getattr(self, "_execution_config", None)
@@ -245,8 +250,9 @@ def create_agent_method_wrapper(
                     async def _core_agent(ctx: AgentCallContext) -> AgentCallContext:
                         # Tracing hooks fire INSIDE middleware so they
                         # see the post-middleware args/kwargs.
-                        nonlocal hook_context
+                        nonlocal hook_context, before_hook_attempted
                         if _tracing_enabled[0]:
+                            before_hook_attempted = True
                             hook_context = call_before_hook(
                                 "before_agent_call",
                                 agent=self,
@@ -271,6 +277,7 @@ def create_agent_method_wrapper(
                 else:
                     # Fast path — no agent_call middleware
                     if _tracing_enabled[0]:
+                        before_hook_attempted = True
                         hook_context = call_before_hook(
                             "before_agent_call",
                             agent=self,
@@ -316,9 +323,9 @@ def create_agent_method_wrapper(
                 # Reset parent agent context
                 _parent_agent_var.reset(parent_token)
                 _pop_agent_call_id()
-                # Only fire after_agent_call if before_agent_call ran
-                # (skipped when middleware short-circuits).
-                if hook_context is not None:
+                # Fire whenever before_agent_call was attempted, even if it
+                # failed (skipped only when middleware short-circuits first).
+                if before_hook_attempted:
                     call_after_hook(
                         "after_agent_call",
                         hook_context,
@@ -326,6 +333,8 @@ def create_agent_method_wrapper(
                         method_name=original_func.__name__,
                         result=result,
                         exception=exception_caught,
+                        call_id=call_id,
+                        parent_call_id=parent_call_id,
                     )
 
         elif needs_generation and args and isinstance(args[0], RuntimeServices):  # pyright: ignore[reportPossiblyUnboundVariable]
@@ -463,10 +472,12 @@ def create_sync_agent_method_wrapper(
             logger.debug("agent-call: BeforeAgentCall emission failed (sync)", exc_info=True)
 
         hook_context = None
+        before_hook_attempted = False
         result = None
         exception_caught: Exception | None = None
         try:
             if _tracing_enabled[0]:
+                before_hook_attempted = True
                 hook_context = call_before_hook(
                     "before_agent_call",
                     agent=self,
@@ -502,7 +513,7 @@ def create_sync_agent_method_wrapper(
             except Exception:  # noqa: BLE001
                 logger.debug("agent-call: AfterAgentCall emission failed (sync)", exc_info=True)
             _pop_agent_call_id()
-            if hook_context is not None:
+            if before_hook_attempted:
                 call_after_hook(
                     "after_agent_call",
                     hook_context,
@@ -510,6 +521,8 @@ def create_sync_agent_method_wrapper(
                     method_name=original_func.__name__,
                     result=result,
                     exception=exception_caught,
+                    call_id=call_id,
+                    parent_call_id=parent_call_id,
                 )
 
     setattr(wrapper, "_agent_decorator", "auto")  # noqa: B010

--- a/src/nooa/runtime/stream_wrappers.py
+++ b/src/nooa/runtime/stream_wrappers.py
@@ -4,8 +4,40 @@
 
 import contextvars
 import io
+import sys
+import warnings
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, TextIO
+
+# Captured before pytest's warning-capture plugin can replace it; used as the
+# fallback when a caller passes an explicit `file=`.
+_default_showwarning = warnings.showwarning
+
+
+def _capturing_showwarning(
+    message: Warning | str,
+    category: type[Warning],
+    filename: str,
+    lineno: int,
+    file: TextIO | None = None,
+    line: str | None = None,
+) -> None:
+    """Route warnings.warn() through sys.stderr so ContextVarStream captures it."""
+    if file is not None:
+        _default_showwarning(message, category, filename, lineno, file, line)
+        return
+    text = warnings.formatwarning(message, category, filename, lineno, line)
+    sys.stderr.write(text)
+
+
+def install_warnings_capture() -> None:
+    """(Re-)install the warnings.warn() -> sys.stderr redirect.
+
+    pytest resets warnings.showwarning around every test, so this must be
+    called before each code execution rather than once at import time.
+    """
+    warnings.showwarning = _capturing_showwarning
+
 
 # Task-local flag to block stdin reads (prevents hangs from input(), sys.stdin.read(), etc.)
 # When True for the current async task, any stdin read raises RuntimeError

--- a/src/nooa/tracing/_hooks_impl.py
+++ b/src/nooa/tracing/_hooks_impl.py
@@ -299,6 +299,13 @@ class OpenInferenceHooks:
     ) -> None:
         """Complete AGENT span."""
         if not context:
+            # before_agent_call ran but raised, so there's no span to complete -
+            # emit a minimal error span instead of leaving the call untraced.
+            call_id = kwargs.get("call_id")
+            if call_id:
+                self._record_hook_failure_span(
+                    agent, method_name, call_id, kwargs.get("parent_call_id")
+                )
             return
 
         span: Span = context.get("span")
@@ -330,6 +337,32 @@ class OpenInferenceHooks:
         # Remove from tracking
         if call_id and call_id in _get_active_spans():
             del _get_active_spans()[call_id]
+
+    def _record_hook_failure_span(
+        self,
+        agent: Any,
+        method_name: str,
+        call_id: str,
+        parent_call_id: str | None,
+    ) -> None:
+        """Emit a minimal ERROR span for a call whose before_agent_call hook raised."""
+        parent_span = _get_active_spans().get(parent_call_id) if parent_call_id else None
+        context = trace.set_span_in_context(parent_span) if parent_span else None
+        span = self.tracer.start_span(
+            name=f"method.{method_name}",
+            context=context,
+            start_time=time.time_ns(),
+        )
+        span.set_attribute(SpanAttributes.OPENINFERENCE_SPAN_KIND, SpanKind.AGENT)
+        span.set_attribute(VIEWER_PLUGIN_ATTR, ViewerPlugin.METHOD)
+        span.set_attribute("agent.name", type(agent).__name__)
+        span.set_attribute("agent.method", method_name)
+        span.set_attribute("agent.call_id", call_id)
+        if parent_call_id:
+            span.set_attribute("agent.parent_call_id", parent_call_id)
+        span.set_status(Status(StatusCode.ERROR, "before_agent_call hook raised"))
+        span.set_attribute("error.message", "before_agent_call hook raised an exception")
+        span.end(end_time=time.time_ns())
 
     def before_generation(
         self,

--- a/tests/integration/test_hook_failure_traces.py
+++ b/tests/integration/test_hook_failure_traces.py
@@ -13,10 +13,12 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from opentelemetry.trace import StatusCode
 
 from nooa import Agent
 from nooa.runtime.hooks import call_before_hook, set_hooks
 from nooa.tracing._hooks_impl import OpenInferenceHooks
+from nooa.unifiedllm import FakeLLMClient
 
 
 class SimpleAgent(Agent):
@@ -159,8 +161,57 @@ async def test_concurrent_hook_failures_cause_missing_traces(temp_trace_dir):
 async def test_with_fix_all_samples_traced(temp_trace_dir):
     """After the fix, even failed hooks should result in some trace record.
 
-    This test will FAIL until the fix is applied.
+    Drives real SimpleAgent.process() calls with a hooks implementation whose
+    before_agent_call raises for half the calls. Every call - failed or not -
+    must still produce a "method.process" span.
     """
-    # TODO: This test should pass after the fix is applied
-    # For now, it demonstrates what we want to achieve
-    pass
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    from nooa.tracing._hooks_impl import OpenInferenceHooks
+
+    exporter = InMemorySpanExporter()
+    provider = trace.get_tracer_provider()
+    if not hasattr(provider, "add_span_processor"):
+        provider = TracerProvider()
+        trace.set_tracer_provider(provider)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    class FlakyHooks(OpenInferenceHooks):
+        """Real OpenInferenceHooks, but before_agent_call raises on some calls."""
+
+        def __init__(self, tracer, fail_indices: set[int]):
+            super().__init__(tracer)
+            self.fail_indices = fail_indices
+            self.call_count = 0
+
+        def before_agent_call(self, **kwargs):
+            self.call_count += 1
+            if self.call_count in self.fail_indices:
+                raise ValueError(f"Simulated hook failure for call {self.call_count}")
+            return super().before_agent_call(**kwargs)
+
+    tracer = provider.get_tracer("test-hook-failure-traces")
+    set_hooks(FlakyHooks(tracer, fail_indices={6, 7, 8, 9, 10}))
+
+    try:
+        agent = SimpleAgent(llm=FakeLLMClient())
+        results = await asyncio.gather(*[agent.process(i) for i in range(1, 11)])
+        assert len(results) == 10
+
+        method_spans = [s for s in exporter.get_finished_spans() if s.name == "method.process"]
+        assert len(method_spans) == 10, (
+            f"Expected 10 traced calls (5 successful + 5 hook-failure fallback "
+            f"spans), got {len(method_spans)}"
+        )
+
+        ok_spans = [s for s in method_spans if s.status.status_code == StatusCode.OK]
+        error_spans = [s for s in method_spans if s.status.status_code == StatusCode.ERROR]
+        assert len(ok_spans) == 5
+        assert len(error_spans) == 5
+    finally:
+        set_hooks(None)

--- a/tests/runtime/test_async_output_capture.py
+++ b/tests/runtime/test_async_output_capture.py
@@ -85,17 +85,8 @@ sys.stderr.flush()
         assert result.error is None
         assert "error message" in result.stderr
 
-    @pytest.mark.skip(
-        reason="warnings.warn() uses Python's internal warning system, not sys.stderr.write(). "
-        "The warning is captured by pytest's warning capture, not our stream wrapper."
-    )
     async def test_warnings_captured(self, agent):
-        """warnings.warn() is captured in stderr.
-
-        NOTE: This test is skipped because warnings.warn() doesn't write directly
-        to sys.stderr - it uses Python's internal warning infrastructure which
-        pytest captures separately. Direct sys.stderr.write() IS captured.
-        """
+        """warnings.warn() is captured in stderr."""
         code = """
 import warnings
 warnings.warn("this is a warning")

--- a/tests/runtime/test_code_validator.py
+++ b/tests/runtime/test_code_validator.py
@@ -1496,6 +1496,19 @@ TestAgent.process = _make_method()
             with pytest.raises(ValidationError, match="[Cc]annot assign to class"):
                 validator.validate(code, context)
 
+        def test_reject_class_assignment_after_conditional_shadow(
+            self, validator: UnifiedCodeValidator, agent_context
+        ):
+            """A reassignment inside a branch that may not run must not bypass detection."""
+            context, _ = agent_context
+            code = """
+if False:
+    TestAgent = {}
+TestAgent.process = lambda self: None
+"""
+            with pytest.raises(ValidationError, match="[Cc]annot assign to class"):
+                validator.validate(code, context)
+
         def test_reject_annotated_class_assignment(
             self, validator: UnifiedCodeValidator, agent_context
         ):
@@ -1577,11 +1590,20 @@ TestAgent.process = _make_method()
             """Local variable shadowing class name is allowed if assigned first."""
             context, _ = agent_context
             # This creates a local variable, then assigns to it
-            # The validator should ideally track this, but for now
-            # we test that simple local var assignment works
             code = """
 result = {}
 result.value = 42
+"""
+            validator.validate(code, context)  # Should NOT raise
+
+        def test_allow_attribute_assign_after_shadowing_class_name(
+            self, validator: UnifiedCodeValidator, agent_context
+        ):
+            """A top-level reassignment of a class name shadows it for later code."""
+            context, _ = agent_context
+            code = """
+TestAgent = {}
+TestAgent.value = 42
 """
             validator.validate(code, context)  # Should NOT raise
 
@@ -1763,30 +1785,14 @@ setattr(type(agent), 'process', lambda self: None)
         def test_no_false_positive_local_var_same_name_as_class(
             self, validator: UnifiedCodeValidator, agent_context
         ):
-            """Local variable with same name as class should be allowed AFTER reassignment.
-
-            Edge case: If LLM creates a local variable that shadows a class name,
-            subsequent assignments to that variable should be allowed.
-
-            Note: This is tricky - we can't do full data flow analysis in AST validation.
-            Current behavior: We reject this as a false positive because we can't
-            distinguish between the class and a local variable with the same name.
-            """
+            """Local variable with same name as class is allowed AFTER reassignment."""
             context, TestAgent = agent_context
 
-            # This creates a local variable shadowing the class name
-            # Ideally this should be allowed, but we can't distinguish it from class
             code = """
 TestAgent = {"mock": True}  # Local var shadows class
-TestAgent.method = lambda: None  # Assignment to local... but looks like class
+TestAgent.method = lambda: None  # Assignment to the local dict, not the class
 """
-            # Current behavior: This IS rejected (false positive)
-            # This is acceptable because:
-            # 1. Shadowing class names is bad practice
-            # 2. LLM shouldn't be doing this anyway
-            # 3. Better to be safe than sorry
-            with pytest.raises(ValidationError, match="[Cc]annot assign to class"):
-                validator.validate(code, context)
+            validator.validate(code, context)  # Should NOT raise
 
         def test_allow_method_call_that_looks_like_assignment(
             self, validator: UnifiedCodeValidator, agent_context

--- a/util/eval_pipeline/README.md
+++ b/util/eval_pipeline/README.md
@@ -4,8 +4,15 @@ A flexible evaluation framework for nooa agents. Use it from **Python** or via *
 
 ## Installation
 
+`eval_pipeline` is a `uv` workspace member and part of the `dev` dependency
+group, so `uv sync --group dev` from the repo root already installs it
+editable — no separate step needed for repo development.
+
+To add it to a different project, install it from the repo (it isn't
+published to PyPI):
+
 ```bash
-pip install -e ./util/eval_pipeline
+uv add "eval_pipeline @ git+https://github.com/NVIDIA-NeMo/labs-OO-Agents.git@main#subdirectory=util/eval_pipeline"
 ```
 
 ---


### PR DESCRIPTION
## What's in here

**Warnings capture** — `warnings.warn()` bypassed the `ContextVarStream` stdout/stderr capture since it goes through Python's warning machinery, not `sys.stderr.write()` directly. Installs a `showwarning` hook that writes into `sys.stderr`, re-installed before every execution since pytest resets `warnings.showwarning` per test.

**Hook-failure tracing** -> `after_agent_call` only fired when `hook_context is not None`, which can't tell "middleware short-circuited" apart from "`before_agent_call` raised and `call_before_hook` swallowed it." The second case silently dropped the trace. Now tracks whether the before-hook actually ran, and `OpenInferenceHooks.after_agent_call` emits a
minimal ERROR span when it gets no context instead of skipping the call entirely.

**Class-assignment false positive** -> `ClassAssignmentValidator` blocks
`ClassName.attr = value` to stop generated code corrupting shared class state, but matched on name only. `ClassName = {}` followed by `ClassName.attr = value` (a plain local dict) got flagged too — a known false positive the tests had marked "acceptable" instead of fixed. Now tracks the first top-level reassignment of a class name and treats writes after that line as safe. Only top-level statements count, on purpose: a reassignment inside `if`/`for`/`try` could be on a branch that never runs, and honoring it there would let generated code fake a shadow to slip a real corruption past the check.

**eval_pipeline docs** -> it's already a uv workspace member in the `dev` group, so `uv sync --group dev` installs it editable. The README still said `pip install -e`.

## Testing

- `pytest tests/runtime` — 1055 passed
- `pytest tests/integration/test_hook_failure_traces.py` — 4 passed
- `pytest tests/runtime/test_code_validator.py` — 228 passed
- `pytest` (full suite, minus `test_mcp` which fails on main too from a missing optional
  dependency) — 5222 passed
- `ruff check` and `pyright` clean on touched files