### PR TITLE
fix(skills): load and reload external skills per agent

### DIFF
--- a/src/nooa/skill_registry.py
+++ b/src/nooa/skill_registry.py
@@ -7,15 +7,27 @@ import importlib.util
 import inspect
 import logging
 import sys
+from dataclasses import dataclass
 from importlib.metadata import entry_points
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from nooa.skill import Skill, TextSkill
 
 logger = logging.getLogger(__name__)
 
 ENTRY_POINT_GROUP = "nooa.skills"
+
+
+@dataclass(frozen=True)
+class _SkillSource:
+    """Recipe for constructing a fresh skill object for one agent."""
+
+    kind: Literal["package", "python", "text"]
+    path: Path
+    target: str | None = None
+    module_name: str | None = None
+
 
 _RESERVED_ATTRS = frozenset(
     {
@@ -29,6 +41,20 @@ _RESERVED_ATTRS = frozenset(
         "event_query",
     }
 )
+
+
+def _package_search_paths(lib_dir: Path, top_package: str) -> tuple[str, ...]:
+    """Find import roots for flat, package, and src package layouts."""
+    candidates = [lib_dir.parent]
+    checkout_is_package = lib_dir.name == top_package and (lib_dir / "__init__.py").is_file()
+    if not checkout_is_package and (
+        (lib_dir / top_package).is_dir() or (lib_dir / f"{top_package}.py").is_file()
+    ):
+        candidates.append(lib_dir)
+    src_dir = lib_dir / "src"
+    if (src_dir / top_package).is_dir() or (src_dir / f"{top_package}.py").is_file():
+        candidates.append(src_dir)
+    return tuple(dict.fromkeys(str(path) for path in candidates))
 
 
 # ---------------------------------------------------------------------------
@@ -100,14 +126,21 @@ def skill_from_module(module: Any, module_name: str, source: str = "") -> "Skill
         return None
 
 
-def _load_python_skill(path: Path) -> "Skill | None":
+def _load_python_skill(
+    path: Path,
+    *,
+    namespace: str = "",
+) -> "tuple[Skill | None, str | None]":
     """Import *path* and extract a ``Skill`` via :func:`skill_from_module`."""
-    module_name = f"_nooa_skill_{path.stem}_{abs(hash(str(path.resolve()))) & 0xFFFFFFFF:08x}"
+    suffix = f"_{namespace}" if namespace else ""
+    module_name = (
+        f"_nooa_skill_{path.stem}_{abs(hash(str(path.resolve()))) & 0xFFFFFFFF:08x}{suffix}"
+    )
     try:
         spec = importlib.util.spec_from_file_location(module_name, path)
         if spec is None or spec.loader is None:
             logger.warning("Skill file %s skipped: could not build import spec", path)
-            return None
+            return None, None
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
         try:
@@ -117,10 +150,14 @@ def _load_python_skill(path: Path) -> "Skill | None":
             raise
     except Exception:
         logger.warning("Skill file %s skipped: import failed", path, exc_info=True)
-        return None
+        return None, None
 
     try:
-        return skill_from_module(module, module_name, source=f"Skill file {path}")
+        skill = skill_from_module(module, module_name, source=f"Skill file {path}")
+        if skill is None:
+            sys.modules.pop(module_name, None)
+            return None, None
+        return skill, module_name
     except Exception:
         sys.modules.pop(module_name, None)
         raise
@@ -155,7 +192,10 @@ class SkillRegistry(Skill):
         self._loaded: set[str] = set()
         self._activated: set[str] = set()
         self._attr_map: dict[str, str] = {}  # registry name → actual attr name on agent
-        self._lib_paths: dict[str, str] = {}  # lib_name → sys.path entry added for it
+        self._load_order: list[str] = []  # deterministic dependency-safe teardown order
+        self._sources: dict[str, _SkillSource] = {}
+        self._python_modules: dict[str, Any] = {}  # local synthetic name → imported module
+        self._load_generation = 0
         self._discover()
         super().__init__()
         # Self-register our own context block (we're never activated through ourselves)
@@ -212,24 +252,32 @@ class SkillRegistry(Skill):
         libs_path = Path(libs_path)
         if not libs_path.is_dir():
             return
-        for lib_dir in sorted(libs_path.iterdir()):
-            if not (lib_dir.is_dir() and (lib_dir / "pyproject.toml").exists()):
-                continue
+        libraries = [
+            entry
+            for entry in sorted(libs_path.iterdir())
+            if entry.is_dir() and (entry / "pyproject.toml").exists()
+        ]
+        for lib_dir in libraries:
             lib_name = lib_dir.name
-            reg_name = self._read_skill_name(lib_dir, lib_name)
+            reg_name, target = self._read_skill_entry(lib_dir, lib_name)
             if reg_name in self._loaded:
                 continue
             try:
-                skill = self._import_lib(lib_dir, lib_name)
+                skill = self._import_lib(lib_dir, lib_name, target)
                 if skill is not None:
                     skill._source_dir = lib_dir
                     self.register(reg_name, skill)
+                    self._sources[reg_name] = _SkillSource(
+                        "package",
+                        lib_dir.resolve(),
+                        target=target or lib_name,
+                    )
             except Exception:
                 logger.warning("Library %s skipped", lib_name, exc_info=True)
 
     @staticmethod
-    def _read_skill_name(lib_dir: "Path", lib_name: str) -> str:
-        """Read the skill registry name from pyproject.toml entry_points.
+    def _read_skill_entry(lib_dir: "Path", lib_name: str) -> tuple[str, str | None]:
+        """Read the first skill registry name and import target from pyproject.toml.
 
         Falls back to ``local.<lib_name>`` if no entry_point is declared.
         """
@@ -241,55 +289,92 @@ class SkillRegistry(Skill):
                 data = tomllib.load(f)
             eps = data.get("project", {}).get("entry-points", {}).get(ENTRY_POINT_GROUP, {})
             if eps:
-                # Use the first declared entry_point name
-                return next(iter(eps))
+                # One directory is one library skill. Its entry-point value is
+                # authoritative: the import package need not match the checkout
+                # directory or project distribution name.
+                name, target = next(iter(eps.items()))
+                return name, target if isinstance(target, str) else None
         except Exception:
             pass
-        return f"local.{lib_name}"
+        return f"local.{lib_name}", None
 
-    def _import_lib(self, lib_dir: "Path", lib_name: str) -> "Skill | None":
-        """Import a library package and extract its Skill instance."""
+    def _import_lib(
+        self,
+        lib_dir: "Path",
+        lib_name: str,
+        target: str | None = None,
+    ) -> "Skill | None":
+        """Freshly import a library package and construct one local Skill object.
+
+        Existing agents keep their old class and module objects through normal
+        Python references. ``sys.modules`` is only refreshed so this load sees
+        current source; it is not treated as NOOA-owned lifecycle state.
+        """
         import importlib
         import sys as _sys
 
-        libs_str = str(lib_dir.parent)
-        added_to_path = False
-        if libs_str not in _sys.path:
-            _sys.path.insert(0, libs_str)
-            added_to_path = True
-
-        prefix = lib_name + "."
-        for key in [k for k in _sys.modules if k == lib_name or k.startswith(prefix)]:
-            del _sys.modules[key]
-
+        module_name, _, attr_path = (target or lib_name).partition(":")
+        top_package = module_name.split(".", 1)[0]
+        search_paths = _package_search_paths(lib_dir, top_package)
+        prefix = top_package + "."
+        previous_modules = {
+            key: module
+            for key, module in _sys.modules.items()
+            if key == top_package or key.startswith(prefix)
+        }
+        original_path = list(_sys.path)
+        for key in previous_modules:
+            _sys.modules.pop(key, None)
+        _sys.path[:] = [*search_paths, *(p for p in original_path if p not in search_paths)]
+        importlib.invalidate_caches()
         try:
-            module = importlib.import_module(lib_name)
+            module = importlib.import_module(module_name)
+
+            if attr_path:
+                value: Any = module
+                for part in attr_path.split("."):
+                    value = getattr(value, part)
+                if isinstance(value, Skill):
+                    return value
+                if inspect.isclass(value) and issubclass(value, Skill):
+                    return value()
+                raise TypeError(f"Library {lib_name!r} target {target!r} is not a Skill")
+
+            skill = skill_from_module(
+                module,
+                module_name,
+                source=f"Library {lib_name!r}",
+            )
+            if skill is None:
+                raise TypeError(f"Library {lib_name!r} does not export a Skill")
+            return skill
         except Exception:
-            if added_to_path:
-                _sys.path.remove(libs_str)
+            for key in [
+                key for key in _sys.modules if key == top_package or key.startswith(prefix)
+            ]:
+                _sys.modules.pop(key, None)
+            _sys.modules.update(previous_modules)
             raise
-
-        # Track the path addition so it can be cleaned up if the skill is unloaded
-        if added_to_path:
-            self._lib_paths[lib_name] = libs_str
-
-        return skill_from_module(module, lib_name, source=f"Library {lib_name!r}")
+        finally:
+            _sys.path[:] = original_path
 
     def discover_skills_dirs(self, dirs: "list[Path]") -> None:
-        """Scan skills directories for TextSkills and Python skills.
+        """Scan skill roots for packaged libraries, TextSkills, and Python skills.
 
-        TextSkills (SKILL.md directories) register as cmd.<skill_id>.
-        Python skills (.py files with Skill subclass) register as ext.<name>.
+        Immediate child directories with a ``pyproject.toml`` are discovered
+        through :meth:`discover_libs`, using their ``nooa.skills`` entry-point
+        metadata. TextSkills (SKILL.md directories) register as
+        cmd.<skill_id>. Python skills (.py files with Skill subclass) register
+        as ext.<name>.
 
         Args:
-            dirs: List of directories to scan.
+            dirs: List of skill roots to scan.
         """
         from pathlib import Path
 
-        for skills_dir in dirs:
-            skills_dir = Path(skills_dir)
-            if not skills_dir.is_dir():
-                continue
+        skill_roots = [Path(path) for path in dirs if Path(path).is_dir()]
+        for skills_dir in skill_roots:
+            self.discover_libs(skills_dir)
             for entry in skills_dir.iterdir():
                 if entry.is_dir():
                     skill_md = entry / "SKILL.md"
@@ -297,7 +382,7 @@ class SkillRegistry(Skill):
                         skill_md = entry / "skill.md"
                     if skill_md.exists():
                         self._register_text_skill(entry)
-                elif entry.is_file() and entry.suffix == ".py" and not entry.name.startswith("_"):
+                elif _is_python_skill_file(entry):
                     self._register_python_skill(entry)
 
     def _register_text_skill(self, entry: "Path") -> None:
@@ -309,22 +394,40 @@ class SkillRegistry(Skill):
             reg_name = f"cmd.{skill.id}"
             if reg_name not in self._loaded:
                 self.register(reg_name, skill)
+                self._sources[reg_name] = _SkillSource("text", entry.resolve())
         except Exception:
             logger.warning("TextSkill %s skipped", entry, exc_info=True)
 
     def _register_python_skill(self, entry: "Path") -> None:
         """Register a Python skill from a .py file."""
 
+        module_name: str | None = None
         try:
-            skill = _load_python_skill(entry)
+            skill, module_name = _load_python_skill(entry, namespace=self._next_namespace())
             if skill is not None:
                 skill._source_dir = entry.parent
                 name = entry.stem.replace("-", "_").replace(" ", "_")
                 reg_name = f"ext.{name}"
                 if reg_name not in self._loaded:
                     self.register(reg_name, skill)
+                    if module_name is not None:
+                        self._python_modules[module_name] = sys.modules[module_name]
+                    self._sources[reg_name] = _SkillSource(
+                        "python",
+                        entry.resolve(),
+                        module_name=module_name,
+                    )
+                elif module_name is not None:
+                    sys.modules.pop(module_name, None)
         except Exception:
+            if module_name is not None:
+                sys.modules.pop(module_name, None)
             logger.warning("Python skill %s skipped", entry, exc_info=True)
+
+    def _next_namespace(self) -> str:
+        """Return an agent-local generation name for a freshly loaded module."""
+        self._load_generation += 1
+        return f"{id(self):x}_{self._load_generation:x}"
 
     # ------------------------------------------------------------------
     # Loading
@@ -342,6 +445,7 @@ class SkillRegistry(Skill):
         args must be constructed manually and registered via register().
         """
         matched = self._match(patterns, set(self._discovered.keys()))
+        changed = False
         for name in matched:
             if name in self._loaded:
                 continue
@@ -372,9 +476,13 @@ class SkillRegistry(Skill):
                 skill.attach(self._agent)
                 self._loaded.add(name)
                 self._attr_map[name] = attr_name
+                self._load_order.append(name)
+                changed = True
                 logger.info("Loaded skill %s as self.%s", name, attr_name)
             except Exception:
                 logger.warning("Failed to load skill %s", name, exc_info=True)
+        if changed:
+            self._refresh_host_commands()
 
     def register(
         self, name: str, skill_or_cls: "Skill | type[Skill] | None" = None, /, **kwargs
@@ -421,11 +529,25 @@ class SkillRegistry(Skill):
                     skill.detach()
             if existing_agent is not self._agent:
                 skill.attach(self._agent)
+        newly_loaded = name not in self._loaded
         self._loaded.add(name)
         self._attr_map[name] = attr
+        if newly_loaded:
+            self._load_order.append(name)
         if name not in self._discovered:
             category = name.split(".")[0] if "." in name else ""
             self._discovered[name] = _SkillEntry(name=name, entry_point=None, category=category)
+        self._refresh_host_commands()
+
+    def _refresh_host_commands(self) -> None:
+        """Notify an attached interactive host that loaded commands changed."""
+        command_registry = getattr(self._agent, "_command_registry", None)
+        if command_registry is None or not hasattr(command_registry, "refresh_skill_commands"):
+            return
+        try:
+            command_registry.refresh_skill_commands()
+        except Exception:
+            logger.debug("Failed to refresh host slash commands", exc_info=True)
 
     # ------------------------------------------------------------------
     # Activation
@@ -634,13 +756,79 @@ class SkillRegistry(Skill):
         if skill is None:
             return f"Skill {name!r} has no instance on agent"
 
+        source = self._sources.get(name)
+        if source is not None:
+            return await self._reload_from_source(name, attr, source)
+
         mod_name = type(skill).__module__
         # For package modules (e.g. "excalidraw.__init__"), use the top-level package
         top_pkg = mod_name.split(".")[0]
 
         if top_pkg in self._NO_RELOAD or top_pkg.startswith("_"):
             return await self._reload_single_module(name, attr, skill, mod_name)
-        return await self._reload_package(name, attr, top_pkg)
+        return await self._reload_package(
+            name,
+            attr,
+            top_pkg,
+            mod_name,
+            type(skill).__name__,
+        )
+
+    async def _reload_from_source(
+        self,
+        name: str,
+        attr: str,
+        source: _SkillSource,
+    ) -> str:
+        """Construct fresh source code and swap only this agent's skill object."""
+        import asyncio
+
+        if source.kind == "text":
+            try:
+                new_skill = TextSkill(path=source.path)
+            except Exception as exc:
+                return f"Reload failed for {name}: {exc}"
+            return await self._install_reloaded_instance(name, attr, new_skill)
+
+        if source.kind == "python":
+            new_skill, module_name = await asyncio.to_thread(
+                _load_python_skill,
+                source.path,
+                namespace=self._next_namespace(),
+            )
+            if new_skill is None or module_name is None:
+                return f"Reload failed for {name}: could not load {source.path}"
+            new_skill._source_dir = source.path.parent
+            result = await self._install_reloaded_instance(name, attr, new_skill)
+            if not result.startswith("Reloaded "):
+                sys.modules.pop(module_name, None)
+                return result
+
+            previous_name = source.module_name
+            previous_module = self._python_modules.pop(previous_name, None)
+            if previous_name is not None and sys.modules.get(previous_name) is previous_module:
+                sys.modules.pop(previous_name, None)
+            self._python_modules[module_name] = sys.modules[module_name]
+            self._sources[name] = _SkillSource(
+                "python",
+                source.path,
+                module_name=module_name,
+            )
+            return result
+
+        try:
+            new_skill = await asyncio.to_thread(
+                self._import_lib,
+                source.path,
+                source.path.name,
+                source.target,
+            )
+        except Exception as exc:
+            return f"Reload failed for {name}: {exc}"
+        if new_skill is None:
+            return f"Reload failed for {name}: {source.path} does not export a Skill"
+        new_skill._source_dir = source.path
+        return await self._install_reloaded_instance(name, attr, new_skill)
 
     async def _detach_old_for_reload(self, attr: str) -> tuple[Any, bool]:
         """Detach the existing agent skill before reloading its module code."""
@@ -668,7 +856,31 @@ class SkillRegistry(Skill):
                     exc_info=True,
                 )
 
-    async def _reload_package(self, name: str, attr: str, top_pkg: str) -> str:
+    async def _reload_package(
+        self,
+        name: str,
+        attr: str,
+        top_pkg: str,
+        module_name: str,
+        class_name: str,
+    ) -> str:
+        """Reload a package skill that has no explicit local source recipe."""
+        return await self._reload_package_exclusive(
+            name,
+            attr,
+            top_pkg,
+            module_name,
+            class_name,
+        )
+
+    async def _reload_package_exclusive(
+        self,
+        name: str,
+        attr: str,
+        top_pkg: str,
+        module_name: str,
+        class_name: str,
+    ) -> str:
         """Purge and re-import an entire top-level package (user/lib skills)."""
         import asyncio
         import importlib
@@ -685,29 +897,60 @@ class SkillRegistry(Skill):
         try:
             # Clear all submodules so reimport gets fresh code from disk
             prefix = top_pkg + "."
-            for key in [k for k in _sys.modules if k == top_pkg or k.startswith(prefix)]:
+            old_modules = {
+                key: value
+                for key, value in _sys.modules.items()
+                if key == top_pkg or key.startswith(prefix)
+            }
+            for key in old_modules:
                 del _sys.modules[key]
-            mod = await asyncio.to_thread(importlib.import_module, top_pkg)
-            # Find the Skill subclass in the reloaded module
+            mod = await asyncio.to_thread(importlib.import_module, module_name)
             from nooa.skill import Skill as _Skill
         except Exception as e:
+            self._restore_package_modules(_sys.modules, top_pkg, old_modules)
             await self._restore_old_after_reload_failure(name, old_skill, old_detached)
             return f"Reload failed for {name}: {e}"
 
-        for obj in vars(mod).values():
-            if isinstance(obj, type) and issubclass(obj, _Skill) and obj is not _Skill:
-                try:
-                    return await self._install_reloaded(
-                        name,
-                        attr,
-                        obj,
-                        old_skill=old_skill,
-                        old_detached=old_detached,
-                    )
-                except Exception as e:
-                    return f"Reload failed for {name}: {e}"
+        new_class = getattr(mod, class_name, None)
+        if (
+            isinstance(new_class, type)
+            and issubclass(new_class, _Skill)
+            and new_class is not _Skill
+        ):
+            try:
+                result = await self._install_reloaded(
+                    name,
+                    attr,
+                    new_class,
+                    old_skill=old_skill,
+                    old_detached=old_detached,
+                )
+                if result.startswith("Reload failed") or result.startswith("Skill "):
+                    self._restore_package_modules(_sys.modules, top_pkg, old_modules)
+                    if result.startswith("Skill "):
+                        return f"Reload failed for {name}: {result}"
+                return result
+            except Exception as e:
+                self._restore_package_modules(_sys.modules, top_pkg, old_modules)
+                return f"Reload failed for {name}: {e}"
+        self._restore_package_modules(_sys.modules, top_pkg, old_modules)
         await self._restore_old_after_reload_failure(name, old_skill, old_detached)
-        return f"Reloaded module {top_pkg} but no Skill subclass found"
+        return (
+            f"Reload failed for {name}: reloaded module {module_name!r} "
+            f"has no Skill class {class_name!r}"
+        )
+
+    @staticmethod
+    def _restore_package_modules(
+        modules: dict[str, Any],
+        top_pkg: str,
+        previous: dict[str, Any],
+    ) -> None:
+        """Restore the exact pre-reload package tree after a failed swap."""
+        prefix = top_pkg + "."
+        for key in [key for key in modules if key == top_pkg or key.startswith(prefix)]:
+            del modules[key]
+        modules.update(previous)
 
     async def _reload_single_module(self, name: str, attr: str, skill: Any, mod_name: str) -> str:
         """Reload only the skill's own leaf module via ``importlib.reload``.
@@ -799,14 +1042,44 @@ class SkillRegistry(Skill):
         except Exception:
             await self._restore_old_after_reload_failure(name, old_skill, old_detached)
             raise
+        return await self._install_reloaded_instance(
+            name,
+            attr,
+            new_skill,
+            old_skill=old_skill,
+            old_detached=old_detached,
+        )
+
+    async def _install_reloaded_instance(
+        self,
+        name: str,
+        attr: str,
+        new_skill: Any,
+        *,
+        old_skill: Any | None = None,
+        old_detached: bool = False,
+    ) -> str:
+        """Atomically replace one agent's skill with a prepared local object."""
+        if old_skill is None:
+            old_skill = getattr(self._agent, attr, None)
+        if not old_detached:
+            try:
+                old_skill, old_detached = await self._detach_old_for_reload(attr)
+            except Exception as exc:
+                await self._restore_old_after_reload_failure(
+                    name,
+                    old_skill,
+                    old_skill is not None,
+                )
+                return f"Reload failed for {name}: {exc}"
         try:
             if hasattr(new_skill, "attach"):
                 result = new_skill.attach(self._agent)
                 if inspect.isawaitable(result):
                     await result
-        except Exception:
+        except Exception as exc:
             await self._restore_old_after_reload_failure(name, old_skill, old_detached)
-            raise
+            return f"Reload failed for {name}: {exc}"
         if name in self._activated:
             self._unregister_context_block(name)
         setattr(self._agent, attr, new_skill)
@@ -820,6 +1093,65 @@ class SkillRegistry(Skill):
             except Exception:
                 pass
         return f"Reloaded {name} (self.{attr})"
+
+    async def aclose(self) -> None:
+        """Detach this agent's skills and release its synthetic Python modules."""
+        detach_order: list[str] = []
+        visited: set[str] = set()
+
+        def visit(name: str) -> None:
+            if name in visited:
+                return
+            visited.add(name)
+            # Visit every dependent before the requirement it can still use.
+            for candidate in reversed(self._load_order):
+                attr = self._attr_map.get(candidate)
+                skill = getattr(self._agent, attr, None) if attr is not None else None
+                if name in getattr(skill, "requires", ()):
+                    visit(candidate)
+            detach_order.append(name)
+
+        for name in reversed(self._load_order):
+            visit(name)
+
+        for name in detach_order:
+            attr = self._attr_map.get(name)
+            skill = getattr(self._agent, attr, None) if attr is not None else None
+            if name in self._activated:
+                self._unregister_context_block(name)
+            if skill is not None and hasattr(skill, "detach"):
+                try:
+                    result = skill.detach()
+                    if inspect.isawaitable(result):
+                        await result
+                except Exception:
+                    logger.warning("Failed to detach skill %s during shutdown", name, exc_info=True)
+            if attr is not None and getattr(self._agent, attr, None) is skill:
+                try:
+                    delattr(self._agent, attr)
+                except AttributeError:
+                    pass
+        self._loaded.clear()
+        self._activated.clear()
+        self._attr_map.clear()
+        self._load_order.clear()
+        self._sources.clear()
+
+        for module_name, module in tuple(self._python_modules.items()):
+            if sys.modules.get(module_name) is module:
+                sys.modules.pop(module_name, None)
+        self._python_modules.clear()
+
+    def close(self) -> None:
+        """Synchronous shutdown helper for registries outside an event loop."""
+        import asyncio
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(self.aclose())
+            return
+        raise RuntimeError("SkillRegistry.close() cannot run on an event loop; await aclose()")
 
     # ------------------------------------------------------------------
     # Access

--- a/src/nooa/skill_registry.py
+++ b/src/nooa/skill_registry.py
@@ -129,10 +129,10 @@ def skill_from_module(module: Any, module_name: str, source: str = "") -> "Skill
 def _load_python_skill(
     path: Path,
     *,
-    namespace: str = "",
+    module_instance_key: str = "",
 ) -> "tuple[Skill | None, str | None]":
     """Import *path* and extract a ``Skill`` via :func:`skill_from_module`."""
-    suffix = f"_{namespace}" if namespace else ""
+    suffix = f"_{module_instance_key}" if module_instance_key else ""
     module_name = (
         f"_nooa_skill_{path.stem}_{abs(hash(str(path.resolve()))) & 0xFFFFFFFF:08x}{suffix}"
     )
@@ -403,7 +403,10 @@ class SkillRegistry(Skill):
 
         module_name: str | None = None
         try:
-            skill, module_name = _load_python_skill(entry, namespace=self._next_namespace())
+            skill, module_name = _load_python_skill(
+                entry,
+                module_instance_key=self._next_module_instance_key(),
+            )
             if skill is not None:
                 skill._source_dir = entry.parent
                 name = entry.stem.replace("-", "_").replace(" ", "_")
@@ -424,8 +427,8 @@ class SkillRegistry(Skill):
                 sys.modules.pop(module_name, None)
             logger.warning("Python skill %s skipped", entry, exc_info=True)
 
-    def _next_namespace(self) -> str:
-        """Return an agent-local generation name for a freshly loaded module."""
+    def _next_module_instance_key(self) -> str:
+        """Return a unique key for a freshly loaded standalone skill module."""
         self._load_generation += 1
         return f"{id(self):x}_{self._load_generation:x}"
 
@@ -794,7 +797,7 @@ class SkillRegistry(Skill):
             new_skill, module_name = await asyncio.to_thread(
                 _load_python_skill,
                 source.path,
-                namespace=self._next_namespace(),
+                module_instance_key=self._next_module_instance_key(),
             )
             if new_skill is None or module_name is None:
                 return f"Reload failed for {name}: could not load {source.path}"

--- a/src/nooa/skill_registry.py
+++ b/src/nooa/skill_registry.py
@@ -7,6 +7,7 @@ import importlib.util
 import inspect
 import logging
 import sys
+import threading
 from dataclasses import dataclass
 from importlib.metadata import entry_points
 from pathlib import Path
@@ -17,6 +18,11 @@ from nooa.skill import Skill, TextSkill
 logger = logging.getLogger(__name__)
 
 ENTRY_POINT_GROUP = "nooa.skills"
+
+# Package imports mutate process-global import state. Serialize mutations made
+# by registries, including rollback, so concurrent registry operations cannot
+# observe one another's temporary sys.path/sys.modules state.
+_PACKAGE_IMPORT_LOCK = threading.RLock()
 
 
 @dataclass(frozen=True)
@@ -310,53 +316,47 @@ class SkillRegistry(Skill):
         Python references. ``sys.modules`` is only refreshed so this load sees
         current source; it is not treated as NOOA-owned lifecycle state.
         """
-        import importlib
-        import sys as _sys
-
         module_name, _, attr_path = (target or lib_name).partition(":")
         top_package = module_name.split(".", 1)[0]
         search_paths = _package_search_paths(lib_dir, top_package)
         prefix = top_package + "."
-        previous_modules = {
-            key: module
-            for key, module in _sys.modules.items()
-            if key == top_package or key.startswith(prefix)
-        }
-        original_path = list(_sys.path)
-        for key in previous_modules:
-            _sys.modules.pop(key, None)
-        _sys.path[:] = [*search_paths, *(p for p in original_path if p not in search_paths)]
-        importlib.invalidate_caches()
-        try:
-            module = importlib.import_module(module_name)
+        with _PACKAGE_IMPORT_LOCK:
+            previous_modules = {
+                key: module
+                for key, module in sys.modules.items()
+                if key == top_package or key.startswith(prefix)
+            }
+            original_path = list(sys.path)
+            for key in previous_modules:
+                sys.modules.pop(key, None)
+            sys.path[:] = [*search_paths, *(p for p in original_path if p not in search_paths)]
+            importlib.invalidate_caches()
+            try:
+                module = importlib.import_module(module_name)
 
-            if attr_path:
-                value: Any = module
-                for part in attr_path.split("."):
-                    value = getattr(value, part)
-                if isinstance(value, Skill):
-                    return value
-                if inspect.isclass(value) and issubclass(value, Skill):
-                    return value()
-                raise TypeError(f"Library {lib_name!r} target {target!r} is not a Skill")
+                if attr_path:
+                    value: Any = module
+                    for part in attr_path.split("."):
+                        value = getattr(value, part)
+                    if isinstance(value, Skill):
+                        return value
+                    if inspect.isclass(value) and issubclass(value, Skill):
+                        return value()
+                    raise TypeError(f"Library {lib_name!r} target {target!r} is not a Skill")
 
-            skill = skill_from_module(
-                module,
-                module_name,
-                source=f"Library {lib_name!r}",
-            )
-            if skill is None:
-                raise TypeError(f"Library {lib_name!r} does not export a Skill")
-            return skill
-        except Exception:
-            for key in [
-                key for key in _sys.modules if key == top_package or key.startswith(prefix)
-            ]:
-                _sys.modules.pop(key, None)
-            _sys.modules.update(previous_modules)
-            raise
-        finally:
-            _sys.path[:] = original_path
+                skill = skill_from_module(
+                    module,
+                    module_name,
+                    source=f"Library {lib_name!r}",
+                )
+                if skill is None:
+                    raise TypeError(f"Library {lib_name!r} does not export a Skill")
+                return skill
+            except Exception:
+                self._restore_package_modules(sys.modules, top_package, previous_modules)
+                raise
+            finally:
+                sys.path[:] = original_path
 
     def discover_skills_dirs(self, dirs: "list[Path]") -> None:
         """Scan skill roots for packaged libraries, TextSkills, and Python skills.
@@ -449,7 +449,7 @@ class SkillRegistry(Skill):
         """
         matched = self._match(patterns, set(self._discovered.keys()))
         changed = False
-        for name in matched:
+        for name in sorted(matched):
             if name in self._loaded:
                 continue
             entry = self._discovered[name]
@@ -819,6 +819,15 @@ class SkillRegistry(Skill):
             )
             return result
 
+        module_name = (source.target or source.path.name).partition(":")[0]
+        top_package = module_name.split(".", 1)[0]
+        with _PACKAGE_IMPORT_LOCK:
+            prefix = top_package + "."
+            previous_modules = {
+                key: value
+                for key, value in sys.modules.items()
+                if key == top_package or key.startswith(prefix)
+            }
         try:
             new_skill = await asyncio.to_thread(
                 self._import_lib,
@@ -831,7 +840,10 @@ class SkillRegistry(Skill):
         if new_skill is None:
             return f"Reload failed for {name}: {source.path} does not export a Skill"
         new_skill._source_dir = source.path
-        return await self._install_reloaded_instance(name, attr, new_skill)
+        result = await self._install_reloaded_instance(name, attr, new_skill)
+        if not result.startswith("Reloaded "):
+            self._restore_package_modules(sys.modules, top_package, previous_modules)
+        return result
 
     async def _detach_old_for_reload(self, attr: str) -> tuple[Any, bool]:
         """Detach the existing agent skill before reloading its module code."""
@@ -897,6 +909,7 @@ class SkillRegistry(Skill):
         except Exception as e:
             await self._restore_old_after_reload_failure(name, old_skill, old_skill is not None)
             return f"Reload failed for {name}: {e}"
+        old_modules: dict[str, Any] = {}
         try:
             # Clear all submodules so reimport gets fresh code from disk
             prefix = top_pkg + "."
@@ -951,9 +964,10 @@ class SkillRegistry(Skill):
     ) -> None:
         """Restore the exact pre-reload package tree after a failed swap."""
         prefix = top_pkg + "."
-        for key in [key for key in modules if key == top_pkg or key.startswith(prefix)]:
-            del modules[key]
-        modules.update(previous)
+        with _PACKAGE_IMPORT_LOCK:
+            for key in [key for key in modules if key == top_pkg or key.startswith(prefix)]:
+                del modules[key]
+            modules.update(previous)
 
     async def _reload_single_module(self, name: str, attr: str, skill: Any, mod_name: str) -> str:
         """Reload only the skill's own leaf module via ``importlib.reload``.
@@ -1144,6 +1158,12 @@ class SkillRegistry(Skill):
             if sys.modules.get(module_name) is module:
                 sys.modules.pop(module_name, None)
         self._python_modules.clear()
+
+        if self.context_block and hasattr(self._agent, "context_manager"):
+            key, _ = self.context_block
+            cm = self._agent.context_manager
+            if key in cm and key not in cm.protected_keys:
+                cm.pop(key, None)
 
     def close(self) -> None:
         """Synchronous shutdown helper for registries outside an event loop."""

--- a/src/nooa/skill_registry.py
+++ b/src/nooa/skill_registry.py
@@ -52,8 +52,8 @@ _RESERVED_ATTRS = frozenset(
 def _package_search_paths(lib_dir: Path, top_package: str) -> tuple[str, ...]:
     """Find import roots for flat, package, and src package layouts."""
     candidates = [lib_dir.parent]
-    checkout_is_package = lib_dir.name == top_package and (lib_dir / "__init__.py").is_file()
-    if not checkout_is_package and (
+    lib_dir_is_package = lib_dir.name == top_package and (lib_dir / "__init__.py").is_file()
+    if not lib_dir_is_package and (
         (lib_dir / top_package).is_dir() or (lib_dir / f"{top_package}.py").is_file()
     ):
         candidates.append(lib_dir)
@@ -186,6 +186,23 @@ class SkillRegistry(Skill):
 
         self.skills.load(['nemo.*'])
         self.skills.activate(['nemo.shell', 'nemo.repo'])
+
+    Cleanup of superseded skills is deliberately split in two:
+
+    * **Skill objects and their classes are never torn down.** A reload
+      builds a new object; agents holding the old one keep working against
+      it, and it is collected once the last reference goes away. Lifetime
+      is by reference, not by registry bookkeeping.
+    * **Synthetic modules are tracked and reclaimed.** Every standalone
+      ``.py`` load gets a unique module name recorded in
+      ``_python_modules``. :meth:`reload` drops the module it replaces and
+      :meth:`shutdown` drops all of them, each only when ``sys.modules``
+      still holds the object this registry installed, so a third party that
+      replaced the entry is left alone. Failed loads unwind immediately.
+
+    Package skills follow the same rule for objects, but refresh
+    ``sys.modules`` under the top-level package on reload instead of using
+    a synthetic name, restoring the previous state if the reload fails.
     """
 
     __agentdoc_skip__ = True
@@ -296,8 +313,8 @@ class SkillRegistry(Skill):
             eps = data.get("project", {}).get("entry-points", {}).get(ENTRY_POINT_GROUP, {})
             if eps:
                 # One directory is one library skill. Its entry-point value is
-                # authoritative: the import package need not match the checkout
-                # directory or project distribution name.
+                # authoritative: the import package need not match the library
+                # directory name or the project distribution name.
                 name, target = next(iter(eps.items()))
                 return name, target if isinstance(target, str) else None
         except Exception:

--- a/src/nooa/skill_registry.py
+++ b/src/nooa/skill_registry.py
@@ -309,6 +309,7 @@ class SkillRegistry(Skill):
         lib_dir: "Path",
         lib_name: str,
         target: str | None = None,
+        previous_module_state: dict[str, Any] | None = None,
     ) -> "Skill | None":
         """Freshly import a library package and construct one local Skill object.
 
@@ -326,6 +327,8 @@ class SkillRegistry(Skill):
                 for key, module in sys.modules.items()
                 if key == top_package or key.startswith(prefix)
             }
+            if previous_module_state is not None:
+                previous_module_state.update(previous_modules)
             original_path = list(sys.path)
             for key in previous_modules:
                 sys.modules.pop(key, None)
@@ -821,19 +824,14 @@ class SkillRegistry(Skill):
 
         module_name = (source.target or source.path.name).partition(":")[0]
         top_package = module_name.split(".", 1)[0]
-        with _PACKAGE_IMPORT_LOCK:
-            prefix = top_package + "."
-            previous_modules = {
-                key: value
-                for key, value in sys.modules.items()
-                if key == top_package or key.startswith(prefix)
-            }
+        previous_modules: dict[str, Any] = {}
         try:
             new_skill = await asyncio.to_thread(
                 self._import_lib,
                 source.path,
                 source.path.name,
                 source.target,
+                previous_modules,
             )
         except Exception as exc:
             return f"Reload failed for {name}: {exc}"
@@ -888,6 +886,25 @@ class SkillRegistry(Skill):
             class_name,
         )
 
+    @staticmethod
+    def _import_reloaded_package(top_pkg: str, module_name: str) -> tuple[Any, dict[str, Any]]:
+        """Purge and import one package while holding the import-state lock."""
+        prefix = top_pkg + "."
+        old_modules: dict[str, Any] = {}
+        with _PACKAGE_IMPORT_LOCK:
+            try:
+                old_modules = {
+                    key: value
+                    for key, value in sys.modules.items()
+                    if key == top_pkg or key.startswith(prefix)
+                }
+                for key in old_modules:
+                    del sys.modules[key]
+                return importlib.import_module(module_name), old_modules
+            except Exception:
+                SkillRegistry._restore_package_modules(sys.modules, top_pkg, old_modules)
+                raise
+
     async def _reload_package_exclusive(
         self,
         name: str,
@@ -898,10 +915,8 @@ class SkillRegistry(Skill):
     ) -> str:
         """Purge and re-import an entire top-level package (user/lib skills)."""
         import asyncio
-        import importlib
-        import sys as _sys
 
-        if top_pkg not in _sys.modules:
+        if top_pkg not in sys.modules:
             return f"Package {top_pkg} not in sys.modules — cannot reload"
         old_skill = getattr(self._agent, attr, None)
         try:
@@ -911,28 +926,15 @@ class SkillRegistry(Skill):
             return f"Reload failed for {name}: {e}"
         old_modules: dict[str, Any] = {}
         try:
-            # Clear all submodules so reimport gets fresh code from disk
-            prefix = top_pkg + "."
-            old_modules = {
-                key: value
-                for key, value in _sys.modules.items()
-                if key == top_pkg or key.startswith(prefix)
-            }
-            for key in old_modules:
-                del _sys.modules[key]
-            mod = await asyncio.to_thread(importlib.import_module, module_name)
-            from nooa.skill import Skill as _Skill
+            mod, old_modules = await asyncio.to_thread(
+                self._import_reloaded_package, top_pkg, module_name
+            )
         except Exception as e:
-            self._restore_package_modules(_sys.modules, top_pkg, old_modules)
             await self._restore_old_after_reload_failure(name, old_skill, old_detached)
             return f"Reload failed for {name}: {e}"
 
         new_class = getattr(mod, class_name, None)
-        if (
-            isinstance(new_class, type)
-            and issubclass(new_class, _Skill)
-            and new_class is not _Skill
-        ):
+        if isinstance(new_class, type) and issubclass(new_class, Skill) and new_class is not Skill:
             try:
                 result = await self._install_reloaded(
                     name,
@@ -942,14 +944,14 @@ class SkillRegistry(Skill):
                     old_detached=old_detached,
                 )
                 if result.startswith("Reload failed") or result.startswith("Skill "):
-                    self._restore_package_modules(_sys.modules, top_pkg, old_modules)
+                    self._restore_package_modules(sys.modules, top_pkg, old_modules)
                     if result.startswith("Skill "):
                         return f"Reload failed for {name}: {result}"
                 return result
             except Exception as e:
-                self._restore_package_modules(_sys.modules, top_pkg, old_modules)
+                self._restore_package_modules(sys.modules, top_pkg, old_modules)
                 return f"Reload failed for {name}: {e}"
-        self._restore_package_modules(_sys.modules, top_pkg, old_modules)
+        self._restore_package_modules(sys.modules, top_pkg, old_modules)
         await self._restore_old_after_reload_failure(name, old_skill, old_detached)
         return (
             f"Reload failed for {name}: reloaded module {module_name!r} "

--- a/tests/test_skill_registry.py
+++ b/tests/test_skill_registry.py
@@ -279,6 +279,14 @@ class TestContextBlockRegistration:
         assert "skills" in non_protected  # from SkillRegistry itself
         assert len(non_protected) == 1  # no block from the mock
 
+    @pytest.mark.asyncio
+    async def test_aclose_removes_registry_context_block(self, registry_ctx, agent_ctx):
+        assert "skills" in agent_ctx.context_manager
+
+        await registry_ctx.aclose()
+
+        assert "skills" not in agent_ctx.context_manager
+
     def test_skill_registry_registers_own_context_block(self, agent_ctx):
         """SkillRegistry itself has context_block and registers it on activate."""
         # SkillRegistry is registered on the agent as "skills" attr

--- a/tests/test_skill_registry_extended.py
+++ b/tests/test_skill_registry_extended.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for SkillRegistry — file-based discovery, deps, libs, reload."""
 
+import sys
 import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -36,7 +37,9 @@ def agent():
 @pytest.fixture
 def registry(agent):
     with patch("nooa.skill_registry.entry_points", return_value=[]):
-        return SkillRegistry(agent)
+        value = SkillRegistry(agent)
+        yield value
+        value.close()
 
 
 # ---------------------------------------------------------------------------
@@ -45,6 +48,28 @@ def registry(agent):
 
 
 class TestDiscoverSkillsDirs:
+    def test_packaged_and_text_skills_are_discovered_in_one_call(self, registry, tmp_path):
+        lib_dir = tmp_path / "workflow_lib"
+        lib_dir.mkdir()
+        (lib_dir / "pyproject.toml").write_text(
+            '[project]\nname = "workflow-lib"\n\n'
+            '[project.entry-points."nooa.skills"]\n'
+            '"nvzurich.workflow" = "workflow_lib:WorkflowSkill"\n'
+        )
+        (lib_dir / "__init__.py").write_text(
+            "from nooa.skill import Skill\n\nclass WorkflowSkill(Skill):\n    pass\n"
+        )
+        text_dir = tmp_path / "root-cause"
+        text_dir.mkdir()
+        (text_dir / "SKILL.md").write_text(
+            "---\nname: root-cause\ndescription: Diagnose a defect\n---\nFind the cause.\n"
+        )
+
+        registry.discover_skills_dirs([tmp_path])
+
+        assert "nvzurich.workflow" in registry.loaded()
+        assert "cmd.root-cause" in registry.loaded()
+
     def test_python_skill_file_discovered(self, registry, agent, tmp_path):
         """A .py file with a Skill subclass is discovered as ext.<name>."""
         skill_file = tmp_path / "my_tool.py"
@@ -60,6 +85,52 @@ class TestDiscoverSkillsDirs:
         registry.discover_skills_dirs([tmp_path])
         assert "ext.my_tool" in registry.loaded()
         assert hasattr(agent, "my_tool")
+
+    @pytest.mark.asyncio
+    async def test_standalone_python_skill_detaches_and_releases_module(self, tmp_path):
+        marker = tmp_path / "detached"
+        skill_file = tmp_path / "resource.py"
+        skill_file.write_text(
+            "from pathlib import Path\n"
+            "from nooa.skill import Skill\n\n"
+            "class ResourceSkill(Skill):\n"
+            "    def detach(self):\n"
+            f"        Path({str(marker)!r}).write_text('yes')\n"
+            "        super().detach()\n"
+        )
+        value = SkillRegistry(_FakeAgent())
+        value.discover_skills_dirs([tmp_path])
+        module_name = type(value["ext.resource"]).__module__
+
+        assert module_name in sys.modules
+        await value.aclose()
+
+        assert marker.read_text() == "yes"
+        assert module_name not in sys.modules
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("first_to_close", [0, 1])
+    async def test_standalone_python_modules_are_isolated_per_live_registry(
+        self, tmp_path, first_to_close
+    ):
+        skill_file = tmp_path / "isolated.py"
+        skill_file.write_text(
+            "from nooa.skill import Skill\n\nclass IsolatedSkill(Skill):\n    value = 'live'\n"
+        )
+        registries = [SkillRegistry(_FakeAgent()), SkillRegistry(_FakeAgent())]
+        for value in registries:
+            value.discover_skills_dirs([tmp_path])
+        modules = [type(value["ext.isolated"]).__module__ for value in registries]
+
+        assert modules[0] != modules[1]
+        await registries[first_to_close].aclose()
+        remaining = 1 - first_to_close
+        assert modules[first_to_close] not in sys.modules
+        assert modules[remaining] in sys.modules
+        assert registries[remaining]["ext.isolated"].value == "live"
+
+        await registries[remaining].aclose()
+        assert modules[remaining] not in sys.modules
 
     def test_underscore_files_skipped(self, registry, tmp_path):
         """Files starting with _ are not loaded."""
@@ -102,6 +173,161 @@ class TestDiscoverSkillsDirs:
 
 
 class TestDiscoverLibs:
+    def test_agents_load_local_objects_from_different_checkouts(self, tmp_path):
+        def write_checkout(root: Path, value: str) -> Path:
+            lib_dir = root / "workflow-checkout"
+            package = lib_dir / "src" / "shared_workflow"
+            package.mkdir(parents=True)
+            (lib_dir / "pyproject.toml").write_text(
+                '[project]\nname = "workflow-distribution"\n\n'
+                '[project.entry-points."nooa.skills"]\n'
+                '"test.workflow" = "shared_workflow:WorkflowSkill"\n'
+            )
+            (package / "__init__.py").write_text(
+                "from nooa.skill import Skill\n\n"
+                "class WorkflowSkill(Skill):\n"
+                f"    value = {value!r}\n"
+            )
+            return root
+
+        first_root = write_checkout(tmp_path / "first", "first")
+        second_root = write_checkout(tmp_path / "second", "second")
+        first = SkillRegistry(_FakeAgent())
+        second = SkillRegistry(_FakeAgent())
+        try:
+            first.discover_libs(first_root)
+            second.discover_libs(second_root)
+
+            assert first["test.workflow"].value == "first"
+            assert second["test.workflow"].value == "second"
+            assert first["test.workflow"] is not second["test.workflow"]
+        finally:
+            first.close()
+            second.close()
+
+    def test_same_checkout_creates_distinct_agent_local_objects(self, tmp_path):
+        lib_dir = tmp_path / "workflow-checkout"
+        package = lib_dir / "src" / "reference_workflow"
+        package.mkdir(parents=True)
+        (lib_dir / "pyproject.toml").write_text(
+            '[project]\nname = "workflow"\n\n'
+            '[project.entry-points."nooa.skills"]\n'
+            '"test.workflow" = "reference_workflow:WorkflowSkill"\n'
+        )
+        (package / "__init__.py").write_text(
+            "from nooa.skill import Skill\n\nclass WorkflowSkill(Skill):\n    value = 'shared'\n"
+        )
+        first = SkillRegistry(_FakeAgent())
+        second = SkillRegistry(_FakeAgent())
+        try:
+            first.discover_libs(tmp_path)
+            second.discover_libs(tmp_path)
+
+            assert first["test.workflow"] is not second["test.workflow"]
+            first.close()
+            assert second["test.workflow"].value == "shared"
+        finally:
+            first.close()
+            second.close()
+
+    @pytest.mark.asyncio
+    async def test_each_agent_reloads_its_own_package_object(self, tmp_path):
+        lib_dir = tmp_path / "shared-checkout"
+        package = lib_dir / "src" / "shared_reload_workflow"
+        package.mkdir(parents=True)
+        (lib_dir / "pyproject.toml").write_text(
+            '[project]\nname = "shared-reload"\n\n'
+            '[project.entry-points."nooa.skills"]\n'
+            '"test.shared" = "shared_reload_workflow:SharedSkill"\n'
+        )
+        (package / "__init__.py").write_text(
+            "from nooa.skill import Skill\nclass SharedSkill(Skill):\n    value = 'old'\n"
+        )
+        first = SkillRegistry(_FakeAgent())
+        second = SkillRegistry(_FakeAgent())
+        first.discover_libs(tmp_path)
+        second.discover_libs(tmp_path)
+        try:
+            assert first["test.shared"].value == "old"
+            assert second["test.shared"].value == "old"
+
+            module = package / "__init__.py"
+            module.write_text(
+                "from nooa.skill import Skill\n"
+                "class SharedSkill(Skill):\n    value = 'new-version'\n"
+            )
+            stat = module.stat()
+            import os
+
+            os.utime(module, (stat.st_atime + 2, stat.st_mtime + 2))
+
+            assert await first.reload("test.shared") == "Reloaded test.shared (self.shared)"
+            assert first["test.shared"].value == "new-version"
+            assert second["test.shared"].value == "old"
+
+            assert await second.reload("test.shared") == "Reloaded test.shared (self.shared)"
+            assert first["test.shared"].value == "new-version"
+            assert second["test.shared"].value == "new-version"
+            assert first["test.shared"] is not second["test.shared"]
+        finally:
+            await first.aclose()
+            await second.aclose()
+
+    def test_direct_module_entry_point_layout_is_importable(self, registry, tmp_path):
+        lib_dir = tmp_path / "workflow-checkout"
+        lib_dir.mkdir()
+        (lib_dir / "pyproject.toml").write_text(
+            '[project]\nname = "direct-workflow"\n\n'
+            '[project.entry-points."nooa.skills"]\n'
+            '"test.direct" = "direct_workflow:DirectSkill"\n'
+        )
+        (lib_dir / "direct_workflow.py").write_text(
+            "from nooa.skill import Skill\nclass DirectSkill(Skill):\n    value = 'direct'\n"
+        )
+
+        registry.discover_libs(tmp_path)
+
+        assert registry["test.direct"].value == "direct"
+
+    def test_package_with_same_named_module_preserves_package_precedence(self, registry, tmp_path):
+        lib_dir = tmp_path / "worktrees"
+        lib_dir.mkdir()
+        (lib_dir / "pyproject.toml").write_text(
+            '[project]\nname = "worktrees"\n\n'
+            '[project.entry-points."nooa.skills"]\n'
+            '"test.worktrees" = "worktrees.worktrees:Worktrees"\n'
+        )
+        (lib_dir / "__init__.py").write_text("")
+        (lib_dir / "worktrees.py").write_text(
+            "from nooa.skill import Skill\nclass Worktrees(Skill):\n    value = 'package'\n"
+        )
+
+        registry.discover_libs(tmp_path)
+
+        assert registry["test.worktrees"].value == "package"
+        assert type(registry["test.worktrees"]).__module__ == "worktrees.worktrees"
+
+    def test_entry_point_target_controls_import_package_and_class(self, registry, agent, tmp_path):
+        """Checkout, distribution, module, and Skill class names may all differ."""
+        lib_dir = tmp_path / "workflow-checkout"
+        package = lib_dir / "src" / "actual_workflow" / "commands"
+        package.mkdir(parents=True)
+        (lib_dir / "pyproject.toml").write_text(
+            '[project]\nname = "workflow-distribution"\n\n'
+            '[project.entry-points."nooa.skills"]\n'
+            '"nvzurich.workflow" = "actual_workflow.commands:WorkflowSkill"\n'
+        )
+        (package.parent / "__init__.py").write_text("")
+        (package / "__init__.py").write_text(
+            "from nooa.skill import Skill\n\nclass WorkflowSkill(Skill):\n    pass\n"
+        )
+
+        registry.discover_libs(tmp_path)
+
+        assert "nvzurich.workflow" in registry.loaded()
+        assert type(registry["nvzurich.workflow"]).__module__ == "actual_workflow.commands"
+        assert agent.workflow is registry["nvzurich.workflow"]
+
     def test_lib_with_pyproject_discovered(self, registry, agent, tmp_path):
         """A library with pyproject.toml and Skill subclass is registered."""
         lib_dir = tmp_path / "my_lib"
@@ -202,6 +428,242 @@ class TestResolveDeps:
 
 
 class TestReload:
+    @pytest.mark.asyncio
+    async def test_each_agent_reloads_its_own_text_skill(self, tmp_path):
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("---\nname: demo\ndescription: old description\n---\nold body\n")
+        first = SkillRegistry(_FakeAgent())
+        second = SkillRegistry(_FakeAgent())
+        first.discover_skills_dirs([tmp_path])
+        second.discover_skills_dirs([tmp_path])
+        try:
+            skill_md.write_text("---\nname: demo\ndescription: new description\n---\nnew body\n")
+
+            assert await first.reload("cmd.demo") == "Reloaded cmd.demo (self.demo)"
+            assert first["cmd.demo"].description == "new description"
+            assert second["cmd.demo"].description == "old description"
+
+            assert await second.reload("cmd.demo") == "Reloaded cmd.demo (self.demo)"
+            assert second["cmd.demo"].description == "new description"
+            assert first["cmd.demo"] is not second["cmd.demo"]
+        finally:
+            await first.aclose()
+            await second.aclose()
+
+    @pytest.mark.asyncio
+    async def test_each_agent_reloads_its_own_standalone_python_skill(self, tmp_path):
+        import os
+
+        skill_file = tmp_path / "demo.py"
+        skill_file.write_text(
+            "from nooa.skill import Skill\nclass Demo(Skill):\n    value = 'old'\n"
+        )
+        first = SkillRegistry(_FakeAgent())
+        second = SkillRegistry(_FakeAgent())
+        first.discover_skills_dirs([tmp_path])
+        second.discover_skills_dirs([tmp_path])
+        first_module = type(first["ext.demo"]).__module__
+        second_module = type(second["ext.demo"]).__module__
+        try:
+            skill_file.write_text(
+                "from nooa.skill import Skill\nclass Demo(Skill):\n    value = 'new'\n"
+            )
+            stat = skill_file.stat()
+            os.utime(skill_file, (stat.st_atime + 2, stat.st_mtime + 2))
+
+            assert await first.reload("ext.demo") == "Reloaded ext.demo (self.demo)"
+            assert first["ext.demo"].value == "new"
+            assert second["ext.demo"].value == "old"
+            assert first_module not in sys.modules
+            assert second_module in sys.modules
+
+            assert await second.reload("ext.demo") == "Reloaded ext.demo (self.demo)"
+            assert second["ext.demo"].value == "new"
+            assert second_module not in sys.modules
+            assert first["ext.demo"] is not second["ext.demo"]
+        finally:
+            await first.aclose()
+            await second.aclose()
+
+    @pytest.mark.asyncio
+    async def test_nested_entry_point_module_reloads_its_declared_skill(self, registry, tmp_path):
+        lib_dir = tmp_path / "nested-checkout"
+        package = lib_dir / "src" / "nested_reload_workflow"
+        package.mkdir(parents=True)
+        (lib_dir / "pyproject.toml").write_text(
+            '[project]\nname = "nested-reload"\n\n'
+            '[project.entry-points."nooa.skills"]\n'
+            '"test.nested" = "nested_reload_workflow.commands:NestedSkill"\n'
+        )
+        (package / "__init__.py").write_text("")
+        commands = package / "commands.py"
+        commands.write_text(
+            "from nooa.skill import Skill\nclass NestedSkill(Skill):\n    value = 'old'\n"
+        )
+        registry.discover_libs(tmp_path)
+        assert registry["test.nested"].value == "old"
+        commands.write_text(
+            "from nooa.skill import Skill\nclass NestedSkill(Skill):\n    value = 'new-version'\n"
+        )
+        stat = commands.stat()
+        commands.touch()
+        import os
+
+        os.utime(commands, (stat.st_atime + 2, stat.st_mtime + 2))
+
+        result = await registry.reload("test.nested")
+
+        assert result == "Reloaded test.nested (self.nested)"
+        assert registry["test.nested"].value == "new-version"
+
+    @pytest.mark.asyncio
+    async def test_shutdown_detaches_later_skills_before_their_dependencies(self):
+        seen: list[str] = []
+
+        class Dependency(Skill):
+            def detach(self):
+                seen.append("dependency")
+                super().detach()
+
+        class Dependent(Skill):
+            def detach(self):
+                assert hasattr(self._agent, "dependency")
+                seen.append("dependent")
+                super().detach()
+
+        agent = _FakeAgent()
+        value = SkillRegistry(agent)
+        value.register("test.dependency", Dependency())
+        value.register("test.dependent", Dependent())
+
+        await value.aclose()
+
+        assert seen == ["dependent", "dependency"]
+
+    @pytest.mark.asyncio
+    async def test_shutdown_detaches_auto_loaded_dependent_before_requirement(self):
+        seen: list[str] = []
+
+        class Requirement(Skill):
+            def detach(self):
+                seen.append("requirement")
+                super().detach()
+
+        class Dependent(Skill):
+            requires = ("test.requirement",)
+
+            def detach(self):
+                assert hasattr(self._agent, "requirement")
+                seen.append("dependent")
+                super().detach()
+
+        requirement_ep = MagicMock()
+        requirement_ep.name = "test.requirement"
+        requirement_ep.load.return_value = Requirement
+        agent = _FakeAgent()
+        with patch("nooa.skill_registry.entry_points", return_value=[requirement_ep]):
+            value = SkillRegistry(agent)
+        value.register("test.dependent", Dependent())
+        value.activate(["test.dependent"])
+        assert value._load_order == ["test.dependent", "test.requirement"]
+
+        await value.aclose()
+
+        assert seen == ["dependent", "requirement"]
+
+    @pytest.mark.asyncio
+    async def test_failed_package_reload_restores_lazy_submodule_imports(self, registry, tmp_path):
+        lib_dir = tmp_path / "lazy-checkout"
+        package = lib_dir / "src" / "lazy_reload_workflow"
+        package.mkdir(parents=True)
+        (lib_dir / "pyproject.toml").write_text(
+            '[project]\nname = "lazy-reload"\n\n'
+            '[project.entry-points."nooa.skills"]\n'
+            '"test.lazy" = "lazy_reload_workflow:LazySkill"\n'
+        )
+        init = package / "__init__.py"
+        init.write_text(
+            "from nooa.skill import Skill\n\n"
+            "class LazySkill(Skill):\n"
+            "    def value(self):\n"
+            "        from lazy_reload_workflow.helper import VALUE\n"
+            "        return VALUE\n"
+        )
+        (package / "helper.py").write_text("VALUE = 'still-works'\n")
+        registry.discover_libs(tmp_path)
+        old_skill = registry["test.lazy"]
+        init.write_text("this is invalid Python !!!\n")
+
+        result = await registry.reload("test.lazy")
+
+        assert result.startswith("Reload failed for test.lazy:")
+        assert registry["test.lazy"] is old_skill
+        assert old_skill.value() == "still-works"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("constructor", ["runtime-error", "requires-argument"])
+    async def test_failed_skill_swap_restores_previous_package_tree(
+        self, registry, tmp_path, constructor
+    ):
+        lib_dir = tmp_path / "swap-checkout"
+        package = lib_dir / "src" / "swap_reload_workflow"
+        package.mkdir(parents=True)
+        (lib_dir / "pyproject.toml").write_text(
+            '[project]\nname = "swap-reload"\n\n'
+            '[project.entry-points."nooa.skills"]\n'
+            '"test.swap" = "swap_reload_workflow:SwapSkill"\n'
+        )
+        init = package / "__init__.py"
+        init.write_text(
+            "from nooa.skill import Skill\n\n"
+            "class SwapSkill(Skill):\n"
+            "    def value(self):\n"
+            "        from swap_reload_workflow.helper import VALUE\n"
+            "        return VALUE\n"
+        )
+        helper = package / "helper.py"
+        helper.write_text("VALUE = 'old-code'\n")
+        registry.discover_libs(tmp_path)
+        old_skill = registry["test.swap"]
+        assert old_skill.value() == "old-code"
+        old_package = sys.modules["swap_reload_workflow"]
+        old_helper = sys.modules["swap_reload_workflow.helper"]
+        helper.write_text("VALUE = 'replacement-code'\n")
+        if constructor == "runtime-error":
+            failed_constructor = (
+                "    def __init__(self):\n        raise RuntimeError('new constructor failed')\n"
+            )
+        else:
+            failed_constructor = (
+                "    def __init__(self, required):\n        self.required = required\n"
+            )
+        init.write_text(
+            "from nooa.skill import Skill\n\nclass SwapSkill(Skill):\n" + failed_constructor
+        )
+
+        result = await registry.reload("test.swap")
+
+        assert result.startswith("Reload failed for test.swap:")
+        assert registry["test.swap"] is old_skill
+        assert sys.modules["swap_reload_workflow"] is old_package
+        assert sys.modules["swap_reload_workflow.helper"] is old_helper
+        assert old_skill.value() == "old-code"
+
+        init.write_text(
+            "from nooa.skill import Skill\n\n"
+            "class SwapSkill(Skill):\n"
+            "    def value(self):\n"
+            "        return 'recovered'\n"
+        )
+        stat = init.stat()
+        import os
+
+        os.utime(init, (stat.st_atime + 2, stat.st_mtime + 2))
+        assert await registry.reload("test.swap") == "Reloaded test.swap (self.swap)"
+        assert registry["test.swap"].value() == "recovered"
+
     @pytest.mark.asyncio
     async def test_reload_not_loaded_raises(self, registry):
         """Reloading an unknown skill raises loudly instead of silently no-op'ing (issue 250)."""

--- a/tests/test_skill_registry_extended.py
+++ b/tests/test_skill_registry_extended.py
@@ -173,9 +173,9 @@ class TestDiscoverSkillsDirs:
 
 
 class TestDiscoverLibs:
-    def test_agents_load_local_objects_from_different_checkouts(self, tmp_path):
-        def write_checkout(root: Path, value: str) -> Path:
-            lib_dir = root / "workflow-checkout"
+    def test_agents_load_local_objects_from_different_library_dirs(self, tmp_path):
+        def write_library(root: Path, value: str) -> Path:
+            lib_dir = root / "workflow-lib"
             package = lib_dir / "src" / "shared_workflow"
             package.mkdir(parents=True)
             (lib_dir / "pyproject.toml").write_text(
@@ -190,8 +190,8 @@ class TestDiscoverLibs:
             )
             return root
 
-        first_root = write_checkout(tmp_path / "first", "first")
-        second_root = write_checkout(tmp_path / "second", "second")
+        first_root = write_library(tmp_path / "first", "first")
+        second_root = write_library(tmp_path / "second", "second")
         first = SkillRegistry(_FakeAgent())
         second = SkillRegistry(_FakeAgent())
         try:
@@ -205,8 +205,8 @@ class TestDiscoverLibs:
             first.close()
             second.close()
 
-    def test_same_checkout_creates_distinct_agent_local_objects(self, tmp_path):
-        lib_dir = tmp_path / "workflow-checkout"
+    def test_same_library_dir_creates_distinct_agent_local_objects(self, tmp_path):
+        lib_dir = tmp_path / "workflow-lib"
         package = lib_dir / "src" / "reference_workflow"
         package.mkdir(parents=True)
         (lib_dir / "pyproject.toml").write_text(
@@ -232,7 +232,7 @@ class TestDiscoverLibs:
 
     @pytest.mark.asyncio
     async def test_each_agent_reloads_its_own_package_object(self, tmp_path):
-        lib_dir = tmp_path / "shared-checkout"
+        lib_dir = tmp_path / "shared-lib"
         package = lib_dir / "src" / "shared_reload_workflow"
         package.mkdir(parents=True)
         (lib_dir / "pyproject.toml").write_text(
@@ -274,7 +274,7 @@ class TestDiscoverLibs:
             await second.aclose()
 
     def test_direct_module_entry_point_layout_is_importable(self, registry, tmp_path):
-        lib_dir = tmp_path / "workflow-checkout"
+        lib_dir = tmp_path / "workflow-lib"
         lib_dir.mkdir()
         (lib_dir / "pyproject.toml").write_text(
             '[project]\nname = "direct-workflow"\n\n'
@@ -309,7 +309,7 @@ class TestDiscoverLibs:
 
     def test_entry_point_target_controls_import_package_and_class(self, registry, agent, tmp_path):
         """Checkout, distribution, module, and Skill class names may all differ."""
-        lib_dir = tmp_path / "workflow-checkout"
+        lib_dir = tmp_path / "workflow-lib"
         package = lib_dir / "src" / "actual_workflow" / "commands"
         package.mkdir(parents=True)
         (lib_dir / "pyproject.toml").write_text(
@@ -514,7 +514,7 @@ class TestReload:
 
     @pytest.mark.asyncio
     async def test_nested_entry_point_module_reloads_its_declared_skill(self, registry, tmp_path):
-        lib_dir = tmp_path / "nested-checkout"
+        lib_dir = tmp_path / "nested-lib"
         package = lib_dir / "src" / "nested_reload_workflow"
         package.mkdir(parents=True)
         (lib_dir / "pyproject.toml").write_text(
@@ -600,7 +600,7 @@ class TestReload:
 
     @pytest.mark.asyncio
     async def test_failed_package_reload_restores_lazy_submodule_imports(self, registry, tmp_path):
-        lib_dir = tmp_path / "lazy-checkout"
+        lib_dir = tmp_path / "lazy-lib"
         package = lib_dir / "src" / "lazy_reload_workflow"
         package.mkdir(parents=True)
         (lib_dir / "pyproject.toml").write_text(
@@ -632,7 +632,7 @@ class TestReload:
     async def test_failed_skill_swap_restores_previous_package_tree(
         self, registry, tmp_path, constructor
     ):
-        lib_dir = tmp_path / "swap-checkout"
+        lib_dir = tmp_path / "swap-lib"
         package = lib_dir / "src" / "swap_reload_workflow"
         package.mkdir(parents=True)
         (lib_dir / "pyproject.toml").write_text(
@@ -693,7 +693,7 @@ class TestReload:
     async def test_failed_source_package_attach_restores_previous_package_tree(
         self, registry, tmp_path
     ):
-        lib_dir = tmp_path / "attach-checkout"
+        lib_dir = tmp_path / "attach-lib"
         package = lib_dir / "src" / "attach_reload_workflow"
         package.mkdir(parents=True)
         (lib_dir / "pyproject.toml").write_text(

--- a/tests/test_skill_registry_extended.py
+++ b/tests/test_skill_registry_extended.py
@@ -422,6 +422,31 @@ class TestResolveDeps:
         assert "nemo.base" not in registry.loaded()
 
 
+class TestDeterministicLoadOrder:
+    def test_load_sorts_unrelated_matches(self):
+        loaded: list[str] = []
+
+        class RecordingEntryPoint:
+            def __init__(self, name: str):
+                self.name = name
+
+            def load(self):
+                loaded.append(self.name)
+                return FakeSkill
+
+        entries = [
+            RecordingEntryPoint("test.zulu"),
+            RecordingEntryPoint("test.alpha"),
+        ]
+        with patch("nooa.skill_registry.entry_points", return_value=entries):
+            value = SkillRegistry(_FakeAgent())
+        try:
+            value.load(["test.*"])
+            assert loaded == ["test.alpha", "test.zulu"]
+        finally:
+            value.close()
+
+
 # ---------------------------------------------------------------------------
 # Tests: reload
 # ---------------------------------------------------------------------------
@@ -663,6 +688,40 @@ class TestReload:
         os.utime(init, (stat.st_atime + 2, stat.st_mtime + 2))
         assert await registry.reload("test.swap") == "Reloaded test.swap (self.swap)"
         assert registry["test.swap"].value() == "recovered"
+
+    @pytest.mark.asyncio
+    async def test_failed_source_package_attach_restores_previous_package_tree(
+        self, registry, tmp_path
+    ):
+        lib_dir = tmp_path / "attach-checkout"
+        package = lib_dir / "src" / "attach_reload_workflow"
+        package.mkdir(parents=True)
+        (lib_dir / "pyproject.toml").write_text(
+            '[project]\nname = "attach-reload"\n\n'
+            '[project.entry-points."nooa.skills"]\n'
+            '"test.attach" = "attach_reload_workflow:AttachSkill"\n'
+        )
+        init = package / "__init__.py"
+        init.write_text(
+            "from nooa.skill import Skill\nclass AttachSkill(Skill):\n    value = 'old'\n"
+        )
+        registry.discover_libs(tmp_path)
+        old_skill = registry["test.attach"]
+        old_package = sys.modules["attach_reload_workflow"]
+        init.write_text(
+            "from nooa.skill import Skill\n"
+            "class AttachSkill(Skill):\n"
+            "    value = 'new'\n"
+            "    def attach(self, agent):\n"
+            "        raise RuntimeError('attach failed')\n"
+        )
+
+        result = await registry.reload("test.attach")
+
+        assert result == "Reload failed for test.attach: attach failed"
+        assert registry["test.attach"] is old_skill
+        assert sys.modules["attach_reload_workflow"] is old_package
+        assert old_skill.value == "old"
 
     @pytest.mark.asyncio
     async def test_reload_not_loaded_raises(self, registry):


### PR DESCRIPTION
## Summary

- discover packaged library skills and text skills through the same registry call
- respect each library declared `nooa.skills` entry-point import target, including `src` and direct-module layouts
- create separate skill objects for agents during normal loading
- reload packaged, standalone Python, and `SKILL.md` skills on the requesting registry
- preserve activation, context blocks, slash commands, and the previous object when a reload fails
- detach each registry skills in dependency-safe order when that registry closes

## Design

`SkillRegistry` owns agent-local skill objects and source descriptors. It has no process-wide skill ownership table, package reference counts, or cross-agent reload coordination.

Reload reads current source, constructs a fresh object, and swaps that object onto the requesting agent. Text skills and standalone Python skills follow this agent-local model.

## Known limitation

Python package modules remain process-global through `sys.modules`. Package hot reload is therefore best-effort, not isolated between live agents, and does not automatically refresh other agents. Lazy imports or concurrent package reloads can produce mixed module generations; restarting the process is the reliable fallback. This limitation is accepted for this PR rather than adding global coordination machinery.

## Validation

- `92 passed` across:
  - `tests/test_skill_registry.py`
  - `tests/test_skill_registry_extended.py`
  - `tests/tools/test_library_writing_lib.py`
  - `tests/tools/test_single_module_skill_reload.py`
- multi-agent coverage for package, standalone Python, and text-skill object construction and reload
- reload rollback and dependency-safe teardown tests
- Ruff check passed
- Ruff formatting check passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable skill discovery across packaged, text, standalone Python, and `src`-layout libraries.
  * Added skill reloading with recovery when an update fails.
  * Added graceful shutdown support, including synchronous and asynchronous cleanup.
  * Improved dependency-aware unloading and refresh of available commands.

* **Bug Fixes**
  * Prevented failed or duplicate skill loads from leaving behind stale modules or registrations.
  * Preserved working skills and module state when reloads cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->