### PR TITLE
fix(interactive): report pending user/system messages as metadata (#124)

### DIFF
--- a/src/nooa/interactive.py
+++ b/src/nooa/interactive.py
@@ -359,11 +359,17 @@ class InteractiveAgent(Agent, llm=_DEFAULT_LLM):
         self._render_message = None
         self.vars = SnapshotVars()
         self.queue_manager = QueueManager(event_manager=self.event_manager)
-        self._user_messages_in = self.queue_manager.queue("user_messages")
+        # user/system messages are delivered to the agent through the
+        # dispatcher's notification, so the per-turn queue status must report
+        # only their pending count -- previewing the content there would make
+        # the agent answer the same message twice.
+        self._user_messages_in = self.queue_manager.queue("user_messages", preview_content=False)
         self.user_messages = self._user_messages_in.reader
         self._slash_commands_in = self.queue_manager.queue("slash_commands")
         self.slash_commands = self._slash_commands_in.reader
-        self._system_messages_in = self.queue_manager.queue("system_messages")
+        self._system_messages_in = self.queue_manager.queue(
+            "system_messages", preview_content=False
+        )
         self.system_messages = self._system_messages_in.reader
         self.producers = ProducersSkill()
         # Surface pending-queue counts (and a short preview of each item)

--- a/src/nooa/runtime/channels.py
+++ b/src/nooa/runtime/channels.py
@@ -209,6 +209,7 @@ class Channel[T]:
         on_get: Callable[[T], None] | None = None,
         on_put: Callable[[], None] | None = None,
         preview: Callable[[T], str] | None = None,
+        preview_content: bool = True,
     ) -> None:
         if mode not in ("queue", "event"):
             raise ValueError(
@@ -230,6 +231,12 @@ class Channel[T]:
         # _notify event so race() can wake on event-mode puts.
         self._on_put: Callable[[], None] | None = on_put
         self._preview: Callable[[T], str] = preview or _default_event_preview
+        # When False, ``status()`` reports only the pending count, never the
+        # item content. Used for message-input channels (e.g. user_messages)
+        # whose content is delivered to the agent through the dispatcher's
+        # notification; previewing that content in the per-turn status block
+        # would show it a second time and make the agent answer it twice.
+        self._preview_content = preview_content
 
     # ---- producer side ---------------------------------------------------
 
@@ -467,6 +474,10 @@ class Channel[T]:
         """
         if self.mode != "queue" or not self._items:
             return ""
+        if not self._preview_content:
+            # Metadata only: the content is delivered through the dispatcher,
+            # so previewing it here would make the agent handle it twice.
+            return f"{self.name}: {len(self._items)} pending (awaiting delivery)"
         lines = [f"{self.name}: {len(self._items)} pending"]
         snapshot = list(self._items)
         for i, item in enumerate(snapshot[:max_items], start=1):
@@ -667,6 +678,7 @@ class QueueManager:
         *,
         on_get: Callable[[T], None] | None = None,
         replace: bool = False,
+        preview_content: bool = True,
     ) -> Channel[T]:
         """Register a queue-mode channel.
 
@@ -677,12 +689,23 @@ class QueueManager:
         exists, it is removed (via ``remove_channel``) before the new
         one is created. Otherwise a duplicate name raises
         ``ValueError``.
+
+        Pass ``preview_content=False`` for channels whose items are
+        delivered to the agent through the dispatcher (e.g. user
+        messages): ``status()`` then reports only the pending count so
+        the content is not shown a second time.
         """
         if name in self._channels:
             if not replace:
                 raise ValueError(f"channel {name!r} already registered")
             self.remove_channel(name)
-        ch: Channel[T] = Channel(name, "queue", on_get=on_get, on_put=self._set_notify)
+        ch: Channel[T] = Channel(
+            name,
+            "queue",
+            on_get=on_get,
+            on_put=self._set_notify,
+            preview_content=preview_content,
+        )
         self._channels[name] = ch
         return ch
 

--- a/src/nooa/runtime/tests/test_channels.py
+++ b/src/nooa/runtime/tests/test_channels.py
@@ -363,6 +363,46 @@ def test_output_queue_status_delegates_to_input_queue():
     assert q.reader.status() == q.status()
 
 
+def test_status_metadata_only_when_preview_content_false():
+    """A message-input channel reports the pending count without its content.
+
+    The content is delivered to the agent through the dispatcher's
+    notification; previewing it in the per-turn status block would show it a
+    second time and make the agent answer the same message twice (#124).
+    """
+    q: Channel[str] = Channel("user_messages", "queue", preview_content=False)
+    q.put("what is the capital of France?")
+    status = q.status()
+    assert status == "user_messages: 1 pending (awaiting delivery)"
+    assert "capital of France" not in status
+
+
+def test_status_metadata_only_hides_every_item():
+    q: Channel[str] = Channel("user_messages", "queue", preview_content=False)
+    q.put("first")
+    q.put("second")
+    status = q.status()
+    assert "user_messages: 2 pending" in status
+    assert "first" not in status
+    assert "second" not in status
+    assert "1." not in status  # no numbered preview lines
+
+
+def test_queue_manager_threads_preview_content_flag():
+    qm = QueueManager()
+    ch = qm.queue("user_messages", preview_content=False)
+    ch.put("hello")
+    assert "user_messages: 1 pending (awaiting delivery)" in qm.status()
+    assert "hello" not in qm.status()
+
+
+def test_status_default_still_previews_content():
+    """Regression: producer channels keep their content previews."""
+    q: Channel[str] = Channel("job_outputs", "queue")
+    q.put("build finished")
+    assert "build finished" in q.status()
+
+
 # ---------------------------------------------------------------------------
 # QueueManager.race()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

Fixes #124. In the TUI, a submitted user message is answered twice.

The per-turn `queues` context block (`interactive.py`, `self.context["queues"] = Context(expr="self.queue_manager.status()")`) renders a short preview of each pending item, including the text of pending `user_messages`. That message is then delivered to the agent again through the dispatcher's `notification` (`handle(...)`), so the agent sees the same content on two paths and responds to it twice.

## What changed

- `Channel.__init__` gains a `preview_content: bool = True` flag, threaded through `QueueManager.queue(...)`. When `False`, `Channel.status()` reports only the pending count (`"<name>: N pending (awaiting delivery)"`) and never the item content.
- `InteractiveAgent` creates its `user_messages` and `system_messages` channels with `preview_content=False`, since those items are delivered through the dispatcher. Producer channels (e.g. `job_outputs`) are unchanged and still show content previews.

No dispatcher change; behavior is preserved for every other channel.

## Tests

Added to `src/nooa/runtime/tests/test_channels.py`:
- metadata-only status hides a single message's content,
- hides every item and the numbered preview lines,
- the flag threads through `QueueManager.queue()`,
- regression: default channels still preview content.

`test_channels.py` passes (42), the broader `runtime/tests/` suite passes (174 passed, 1 skipped), and `ruff check` / `ruff format --check` are clean.
