### PR TITLE
fix(config): bound the total size of one rendered value 🤖🤖🤖

### DIFF
--- a/src/nooa/config/truncation_config.py
+++ b/src/nooa/config/truncation_config.py
@@ -207,6 +207,31 @@ class TruncationConfig(BaseModel):
             )
         ),
     ] = 4_096
+    # Total cap on ONE rendered value, applied on top of the per-value
+    # FormatConfig bounds. Those bounds multiply rather than compose: at the
+    # event_format defaults, ``max_length ** max_depth`` is 200**5 leaf slots at
+    # up to max_string chars each, and a list of depth 4 / width 30 — inside
+    # every FormatConfig limit — renders 25 MB. Eviction cannot help, because it
+    # runs at assembly, after the string has been materialised.
+    #
+    # This is the ceiling ``truncating_pformat`` enforces via TruncatingStringIO,
+    # which head/tail-truncates with a visible notice rather than dropping
+    # content silently.
+    #
+    # It lives here, not on FormatConfig, on purpose: that class documents its
+    # field names as matching ``pformat()``'s kwargs exactly so ``model_dump()``
+    # can be splatted straight in, and ``pformat()`` accepts no ``**kwargs`` — a
+    # field there raises TypeError at every splat site.
+    max_render_chars: Annotated[
+        int | None,
+        Field(
+            description=(
+                "Hard char cap on a single rendered value, on top of the "
+                "per-value FormatConfig bounds. None = unlimited. Mirrors "
+                "capture.max_stdout, which bounds the analogous raw-text path."
+            )
+        ),
+    ] = 50_000
     capture: CaptureConfig = CaptureConfig()
     media_capture: MediaCaptureConfig = MediaCaptureConfig()
     # Generous: rendered every turn, especially PythonOutput.value (the LLM
@@ -224,7 +249,7 @@ class TruncationConfig(BaseModel):
     @model_validator(mode="after")
     def _check(self) -> "TruncationConfig":
         errors = []
-        for name in ("max_context_tokens", "max_event_tokens"):
+        for name in ("max_context_tokens", "max_event_tokens", "max_render_chars"):
             v = getattr(self, name)
             if v is not None and v <= 0:
                 errors.append(f"{name} must be > 0 or None, got {v}")

--- a/src/nooa/strategies/codeact_errors.py
+++ b/src/nooa/strategies/codeact_errors.py
@@ -13,7 +13,7 @@ from typing import Any
 from pydantic import ValidationError as PydanticValidationError
 from pydantic_core import ErrorDetails
 
-from nooa.agentdoc import pformat
+from nooa.agentdoc import truncating_pformat
 from nooa.agentdoc.visibility import is_hidden_field
 from nooa.config.truncation_config import DEFAULT_TRUNCATION_CONFIG, TruncationConfig
 from nooa.strategy_validation import InvariantError
@@ -169,8 +169,14 @@ def _format_expected_schema(return_type: Any) -> str:
 
 
 def _pformat(value: Any, tc: TruncationConfig) -> str:
-    """Format a value using the agent's value-render truncation settings."""
-    return pformat(value, **tc.event_format.model_dump())
+    """Format a value using the agent's value-render truncation settings.
+
+    Bounded by ``max_render_chars`` on top of ``event_format``'s per-value
+    limits. This path renders the offending value into an error message, so a
+    value that is expensive to render would otherwise be rendered again on the
+    failure path.
+    """
+    return truncating_pformat(value, max_chars=tc.max_render_chars, **tc.event_format.model_dump())
 
 
 def _format_value_for_error(

--- a/src/nooa/strategies/generated_code.py
+++ b/src/nooa/strategies/generated_code.py
@@ -21,13 +21,19 @@ from pydantic import TypeAdapter
 from pydantic import ValidationError as PydanticValidationError
 from pydantic.errors import PydanticSchemaGenerationError
 
-from nooa.agentdoc import pformat
+from nooa.agentdoc import truncating_pformat
 from nooa.config.truncation_config import DEFAULT_TRUNCATION_CONFIG, TruncationConfig
 
 
 def _pformat(value: Any, tc: TruncationConfig) -> str:
-    """Format a value using truncation config's value-render settings."""
-    return pformat(value, **tc.event_format.model_dump())
+    """Format a value using truncation config's value-render settings.
+
+    Uses ``truncating_pformat`` rather than ``pformat`` so ``max_render_chars``
+    bounds the *total* output. ``event_format``'s per-value limits multiply, so
+    on their own they let one value render to tens of megabytes — and this
+    renders every turn for the rest of the run.
+    """
+    return truncating_pformat(value, max_chars=tc.max_render_chars, **tc.event_format.model_dump())
 
 
 @dataclass(frozen=True)

--- a/src/nooa/strategies/reflexion.py
+++ b/src/nooa/strategies/reflexion.py
@@ -303,9 +303,12 @@ class ReflexionStrategy(GenerationStrategy):
         # Show as much of the result as possible — the LLM must evaluate its quality.
         # event_format provides max_string/max_length/max_depth so nested strings
         # within structured results are bounded by cfg.event_format rather than
-        # pformat's hidden 150-char fallback.
+        # pformat's hidden 150-char fallback. max_chars then bounds the total:
+        # without it this already took truncating_pformat's uncapped branch, since
+        # max_chars defaults to None.
         return truncating_pformat(
             result,
+            max_chars=tc.max_render_chars,
             **tc.event_format.model_dump(),
         )
 

--- a/tests/config/test_max_render_chars.py
+++ b/tests/config/test_max_render_chars.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Total-size bound on rendered values (#96).
+
+``FormatConfig`` bounds rendering *per value* — ``max_string``, ``max_length``,
+``max_depth``. Those limits multiply rather than compose, so respecting all three
+does not bound the total: at the ``event_format`` defaults
+``max_length ** max_depth`` is 200**5 leaf slots at up to 10,000 chars each.
+
+These tests assert the total bound holds, and are written so they fail without
+``max_render_chars``: every fixture stays *inside* the per-value limits, so only
+a total cap can keep the output small.
+
+**Scope of the bound.** ``max_render_chars`` bounds the rendered *output*, not
+peak allocation while rendering. ``TruncatingStringIO`` discards overflow as it
+arrives, but the renderer still walks the whole structure and allocates each
+chunk before the sink drops it — measured, a value that renders to 72 MB
+uncapped still peaks around 65 MB with the cap applied. What the cap removes is
+the multi-megabyte string entering the trajectory and being re-sent every turn,
+which is the recurring cost. Bounding allocation as well means aborting the
+traversal once the budget is spent, which is a change inside the renderer rather
+than in config, and is left as follow-up.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nooa.config.truncation_config import DEFAULT_TRUNCATION_CONFIG, TruncationConfig
+from nooa.strategies.codeact_errors import _pformat as error_pformat
+from nooa.strategies.generated_code import _pformat as event_pformat
+
+
+def nest(depth: int, width: int, leaf: str):
+    """A structure that stays within max_depth/max_length but fans out."""
+    if depth == 0:
+        return leaf
+    return [nest(depth - 1, width, leaf) for _ in range(width)]
+
+
+@pytest.fixture
+def wide_value():
+    """Depth 4, width 30 — inside event_format's max_depth=5 and max_length=200."""
+    ef = DEFAULT_TRUNCATION_CONFIG.event_format
+    assert ef.max_depth is not None and 4 < ef.max_depth
+    assert ef.max_length is not None and 30 < ef.max_length
+    return nest(4, 30, "x" * 10)
+
+
+class TestDefaults:
+    def test_default_is_set_and_mirrors_max_stdout(self):
+        tc = DEFAULT_TRUNCATION_CONFIG
+        assert tc.max_render_chars == 50_000
+        # Same budget as the analogous raw-text path.
+        assert tc.max_render_chars == tc.capture.max_stdout
+
+    def test_rejects_non_positive(self):
+        with pytest.raises(ValueError, match="max_render_chars must be > 0 or None"):
+            TruncationConfig(max_render_chars=0)
+        with pytest.raises(ValueError, match="max_render_chars must be > 0 or None"):
+            TruncationConfig(max_render_chars=-1)
+
+    def test_none_means_unlimited(self, wide_value):
+        tc = TruncationConfig(max_render_chars=None)
+        assert len(event_pformat(wide_value, tc)) > 1_000_000
+
+    def test_merge_with_carries_the_field(self):
+        merged = DEFAULT_TRUNCATION_CONFIG.merge_with(TruncationConfig(max_render_chars=123))
+        assert merged.max_render_chars == 123
+        # Untouched fields survive the merge.
+        assert merged.event_format.max_string == DEFAULT_TRUNCATION_CONFIG.event_format.max_string
+
+
+class TestEventRenderIsBounded:
+    def test_event_render_respects_the_total_cap(self, wide_value):
+        tc = DEFAULT_TRUNCATION_CONFIG
+        rendered = event_pformat(wide_value, tc)
+        assert tc.max_render_chars is not None
+        # TruncatingStringIO appends a truncation notice, so allow modest overhead
+        # rather than asserting an exact equality that the notice would break.
+        assert len(rendered) < tc.max_render_chars * 2
+
+    def test_error_render_respects_the_total_cap(self, wide_value):
+        tc = DEFAULT_TRUNCATION_CONFIG
+        rendered = error_pformat(wide_value, tc)
+        assert tc.max_render_chars is not None
+        assert len(rendered) < tc.max_render_chars * 2
+
+    def test_truncation_is_visible_not_silent(self, wide_value):
+        """The model must be able to tell content was elided."""
+        rendered = event_pformat(wide_value, DEFAULT_TRUNCATION_CONFIG)
+        lowered = rendered.lower()
+        assert "truncat" in lowered or "not shown" in lowered
+
+    def test_cap_holds_as_the_structure_grows(self):
+        """Output size is decided by the cap, not by the value's shape.
+
+        Two fixtures an order of magnitude apart in leaf count must render to
+        about the same size. This is the property that matters for the recurring
+        cost: ``event_format`` renders every turn for the rest of the run, so an
+        output that scales with the value scales the whole remaining run.
+        """
+        tc = DEFAULT_TRUNCATION_CONFIG
+        smaller = len(event_pformat(nest(3, 30, "x" * 10), tc))
+        larger = len(event_pformat(nest(4, 30, "x" * 10), tc))
+        assert tc.max_render_chars is not None
+        assert smaller < tc.max_render_chars * 2
+        assert larger < tc.max_render_chars * 2
+        # ~27k leaves vs ~810k leaves, yet the rendered sizes stay comparable.
+        assert abs(larger - smaller) < tc.max_render_chars
+
+    def test_small_values_are_untouched(self):
+        """The cap must not disturb ordinary rendering."""
+        tc = DEFAULT_TRUNCATION_CONFIG
+        for value in ({"a": 1, "b": [1, 2, 3]}, [1, 2, 3], {"nested": {"x": "y"}}):
+            rendered = event_pformat(value, tc)
+            assert "truncat" not in rendered.lower()
+            assert "not shown" not in rendered.lower()
+
+    def test_strings_still_pass_through_verbatim(self):
+        """truncating_pformat returns str inputs unchanged, as pformat did."""
+        text = "plain string, not a structure"
+        assert event_pformat(text, DEFAULT_TRUNCATION_CONFIG) == text
+
+
+class TestContextBlocksStayUnlimited:
+    def test_context_block_format_is_still_unbounded(self):
+        """Context blocks are author-curated and documented as rendering in full.
+
+        The cap is applied at the event/error render helpers, not to
+        context_block_format, so this stays deliberately unlimited.
+        """
+        cbf = DEFAULT_TRUNCATION_CONFIG.context_block_format
+        assert cbf.max_string is None
+        assert cbf.max_length is None
+        assert cbf.max_depth is None

--- a/tests/strategies/test_sampling_params_forwarded.py
+++ b/tests/strategies/test_sampling_params_forwarded.py
@@ -14,6 +14,7 @@ import pytest
 from pydantic import BaseModel
 
 from nooa.config.strategy_config import PredictConfig, ReflexionConfig
+from nooa.config.truncation_config import DEFAULT_TRUNCATION_CONFIG
 from nooa.strategies.predict import PredictStrategy
 from nooa.strategies.reflexion import ReflectionOutput, ReflexionStrategy
 
@@ -70,7 +71,10 @@ async def test_reflexion_forwards_sampling_params_to_generate():
     strat = ReflexionStrategy(config=ReflexionConfig(max_tokens=64, temperature=0.3))
     runtime = MagicMock()
     runtime.event_manager = MagicMock()
-    runtime.truncation_config = MagicMock()
+    # A real config, not a MagicMock: value rendering reads numeric budgets off
+    # it (max_render_chars), and a mock satisfies the attribute access with an
+    # object that then fails the comparison.
+    runtime.truncation_config = DEFAULT_TRUNCATION_CONFIG
     runtime.generate = AsyncMock(
         return_value=(
             MagicMock(content=ReflectionOutput(is_satisfactory=True, reasoning="ok")),

--- a/tests/test_method_llm_callable.py
+++ b/tests/test_method_llm_callable.py
@@ -12,6 +12,7 @@ import json
 import pytest
 
 from nooa import Agent, strategy
+from nooa.config.truncation_config import DEFAULT_TRUNCATION_CONFIG
 from nooa.method_llm import resolve_method_llm, validate_method_llm_spec
 from nooa.strategies.predict import PredictStrategy
 from nooa.unifiedllm import FakeLLMClient, LLMResponse
@@ -197,8 +198,15 @@ class TestStrategyHelperPath:
         class _Bare:  # no 'runtime' attribute → strategy-helper branch
             pass
 
+        # A real truncation config rather than the spec'd mock's auto-attribute:
+        # value rendering reads numeric budgets off it (max_render_chars), and a
+        # mock satisfies the attribute access with an object that then fails the
+        # comparison — masking the TypeError this test is actually asserting.
+        runtime = MagicMock(spec=RuntimeServices)
+        runtime.truncation_config = DEFAULT_TRUNCATION_CONFIG
+
         with pytest.raises(TypeError, match="unexpected keyword argument 'llm'"):
-            await wrapper(_Bare(), MagicMock(spec=RuntimeServices), 42, llm=_fake("x"))
+            await wrapper(_Bare(), runtime, 42, llm=_fake("x"))
 
 
 class TestEndToEnd:


### PR DESCRIPTION
## What does this PR do?

Bounds the total size of one rendered value. `event_format` bounds rendering *per value* — `max_string`, `max_length`, `max_depth` — but nothing bounded the total, and those limits multiply rather than compose.

At the shipped defaults, `max_length ** max_depth` is `200 ** 5` leaf slots at up to `max_string` chars each. A list of **depth 4, width 30 — inside every `FormatConfig` limit** — rendered:

```
generated_code._pformat -> 25,102,293 chars
tracemalloc peak        ->  72,600,824 bytes
```

Two things made that more than a one-off allocation. It recurs: per `truncation_config`'s own docstring, `event_format` "renders every turn for the rest of the run". And eviction can't help — `max_event_tokens` defaults to `None`, and even when set, L4 eviction runs at *assembly*, after the string is already materialised.

**The guard already existed.** `pformat`'s docstring says to use `truncating_pformat` "preventing OOM on huge objects", and `reflexion.py:307` had already reached for it — but with no `max_chars` to pass, so it took the uncapped branch anyway. The missing piece was a configured budget, not the choice of function.

### Changes

- `TruncationConfig.max_render_chars`, default `50_000`, `None` = unlimited. `50_000` mirrors `capture.max_stdout`, which bounds the analogous raw-text path.
- Passed at the three render sites: `generated_code._pformat`, `codeact_errors._pformat`, and `reflexion._format_result_for_reflection` (a one-line addition there — it was already calling the right function).
- `context_block_format` stays unlimited. Those values are author-curated and documented as meant to render in full, so the cap is applied at the event/error render helpers rather than globally.

### Why the field is on `TruncationConfig` and not `FormatConfig`

`FormatConfig` documents its field names as matching `pformat()`'s kwargs exactly so `model_dump()` can be splatted straight in, and `pformat()` accepts no `**kwargs`:

```
>>> kwargs = FormatConfig().model_dump(); kwargs["max_chars"] = 50_000
>>> pformat({"a": 1}, **kwargs)
TypeError: pformat() got an unexpected keyword argument 'max_chars'
```

That would fire at six bare-`pformat` splat sites (`events.py:235`, `codeact_errors.py:173`, `current_call.py:161`, `generated_code.py:30`, `predict.py:315`, `plain_formatter.py:49`) plus several more that merge a dump into a kwargs dict. I proposed the `FormatConfig` route in #96 first and it was wrong; putting the total budget beside the other cross-cutting totals keeps the sub-configs meaning "per-value structural bounds" and leaves every splat site untouched.

### Scope of the bound — stated plainly

**This caps the rendered output, not peak allocation.** `TruncatingStringIO` discards overflow as it arrives, but the renderer still walks the whole structure and allocates each chunk before the sink drops it. Measured: a value that renders to 72 MB uncapped still peaks near **65 MB** with the cap applied.

What the cap removes is the multi-megabyte string entering the trajectory and being re-sent every turn — the recurring cost. Bounding allocation as well means aborting the traversal once the budget is spent, which belongs inside the renderer rather than in config, and I've left it as follow-up. My first version of the test asserted a memory bound, failed, and that's how I found this; the test module now documents the limitation instead of implying a stronger guarantee.

### Two unrelated tests touched

`test_sampling_params_forwarded.py` and `test_method_llm_callable.py` mocked `runtime.truncation_config` with `MagicMock`. A new numeric field made the mock's auto-attribute fail a comparison inside `truncating_pformat`, which masked the error each test was actually asserting (`unexpected keyword argument 'llm'` became a `MagicMock`/`int` `TypeError`). Both now use `DEFAULT_TRUNCATION_CONFIG`, which is more faithful to what they check — neither test is about truncation. Flagging it because "your change edited unrelated tests" is a fair thing to want explained.

## Related issues

Refs #96 — filed with the measurements and a design question about the default. Opening this as the concrete-diff option I offered there rather than leaving the proposal sitting; **`50_000` is still the open question**, and it's a one-line change if you want a different figure.

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [x] Docs updated if behavior or public APIs changed — the new field carries a `Field(description=...)`, and the reasoning for its placement is in a comment next to it
- [x] New source files carry an SPDX license header (`scripts/check_license_headers.py`: 882 files OK)

### Verification

Full CI unit suite on Linux with `uv sync --all-extras --no-extra sandbox`: **6568 passed, 4 skipped**. `ruff check .`, `ruff format --check .`, and `scripts/check_license_headers.py` clean.

11 new tests in `tests/config/test_max_render_chars.py`. They're built so the cap is what does the work rather than the fixture: every fixture stays *inside* the per-value limits, and `test_none_means_unlimited` asserts the same value renders past 1 MB with `max_render_chars=None`, so the pair fails if the cap stops being applied. Also covered: the boundary validator, `merge_with` carrying the field, truncation being *visible* rather than silent, small values rendering untouched, strings still passing through verbatim, and `context_block_format` still unlimited.

One note on the base: this branch is cut from `2197e61` rather than current `main`. My token lacks `workflow` scope, and basing on current `main` would carry upstream's `ci.yml` commits into my fork, which GitHub refuses. No overlap with the files those commits touched, and the suite is green either way — I verified on both bases.

🤖🤖🤖
