### PR TITLE
fix(windows): raise explicit RuntimeError when instantiating BashSess…

### DIFF
--- a/src/nooa/tools/_bash_session.py
+++ b/src/nooa/tools/_bash_session.py
@@ -48,6 +48,13 @@ class BashSession:
     """
 
     def __init__(self, cwd: str | Path = ".", init_command: str | None = None) -> None:
+        import sys
+
+        if sys.platform == "win32":
+            raise RuntimeError(
+                "BashSession is only supported on Unix-like operating systems (Linux/macOS)."
+            )
+
         self._cwd = Path(cwd).resolve()
         # Optional shell snippet run once every time the session (re)starts —
         # before any user command — to set up the environment (e.g. activating a
@@ -71,7 +78,7 @@ class BashSession:
 
     def __del__(self) -> None:
         """Best-effort cleanup: kill the bash subprocess if still running."""
-        proc = self._process
+        proc = getattr(self, "_process", None)
         if proc is not None and proc.returncode is None:
             try:
                 # During interpreter shutdown, module globals (os, signal) may


### PR DESCRIPTION
## What does this PR do?

This PR fixes a critical crash point for Windows users by explicitly documenting that `BashSession` is a Unix-only tool. 

Previously, instantiating `BashSession` on Windows would throw a low-level `AssertionError: pass_fds not supported on Windows` from `asyncio.create_subprocess_exec`, and fallback paths leaked zombie child processes via `proc.kill()`. This PR adds an explicit check in `__init__` to raise a clean `RuntimeError` on `win32` platforms.

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [ ] Tests added/updated and passing (`uv run pytest`)
- [ ] Docs updated if behavior or public APIs changed
- [x] New source files carry an SPDX license header
