### PR TITLE
Drop mouse escape sequences leaking into TUI subview input

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -758,7 +758,19 @@ class TUIApplication:
 
         @kb.add(Keys.Any, filter=subview_active, eager=True)
         def _(event):
-            self._subview_key(event, "text", event.data)
+            # Drop parsed mouse events and any raw mouse CSI bytes that slip
+            # through — subviews disable mouse_support so these would otherwise
+            # be appended verbatim to text buffers (e.g. API-key prompt).
+            for kp in event.key_sequence:
+                if kp.key in (Keys.Vt100MouseEvent, Keys.WindowsMouseEvent):
+                    return
+            data = event.data or ""
+            if data.startswith("\x1b[M") or data.startswith("\x1b[<") or (
+                len(data) > 3 and data[:2] == "\x1b[" and data[-1] in "Mm"
+                and all(c.isdigit() or c == ";" for c in data[2:-1])
+            ):
+                return
+            self._subview_key(event, "text", data)
 
         @kb.add(Keys.BracketedPaste, filter=subview_active, eager=True)
         def _(event):


### PR DESCRIPTION
Subviews (model picker, API-key prompt) disable mouse_support so users can text-select. The Keys.Any handler for active subviews was appending event.data verbatim to the input buffer, so raw mouse CSI sequences (clicks, moves) landed in fields like the API-key prompt as garbled text. Filter parsed mouse KeyPresses and raw mouse CSI byte shapes before treating input as text. Arrow keys, function keys, and bracketed paste are unaffected.
