### PR TITLE
fix(memory): tolerate recovered JSON payloads

### DIFF
--- a/packages/nooa-memory/src/nooa_memory/store.py
+++ b/packages/nooa-memory/src/nooa_memory/store.py
@@ -236,7 +236,30 @@ class MemoryStore:
                 self._index.add(row["id"], vector)
 
     def _row_to_memory(self, row: sqlite3.Row) -> Memory:
-        data = json.loads(row["data"])
+        try:
+            data = json.loads(row["data"])
+            if not isinstance(data, dict):
+                raise ValueError("memory payload is not a JSON object")
+        except (json.JSONDecodeError, TypeError, ValueError):
+            # SQLite recovery can retain the promoted/searchable columns while
+            # replacing an unreadable JSON payload with an empty string. Build
+            # the smallest lossless record available from those columns so one
+            # damaged payload cannot disable recall or reflection entirely.
+            logger.warning(
+                "memory %s has a malformed JSON payload; reconstructing it from columns",
+                row["id"],
+            )
+            data = {
+                "id": row["id"],
+                "type": row["type"],
+                "content": row["content"],
+                "importance": row["importance"],
+                "salience": row["salience"],
+                "strength": row["strength"],
+                "created_at": row["created_at"],
+                "last_accessed_at": row["last_accessed"],
+                "access_count": row["access_count"],
+            }
         edges = [
             Edge(target_id=e["dst"], type=EdgeType(e["type"]), weight=e["weight"])
             for e in self._edge_rows(row["id"])

--- a/packages/nooa-memory/tests/memory/test_memory_store.py
+++ b/packages/nooa-memory/tests/memory/test_memory_store.py
@@ -134,6 +134,33 @@ def test_file_store_uses_durable_wal(tmp_path):
     store.close()
 
 
+def test_malformed_json_payload_is_reconstructed_from_columns(tmp_path, caplog):
+    path = tmp_path / "recovered.sqlite"
+    store = MemoryStore(path)
+    memory = Memory(
+        type=MemoryType.EPISODE,
+        content="survived recovery",
+        importance=7.0,
+        salience=0.8,
+        owner="agent@test",
+    )
+    store.add(memory)
+    store._conn.execute("UPDATE memories SET data = '' WHERE id = ?", (memory.id,))
+    store._conn.commit()
+
+    recovered = store.get(memory.id)
+
+    assert recovered is not None
+    assert recovered.id == memory.id
+    assert recovered.type == MemoryType.EPISODE
+    assert recovered.content == "survived recovery"
+    assert recovered.importance == 7.0
+    assert recovered.salience == 0.8
+    assert recovered.owner == "agent@test"
+    assert "has a malformed JSON payload; reconstructing it from columns" in caplog.text
+    store.close()
+
+
 def test_malformed_stored_embeddings_do_not_disable_memory(tmp_path, emb, caplog):
     path = tmp_path / "recovered.sqlite"
     store = MemoryStore(path, embedding_dim=128)


### PR DESCRIPTION
## Summary

- reconstruct memories from promoted SQLite columns when recovery leaves an empty or malformed JSON payload
- preserve recall/reflection availability when an individual recovered payload is damaged
- add regression coverage for reconstructed records

## Validation

- `uv run ruff check packages/nooa-memory/src/nooa_memory/store.py packages/nooa-memory/tests/memory/test_memory_store.py`
- `uv run pytest -q packages/nooa-memory/tests/memory/test_memory_store.py`
- full memory suite before extracting this follow-up: 271 passed, 13 skipped, 1 deselected

Signed-off-by: Paul Furgale <pfurgale@nvidia.com>