### PR TITLE
Remove duplicate pytest-cov dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,6 @@ dev = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.21.0",
     "pytest-rerunfailures>=14.0",
-    "pytest-cov>=4.0.0",
     "mypy>=1.7.0",
     "ruff>=0.14.14",
     "httpx[socks]>=0.28.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1465,7 +1465,6 @@ dev = [
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
-    { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-rerunfailures", specifier = ">=14.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },


### PR DESCRIPTION
## What does this PR do?

This PR cleans up the `pyproject.toml` file by removing a redundant `pytest-cov>=4.0.0` dependency boundary. 

Previously, `pytest-cov` was defined twice in the `dev` dependency group (once as `>=4.0.0` and again as `>=7.1.0`). This PR removes the redundant line, relying solely on the `>=7.1.0` boundary to resolve dependency manager warnings and improve file hygiene.

## Related issues

N/A

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [ ] Docs updated if behavior or public APIs changed
- [x] New source files carry an SPDX license header
