### PR TITLE
Fix resource bug

### DIFF
--- a/src/nooa/runtime/debug_handler.py
+++ b/src/nooa/runtime/debug_handler.py
@@ -426,8 +426,10 @@ def install_debug_handler(dump_dir: Path | None = None) -> None:
 
     # Install SIGUSR2 handler (less commonly used than SIGUSR1)
     try:
-        signal.signal(signal.SIGUSR2, _debug_signal_handler)
-        _handler_installed = True
+        sig = getattr(signal, "SIGUSR2", None)
+        if sig is not None:
+            signal.signal(sig, _debug_signal_handler)
+            _handler_installed = True
     except (ValueError, OSError):
         # Can't set signal handler (not main thread, or platform issue)
         pass

--- a/src/nooa/runtime/sandbox/guards.py
+++ b/src/nooa/runtime/sandbox/guards.py
@@ -180,6 +180,7 @@ def probe_capabilities() -> Capabilities:
     """Probe the host once for every enforcement mechanism the sandbox uses."""
     try:
         import resource
+
         has_rlimit = hasattr(resource, "RLIMIT_AS") and hasattr(resource, "RLIMIT_CPU")
     except ImportError:
         has_rlimit = False

--- a/src/nooa/runtime/sandbox/guards.py
+++ b/src/nooa/runtime/sandbox/guards.py
@@ -178,14 +178,18 @@ class Capabilities:
 
 def probe_capabilities() -> Capabilities:
     """Probe the host once for every enforcement mechanism the sandbox uses."""
-    import resource
+    try:
+        import resource
+        has_rlimit = hasattr(resource, "RLIMIT_AS") and hasattr(resource, "RLIMIT_CPU")
+    except ImportError:
+        has_rlimit = False
 
     is_linux = platform.system() == "Linux"
     return Capabilities(
         linux=is_linux,
         landlock_abi=landlock_abi() if is_linux else 0,
         seccomp=seccomp_supported() if is_linux else False,
-        rlimit=hasattr(resource, "RLIMIT_AS") and hasattr(resource, "RLIMIT_CPU"),
+        rlimit=has_rlimit,
     )
 
 

--- a/src/nooa/storage/sqlite.py
+++ b/src/nooa/storage/sqlite.py
@@ -7,7 +7,13 @@ Provides persistent storage using stdlib sqlite3 — no new dependencies.
 
 from __future__ import annotations
 
-import fcntl
+import sys
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
 import json
 import logging
 import os
@@ -643,7 +649,10 @@ def _acquire_session_lock(lock_path: str) -> int:
     """
     fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
     try:
-        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        if sys.platform == "win32":
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        else:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:
         os.close(fd)
         owner_pid = _read_lock_pid(lock_path)
@@ -832,7 +841,11 @@ class SQLiteStorageManager:
                     conn.close()
         finally:
             if self._lock_fd is not None:
-                fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
+                if sys.platform == "win32":
+                    os.lseek(self._lock_fd, 0, os.SEEK_SET)
+                    msvcrt.locking(self._lock_fd, msvcrt.LK_UNLCK, 1)
+                else:
+                    fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
                 os.close(self._lock_fd)
                 self._lock_fd = None
 


### PR DESCRIPTION
**Note:** This PR builds on top of my previous Windows fix (PR #132). Once PR #132 is merged, the diff for this PR will automatically shrink to isolate perfectly to just the `resource` module fix.

## What does this PR do?

This PR fixes a Windows incompatibility issue that crashes the test collector during `pytest` discovery. 

The `probe_capabilities` function unconditionally imported the `resource` module, which only exists on Unix systems. This PR wraps the import in a standard `try...except ImportError` block, allowing the function to gracefully return `False` for `rlimit` capabilities on Windows instead of throwing a fatal `ModuleNotFoundError`.

## Related issues

N/A

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [ ] Docs updated if behavior or public APIs changed
- [x] New source files carry an SPDX license header
