### PR TITLE
ci: import smoke test on Windows and macOS 🤖🤖🤖

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,54 @@ jobs:
       - name: Sandbox containment tests
         run: uv run pytest -q -m sandbox
 
+  # Every other job here is ubuntu-latest, so a module-level POSIX-only import
+  # (fcntl, resource, signal.SIGUSR2) reaches PyPI with nothing failing first.
+  # That is not hypothetical: 0.0.8 shipped unimportable on native Windows.
+  # See #84, #85, #92, #95.
+  #
+  # Deliberately import-only. The full suite cannot run on these hosts —
+  # BashSession needs bash and subprocess pass_fds, and the Landlock/seccomp/
+  # RLIMIT sandbox is Linux-only by design — but importability is the whole
+  # bug class that has actually escaped, and it costs seconds to gate.
+  #
+  # The macOS leg is future-proofing, not a detector of anything on main today:
+  # the import closure of `import nooa` is 133 modules, and the only
+  # platform-specific things in it are fcntl (#84) and signal.SIGUSR2 (#85),
+  # both of which macOS has. sandbox/guards.py — the `import resource` from
+  # #92 — is not in that closure at all; it loads on SandboxedExecutor
+  # construction. macOS earns its place by catching the other direction (a
+  # Linux-only /proc or landlock assumption reaching module scope) and because
+  # it is the platform contributors are most likely on after Linux.
+  import-smoke:
+    strategy:
+      # A Windows-only break must not cancel the macOS leg before it reports.
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          # litellm publishes manylinux wheels only, so both of these legs
+          # resolve to its sdist — a pyo3/maturin Rust project that maturin
+          # compiles after silently bootstrapping a toolchain. Measured cold on
+          # an M1: 39s wall, 145s CPU, producing a 5.7 MB native extension.
+          # Without a cache every run pays that on the slowest runners we have.
+          enable-cache: true
+      # All four distributions the build job produces, not just nooa: each is
+      # published separately, so each can independently become unimportable.
+      # --no-project installs them as a consumer would rather than syncing the
+      # dev environment, which is what the failing user report exercised.
+      - name: Import every published distribution
+        run: >
+          uv run --no-project
+          --with . --with ./packages/nooa-cli
+          --with ./packages/nooa-memory --with ./packages/nooa-bench
+          python -c "import nooa, nooa_cli, nooa_memory, nooa_bench; print(nooa.__version__)"
+
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What does this PR do?

Adds an `import-smoke` CI job on `windows-latest` + `macos-latest`. One file, CI config only — no changes under `src/`, and no docs changes.

**Why.** Every job in `ci.yml` and `publish.yml` is `runs-on: ubuntu-latest`, so a module-level POSIX-only import reaches PyPI with nothing failing first. Three instances of that class have shipped, each found by a user rather than CI: #84 (`fcntl`), #85 (`signal.SIGUSR2`), #92 (`resource`, `SIGXCPU`/`SIGKILL`). The repo already has the convention — `hasattr(signal, "SIGUSR1")` in `nooa_cli/commands/eval.py:47` and `eval_pipeline/__main__.py:13` — applied twice, missed four times. A per-PR gate fixes that; code review does not.

The job installs all four published distributions with `--no-project` (as a consumer would, which is what the user reports exercised) and imports each.

## Decisions

- **Import-only, on purpose.** The full suite cannot run on these hosts: `BashSession` needs `bash` and `pass_fds`, and Landlock/seccomp/RLIMIT are Linux-only by design.
- **`fail-fast: false`** — a Windows-only break must not cancel the macOS leg before it reports.
- **All four distributions** — each is published separately, so each can independently become unimportable.
- **`publish.yml` untouched** — out of scope. The release path is still unguarded; this job on `main` is the gate.
- **`enable-cache: true`** — see the litellm finding below. Without it every cold run recompiles a Rust extension on the slowest runners in the matrix.

## The macOS leg is future-proofing, and the comment now says so

I measured the actual import closure rather than assuming. `import nooa, nooa_cli, nooa_memory, nooa_bench` loads **133** first-party modules; grepping only those files for Linux/POSIX-only markers gives the complete set:

| File | Hit | Status |
| --- | --- | --- |
| `src/nooa/storage/sqlite.py:10` | `import fcntl` | #84 — Windows-only |
| `src/nooa/runtime/debug_handler.py:429` | `signal.SIGUSR2` | #85 — Windows-only |
| `packages/nooa-cli/src/nooa_cli/commands/eval.py:48` | `signal.SIGUSR1` | correctly guarded by `hasattr` at :47 |
| `src/nooa/runtime/sandbox/config.py:155` | `landlock_rules` | dataclass field and docstrings only — no Linux import |

No `/proc`, no landlock module import, no `import resource`, no `epoll`/`inotify`/`os.sched_*`/`os.killpg`. Notably `sandbox/guards.py` — the `import resource` from #92 — is **not** in the closure; it loads on `SandboxedExecutor` construction, which a smoke test never reaches.

So the macOS leg catches nothing on `main` today and would not have caught any of #84/#85/#92. It is cheap insurance against a future Linux-only assumption reaching module scope, and it is the platform contributors are most likely on after Linux. The workflow comment states this plainly rather than implying it is doing more.

## litellm has no macOS or Windows wheels, so both legs compile Rust

Found while measuring cold-start cost. `litellm==1.93.0` publishes **10 wheels, all `manylinux_2_28`**, plus an sdist — no macOS wheel, no Windows wheel. That sdist is a pyo3/maturin Rust project:

```toml
[build-system]
requires = ["maturin==1.9.4"]
[tool.maturin]
manifest-path = "litellm-rust/crates/python-bridge/Cargo.toml"
bindings = "pyo3"
```

Measured on an M1 with an empty `UV_CACHE_DIR` and **no `cargo` or `rustc` on `PATH`** — maturin bootstraps a toolchain silently:

```
39.0s wall, 145.6s user, 420% cpu, EXIT=0
→ litellm/rust_bridge/_native.cpython-312-darwin.so   5,761,216 bytes
```

Hence `enable-cache: true`. Filed separately as a question for maintainers, since it affects every non-Linux `pip install nooa`, not just CI.

## Expected CI result

**The Windows leg is red on this PR.** That is the gate working — #84 and #85 are unfixed on `main`. PR #98 patches them and has zero file overlap with this PR (it touches no workflow file). Maintainer's call, happy to do either:

1. Merge this after #98 lands. Cleanest.
2. Merge now with `continue-on-error: true`, flip it once #98 is in.

## Verification

**macOS 15, arm64 (M1)** — the literal job command, unmodified:

- Warm: `0.0.9.dev57`, exit 0, ~10s.
- Cold (`UV_CACHE_DIR` emptied): exit 0, 39s wall — the litellm build above.
- A deliberately failing import exits 1, confirming the `run:` step does not swallow errors.
- `ruff check .` → `All checks passed!`; `ruff format --check .` → `878 files already formatted`.

**Native Windows 11, no WSL** — same command against `main`:

```
ModuleNotFoundError: No module named 'fcntl'
```

which is exactly the failure this job exists to catch, and which cannot be reproduced on macOS: `fcntl` is a **builtin** module there (no `__file__`), so `PYTHONPATH` shadowing does not work and an attempted negative test exits 0. Windows is the only host that produces it naturally.

Also verified on that box, on top of PR #98's branch: `SandboxedExecutor(config=SandboxConfig(require=False), ...)` constructs, and the `pass_fds` guard holds. Two follow-up findings from that session are being filed as their own issues rather than expanded here.

## Related issues

Refs #95. Related: #84, #85, #92 (the bug class this gates), #98 (the fixes). Deliberately not `Closes #95` — Tier 2 of that issue (a `posix` pytest marker) is a separate PR.

## Checklist

- [x] Code follows the project style (`ruff check .` and `ruff format --check .` pass)
- [ ] Tests added/updated and passing — n/a, no Python changed; the new CI job *is* the test, and its command was run on both macOS and native Windows
- [x] Docs updated if behavior or public APIs changed — n/a, no behavior or API change
- [x] New source files carry an SPDX license header — no new source files; `scripts/check_license_headers.py` passes (881 files)
