### PR TITLE
fix(tools): keep the shell parser away from the control protocol

### DIFF
--- a/src/nooa/tools/_bash_session.py
+++ b/src/nooa/tools/_bash_session.py
@@ -14,6 +14,7 @@ Architecture:
 """
 
 import asyncio
+import base64
 import logging
 import os
 import secrets
@@ -221,6 +222,25 @@ class BashSession:
             finally:
                 self._running_init = False
 
+    def _build_script(self, command: str, sentinel: str) -> str:
+        """Compose the wire script: the command, then the control-channel protocol.
+
+        The command is base64'd and decoded inside bash, so bash's parser never
+        reads it as shell text. Parsing it directly is unsafe; the
+        protocol lines travel on the same stdin. An unbalanced quote, paren or
+        heredoc in the command will consume them as string content. A command
+        that reads a bare stdin (``cat``) swallows the same lines as input;
+        the redirect from /dev/null prevents this.
+
+        The payload travels in a here-string so command length is bounded by memory
+        rather than ARG_MAX.
+        """
+        protocol = f"_nemo_ec=$?\necho $_nemo_ec >&3\npwd >&3\necho {sentinel} >&3\n"
+        # b64encode, not encodebytes: the latter wraps at 76 characters, and a
+        # newline inside the here-string would split the payload across lines.
+        blob = base64.b64encode(command.encode()).decode()
+        return f'eval "$(base64 -d <<<{blob})" </dev/null\n{protocol}'
+
     def _ensure_lock_on_current_loop(self) -> None:
         """Recreate the lock if the event loop changed since it was created."""
         if (
@@ -266,7 +286,7 @@ class BashSession:
         sentinel = f"__CTRL_{secrets.token_hex(8)}__"
 
         # Command runs normally; exit code + cwd + sentinel go to fd 3.
-        script = f"{command}\n_nemo_ec=$?\necho $_nemo_ec >&3\npwd >&3\necho {sentinel} >&3\n"
+        script = self._build_script(command, sentinel)
 
         ctrl_lines, stdout, stderr, timed_out = await self._send_and_wait(script, sentinel, timeout)
 
@@ -322,7 +342,7 @@ class BashSession:
 
         self._last_command = command
         sentinel = f"__CTRL_{secrets.token_hex(8)}__"
-        script = f"{command}\n_nemo_ec=$?\necho $_nemo_ec >&3\npwd >&3\necho {sentinel} >&3\n"
+        script = self._build_script(command, sentinel)
 
         proc = self._process
         ctrl = self._control_reader

--- a/tests/tools/test_bash_session_framing.py
+++ b/tests/tools/test_bash_session_framing.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for how BashSession frames a command on the wire.
+
+The control protocol (exit code, cwd, sentinel) travels on the same stdin as
+the command, so the command must not be parsed as shell text by the same
+parser that has to reach those lines. These tests pin the properties that
+depend on it:
+
+1. A command bash cannot parse exits non-zero instead of hanging
+2. A command that reads stdin cannot consume the protocol
+3. cd / export still persist across commands
+4. Command length is not bounded by ARG_MAX
+"""
+
+import asyncio
+
+import pytest
+
+from nooa.tools._bash_session import BashSession
+
+# Unbalanced double quote. Parsed as shell text this swallows every following
+# line, including the protocol, so the sentinel never arrives.
+UNPARSEABLE = """grep -n "needle\\(/tmp --glob '!build' """
+
+
+@pytest.fixture
+async def session(tmp_path):
+    """Fresh BashSession for each test."""
+    s = BashSession(cwd=tmp_path)
+    await s.start()
+    yield s
+    await s.close()
+
+
+class TestUnparseableCommands:
+    """A command bash cannot parse is an error, not a hang."""
+
+    async def test_unbalanced_quote_returns_promptly(self, session):
+        stdout, stderr, code, timed_out = await asyncio.wait_for(
+            session.run_with_timeout_flag(UNPARSEABLE, timeout=10.0), timeout=20.0
+        )
+        assert not timed_out, "unparseable command hung instead of returning"
+        assert code != 0
+
+    async def test_unbalanced_quote_reports_the_syntax_error(self, session):
+        _stdout, stderr, _code, _timed = await session.run_with_timeout_flag(
+            UNPARSEABLE, timeout=10.0
+        )
+        # The caller is an agent that can correct itself only if it is told why.
+        assert "unexpected EOF" in stderr or "syntax error" in stderr
+
+    async def test_session_survives_an_unparseable_command(self, session):
+        await session.run(UNPARSEABLE, timeout=10.0)
+        stdout, _stderr, code = await session.run("echo alive")
+        assert stdout == "alive"
+        assert code == 0
+
+    async def test_unparseable_command_does_not_restart_the_session(self, session):
+        """A syntax error is handled in-shell, so no reset is needed."""
+        before = session._start_count
+        await session.run(UNPARSEABLE, timeout=10.0)
+        assert session._start_count == before
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'echo "unterminated',
+            "echo 'unterminated",
+            "for i in 1 2 3; do echo $i",
+            "cat <<EOF\nno terminator",
+            "echo $(",
+        ],
+    )
+    async def test_malformed_shapes_all_return(self, session, command):
+        _stdout, _stderr, _code, timed_out = await asyncio.wait_for(
+            session.run_with_timeout_flag(command, timeout=10.0), timeout=20.0
+        )
+        assert not timed_out
+
+
+class TestProtocolIsolation:
+    """A command that reads stdin cannot consume the control protocol."""
+
+    async def test_cat_does_not_consume_the_protocol(self, session):
+        stdout, _stderr, code, timed_out = await session.run_with_timeout_flag("cat", timeout=10.0)
+        assert not timed_out
+        assert code == 0
+        assert stdout == ""
+
+    async def test_read_builtin_gets_eof(self, session):
+        stdout, _stderr, code, timed_out = await session.run_with_timeout_flag(
+            "read line; echo got=$line", timeout=10.0
+        )
+        assert not timed_out
+        assert code == 0
+        assert stdout == "got="
+
+
+class TestStatePersistence:
+    """Framing must not cost the session its defining property."""
+
+    async def test_cd_persists(self, session, tmp_path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        await session.run(f"cd {sub}")
+        stdout, _stderr, _code = await session.run("pwd")
+        assert stdout.endswith("sub")
+        assert session.cwd == sub
+
+    async def test_exported_variables_persist(self, session):
+        await session.run("export NOOA_TEST_VAR=persisted")
+        stdout, _stderr, _code = await session.run("echo $NOOA_TEST_VAR")
+        assert stdout == "persisted"
+
+    async def test_shell_functions_persist(self, session):
+        await session.run("noofn() { echo from_function; }")
+        stdout, _stderr, _code = await session.run("noofn")
+        assert stdout == "from_function"
+
+    async def test_exit_code_is_reported(self, session):
+        _stdout, _stderr, code = await session.run("(exit 42)")
+        assert code == 42
+
+
+class TestLongCommands:
+    """Command length is bounded by memory, not by ARG_MAX."""
+
+    async def test_200kb_command_runs(self, session):
+        payload = "x" * 200_000
+        stdout, _stderr, code = await session.run(f"echo {payload} | wc -c", timeout=30.0)
+        assert code == 0
+        assert stdout.strip() == str(len(payload) + 1)
+
+
+class TestStreamingUsesTheSameFraming:
+    """run_stream shares _build_script, so it gets the same guarantees."""
+
+    async def test_stream_of_unparseable_command_terminates(self, session):
+        events = []
+        async for name, chunk in session.run_stream(UNPARSEABLE, timeout=10.0):
+            events.append((name, chunk))
+        kind, payload = events[-1]
+        assert kind == "__done__"
+        exit_code, timed_out_flag = payload.split(",")
+        assert timed_out_flag == "0", "unparseable command timed out instead of returning"
+        assert exit_code != "0"
+
+    async def test_stream_yields_output_and_persists_cd(self, session, tmp_path):
+        sub = tmp_path / "streamed"
+        sub.mkdir()
+        chunks = [
+            c async for n, c in session.run_stream(f"cd {sub} && echo streamed", timeout=10.0)
+        ]
+        assert "streamed" in "".join(chunks)
+        assert session.cwd == sub


### PR DESCRIPTION
## What does this PR do?

BashSession writes the command and the control-channel lines (exit code, cwd, sentinel) to the same bash stdin. bash parses that stream as shell text, so a command with an unbalanced quote, paren or heredoc consumes the protocol lines below it as string content. The sentinel is never emitted and the caller waits out its whole timeout.

The recovery path cannot help there. _interrupt_and_recover looks for child processes to signal, but a parser wedge has not forked yet, so it falls through to SIGINT on bash itself, which kills a non-interactive shell. The control fd then reaches EOF, recovery reports failure, and the session resets. Every malformed command costs a full restart.

Base64 encode the command and decode it inside bash, so the parser only ever sees an alphanumeric blob. A malformed command becomes an ordinary non-zero exit with the shell's error on stderr, something an agent can read and correct. Feed eval from /dev/null so a command that reads a bare stdin (e.g. "cat") cannot consume the protocol either. The payload travels in a here-string, so command length is bounded by memory rather than ARG_MAX.

A quoted heredoc does not work in place of the encoding. Quoting the delimiter stops expansion of the body, but bash still parses forward to find the closing paren of the command substitution, and an unbalanced quote in the body defeats that search the same way it defeats the current framing. Base64 works because the payload carries no shell metacharacters at all.

This puts base64 on the path of every command. ShellTools already requires it to pass stdin to a command.


## Related issues

<!-- e.g. Closes #123 -->

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [ ] Docs updated if behavior or public APIs changed
- [x] New source files carry an SPDX license header


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bash command execution reliability, including commands containing complex or unusually large content.
  * Prevented commands that read standard input from interfering with session control and completion reporting.
  * Improved handling and reporting of malformed commands and syntax errors.
  * Preserved working directories, variables, functions, and exit codes consistently across commands.
  * Aligned streaming execution behavior with regular execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->