### PR TITLE
fix(tui): show OAuth URL in scrollback

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 logger = logging.getLogger(__name__)
 
 from .output import (  # noqa: E402
+    AgentMessage,
     ClearScreen,
     CodeExecution,
     DiffOutput,
@@ -47,6 +48,29 @@ def _mcp_auto_connect_names(value: object) -> list[str]:
     if isinstance(value, list):
         return [v for v in value if isinstance(v, str)]
     return []
+
+
+def _mcp_oauth_markdown_link(auth_url: str) -> str | None:
+    """Return a safe Markdown link whose visible label is the complete URL."""
+    safe_url = auth_url.strip()
+    try:
+        parsed = urllib.parse.urlsplit(safe_url)
+    except ValueError:
+        return None
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or any(
+            character.isspace()
+            or character in "<>"
+            or ord(character) < 0x20
+            or 0x7F <= ord(character) <= 0x9F
+            for character in safe_url
+        )
+    ):
+        return None
+    label = re.sub(r"([\\`*_\[\]{}])", r"\\\1", safe_url)
+    return f"[{label}](<{safe_url}>)"
 
 
 def _batch_render_ctx(frontend: "Frontend"):
@@ -2518,9 +2542,26 @@ class CommandRegistry:
             prompt_sensitive = getattr(self.frontend, "prompt_sensitive", None)
             if not callable(prompt_sensitive):
                 raise RuntimeError("This frontend cannot collect MCP OAuth codes securely")
+
+            # Put a full, clickable Markdown link in terminal scrollback before
+            # opening the bounded modal. This survives tmux redraws and remains
+            # selectable when OSC 52 clipboard forwarding is unavailable.
+            markdown_link = _mcp_oauth_markdown_link(auth_url)
+            if markdown_link is not None:
+                await self.frontend.render(
+                    AgentMessage(
+                        "Open the MCP OAuth authorization URL in a browser:\n\n"
+                        f"{markdown_link}\n\n"
+                        "If the link is not clickable (for example through tmux), "
+                        "copy and paste the displayed URL.",
+                        show_rule=False,
+                        soft_wrap=True,
+                    )
+                )
+
             return await prompt_sensitive(
                 "MCP OAuth authorization",
-                "Open the authorization URL below in a browser, authorize the server, "
+                "Open the authorization URL shown in scrollback, authorize the server, "
                 "then paste the authorization code or callback URL.",
                 link_url=auth_url,
             )

--- a/packages/nooa-cli/src/nooa_cli/tui/console.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/console.py
@@ -68,8 +68,8 @@ class TUIConsole:
             self._live_spinner = None
             self._spinner = None
 
-    def print_agent(self, message: str, *, show_rule: bool = True) -> None:
-        """Print an agent response, optionally with the OO ── rule header."""
+    def print_agent(self, message: str, *, show_rule: bool = True, soft_wrap: bool = False) -> None:
+        """Print an agent response, optionally with terminal-managed wrapping."""
         import textwrap
 
         # Aggressive cleanup for markdown rendering:
@@ -91,7 +91,7 @@ class TUIConsole:
             self.console.print(
                 Rule(title="[agent]OO[/agent]", style=COLORS["surface2"], align="left")
             )
-        self.console.print(Markdown(cleaned))
+        self.console.print(Markdown(cleaned), soft_wrap=soft_wrap)
 
     def print_error(self, message: str) -> None:
         """Print an error message."""

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -298,7 +298,9 @@ class TerminalFrontend:
         self._console.print_help(output.commands)
 
     def _render_agent_message(self, output: AgentMessage) -> None:
-        self._console.print_agent(output.content, show_rule=output.show_rule)
+        self._console.print_agent(
+            output.content, show_rule=output.show_rule, soft_wrap=output.soft_wrap
+        )
 
     def _render_clear(self, _output: ClearScreen) -> None:
         stream = getattr(self._console.console, "file", None)

--- a/packages/nooa-cli/src/nooa_cli/tui/output.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/output.py
@@ -84,9 +84,16 @@ class AgentMessage:
     content: str
     # False for 2nd+ message() calls in the same turn — suppresses the OO ── rule
     show_rule: bool = True
+    # Delegate wrapping to the terminal so copied long lines contain no hard newlines.
+    soft_wrap: bool = False
 
     def to_json(self) -> dict:
-        return {"type": "agent_message", "content": self.content, "show_rule": self.show_rule}
+        return {
+            "type": "agent_message",
+            "content": self.content,
+            "show_rule": self.show_rule,
+            "soft_wrap": self.soft_wrap,
+        }
 
 
 @dataclass

--- a/packages/nooa-cli/tests/tui/test_oauth_link_render.py
+++ b/packages/nooa-cli/tests/tui/test_oauth_link_render.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from io import StringIO
+
+from nooa_cli.tui.commands import _mcp_oauth_markdown_link
+from nooa_cli.tui.console import TUIConsole
+from rich.console import Console
+
+
+def test_agent_message_soft_wrap_preserves_long_url_as_one_logical_line():
+    url = "https://login.example.test/authorize?state=" + "a" * 500
+    stream = StringIO()
+    console = TUIConsole()
+    console.replace_console(Console(file=stream, width=60, color_system=None))
+
+    console.print_agent(f"[{url}](<{url}>)", show_rule=False, soft_wrap=True)
+
+    assert stream.getvalue() == f"{url}\n"
+
+
+def test_oauth_link_rejects_malformed_bracketed_host():
+    assert _mcp_oauth_markdown_link("https://[not-ipv6]/oauth") is None
+
+
+def test_oauth_link_rejects_terminal_controls():
+    assert _mcp_oauth_markdown_link("https://example.test/a\x00b") is None
+    assert _mcp_oauth_markdown_link("https://example.test/a\x1bb") is None
+    assert _mcp_oauth_markdown_link("https://example.test/a\x85b") is None

--- a/packages/nooa-cli/tests/tui/test_sensitive_prompt.py
+++ b/packages/nooa-cli/tests/tui/test_sensitive_prompt.py
@@ -6,9 +6,30 @@ import base64
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from nooa_cli.tui.commands import _mcp_oauth_markdown_link
 from nooa_cli.tui.subapp import ChoicePromptView, SensitiveTextPromptView, TextPromptView
 from nooa_cli.tui.tui_application import TUIApplication
 from prompt_toolkit.formatted_text import ANSI
+
+
+def test_mcp_oauth_markdown_link_shows_complete_clickable_url():
+    url = "https://login.example.test/authorize?state=" + "a" * 500 + "&scope=read%20write"
+
+    assert _mcp_oauth_markdown_link(url) == f"[{url}](<{url}>)"
+
+
+def test_mcp_oauth_markdown_link_escapes_label_metacharacters():
+    url = "https://example.test/a_[b]?scope=*read*"
+
+    assert _mcp_oauth_markdown_link(url) == (
+        r"[https://example.test/a\_\[b\]?scope=\*read\*]"
+        f"(<{url}>)"
+    )
+
+
+def test_mcp_oauth_markdown_link_rejects_unsafe_target():
+    assert _mcp_oauth_markdown_link("javascript:alert(1)") is None
+    assert _mcp_oauth_markdown_link("https://example.test/a b") is None
 
 
 def test_sensitive_prompt_masks_value_and_submits():


### PR DESCRIPTION
## Summary

- render MCP OAuth authorization URLs as Markdown links in terminal scrollback
- keep the sensitive prompt flow intact while exposing a clickable/copyable URL
- reject malformed URLs and C0/C1 control characters before passing links to Rich Markdown
- add focused rendering and sensitive-prompt regression coverage

## Validation

- `uv run ruff check` on all changed Python files
- 103 focused TUI tests passed
- malformed bracket-host and NUL/ESC/C1 probes passed
- `git diff --check` passed

Note: Ruff 0.15.20's format check reports pre-existing formatting in `commands.py`; the untouched `origin/dev/tui` version reports the identical formatting delta.
