### PR TITLE
docs(nooa_memory): correct the relative depth on the quickstart link 🤖🤖🤖

### DIFF
--- a/packages/nooa-memory/src/nooa_memory/README.md
+++ b/packages/nooa-memory/src/nooa_memory/README.md
@@ -6,7 +6,7 @@ idea: **the agent authors and curates its own memories** through native tools â€
 rather than a harness extracting them behind the agent's back.
 
 - Runnable demos + measured results: [`examples/memory_bench/`](../../../examples/memory_bench/)
-  and the quickstart [`examples/quickstart/12_memory.py`](../../../examples/quickstart/12_memory.py).
+  and the quickstart [`examples/quickstart/12_memory.py`](../../../../examples/quickstart/12_memory.py).
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Fixes the relative depth on the quickstart link in `packages/nooa-memory/src/nooa_memory/README.md`. The file sits four levels below the repo root, not three, so the link 404s on GitHub.

Verified from the file's own directory:

```
../../../examples/quickstart/12_memory.py     -> packages/examples/quickstart/12_memory.py   missing
../../../../examples/quickstart/12_memory.py  -> examples/quickstart/12_memory.py            exists
```

Same class as #64, which fixed the `tests/memory/` link in this same file.

I found it by resolving every relative markdown link in the repo rather than by reading — it's the only depth-bug of its kind left, and every other relative link in the tree resolves.

## Related issues

None. Separately: the four remaining `examples/memory_bench/` references in this README (lines 8, 303, 401, 449) point at a directory that is absent at *every* depth, so no path adjustment fixes them — I've filed that as its own issue rather than guess at the intended target here, since the right answer is either publishing the directory or dropping the references, and that's a maintainer call.

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`) — docs-only, no test surface
- [x] Docs updated if behavior or public APIs changed
- [x] New source files carry an SPDX license header — no new files

🤖🤖🤖
