### PR TITLE
docs(storage): correct the StorageManager snapshot example to the real API 🤖🤖🤖

### DIFF
--- a/src/nooa/storage/manager.py
+++ b/src/nooa/storage/manager.py
@@ -44,10 +44,11 @@ class StorageManager(Protocol):
 
         # Events stream automatically through agent.event_manager,
         # which writes to storage.event_backend. Snapshot explicitly:
-        snapshot_id = agent.save()
+        snapshot_id = storage.save_snapshot(agent)
 
-        # Restore:
-        agent = MyAgent.load(snapshot_id, storage=storage)
+        # Restore into a freshly constructed agent:
+        agent = MyAgent(storage=storage)
+        storage.restore_snapshot(snapshot_id, agent)
     """
 
     @property

--- a/src/nooa/storage/snapshot.py
+++ b/src/nooa/storage/snapshot.py
@@ -138,7 +138,8 @@ class AgentSnapshot(BaseModel):
         Note: this performs additive restoration — it does not clear
         pre-existing context blocks or attributes on the target agent.
         The expected usage is with a freshly constructed agent (via
-        ``Agent.load()``), not an agent with in-progress state.
+        ``StorageManager.restore_snapshot()``), not an agent with
+        in-progress state.
 
         Args:
             agent: A freshly constructed Agent instance to restore into.


### PR DESCRIPTION
## What does this PR do?

The `StorageManager` protocol docstring teaches persistence with two methods that do not exist, so the first thing a reader copies out of it raises `AttributeError`.

`src/nooa/storage/manager.py:47,50` currently reads:

```python
snapshot_id = agent.save()

# Restore:
agent = MyAgent.load(snapshot_id, storage=storage)
```

But neither method is defined on `Agent`:

```python
>>> from nooa import Agent
>>> hasattr(Agent, "save"), hasattr(Agent, "load")
(False, False)
```

The real API is on the manager, and is declared a few lines *below* the example in this same `Protocol` — `save_snapshot(agent) -> str` and `restore_snapshot(snapshot_id, agent) -> None` — implemented by both `SQLiteStorageManager` and `InMemoryStorageManager`. The example is the only part of the file that disagrees with the rest of it.

This PR points the example at the real API:

```python
snapshot_id = storage.save_snapshot(agent)

# Restore into a freshly constructed agent:
agent = MyAgent(storage=storage)
storage.restore_snapshot(snapshot_id, agent)
```

The two-step restore matches `restore_snapshot`'s own contract, which takes an already-constructed agent and mutates it in place ("A freshly constructed Agent instance to restore into"), rather than returning a new one the way `MyAgent.load(...)` implied.

It also corrects a second, quieter instance of the same stale reference: `AgentSnapshot.restore()` in `src/nooa/storage/snapshot.py:141` points readers at ``Agent.load()`` for that same non-existent constructor path.

### Verification

The replacement snippet was executed against the shipped `SQLiteStorageManager` before submitting — save, construct a fresh agent, restore, and the snapshotted field round-trips. `uv run pytest tests/storage tests/unit/test_util_and_sqlite.py tests/test_sqlite_storage_latest.py` passes (162 passed), and `ruff check` / `ruff format --check` / `scripts/check_license_headers.py` are all clean.

### One open question for maintainers

`SQLiteStorageManager.restore_latest_snapshot(agent)` is arguably the friendlier thing to show a first-time reader, since it removes the need to track a snapshot id at all. I kept the example on the explicit `snapshot_id` pair because it mirrors the two `Protocol` methods being documented, but happy to switch it if you would rather the docstring showcase the convenience method.

## Related issues

None open that I could find — searched issues and PRs (any state) for `save_snapshot`, `agent.save`, and `StorageManager`, and checked the changed-file list of every open PR; nothing touches `manager.py` or `snapshot.py`.

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`) — docstring-only change, no behaviour to test; ran the storage suites to confirm nothing regressed
- [x] Docs updated if behavior or public APIs changed — this PR *is* the docs correction; no public API changed
- [x] New source files carry an SPDX license header — no new files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated storage snapshot examples to use the current `StorageManager` save and restore workflow.
  * Replaced outdated references to agent-level save and load methods in snapshot restoration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->