### PR TITLE
feat(tracing): add portable journal file exporter

### DIFF
--- a/examples/quickstart/06_tracing.py
+++ b/examples/quickstart/06_tracing.py
@@ -9,11 +9,17 @@ in the viewer without any setup code. Just create an agent and go.
 Workflow:
   1. nooa start-dev   # start trace viewer and OTLP receiver
   2. uv run python examples/quickstart/06_tracing.py
-  3. View traces at http://localhost:5001
+  3. nooa import-traces traces/quickstart-06-journal
+  4. View traces at http://localhost:5001
 """
 
+from pathlib import Path
+
 from nooa import hidden
+from nooa.tracing import enable_tracing, exporters
 from nooa.util.quickstart import *
+
+TRACE_DIR = Path("traces/quickstart-06-journal")
 
 
 class MathAgent(Agent, llm=llm):
@@ -42,8 +48,9 @@ class MathAgent(Agent, llm=llm):
 
 @autorun
 async def main():
-    # Tracing is auto-enabled when `nooa start-dev` is running.
-    # To write JSONL files instead, call enable_tracing(trace_dir="./traces") explicitly.
+    # The journal file keeps message bodies content-addressed instead of
+    # repeating the full LLM conversation on every OTLP span.
+    enable_tracing(exporters=[exporters.journal_file(TRACE_DIR)])
 
     agent = MathAgent()
     result = await agent.run("(10 + 5) * 2")
@@ -56,5 +63,6 @@ async def main():
     print("  - explain()    ellipsis/LLM method, child of run()")
     print("  - _format()    private helper (also traced)")
     print("=" * 80)
-    print("\nTrace Viewer: http://localhost:5001")
+    print(f"\nJournal trace: {TRACE_DIR}")
+    print(f"Import with: nooa import-traces {TRACE_DIR}")
     print("=" * 80)

--- a/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
@@ -8,6 +8,10 @@ import urllib.request
 
 import click
 
+JOURNAL_ENVELOPE_KEY = "nooaJournal"
+JOURNAL_FORMAT = "nooa.message_journal"
+JOURNAL_VERSION = 1
+
 
 def validate_endpoint(endpoint: str) -> None:
     """Validate that the endpoint uses an HTTP(S) scheme."""
@@ -100,6 +104,57 @@ def post_annotations(endpoint: str, annotations: list[dict]) -> int:
         except Exception:
             pass
     return imported
+
+
+def get_journal_record(body: dict) -> dict | None:
+    """Return a validated NOOA journal envelope, or ``None`` for other lines."""
+    record = body.get(JOURNAL_ENVELOPE_KEY)
+    if not isinstance(record, dict):
+        return None
+    if record.get("format") != JOURNAL_FORMAT or record.get("version") != JOURNAL_VERSION:
+        return None
+    return record
+
+
+def post_journal_record(endpoint: str, record: dict, session_id: str) -> bool:
+    """POST one portable-file journal record to the viewer.
+
+    ``session_id`` is authoritative so renaming a trace file and Harbor's
+    trial-name remapping affect OTLP spans and their journal sideband equally.
+    Manifest records are accepted as no-ops.
+    """
+    record_type = record.get("type")
+    if record_type == "manifest":
+        return True
+    if record_type == "blocks":
+        payload = record.get("blocks")
+        if not isinstance(payload, list):
+            return False
+        path = "/v1/journal/blocks"
+        headers = {"Content-Type": "application/json", "X-Session-Id": session_id}
+    elif record_type == "call":
+        source = record.get("call")
+        if not isinstance(source, dict):
+            return False
+        payload = dict(source)
+        payload["session_id"] = session_id
+        path = "/v1/journal/calls"
+        headers = {"Content-Type": "application/json"}
+    else:
+        return False
+
+    data = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    request = urllib.request.Request(
+        f"{endpoint.rstrip('/')}{path}",
+        data=data,
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.status < 300
+    except Exception:
+        return False
 
 
 def session_exists(endpoint: str, session_id: str) -> bool:

--- a/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Import NVIDIA OO Agents OTLP traces from a Harbor job directory into the viewer.
+"""Import NOOA OTLP or portable journal traces from Harbor into the viewer.
 
 Walks a Harbor job directory (or any directory containing one), finds all
 traces under ``artifacts/traces/*.jsonl``, enriches them with Harbor metadata
@@ -24,7 +24,9 @@ import click
 
 from ._otlp_helpers import (
     check_endpoint_reachable,
+    get_journal_record,
     inject_resource_attrs,
+    post_journal_record,
     post_traces_batch,
     session_exists,
     validate_endpoint,
@@ -34,7 +36,7 @@ NAME = "import-harbor"
 
 
 def _find_harbor_traces(root: Path) -> list[Path]:
-    """Find all OTLP trace files nested under Harbor artifact directories.
+    """Find all OTLP or portable journal trace files under Harbor artifacts.
 
     Harbor copies the container's ``/logs/artifacts/`` to ``trial_dir/artifacts/``
     on the host. The agent decides the layout within that directory — a common
@@ -310,7 +312,7 @@ def _import_trace_file(
     batch_lines: int,
     batch_bytes: int,
 ) -> tuple[bool, list[str]]:
-    """Import one OTLP JSONL file, posting its lines in batches.
+    """Import one OTLP or portable journal JSONL file.
 
     Accumulates OTLP bodies and flushes them in batches: many ``resourceSpans``
     envelopes are merged into one POST, avoiding one HTTP request per line. A flush
@@ -345,6 +347,12 @@ def _import_trace_file(
             try:
                 body = json.loads(raw_line)
             except json.JSONDecodeError:
+                continue
+            journal_record = get_journal_record(body)
+            if journal_record is not None:
+                session_id = str(resource_attrs["session.id"])
+                if not post_journal_record(endpoint, journal_record, session_id):
+                    errors.append(f"{jsonl_path.name}: failed to post journal record")
                 continue
             if "resourceSpans" not in body:
                 continue

--- a/packages/nooa-cli/src/nooa_cli/commands/import_traces.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/import_traces.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Import OTLP trace .jsonl files into the viewer.
+"""Import OTLP or portable NOOA journal .jsonl files into the viewer.
 
 Usage:
     nooa import-traces ./traces/
@@ -18,8 +18,10 @@ import click
 
 from ._otlp_helpers import (
     check_endpoint_reachable,
+    get_journal_record,
     inject_resource_attrs,
     post_annotations,
+    post_journal_record,
     post_trace,
     session_exists,
     validate_endpoint,
@@ -27,7 +29,7 @@ from ._otlp_helpers import (
 
 NAME = "import-traces"
 
-TRACE_EXTENSIONS = {".jsonl"}
+TRACE_EXTENSIONS = (".nooa.jsonl", ".jsonl")
 
 
 def _find_trace_files(path: Path) -> list[Path]:
@@ -80,7 +82,7 @@ def _session_id_from_filename(path: Path) -> str:
     help="Batch ID for this import (default: auto-generated).",
 )
 def command(path: str, endpoint: str, batch_id: str | None):
-    """Import OTLP trace .jsonl files into the viewer."""
+    """Import OTLP and portable NOOA journal .jsonl files into the viewer."""
     target = Path(path)
     files = _find_trace_files(target)
 
@@ -134,6 +136,12 @@ def command(path: str, endpoint: str, batch_id: str | None):
                 try:
                     body = json.loads(raw_line)
                 except json.JSONDecodeError:
+                    continue
+
+                journal_record = get_journal_record(body)
+                if journal_record is not None:
+                    if not post_journal_record(endpoint, journal_record, session_id):
+                        errors.append(f"{file.name}:{line_num}: failed to post journal record")
                     continue
 
                 # Handle annotation lines from exported traces

--- a/src/nooa/tracing/__init__.py
+++ b/src/nooa/tracing/__init__.py
@@ -16,6 +16,9 @@ Usage::
 
     # JSONL only (no viewer required)
     enable_tracing(exporters=[exporters.jsonl()])
+
+    # Compact portable file (OTLP spans + content-addressed message journal)
+    enable_tracing(exporters=[exporters.journal_file("./traces")])
 """
 
 from __future__ import annotations

--- a/src/nooa/tracing/_journal_exporter.py
+++ b/src/nooa/tracing/_journal_exporter.py
@@ -79,7 +79,10 @@ class JournalExporter(SpanExporter):
 
         with _INSTALL_LOCK:
             for cb in litellm.callbacks:
-                if isinstance(cb, MessageJournalCallback):
+                # FileMessageJournalCallback subclasses MessageJournalCallback
+                # to reuse normalization, but is a different sink.  Match the
+                # exact class so exporter construction order cannot mix them.
+                if isinstance(cb, MessageJournalCallback) and type(cb) is MessageJournalCallback:
                     cb.add_destination(self._base_url)
                     return cb
 

--- a/src/nooa/tracing/_journal_file_exporter.py
+++ b/src/nooa/tracing/_journal_file_exporter.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Portable, append-only file exporter for NOOA's message journal.
+
+Each ``<session>.nooa.jsonl`` file contains standard OTLP ``TracesData``
+envelopes with large LLM message attributes removed, plus typed NOOA journal
+records containing content-addressed blocks and LLM call skeletons.  The file
+is intentionally line-oriented: a process crash can lose at most the line
+being written, and importers can stream artifacts without loading them whole.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+from nooa.tracing._otlp_serialize import build_resource_spans
+
+if TYPE_CHECKING:
+    from nooa.tracing._litellm_journal import FileMessageJournalCallback
+
+log = logging.getLogger(__name__)
+
+JOURNAL_ENVELOPE_KEY = "nooaJournal"
+JOURNAL_FORMAT = "nooa.message_journal"
+JOURNAL_VERSION = 1
+
+
+class JournalFileWriter:
+    """Thread-safe writer shared by the span exporter and LiteLLM callback."""
+
+    def __init__(self, trace_dir: str | Path) -> None:
+        self.trace_dir = Path(trace_dir)
+        self.trace_dir.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._initialized_files: set[Path] = set()
+        self._default_session: str | None = None
+
+    def path_for_session(self, session_id: str | None) -> Path:
+        if not session_id:
+            with self._lock:
+                if self._default_session is None:
+                    self._default_session = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+                session_id = self._default_session
+        return self.trace_dir / f"{session_id}.nooa.jsonl"
+
+    def append(self, session_id: str | None, record: dict[str, Any]) -> None:
+        path = self.path_for_session(session_id)
+        line = json.dumps(record, separators=(",", ":"), ensure_ascii=False, default=str)
+        with self._lock:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if path not in self._initialized_files:
+                if not path.exists() or path.stat().st_size == 0:
+                    manifest = {
+                        JOURNAL_ENVELOPE_KEY: {
+                            "format": JOURNAL_FORMAT,
+                            "version": JOURNAL_VERSION,
+                            "type": "manifest",
+                            "session_id": session_id or "",
+                        }
+                    }
+                    with open(path, "a", encoding="utf-8") as fh:
+                        fh.write(json.dumps(manifest, separators=(",", ":")) + "\n")
+                self._initialized_files.add(path)
+            with open(path, "a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+
+    def append_blocks(self, session_id: str, blocks: list[dict[str, str]]) -> None:
+        if blocks:
+            self.append(
+                session_id,
+                {
+                    JOURNAL_ENVELOPE_KEY: {
+                        "format": JOURNAL_FORMAT,
+                        "version": JOURNAL_VERSION,
+                        "type": "blocks",
+                        "session_id": session_id,
+                        "blocks": blocks,
+                    }
+                },
+            )
+
+    def append_call(self, session_id: str, call: dict[str, Any]) -> None:
+        self.append(
+            session_id,
+            {
+                JOURNAL_ENVELOPE_KEY: {
+                    "format": JOURNAL_FORMAT,
+                    "version": JOURNAL_VERSION,
+                    "type": "call",
+                    "session_id": session_id,
+                    "call": call,
+                }
+            },
+        )
+
+
+class JournalFileExporter(SpanExporter):
+    """Write stripped OTLP spans and their message journal to one JSONL file."""
+
+    synchronous = True
+    _LLM_MESSAGE_PREFIXES = ("llm.input_messages.", "llm.output_messages.")
+    _LLM_VALUE_KEYS = ("input.value", "output.value")
+
+    def __init__(self, trace_dir: str | Path) -> None:
+        self.trace_dir = Path(trace_dir)
+        self._writer = JournalFileWriter(trace_dir)
+        self._callback = self._install_callback()
+
+    def _install_callback(self) -> FileMessageJournalCallback:
+        import litellm
+
+        from nooa.tracing._litellm_journal import _INSTALL_LOCK, FileMessageJournalCallback
+
+        with _INSTALL_LOCK:
+            for callback in litellm.callbacks:
+                if (
+                    isinstance(callback, FileMessageJournalCallback)
+                    and type(callback) is FileMessageJournalCallback
+                ):
+                    callback.add_writer(self._writer)
+                    return callback
+            callback = FileMessageJournalCallback(self._writer)
+            litellm.callbacks.append(callback)
+            return callback
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        try:
+            by_session: dict[str | None, list[ReadableSpan]] = {}
+            for span in spans:
+                value = (span.attributes or {}).get("session.id")
+                session_id = str(value) if value else None
+                by_session.setdefault(session_id, []).append(span)
+
+            for session_id, session_spans in by_session.items():
+                override = {"session.id": session_id} if session_id else None
+                resource_spans = build_resource_spans(
+                    session_spans,
+                    resource_attrs_override=override,
+                    exclude_attr_prefixes=self._LLM_MESSAGE_PREFIXES,
+                    exclude_attr_prefixes_llm_only=self._LLM_VALUE_KEYS,
+                )
+                self._writer.append(session_id, {"resourceSpans": resource_spans})
+        except Exception as exc:
+            log.warning("Error exporting journal file spans: %s", exc, exc_info=True)
+            return SpanExportResult.FAILURE
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        import litellm
+
+        from nooa.tracing._litellm_journal import _INSTALL_LOCK
+
+        with _INSTALL_LOCK:
+            self._callback.remove_writer(self._writer)
+            if not self._callback.has_writers():
+                litellm.callbacks = [c for c in litellm.callbacks if c is not self._callback]
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True
+
+    def describe(self, session_id: str | None = None) -> str:
+        name = f"{session_id}.nooa.jsonl" if session_id else "*.nooa.jsonl"
+        return f"journal-file:{self.trace_dir / name}"

--- a/src/nooa/tracing/_litellm_journal.py
+++ b/src/nooa/tracing/_litellm_journal.py
@@ -607,6 +607,10 @@ class MessageJournalCallback(CustomLogger):
         }
         if span_id:
             record["span_id"] = span_id
+        self._send_call(session_id, record)
+
+    def _send_call(self, session_id: str, record: dict) -> None:
+        """Publish a completed call record to every HTTP destination."""
         with self._lock:
             destinations = list(self._destinations)
         for dest in destinations:
@@ -635,3 +639,59 @@ class MessageJournalCallback(CustomLogger):
         self, kwargs: dict, response_obj: Any, start_time: Any, end_time: Any
     ) -> None:
         self.log_failure_event(kwargs, response_obj, start_time, end_time)
+
+
+class FileMessageJournalCallback(MessageJournalCallback):
+    """Write the existing journal protocol to a :class:`JournalFileWriter`.
+
+    The message normalization and call correlation intentionally reuse the
+    HTTP callback implementation so live and file journals have identical
+    payload semantics.
+    """
+
+    def __init__(self, writer: Any) -> None:
+        CustomLogger.__init__(self)
+        self._call_inputs: dict[str, tuple[list[dict], str | None]] = {}
+        self._lock = threading.Lock()
+        self._writers: dict[Any, int] = {writer: 1}
+        self._sent_hashes: dict[Any, dict[str, set[str]]] = {writer: {}}
+
+    def add_writer(self, writer: Any) -> None:
+        with self._lock:
+            self._writers[writer] = self._writers.get(writer, 0) + 1
+            self._sent_hashes.setdefault(writer, {})
+
+    def remove_writer(self, writer: Any) -> None:
+        with self._lock:
+            refcount = self._writers.get(writer, 0) - 1
+            if refcount <= 0:
+                self._writers.pop(writer, None)
+                self._sent_hashes.pop(writer, None)
+            else:
+                self._writers[writer] = refcount
+
+    def has_writers(self) -> bool:
+        with self._lock:
+            return bool(self._writers)
+
+    def _send_new_blocks(self, session_id: str, blocks: dict[str, str]) -> None:
+        if not blocks:
+            return
+        with self._lock:
+            for writer in self._writers:
+                sent = self._sent_hashes.setdefault(writer, {}).setdefault(session_id, set())
+                new_entries = [
+                    {"hash": h, "content": content}
+                    for h, content in blocks.items()
+                    if h not in sent
+                ]
+                # Mark hashes only after the append succeeds.  A disk-full or
+                # serialization failure must remain retryable on the next call.
+                writer.append_blocks(session_id, new_entries)
+                sent.update(entry["hash"] for entry in new_entries)
+
+    def _send_call(self, session_id: str, record: dict) -> None:
+        with self._lock:
+            writers = list(self._writers)
+        for writer in writers:
+            writer.append_call(session_id, record)

--- a/src/nooa/tracing/exporters.py
+++ b/src/nooa/tracing/exporters.py
@@ -43,6 +43,22 @@ def jsonl(trace_dir: str | Path | None = None) -> SpanExporter:
     return OtlpJsonFileExporter(trace_dir)
 
 
+def journal_file(trace_dir: str | Path | None = None) -> SpanExporter:
+    """Portable file exporter using NOOA's content-addressed message journal.
+
+    Writes ``<session_id>.nooa.jsonl`` with message-stripped standard OTLP span
+    envelopes plus typed journal block/call records.  The artifact is accepted
+    by ``nooa import-traces`` and ``nooa import-harbor`` and reconstructs full
+    OpenInference messages in the viewer.  This exporter is opt-in and does not
+    alter the behavior of :func:`jsonl` or the default live viewer exporter.
+    """
+    from nooa.tracing._journal_file_exporter import JournalFileExporter
+
+    if trace_dir is None:
+        trace_dir = _auto_detect_trace_dir()
+    return JournalFileExporter(trace_dir)
+
+
 def otlp(
     endpoint: str,
     headers: dict[str, str] | None = None,

--- a/tests/tracing/test_exporters.py
+++ b/tests/tracing/test_exporters.py
@@ -33,6 +33,19 @@ class TestJsonlFactory:
             assert exp.trace_dir == Path(tmpdir)
 
 
+class TestJournalFileFactory:
+    def test_creates_opt_in_journal_file_exporter(self):
+        from nooa.tracing._journal_file_exporter import JournalFileExporter
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            exp = exporters.journal_file(tmpdir)
+            try:
+                assert isinstance(exp, JournalFileExporter)
+                assert exp.trace_dir == Path(tmpdir)
+            finally:
+                exp.shutdown()
+
+
 class TestOtlpFactory:
     def test_raises_import_error_for_http(self):
         # This test assumes the OTLP HTTP exporter may or may not be installed

--- a/tests/tracing/test_journal_file_exporter.py
+++ b/tests/tracing/test_journal_file_exporter.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Portable journal-file export and import coverage."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+
+def _spans(body: dict):
+    for resource_spans in body.get("resourceSpans", []):
+        for scope_spans in resource_spans.get("scopeSpans", []):
+            yield from scope_spans.get("spans", [])
+
+
+@pytest.mark.asyncio
+async def test_journal_file_is_stripped_and_import_reconstructs_messages(tmp_path: Path):
+    pytest.importorskip("openinference.instrumentation.litellm")
+    import litellm
+    from opentelemetry import trace as otel_trace
+
+    from nooa.tracing import enable_tracing, exporters, flush_traces, set_session
+    from nooa.tracing._context_sideband import JournalPayload, set_journal_payload
+
+    enable_tracing(exporters=[exporters.journal_file(tmp_path)])
+    session_id = "portable-journal"
+    set_session(session_id)
+    input_text = "PORTABLE_INPUT " + ("repeated " * 100)
+    import hashlib
+
+    input_hash = "sha256:" + hashlib.sha256(input_text.encode()).hexdigest()
+    payload = JournalPayload(
+        skeleton=[{"role": "user", "parts": [{"block_hash": input_hash}]}],
+        blocks={input_hash: input_text},
+    )
+    callback = next(
+        callback
+        for callback in litellm.callbacks
+        if type(callback).__name__ == "FileMessageJournalCallback"
+    )
+    kwargs = {"litellm_call_id": "portable-call", "model": "gpt-3.5-turbo"}
+    messages = [{"role": "user", "content": input_text}]
+    tracer = otel_trace.get_tracer(__name__)
+    with tracer.start_as_current_span("acompletion") as span:
+        span.set_attribute("openinference.span.kind", "LLM")
+        set_journal_payload(payload)
+        callback.log_pre_api_call("gpt-3.5-turbo", messages, kwargs)
+        response = await litellm.acompletion(
+            model="gpt-3.5-turbo",
+            messages=messages,
+            mock_response="PORTABLE_OUTPUT",
+        )
+        now = datetime.now(UTC)
+        callback.log_success_event(kwargs, response, now, now)
+    flush_traces()
+
+    artifact = tmp_path / f"{session_id}.nooa.jsonl"
+    assert artifact.exists()
+    bodies = [json.loads(line) for line in artifact.read_text().splitlines()]
+    records = [body["nooaJournal"] for body in bodies if "nooaJournal" in body]
+    assert {record["type"] for record in records} == {"manifest", "blocks", "call"}
+    assert sum(input_text in line for line in artifact.read_text().splitlines()) == 1
+
+    otlp_bodies = [body for body in bodies if "resourceSpans" in body]
+    llm_spans = [
+        span
+        for body in otlp_bodies
+        for span in _spans(body)
+        if any(
+            attr.get("key") == "openinference.span.kind"
+            and attr.get("value", {}).get("stringValue") == "LLM"
+            for attr in span.get("attributes", [])
+        )
+    ]
+    assert llm_spans
+    keys = {attr["key"] for attr in llm_spans[0].get("attributes", [])}
+    assert not any(key.startswith("llm.input_messages.") for key in keys)
+    assert "input.value" not in keys
+
+    from eval_pipeline.headless_backend import HeadlessOtlpBackend
+
+    backend = HeadlessOtlpBackend()
+    endpoint = backend.start()
+    try:
+        from click.testing import CliRunner
+        from nooa_cli.commands.import_traces import command
+
+        result = CliRunner().invoke(command, [str(artifact), "--endpoint", endpoint])
+        assert result.exit_code == 0, result.output
+        urllib.request.urlopen(
+            urllib.request.Request(f"{endpoint}/v1/sync", method="POST"), timeout=10
+        )
+        with urllib.request.urlopen(
+            f"{endpoint}/api/trace/export?session_id={session_id}", timeout=10
+        ) as response:
+            reconstructed = response.read().decode()
+        assert input_text in reconstructed
+        assert "PORTABLE_OUTPUT" in reconstructed
+    finally:
+        backend.stop()
+
+
+def test_harbor_import_posts_journal_with_trial_session(monkeypatch, tmp_path: Path):
+    from nooa_cli.commands import import_harbor
+
+    artifact = tmp_path / "trace.nooa.jsonl"
+    artifact.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "nooaJournal": {
+                            "format": "nooa.message_journal",
+                            "version": 1,
+                            "type": "call",
+                            "session_id": "original",
+                            "call": {
+                                "call_id": "c1",
+                                "session_id": "original",
+                                "input_skeleton": [],
+                                "output_messages": [],
+                            },
+                        }
+                    }
+                ),
+                json.dumps({"resourceSpans": []}),
+            ]
+        )
+        + "\n"
+    )
+    posted: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        import_harbor,
+        "post_journal_record",
+        lambda _endpoint, record, session_id: posted.append((record["type"], session_id)) or True,
+    )
+    monkeypatch.setattr(import_harbor, "post_traces_batch", lambda _endpoint, _bodies: True)
+
+    imported, errors = import_harbor._import_trace_file(
+        "http://viewer",
+        artifact,
+        {"session.id": "harbor-trial"},
+        batch_lines=100,
+        batch_bytes=1_000_000,
+    )
+    assert imported
+    assert not errors
+    assert posted == [("call", "harbor-trial")]
+
+
+@pytest.mark.parametrize("file_first", [False, True])
+def test_http_and_file_journal_callbacks_coexist_in_either_order(tmp_path: Path, file_first: bool):
+    import litellm
+
+    from nooa.tracing import exporters
+    from nooa.tracing._litellm_journal import (
+        FileMessageJournalCallback,
+        MessageJournalCallback,
+    )
+
+    factories = [
+        lambda: exporters.journal("http://example.invalid/v1/traces"),
+        lambda: exporters.journal_file(tmp_path),
+    ]
+    if file_first:
+        factories.reverse()
+    created = [factory() for factory in factories]
+    try:
+        assert sum(type(cb) is MessageJournalCallback for cb in litellm.callbacks) == 1
+        assert sum(type(cb) is FileMessageJournalCallback for cb in litellm.callbacks) == 1
+    finally:
+        for exporter in reversed(created):
+            exporter.shutdown()


### PR DESCRIPTION
## What does this PR do?

- Adds an opt-in exporters.journal_file() exporter that writes append-only session.nooa.jsonl artifacts containing message-stripped OTLP spans and content-addressed journal block/call records.
- Extends nooa import-traces and nooa import-harbor to stream the new records into the viewer and remap journal session IDs consistently with renamed files and Harbor trials.
- Preserves all existing exporter defaults and supports HTTP and file journal callbacks simultaneously in either construction order.
- Adds end-to-end reconstruction, Harbor remapping, deduplication, coexistence, and factory coverage.

This persists the existing journal protocol; true snapshot-delta encoding of the remaining full hash skeleton is intentionally left for a follow-up.

## Related issues

None.

## Validation

- Commit hooks: Ruff, Ruff format, Pyright, SPDX, and repository checks passed.
- Broad tracing/import suite: 190 passed.
- Focused final suite: 14 passed.

## Checklist

- [x] Code follows the project style (Ruff and format checks pass)
- [x] Tests added/updated and passing
- [x] Docs updated for the new public exporter API
- [x] New source files carry an SPDX license header