### PR TITLE
fix(runtime): bound prompt cache key length

### DIFF
--- a/src/nooa/runtime/actor.py
+++ b/src/nooa/runtime/actor.py
@@ -5,6 +5,7 @@
 import ast
 import asyncio
 import contextvars
+import hashlib
 import inspect
 import io
 import linecache
@@ -61,6 +62,15 @@ from nooa.runtime.harness_metrics import (
 from nooa.runtime.hooks import call_after_hook, call_before_hook
 
 logger = logging.getLogger(__name__)
+
+
+def _derive_prompt_cache_key(agent_id: str, strategy_tag: str) -> str:
+    """Return a stable cache shard key within providers' 64-character limit."""
+    digest = hashlib.blake2s(
+        f"{agent_id}-{strategy_tag}".encode(),
+        digest_size=16,
+    ).hexdigest()
+    return f"nooa-{digest}"
 
 
 @contextmanager
@@ -969,7 +979,8 @@ class ActorRuntime:
                         type(_mw_strategy).__name__ if _mw_strategy is not None else "default"
                     )
                     call_params.setdefault(
-                        "prompt_cache_key", f"{self.agent._agent_id}-{_mw_strategy_tag}"
+                        "prompt_cache_key",
+                        _derive_prompt_cache_key(self.agent._agent_id, _mw_strategy_tag),
                     )
                     ctx.response = await llm_client.acall(
                         ctx.messages,
@@ -1054,7 +1065,10 @@ class ActorRuntime:
                 _strategy_tag = (
                     type(_current_strategy).__name__ if _current_strategy is not None else "default"
                 )
-                _kwargs.setdefault("prompt_cache_key", f"{self.agent._agent_id}-{_strategy_tag}")
+                _kwargs.setdefault(
+                    "prompt_cache_key",
+                    _derive_prompt_cache_key(self.agent._agent_id, _strategy_tag),
+                )
                 _emit_llm_start()
                 try:
                     try:
@@ -1506,7 +1520,7 @@ class ActorRuntime:
             # stdout capture and wrapper, so we skip the in-process exec below.
             if sandbox_executor is not None:
                 result = await sandbox_executor.run_cell(code, execution_count=execution_count)
-                return result
+                return cast(ExecutionResult, result)
 
             # Set up stdout/stderr capture BEFORE ast.parse/compile so that
             # SyntaxWarnings (e.g. invalid escape sequences in LLM-generated code)

--- a/tests/test_standalone.py
+++ b/tests/test_standalone.py
@@ -23,7 +23,7 @@ from typing import Any
 import pytest
 from pydantic import BaseModel
 
-from nooa import EventQuery, strategy
+from nooa import Agent, EventQuery, strategy
 from nooa.context_blocks import ScopedContext
 from nooa.strategies import CodeActStrategy, PredictStrategy
 from nooa.unifiedllm import FakeLLMClient, LLMResponse, ToolCall
@@ -711,7 +711,7 @@ class TestStandaloneAgentIdSharding:
     """`prompt_cache_key` sharding contract for standalone functions.
 
     Each standalone call creates a fresh agent stub. The stub's ``_agent_id``
-    feeds the actor's default ``prompt_cache_key = f"{agent_id}-{strategy_tag}"``.
+    feeds the actor's default prompt-cache-key derivation.
     The id must satisfy three properties:
 
     1. Same function in the same process → same shard (fan-out cache hits).
@@ -746,9 +746,6 @@ class TestStandaloneAgentIdSharding:
         assert len(fake_llm.prompt_cache_keys) == 2
         assert fake_llm.prompt_cache_keys[0] == fake_llm.prompt_cache_keys[1]
         assert fake_llm.prompt_cache_keys[0] is not None
-        # The id must carry function identity so two different functions diverge
-        # (asserted in the next test) — sanity-check the format here.
-        assert "classify" in fake_llm.prompt_cache_keys[0]
 
     @pytest.mark.asyncio
     async def test_different_functions_get_different_cache_keys(self) -> None:
@@ -802,8 +799,10 @@ class TestStandaloneAgentIdSharding:
         )
 
     @pytest.mark.asyncio
-    async def test_agent_id_carries_per_process_token(self) -> None:
-        """The id format must include the module-level per-process token.
+    async def test_agent_id_carries_per_process_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Changing the module-level per-process token changes the shard.
 
         This is what spreads load when the same code is run as N separate
         Python processes — each gets a different ``_PROCESS_AGENT_ID`` at
@@ -812,16 +811,73 @@ class TestStandaloneAgentIdSharding:
         """
         from nooa import standalone as standalone_mod
 
-        fake_llm = _CaptureKwargsLLM(scripted_responses=[_resp('{"value": "x"}')])
+        fake_llm = _CaptureKwargsLLM(
+            scripted_responses=[_resp('{"value": "x"}'), _resp('{"value": "y"}')]
+        )
 
-        @strategy(PredictStrategy(), llm=fake_llm)
-        async def summarise(text: str) -> str:
-            """Summarise {text}."""
+        def make_summarise():
+            @strategy(PredictStrategy(), llm=fake_llm)
+            async def summarise(text: str) -> str:
+                """Summarise {text}."""
+                ...
+
+            return summarise
+
+        monkeypatch.setattr(standalone_mod, "_PROCESS_AGENT_ID", "process1")
+        first = make_summarise()
+        monkeypatch.setattr(standalone_mod, "_PROCESS_AGENT_ID", "process2")
+        second = make_summarise()
+
+        await first("input")
+        await second("input")
+
+        assert fake_llm.prompt_cache_keys[0] != fake_llm.prompt_cache_keys[1]
+
+    @pytest.mark.asyncio
+    async def test_long_standalone_identity_produces_bounded_cache_key(self) -> None:
+        """Long package and qualified names cannot exceed the provider limit."""
+        fake_llm = _CaptureKwargsLLM(scripted_responses=[_resp('{"value": "ok"}')])
+
+        async def summarise_document(text: str) -> str:
+            """Summarise the document."""
             ...
 
-        await summarise("input")
+        summarise_document.__module__ = "myproject.agents.summarization.pipeline"
+        summarise_document.__qualname__ = "DocumentSummarizer.summarise_document"
+        wrapped = strategy(PredictStrategy(), llm=fake_llm)(summarise_document)
 
-        assert fake_llm.prompt_cache_keys[0] is not None
-        # Locks in the contract: if anyone ever drops the per-process token
-        # the cybergym-style multi-trial collision returns.
-        assert standalone_mod._PROCESS_AGENT_ID in fake_llm.prompt_cache_keys[0]
+        await wrapped("input")
+
+        key = fake_llm.prompt_cache_keys[0]
+        assert key is not None
+        assert key.startswith("nooa-")
+        assert len(key) <= 64
+
+    @pytest.mark.asyncio
+    async def test_long_agent_strategy_name_produces_bounded_cache_key_with_middleware(
+        self,
+    ) -> None:
+        """Long custom strategy names are bounded on the middleware path too."""
+
+        class MultiStepResearchPlanningAndVerificationStrategy(PredictStrategy):
+            pass
+
+        fake_llm = _CaptureKwargsLLM(scripted_responses=[_resp('{"value": "ok"}')])
+
+        class SummarizerAgent(Agent, llm=fake_llm):
+            @strategy(MultiStepResearchPlanningAndVerificationStrategy())
+            async def summarise(self, text: str) -> str:
+                """Summarise the text."""
+                ...
+
+        async def passthrough(ctx, call_next):
+            return await call_next(ctx)
+
+        agent = SummarizerAgent()
+        agent.event_manager.intercept("llm_call", passthrough)
+        await agent.summarise("input")
+
+        key = fake_llm.prompt_cache_keys[0]
+        assert key is not None
+        assert key.startswith("nooa-")
+        assert len(key) <= 64


### PR DESCRIPTION
## What does this PR do?

Bounds the default `prompt_cache_key` sent to LLM providers.

The actor previously concatenated the unbounded agent ID and strategy class name. Standalone functions in nested packages could therefore exceed the provider's 64-character limit and cause every request to be rejected.

This change:

- derives a stable 37-character key using a 128-bit BLAKE2s digest and a `nooa-` prefix
- applies the shared derivation to both middleware and fast LLM call paths
- preserves per-agent, per-strategy, per-function, and per-process sharding behavior
- replaces encoding-specific tests with behavioral assertions
- adds regressions for long standalone identities and long custom strategy names

A live GPT-5.5 Responses API confirmed that a pre-fix 145-character key becomes 37 characters. Two identical requests used the same key, and the second request reported 8,960 cached input tokens.

## Related issues

None.

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing
- [x] Docs are not required because this changes internal key derivation without changing the public API
- [x] No new source files were added

## Validation

- Commit hooks pass, including Ruff, Pyright, SPDX, and whitespace checks
- 101 focused actor, middleware, context-recovery, and standalone tests pass
- 6,507 tests passed in the default suite; 21 viewer tests were initially affected by a locally configured viewer auth token, and all affected viewer files pass with that local token cleared (27 passed)
- Live GPT-5.5 prompt-cache validation succeeded with 8,960 cached tokens on the second call


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt-cache key generation for more consistent compatibility across providers.
  * Ensured cache keys remain bounded for long agent identities and strategy names.
  * Improved process-level sharding behavior for standalone execution.
  * Standardized sandbox execution results for reliable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->