### PR TITLE
Update stale nemo-oo-agents package references to nooa

### DIFF
--- a/examples/quickstart/11_mcp.py
+++ b/examples/quickstart/11_mcp.py
@@ -21,7 +21,7 @@ from pathlib import Path
 try:
     from nooa.mcp import MCPManager
 except ImportError as e:
-    raise ImportError("mcp-nemo-oo-agents not installed. Run: uv sync --extra mcp") from e
+    raise ImportError("nooa[mcp] not installed. Run: uv sync --extra mcp") from e
 
 from nooa.util.quickstart import *
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ cli = ["nooa-cli"]
 memory = ["nooa-memory"]
 bench = ["nooa-bench"]
 # ARC-AGI-3 example agent (examples/arc_agi_3): the public ARC-AGI-3 SDK + deps.
-# Install with `pip install "nemo-oo-agents[arc]"` (or `uv sync --extra arc`).
+# Install with `pip install "nooa[arc]"` (or `uv sync --extra arc`).
 arc = [
     "arc-agi>=0.9.8",
     "arcengine>=0.9.3",


### PR DESCRIPTION
## What does this PR do?

This PR updates stale references to the legacy `nemo-oo-agents` package name in user-facing documentation and error messages.

Since the repository was renamed to `nooa`, instructions in `pyproject.toml` and fallback error strings in `examples/quickstart/11_mcp.py` were still instructing users to `pip install` the old package. This updates those strings to correctly reference `nooa` and its corresponding extras (like `nooa[arc]` and `nooa[mcp]`) to prevent installation confusion.

## Related issues

N/A

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [ ] Docs updated if behavior or public APIs changed
- [x] New source files carry an SPDX license header
