### PR TITLE
docs(strategies): attribute Configuration fields to the config object 🤖🤖🤖

### DIFF
--- a/src/nooa/strategies/codeact.py
+++ b/src/nooa/strategies/codeact.py
@@ -296,7 +296,7 @@ class CodeActStrategy(CompositeStrategy):
     - Code is executed via explicit tool calls (not raw output)
     - Final response must be structured output matching return type
 
-    Configuration:
+    Configuration (fields of CodeActConfig, passed via config=):
         max_iterations: Maximum number of tool call iterations
         max_retries: Maximum consecutive errors before failure
 

--- a/src/nooa/strategies/predict.py
+++ b/src/nooa/strategies/predict.py
@@ -56,7 +56,7 @@ class PredictStrategy(GenerationStrategy):
     The strategy handles validation retry with clear error feedback if the LLM's
     output doesn't match the schema.
 
-    Configuration:
+    Configuration (fields of PredictConfig, passed via config=):
         max_retries: Maximum validation retry attempts
 
     Example:


### PR DESCRIPTION
## Motivation

`CodeActStrategy` and `PredictStrategy` list their tuning fields under a bare
`Configuration:` heading, which reads as a constructor argument list. Both
constructors take `config=` only and accept no `**kwargs`:

```
>>> CodeActStrategy(max_iterations=10)
TypeError: CodeActStrategy.__init__() got an unexpected keyword argument 'max_iterations'
>>> PredictStrategy(max_retries=3)
TypeError: PredictStrategy.__init__() got an unexpected keyword argument 'max_retries'
```

Each docstring already contradicts itself: the `Example:` block a few lines
below shows the correct `config=CodeActConfig(...)` / `config=PredictConfig(...)`
form. `ReflexionStrategy`'s equivalent block names its constructor parameters
correctly, so these two are the outliers.

The flat-keyword shape is not fictional, which is probably why it persists —
it is the live signature of `PurePythonStrategy` (`max_iterations`,
`max_retries`, `prefill`), which remains importable via `nooa.experimental`.
That makes the ambiguous heading easy to read as an endorsement of a form that
raises on the supported strategies.

## Change

Name the owning config type in the heading, in both files. Docstring text only
— two lines changed, no behavior change, no test changes.

## Verification

`ruff check` and `ruff format --check` pass on both changed files.