### PR TITLE
fix(tui): support MCP server names with spaces

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/completer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/completer.py
@@ -12,6 +12,7 @@ import keyword
 import logging
 import os
 import re
+import shlex
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -486,7 +487,7 @@ class Completer:
 
         items: list[CompletionItem] = []
         for name in names:
-            attr_name = name.replace("-", "_")
+            attr_name = name.replace("-", "_").replace(" ", "_")
             if (
                 not attr_name.isidentifier()
                 or keyword.iskeyword(attr_name)
@@ -505,8 +506,8 @@ class Completer:
                     status = "configured"
             items.append(
                 CompletionItem(
-                    text=prefix + name,
-                    display=prefix + name,
+                    text=prefix + shlex.quote(name),
+                    display=prefix + shlex.quote(name),
                     description=status,
                 )
             )

--- a/packages/nooa-cli/src/nooa_cli/tui/mcp_registry.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/mcp_registry.py
@@ -50,8 +50,8 @@ _FACTORY_CONFIG_FIELDS = (
 
 
 def _to_attr_name(name: str) -> str:
-    """Convert a hyphenated server name to a valid Python attribute name."""
-    return name.replace("-", "_")
+    """Convert common human-readable server-name separators for attribute access."""
+    return name.replace("-", "_").replace(" ", "_")
 
 
 class MCPRegistry(Skill):
@@ -451,7 +451,7 @@ class MCPRegistry(Skill):
         """Connect to configured servers matching *patterns*.
 
         Each connected server is attached to the agent as ``self.<name>``
-        (hyphens become underscores), hidden from ``doc(self)``. By default
+        (hyphens and spaces become underscores), hidden from ``doc(self)``. By default
         newly connected servers are also activated (listed in ``<mcp>``); pass
         ``activate=False`` to keep them connected but unlisted.
 

--- a/packages/nooa-cli/tests/tui/test_completer.py
+++ b/packages/nooa-cli/tests/tui/test_completer.py
@@ -781,9 +781,12 @@ def test_mcp_completion_missing_command_is_safe():
     assert completer.complete("/mcp connect ") == []
 
 
-def test_mcp_completion_omits_unsafe_untrusted_server_names():
-    reg = _mcp_registry(["safe-server", "evil\x1b[2J", "has spaces"])
+def test_mcp_completion_quotes_server_names_with_spaces_and_omits_unsafe_names():
+    reg = _mcp_registry(["safe-server", "evil\x1b[2J", "MaaS Jira"])
     items = Completer(registry=reg).complete("/mcp connect ")
 
-    assert [item.text for item in items] == ["/mcp connect safe-server"]
+    assert [item.text for item in items] == [
+        "/mcp connect 'MaaS Jira'",
+        "/mcp connect safe-server",
+    ]
     assert all("\x1b" not in item.display for item in items)

--- a/packages/nooa-cli/tests/tui/test_mcp_registry.py
+++ b/packages/nooa-cli/tests/tui/test_mcp_registry.py
@@ -383,6 +383,22 @@ async def test_agent_attribute_collision_is_rejected_before_factory(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_server_name_with_spaces_connects_using_underscored_agent_attribute(monkeypatch):
+    calls = _fake_create(monkeypatch)
+    reg, agent = _make(
+        servers={"MaaS Jira": {"url": "https://jira.example/mcp", "transport": "streamable-http"}}
+    )
+
+    assert await reg.connect(["MaaS Jira"]) == ["MaaS Jira"]
+    assert agent.MaaS_Jira is reg["MaaS Jira"]
+    assert calls[0][0] == "MaaS Jira"
+    assert "self.MaaS_Jira" in reg.status()
+
+    assert await reg.disconnect(["MaaS Jira"]) == ["MaaS Jira"]
+    assert not hasattr(agent, "MaaS_Jira")
+
+
+@pytest.mark.asyncio
 async def test_normalized_server_name_collision_is_rejected(monkeypatch):
     calls = _fake_create(monkeypatch)
     reg, _ = _make(


### PR DESCRIPTION
## Summary
- normalize spaces in MCP server names to underscores for agent attributes
- quote names with spaces in slash-command completion
- add connection, disconnect, status, and completion regressions

## Validation
- `uv run --active pytest packages/nooa-cli/tests/tui/test_mcp_registry.py packages/nooa-cli/tests/tui/test_completer.py packages/nooa-cli/tests/test_tui_mcp_config.py packages/nooa-cli/tests/tui/test_mcp_real_transports.py -q` (113 passed)
- `uv run --active ruff check ...`