### PR TITLE
Fix memory store SQLite thread safety

### DIFF
--- a/packages/nooa-memory/src/nooa_memory/store.py
+++ b/packages/nooa-memory/src/nooa_memory/store.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -109,24 +110,30 @@ class MemoryStore:
         self.path = str(path)
         if self.path != ":memory:":
             Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        # ``check_same_thread=False`` lets foreground memory calls and
+        # background reflection workers use this store, but the connection
+        # still needs application-level serialization. Keep the lock reentrant
+        # because row hydration and retrieval paths call other store helpers.
+        self._lock = threading.RLock()
         self._conn = sqlite3.connect(self.path, check_same_thread=False)
-        self._conn.row_factory = sqlite3.Row
-        if self.path != ":memory:":
-            self._conn.execute("PRAGMA journal_mode=WAL")
-            self._conn.execute("PRAGMA busy_timeout=5000")
-        self._migrate()
-        # An explicit index wins; otherwise dispatch on the config's backend
-        # (numpy / sqlite_vec / chroma_*). Default is the zero-dependency numpy index.
-        if vector_index is not None:
-            self._index: VectorIndex = vector_index
-        elif vector_config is not None:
-            self._index = make_vector_index(
-                vector_config, dim=embedding_dim, conn=self._conn, path=self.path
-            )
-        else:
-            self._index = NumpyVectorIndex()
-        self._load_index()
-        self._data_version = self._current_data_version()
+        with self._lock:
+            self._conn.row_factory = sqlite3.Row
+            if self.path != ":memory:":
+                self._conn.execute("PRAGMA journal_mode=WAL")
+                self._conn.execute("PRAGMA busy_timeout=5000")
+            self._migrate()
+            # An explicit index wins; otherwise dispatch on the config's backend
+            # (numpy / sqlite_vec / chroma_*). Default is the zero-dependency numpy index.
+            if vector_index is not None:
+                self._index: VectorIndex = vector_index
+            elif vector_config is not None:
+                self._index = make_vector_index(
+                    vector_config, dim=embedding_dim, conn=self._conn, path=self.path
+                )
+            else:
+                self._index = NumpyVectorIndex()
+            self._load_index()
+            self._data_version = self._current_data_version()
 
     # ------------------------------------------------------------------
     # internal helpers
@@ -140,25 +147,27 @@ class MemoryStore:
         file was written by *newer* code (shared project stores can be opened
         by processes running different checkouts).
         """
-        version = int(self._conn.execute("PRAGMA user_version").fetchone()[0])
-        if version > SCHEMA_VERSION:
-            raise MemorySchemaError(
-                f"memory store {self.path!r} has schema v{version}, but this code "
-                f"understands up to v{SCHEMA_VERSION} — update nooa"
-            )
-        self._conn.executescript(_SCHEMA)
-        cols = {r["name"] for r in self._conn.execute("PRAGMA table_info(memories)").fetchall()}
-        if "owner" not in cols:
-            self._conn.execute("ALTER TABLE memories ADD COLUMN owner TEXT NOT NULL DEFAULT ''")
-        if "status" not in cols:
-            self._conn.execute("ALTER TABLE memories ADD COLUMN status TEXT")
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_mem_owner ON memories(owner)")
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_mem_status ON memories(status)")
-        self._conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
-        self._conn.commit()
+        with self._lock:
+            version = int(self._conn.execute("PRAGMA user_version").fetchone()[0])
+            if version > SCHEMA_VERSION:
+                raise MemorySchemaError(
+                    f"memory store {self.path!r} has schema v{version}, but this code "
+                    f"understands up to v{SCHEMA_VERSION} — update nooa"
+                )
+            self._conn.executescript(_SCHEMA)
+            cols = {r["name"] for r in self._conn.execute("PRAGMA table_info(memories)").fetchall()}
+            if "owner" not in cols:
+                self._conn.execute("ALTER TABLE memories ADD COLUMN owner TEXT NOT NULL DEFAULT ''")
+            if "status" not in cols:
+                self._conn.execute("ALTER TABLE memories ADD COLUMN status TEXT")
+            self._conn.execute("CREATE INDEX IF NOT EXISTS idx_mem_owner ON memories(owner)")
+            self._conn.execute("CREATE INDEX IF NOT EXISTS idx_mem_status ON memories(status)")
+            self._conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+            self._conn.commit()
 
     def _current_data_version(self) -> int:
-        return int(self._conn.execute("PRAGMA data_version").fetchone()[0])
+        with self._lock:
+            return int(self._conn.execute("PRAGMA data_version").fetchone()[0])
 
     def refresh_if_changed(self) -> bool:
         """Reload the derived vector index if another connection committed.
@@ -168,21 +177,23 @@ class MemoryStore:
         numpy index needs rebuilding; sqlite-vec and Chroma read shared storage
         directly. SQL reads are always current and never need this.
         """
-        version = self._current_data_version()
-        if version == self._data_version:
-            return False
-        self._data_version = version
-        if isinstance(self._index, NumpyVectorIndex):
-            self._index = NumpyVectorIndex()
-            self._load_index()
-        return True
+        with self._lock:
+            version = self._current_data_version()
+            if version == self._data_version:
+                return False
+            self._data_version = version
+            if isinstance(self._index, NumpyVectorIndex):
+                self._index = NumpyVectorIndex()
+                self._load_index()
+            return True
 
     def _load_index(self) -> None:
-        cur = self._conn.execute(
-            "SELECT id, embedding FROM memories WHERE archived = 0 AND embedding IS NOT NULL"
-        )
-        for row in cur.fetchall():
-            self._index.add(row["id"], _blob_to_vec(row["embedding"]))
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT id, embedding FROM memories WHERE archived = 0 AND embedding IS NOT NULL"
+            )
+            for row in cur.fetchall():
+                self._index.add(row["id"], _blob_to_vec(row["embedding"]))
 
     def _row_to_memory(self, row: sqlite3.Row) -> Memory:
         data = json.loads(row["data"])
@@ -200,130 +211,142 @@ class MemoryStore:
         return Memory.model_validate(data)
 
     def _edge_rows(self, src: str) -> list[dict]:
-        cur = self._conn.execute("SELECT dst, type, weight FROM memory_edges WHERE src = ?", (src,))
-        return [dict(r) for r in cur.fetchall()]
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT dst, type, weight FROM memory_edges WHERE src = ?", (src,)
+            )
+            return [dict(r) for r in cur.fetchall()]
 
     # ------------------------------------------------------------------
     # writes
     # ------------------------------------------------------------------
     def add(self, memory: Memory, embedding: np.ndarray | None = None) -> Memory:
         """Insert (or replace) a memory and its edges. Persists the embedding."""
-        blob = _vec_to_blob(embedding) if embedding is not None else None
-        payload = memory.model_dump(mode="json", exclude={"edges"})
-        self._conn.execute(
-            """INSERT OR REPLACE INTO memories
-               (id, type, content, importance, salience, strength, created_at,
-                last_accessed, access_count, archived, owner, status, embedding, data)
-               VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-            (
-                memory.id,
-                memory.type.value,
-                memory.content,
-                memory.importance,
-                memory.salience,
-                memory.strength,
-                memory.created_at,
-                memory.last_accessed_at,
-                memory.access_count,
-                int(memory.archived),
-                memory.owner,
-                memory.status,
-                blob,
-                json.dumps(payload),
-            ),
-        )
-        # Rewrite edges for this source.
-        self._conn.execute("DELETE FROM memory_edges WHERE src = ?", (memory.id,))
-        for e in memory.edges:
+        with self._lock:
+            blob = _vec_to_blob(embedding) if embedding is not None else None
+            payload = memory.model_dump(mode="json", exclude={"edges"})
             self._conn.execute(
-                "INSERT OR REPLACE INTO memory_edges (src, dst, type, weight, created_at)"
-                " VALUES (?,?,?,?,?)",
-                (memory.id, e.target_id, e.type.value, e.weight, e.created_at),
+                """INSERT OR REPLACE INTO memories
+                   (id, type, content, importance, salience, strength, created_at,
+                    last_accessed, access_count, archived, owner, status, embedding, data)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    memory.id,
+                    memory.type.value,
+                    memory.content,
+                    memory.importance,
+                    memory.salience,
+                    memory.strength,
+                    memory.created_at,
+                    memory.last_accessed_at,
+                    memory.access_count,
+                    int(memory.archived),
+                    memory.owner,
+                    memory.status,
+                    blob,
+                    json.dumps(payload),
+                ),
             )
-        self._conn.commit()
-        if embedding is not None and not memory.archived:
-            self._index.add(memory.id, embedding)
-        elif memory.archived:
-            self._index.remove(memory.id)
-        return memory
+            # Rewrite edges for this source.
+            self._conn.execute("DELETE FROM memory_edges WHERE src = ?", (memory.id,))
+            for e in memory.edges:
+                self._conn.execute(
+                    "INSERT OR REPLACE INTO memory_edges (src, dst, type, weight, created_at)"
+                    " VALUES (?,?,?,?,?)",
+                    (memory.id, e.target_id, e.type.value, e.weight, e.created_at),
+                )
+            self._conn.commit()
+            if embedding is not None and not memory.archived:
+                self._index.add(memory.id, embedding)
+            elif memory.archived:
+                self._index.remove(memory.id)
+            return memory
 
     def save(self, memory: Memory) -> None:
         """Persist mutations to an existing memory (keeps the stored embedding)."""
-        payload = memory.model_dump(mode="json", exclude={"edges"})
-        self._conn.execute(
-            """UPDATE memories SET type=?, content=?, importance=?, salience=?,
-               strength=?, last_accessed=?, access_count=?, archived=?, owner=?,
-               status=?, data=? WHERE id=?""",
-            (
-                memory.type.value,
-                memory.content,
-                memory.importance,
-                memory.salience,
-                memory.strength,
-                memory.last_accessed_at,
-                memory.access_count,
-                int(memory.archived),
-                memory.owner,
-                memory.status,
-                json.dumps(payload),
-                memory.id,
-            ),
-        )
-        self._conn.execute("DELETE FROM memory_edges WHERE src = ?", (memory.id,))
-        for e in memory.edges:
+        with self._lock:
+            payload = memory.model_dump(mode="json", exclude={"edges"})
             self._conn.execute(
-                "INSERT OR REPLACE INTO memory_edges (src, dst, type, weight, created_at)"
-                " VALUES (?,?,?,?,?)",
-                (memory.id, e.target_id, e.type.value, e.weight, e.created_at),
+                """UPDATE memories SET type=?, content=?, importance=?, salience=?,
+                   strength=?, last_accessed=?, access_count=?, archived=?, owner=?,
+                   status=?, data=? WHERE id=?""",
+                (
+                    memory.type.value,
+                    memory.content,
+                    memory.importance,
+                    memory.salience,
+                    memory.strength,
+                    memory.last_accessed_at,
+                    memory.access_count,
+                    int(memory.archived),
+                    memory.owner,
+                    memory.status,
+                    json.dumps(payload),
+                    memory.id,
+                ),
             )
-        self._conn.commit()
-        if memory.archived:
-            self._index.remove(memory.id)
+            self._conn.execute("DELETE FROM memory_edges WHERE src = ?", (memory.id,))
+            for e in memory.edges:
+                self._conn.execute(
+                    "INSERT OR REPLACE INTO memory_edges (src, dst, type, weight, created_at)"
+                    " VALUES (?,?,?,?,?)",
+                    (memory.id, e.target_id, e.type.value, e.weight, e.created_at),
+                )
+            self._conn.commit()
+            if memory.archived:
+                self._index.remove(memory.id)
 
     def add_edge(
         self, src: str, dst: str, type: EdgeType = EdgeType.RELATED, weight: float = 1.0
     ) -> None:
         from nooa_memory.schema import _now
 
-        self._conn.execute(
-            "INSERT OR REPLACE INTO memory_edges (src, dst, type, weight, created_at)"
-            " VALUES (?,?,?,?,?)",
-            (src, dst, type.value, weight, _now()),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO memory_edges (src, dst, type, weight, created_at)"
+                " VALUES (?,?,?,?,?)",
+                (src, dst, type.value, weight, _now()),
+            )
+            self._conn.commit()
 
     def archive(self, id: str) -> None:
-        self._conn.execute("UPDATE memories SET archived = 1 WHERE id = ?", (id,))
-        self._conn.commit()
-        self._index.remove(id)
+        with self._lock:
+            self._conn.execute("UPDATE memories SET archived = 1 WHERE id = ?", (id,))
+            self._conn.commit()
+            self._index.remove(id)
 
     def delete(self, id: str) -> None:
-        self._conn.execute("DELETE FROM memories WHERE id = ?", (id,))
-        self._conn.execute("DELETE FROM memory_edges WHERE src = ? OR dst = ?", (id, id))
-        self._conn.commit()
-        self._index.remove(id)
+        with self._lock:
+            self._conn.execute("DELETE FROM memories WHERE id = ?", (id,))
+            self._conn.execute("DELETE FROM memory_edges WHERE src = ? OR dst = ?", (id, id))
+            self._conn.commit()
+            self._index.remove(id)
 
     # ------------------------------------------------------------------
     # reads
     # ------------------------------------------------------------------
     def get(self, id: str) -> Memory | None:
-        row = self._conn.execute("SELECT * FROM memories WHERE id = ?", (id,)).fetchone()
-        return self._row_to_memory(row) if row else None
+        with self._lock:
+            row = self._conn.execute("SELECT * FROM memories WHERE id = ?", (id,)).fetchone()
+            return self._row_to_memory(row) if row else None
 
     def resolve_id(self, id_or_prefix: str) -> str | None:
         """Exact id, or a unique id prefix (>=6 chars, as rendered in recalled
         lines). Raises on an ambiguous prefix; returns None when nothing matches."""
-        row = self._conn.execute("SELECT id FROM memories WHERE id = ?", (id_or_prefix,)).fetchone()
-        if row is not None:
-            return str(row["id"])
-        if len(id_or_prefix) < 6:
-            return None
-        rows = self._conn.execute(
-            "SELECT id FROM memories WHERE id LIKE ? LIMIT 2", (id_or_prefix + "%",)
-        ).fetchall()
-        if len(rows) > 1:
-            raise ValueError(f"memory id prefix {id_or_prefix!r} is ambiguous")
-        return str(rows[0]["id"]) if rows else None
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT id FROM memories WHERE id = ?", (id_or_prefix,)
+            ).fetchone()
+            if row is not None:
+                return str(row["id"])
+            if len(id_or_prefix) < 6:
+                return None
+            rows = self._conn.execute(
+                "SELECT id FROM memories WHERE id LIKE ? LIMIT 2", (id_or_prefix + "%",)
+            ).fetchall()
+            if len(rows) > 1:
+                raise ValueError(f"memory id prefix {id_or_prefix!r} is ambiguous")
+            return str(rows[0]["id"]) if rows else None
 
     def rename_owner(self, old: str, new: str) -> int:
         """Re-stamp every row owned by ``old`` to ``new``; returns rows changed.
@@ -332,28 +355,34 @@ class MemoryStore:
         inside the data JSON is harmless. Used to heal legacy owner spellings
         (e.g. the TUI's module:qualname keys) into the canonical short name.
         """
-        if old == new or not old:
-            return 0  # never mass-claim the unowned/shared namespace
-        cur = self._conn.execute("UPDATE memories SET owner = ? WHERE owner = ?", (new, old))
-        self._conn.commit()
-        return cur.rowcount
+        with self._lock:
+            if old == new or not old:
+                return 0  # never mass-claim the unowned/shared namespace
+            cur = self._conn.execute("UPDATE memories SET owner = ? WHERE owner = ?", (new, old))
+            self._conn.commit()
+            return cur.rowcount
 
     def owner_of(self, id: str) -> str | None:
         """The owner column alone (cheap visibility checks during graph spread)."""
-        row = self._conn.execute("SELECT owner FROM memories WHERE id = ?", (id,)).fetchone()
-        return None if row is None else str(row["owner"])
+        with self._lock:
+            row = self._conn.execute("SELECT owner FROM memories WHERE id = ?", (id,)).fetchone()
+            return None if row is None else str(row["owner"])
 
     def get_embedding(self, id: str) -> np.ndarray | None:
-        row = self._conn.execute("SELECT embedding FROM memories WHERE id = ?", (id,)).fetchone()
-        if row and row["embedding"] is not None:
-            return _blob_to_vec(row["embedding"])
-        return None
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT embedding FROM memories WHERE id = ?", (id,)
+            ).fetchone()
+            if row and row["embedding"] is not None:
+                return _blob_to_vec(row["embedding"])
+            return None
 
     def neighbors(self, id: str) -> list[Edge]:
-        return [
-            Edge(target_id=e["dst"], type=EdgeType(e["type"]), weight=e["weight"])
-            for e in self._edge_rows(id)
-        ]
+        with self._lock:
+            return [
+                Edge(target_id=e["dst"], type=EdgeType(e["type"]), weight=e["weight"])
+                for e in self._edge_rows(id)
+            ]
 
     @staticmethod
     def _owner_clause(owner: str) -> tuple[str, list[object]]:
@@ -385,9 +414,10 @@ class MemoryStore:
     def all_memories(
         self, *, include_archived: bool = False, owner: str | None = None
     ) -> list[Memory]:
-        where, params = self._filters(include_archived=include_archived, owner=owner)
-        q = "SELECT * FROM memories" + where
-        return [self._row_to_memory(r) for r in self._conn.execute(q, params).fetchall()]
+        with self._lock:
+            where, params = self._filters(include_archived=include_archived, owner=owner)
+            q = "SELECT * FROM memories" + where
+            return [self._row_to_memory(r) for r in self._conn.execute(q, params).fetchall()]
 
     def iter_memories(
         self, *, include_archived: bool = False, owner: str | None = None
@@ -395,20 +425,22 @@ class MemoryStore:
         yield from self.all_memories(include_archived=include_archived, owner=owner)
 
     def count(self, *, include_archived: bool = False, owner: str | None = None) -> int:
-        where, params = self._filters(include_archived=include_archived, owner=owner)
-        q = "SELECT COUNT(*) AS n FROM memories" + where
-        return int(self._conn.execute(q, params).fetchone()["n"])
+        with self._lock:
+            where, params = self._filters(include_archived=include_archived, owner=owner)
+            q = "SELECT COUNT(*) AS n FROM memories" + where
+            return int(self._conn.execute(q, params).fetchone()["n"])
 
     def _owned_ids(self, ids: list[str], owner: str) -> set[str]:
-        if not ids:
-            return set()
-        placeholders = ",".join("?" * len(ids))
-        clause, owner_params = self._owner_clause(owner)
-        rows = self._conn.execute(
-            f"SELECT id FROM memories WHERE id IN ({placeholders}) AND {clause}",
-            [*ids, *owner_params],
-        ).fetchall()
-        return {r["id"] for r in rows}
+        with self._lock:
+            if not ids:
+                return set()
+            placeholders = ",".join("?" * len(ids))
+            clause, owner_params = self._owner_clause(owner)
+            rows = self._conn.execute(
+                f"SELECT id FROM memories WHERE id IN ({placeholders}) AND {clause}",
+                [*ids, *owner_params],
+            ).fetchall()
+            return {r["id"] for r in rows}
 
     def knn(
         self, query_vec: np.ndarray, k: int, *, owner: str | None = None
@@ -419,18 +451,19 @@ class MemoryStore:
         The ``VectorIndex`` protocol has no metadata filter, so the index is
         oversampled (4x, growing) until ``k`` survive or it is exhausted.
         """
-        self.refresh_if_changed()
-        if owner is None:
-            return self._index.query(query_vec, k)
-        total = len(self._index)
-        n = min(total, max(k * 4, k))
-        while True:
-            ranked = self._index.query(query_vec, n)
-            allowed = self._owned_ids([mid for mid, _ in ranked], owner)
-            out = [(mid, score) for mid, score in ranked if mid in allowed]
-            if len(out) >= k or n >= total:
-                return out[:k]
-            n = min(total, n * 4)
+        with self._lock:
+            self.refresh_if_changed()
+            if owner is None:
+                return self._index.query(query_vec, k)
+            total = len(self._index)
+            n = min(total, max(k * 4, k))
+            while True:
+                ranked = self._index.query(query_vec, n)
+                allowed = self._owned_ids([mid for mid, _ in ranked], owner)
+                out = [(mid, score) for mid, score in ranked if mid in allowed]
+                if len(out) >= k or n >= total:
+                    return out[:k]
+                n = min(total, n * 4)
 
     def keyword_search(
         self,
@@ -443,24 +476,25 @@ class MemoryStore:
         """Cheap sparse fallback: rank by overlapping-token LIKE matches."""
         from nooa_memory.embeddings import _TOKEN_RE
 
-        tokens = list(dict.fromkeys(_TOKEN_RE.findall(text.lower())))[:12]
-        if not tokens:
-            return []
-        scored: dict[str, int] = {}
-        for tok in tokens:
-            clause = "SELECT id FROM memories WHERE archived = 0 AND lower(content) LIKE ?"
-            params: list[object] = [f"%{tok}%"]
-            if mem_type is not None:
-                clause += " AND type = ?"
-                params.append(mem_type.value)
-            if owner is not None:
-                owner_sql, owner_params = self._owner_clause(owner)
-                clause += f" AND {owner_sql}"
-                params.extend(owner_params)
-            for row in self._conn.execute(clause, params).fetchall():
-                scored[row["id"]] = scored.get(row["id"], 0) + 1
-        ranked = sorted(scored.items(), key=lambda kv: kv[1], reverse=True)
-        return [mid for mid, _ in ranked[:k]]
+        with self._lock:
+            tokens = list(dict.fromkeys(_TOKEN_RE.findall(text.lower())))[:12]
+            if not tokens:
+                return []
+            scored: dict[str, int] = {}
+            for tok in tokens:
+                clause = "SELECT id FROM memories WHERE archived = 0 AND lower(content) LIKE ?"
+                params: list[object] = [f"%{tok}%"]
+                if mem_type is not None:
+                    clause += " AND type = ?"
+                    params.append(mem_type.value)
+                if owner is not None:
+                    owner_sql, owner_params = self._owner_clause(owner)
+                    clause += f" AND {owner_sql}"
+                    params.extend(owner_params)
+                for row in self._conn.execute(clause, params).fetchall():
+                    scored[row["id"]] = scored.get(row["id"], 0) + 1
+            ranked = sorted(scored.items(), key=lambda kv: kv[1], reverse=True)
+            return [mid for mid, _ in ranked[:k]]
 
     def log_maintenance(self, kind: str, report: dict) -> None:
         """Append one reflect()/prune() run to the store-level maintenance history.
@@ -471,17 +505,22 @@ class MemoryStore:
         """
         from nooa_memory.schema import _now
 
-        self._conn.execute(
-            "INSERT INTO maintenance_log (ts, kind, report) VALUES (?,?,?)",
-            (_now(), kind, json.dumps(report)),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO maintenance_log (ts, kind, report) VALUES (?,?,?)",
+                (_now(), kind, json.dumps(report)),
+            )
+            self._conn.commit()
 
     def maintenance_history(self, limit: int = 20) -> list[dict]:
-        rows = self._conn.execute(
-            "SELECT ts, kind, report FROM maintenance_log ORDER BY ts DESC LIMIT ?", (limit,)
-        ).fetchall()
-        return [{"ts": r["ts"], "kind": r["kind"], "report": json.loads(r["report"])} for r in rows]
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT ts, kind, report FROM maintenance_log ORDER BY ts DESC LIMIT ?", (limit,)
+            ).fetchall()
+            return [
+                {"ts": r["ts"], "kind": r["kind"], "report": json.loads(r["report"])} for r in rows
+            ]
 
     def close(self) -> None:
-        self._conn.close()
+        with self._lock:
+            self._conn.close()

--- a/packages/nooa-memory/tests/memory/test_memory_store.py
+++ b/packages/nooa-memory/tests/memory/test_memory_store.py
@@ -2,9 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the SQLite-centric memory store + numpy vector index."""
 
+import json
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
 import numpy as np
 import pytest
+from nooa_memory.config import ForgetPolicy, ReflectionPolicy
 from nooa_memory.embeddings import HashingEmbedder
+from nooa_memory.reflection import ReflectionEngine
 from nooa_memory.schema import EdgeType, Memory, MemoryType
 from nooa_memory.store import MemoryStore, NumpyVectorIndex
 
@@ -115,6 +122,7 @@ def test_persistence_reopen(tmp_path, emb):
     s2 = MemoryStore(path)
     assert s2.count() == 1
     got = s2.get(m.id)
+    assert got is not None
     assert got.content == "persisted across sessions"
     # index rebuilt from disk -> knn works
     ranked = s2.knn(emb.embed("persisted across sessions"), 1)
@@ -132,3 +140,148 @@ def test_numpy_index_add_remove():
     idx.remove("a")
     assert len(idx) == 1
     assert idx.query(np.array([1.0, 0.0], dtype=np.float32), 2)[0][0] == "b"
+
+
+class _TrackedRLock:
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._local = threading.local()
+
+    def __enter__(self):
+        self._lock.acquire()
+        self._local.depth = getattr(self._local, "depth", 0) + 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._local.depth -= 1
+        self._lock.release()
+
+    def owned(self) -> bool:
+        return getattr(self._local, "depth", 0) > 0
+
+
+class _GuardedConnection:
+    def __init__(self, conn, lock: _TrackedRLock) -> None:
+        self._conn = conn
+        self._lock = lock
+
+    def _assert_locked(self) -> None:
+        assert self._lock.owned(), "MemoryStore touched sqlite connection without its lock"
+
+    def execute(self, *args, **kwargs):
+        self._assert_locked()
+        return self._conn.execute(*args, **kwargs)
+
+    def executescript(self, *args, **kwargs):
+        self._assert_locked()
+        return self._conn.executescript(*args, **kwargs)
+
+    def commit(self):
+        self._assert_locked()
+        return self._conn.commit()
+
+    def close(self):
+        self._assert_locked()
+        return self._conn.close()
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+class _GuardedIndex:
+    def __init__(self, index, lock: _TrackedRLock) -> None:
+        self._index = index
+        self._lock = lock
+
+    def _assert_locked(self) -> None:
+        assert self._lock.owned(), "MemoryStore touched vector index without its lock"
+
+    def add(self, id, vector):
+        self._assert_locked()
+        return self._index.add(id, vector)
+
+    def remove(self, id):
+        self._assert_locked()
+        return self._index.remove(id)
+
+    def query(self, vector, k):
+        self._assert_locked()
+        return self._index.query(vector, k)
+
+    def __len__(self):
+        self._assert_locked()
+        return len(self._index)
+
+
+def test_store_serializes_connection_and_index_access(store, emb):
+    lock = _TrackedRLock()
+    store._lock = lock
+    store._conn = _GuardedConnection(store._conn, lock)
+    store._index = _GuardedIndex(store._index, lock)
+
+    m = _add(store, emb, "alpha beta", type=MemoryType.INFO)
+    got = store.get(m.id)
+    assert got is not None
+    got.add_edge("other", EdgeType.RELATED, 0.4)
+    store.save(got)
+    store.add_edge(got.id, "other", EdgeType.SUPPORTS)
+
+    assert store.resolve_id(m.id[:8]) == m.id
+    assert store.owner_of(m.id) == ""
+    assert store.get_embedding(m.id) is not None
+    assert store.neighbors(m.id)
+    assert store.all_memories()
+    assert store.count() == 1
+    assert store.knn(emb.embed("alpha beta"), 1)
+    assert store.keyword_search("alpha", 1) == [m.id]
+
+    store.rename_owner("missing-owner", "new-owner")
+    store.log_maintenance("test", {"ok": True})
+    assert store.maintenance_history()[0]["report"] == {"ok": True}
+    store.archive(m.id)
+    store.delete(m.id)
+
+
+def test_store_survives_foreground_and_reflection_thread_overlap(tmp_path, emb):
+    path = tmp_path / "memory.sqlite"
+    store = MemoryStore(path)
+    try:
+        for i in range(12):
+            _add(store, emb, f"seed memory {i}", type=MemoryType.INFO)
+
+        engine = ReflectionEngine(
+            store,
+            emb,
+            ReflectionPolicy(merge_threshold=0.999, edge_threshold=0.999),
+            ForgetPolicy(),
+        )
+
+        def reflect_worker() -> None:
+            for _ in range(20):
+                engine.consolidate()
+
+        def foreground_worker(worker_id: int) -> None:
+            for i in range(40):
+                m = _add(store, emb, f"foreground {worker_id} memory {i}")
+                store.count()
+                store.keyword_search("foreground memory", 5)
+                store.knn(emb.embed(f"foreground {worker_id}"), 5)
+                got = store.get(m.id)
+                if got is not None:
+                    got.touch()
+                    store.save(got)
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(reflect_worker)]
+            futures.extend(pool.submit(foreground_worker, n) for n in range(3))
+            for fut in futures:
+                fut.result(timeout=30)
+
+        with sqlite3.connect(path) as conn:
+            assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+            rows = conn.execute("SELECT data FROM memories").fetchall()
+        assert rows
+        for (payload,) in rows:
+            Memory.model_validate(json.loads(payload))
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary

Fixes `MemoryStore` cross-thread SQLite access by adding a store-level reentrant lock and holding it across complete store operations, including reads, writes, transaction commits, vector-index refresh/load/query, maintenance logging, and close.

## Root cause

`MemoryStore` opens SQLite with `check_same_thread=False` so foreground memory calls and background reflection workers can use the same store instance. That permits cross-thread use, but the shared `sqlite3.Connection` still needs application-level serialization. Without it, foreground operations and reflection can overlap on the same connection and transaction state.

## Validation

- Reproduced the unsafe shared-connection race on `origin/main` with a local foreground/reflection overlap probe.
- Verified the same probe completes without overlapping connection access on this branch.
- Added a deterministic regression test that fails if store methods touch the SQLite connection or vector index outside the store lock.
- Added a foreground-write/read plus reflection stress test that checks SQLite `integrity_check` and validates every persisted `memories.data` JSON payload against the `Memory` schema.

## Tests

- `uv run pytest -q packages/nooa-memory/tests/memory/test_memory_store.py`
- `uv run pytest -q packages/nooa-memory/tests/memory`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright packages/nooa-memory/src/nooa_memory/store.py packages/nooa-memory/tests/memory/test_memory_store.py`

Closes #117
