### PR TITLE
fix(mcp): harden OAuth flow in remote TUI sessions

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/subapp.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/subapp.py
@@ -80,15 +80,12 @@ def _safe_http_url(value: str | None) -> str | None:
     return safe
 
 
-def _terminal_hyperlink(label: str, url: str) -> str:
-    """Build an OSC 8 link wrapped as prompt_toolkit zero-width escapes."""
-    start = f"\x01\x1b]8;;{url}\x07\x02"
-    end = "\x01\x1b]8;;\x07\x02"
-    return start + _safe_terminal_text(label) + end
-
-
 class TextPromptView:
     """Single-line text input hosted by the existing TUI application."""
+
+    # Keep prompts in prompt_toolkit's bounded live region instead of growing
+    # them into a terminal-sized modal. Longer messages remain scrollable.
+    max_height = 10
 
     # Prompt views do not consume mouse events. Leaving terminal mouse mode off
     # lets users use native selection/copy while the modal is open.
@@ -126,16 +123,17 @@ class TextPromptView:
 
     def render(self, width: int, height: int) -> str:
         width = max(int(width), 40)
-        height = max(int(height), 4)
+        height = min(max(int(height), 4), self.max_height)
         header = f" {self.title} ".ljust(width, "─")[:width]
         message_lines: list[str] = []
         safe_message = _safe_terminal_text(self.message)
         for paragraph in safe_message.splitlines():
             message_lines.extend(textwrap.wrap(paragraph, width=width) or [""])
         if self.link_url:
-            message_lines.extend(
-                ("", _terminal_hyperlink("Open authorization URL", self.link_url))
-            )
+            # Do not emit OSC-8 hyperlinks here. A few terminal emulators leak
+            # hyperlink styling when prompt_toolkit repaints this dynamic view,
+            # underlining all subsequent TUI output. Ctrl+Y copies the full URL.
+            message_lines.extend(("", "Authorization URL ready — press Ctrl+Y to copy"))
         if self._copy_status:
             footer_text = f" {self._copy_status}  Enter submit  Esc cancel "
         elif self.link_url:

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -51,6 +51,15 @@ from .subapp import InAppSubview, normalize_key_result
 logger = logging.getLogger(__name__)
 
 
+def _is_raw_mouse_report(data: str) -> bool:
+    """Return whether raw input is a supported terminal mouse report."""
+    return (
+        data.startswith("\x1b[M")
+        or data.startswith("\x1b[<")
+        or re.fullmatch(r"\x1b\[\d+(?:;\d+){2}[Mm]", data) is not None
+    )
+
+
 class DispatcherExit(Exception):
     """Raised by handle() to signal the dispatcher should exit.
 
@@ -829,16 +838,7 @@ class TUIApplication:
                 if kp.key in (Keys.Vt100MouseEvent, Keys.WindowsMouseEvent):
                     return
             data = event.data or ""
-            if (
-                data.startswith("\x1b[M")
-                or data.startswith("\x1b[<")
-                or (
-                    len(data) > 3
-                    and data[:2] == "\x1b["
-                    and data[-1] in "Mm"
-                    and all(c.isdigit() or c == ";" for c in data[2:-1])
-                )
-            ):
+            if _is_raw_mouse_report(data):
                 return
             self._subview_key(event, "text", data)
 

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -526,6 +526,9 @@ class TUIApplication:
             self._subview_control,
             wrap_lines=False,
             always_hide_cursor=True,
+            # Compact prompt views render only their bounded line count, while
+            # explorer views still render a full terminal-sized frame.
+            dont_extend_height=True,
         )
 
         def _root_container():
@@ -826,9 +829,15 @@ class TUIApplication:
                 if kp.key in (Keys.Vt100MouseEvent, Keys.WindowsMouseEvent):
                     return
             data = event.data or ""
-            if data.startswith("\x1b[M") or data.startswith("\x1b[<") or (
-                len(data) > 3 and data[:2] == "\x1b[" and data[-1] in "Mm"
-                and all(c.isdigit() or c == ";" for c in data[2:-1])
+            if (
+                data.startswith("\x1b[M")
+                or data.startswith("\x1b[<")
+                or (
+                    len(data) > 3
+                    and data[:2] == "\x1b["
+                    and data[-1] in "Mm"
+                    and all(c.isdigit() or c == ";" for c in data[2:-1])
+                )
             ):
                 return
             self._subview_key(event, "text", data)
@@ -1378,9 +1387,7 @@ class TUIApplication:
             # instructions (such as the one-shot session-title request). Drain
             # them into this notification so housekeeping shares the normal
             # user turn instead of triggering another LLM call.
-            notification = self._drain_pending_queue_items(
-                qm, [("user_messages", item)]
-            )
+            notification = self._drain_pending_queue_items(qm, [("user_messages", item)])
         self._in_respond = True
         self._on_dispatcher_dequeued()
 

--- a/packages/nooa-cli/tests/tui/test_sensitive_prompt.py
+++ b/packages/nooa-cli/tests/tui/test_sensitive_prompt.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock
 from nooa_cli.tui.commands import _mcp_oauth_markdown_link
 from nooa_cli.tui.subapp import ChoicePromptView, SensitiveTextPromptView, TextPromptView
 from nooa_cli.tui.tui_application import TUIApplication
-from prompt_toolkit.formatted_text import ANSI
 
 
 def test_mcp_oauth_markdown_link_shows_complete_clickable_url():
@@ -67,6 +66,15 @@ def test_sensitive_prompt_strips_terminal_controls_from_server_url():
     assert "\u202e" not in rendered
 
 
+def test_sensitive_prompt_stays_in_bounded_dynamic_area():
+    view = SensitiveTextPromptView("OAuth", "Authorize in your browser.")
+
+    rendered = view.render(120, 40)
+
+    assert len(rendered.splitlines()) == view.max_height
+    assert view.max_height < 40
+
+
 def test_sensitive_prompt_scrolls_long_authorization_url():
     message = "Authorize: https://example.test/" + "a" * 500 + "\nTAIL_VISIBLE"
     view = SensitiveTextPromptView("OAuth", message)
@@ -79,19 +87,16 @@ def test_sensitive_prompt_scrolls_long_authorization_url():
     assert "TAIL_VISIBLE" in last
 
 
-def test_sensitive_prompt_renders_short_clickable_authorization_link():
+def test_sensitive_prompt_renders_safe_authorization_copy_hint():
     url = "https://login.example.test/authorize?" + "state=" + "a" * 500
     view = SensitiveTextPromptView("OAuth", "Authorize in your browser.", link_url=url)
 
     rendered = view.render(60, 10)
-    fragments = ANSI(rendered).__pt_formatted_text__()
-    visible = "".join(text for style, text in fragments if style != "[ZeroWidthEscape]")
-    escapes = "".join(text for style, text in fragments if style == "[ZeroWidthEscape]")
 
-    assert "Open authorization URL" in visible
-    assert url not in visible
-    assert f"\x1b]8;;{url}\x07" in escapes
-    assert "Ctrl+Y copy URL" in visible
+    assert "Authorization URL ready" in rendered
+    assert url not in rendered
+    assert "\x1b" not in rendered
+    assert "Ctrl+Y copy URL" in rendered
 
 
 def test_sensitive_prompt_copies_complete_authorization_url():

--- a/packages/nooa-cli/tests/tui/test_sensitive_prompt.py
+++ b/packages/nooa-cli/tests/tui/test_sensitive_prompt.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 
 from nooa_cli.tui.commands import _mcp_oauth_markdown_link
 from nooa_cli.tui.subapp import ChoicePromptView, SensitiveTextPromptView, TextPromptView
-from nooa_cli.tui.tui_application import TUIApplication
+from nooa_cli.tui.tui_application import TUIApplication, _is_raw_mouse_report
 
 
 def test_mcp_oauth_markdown_link_shows_complete_clickable_url():
@@ -29,6 +29,14 @@ def test_mcp_oauth_markdown_link_escapes_label_metacharacters():
 def test_mcp_oauth_markdown_link_rejects_unsafe_target():
     assert _mcp_oauth_markdown_link("javascript:alert(1)") is None
     assert _mcp_oauth_markdown_link("https://example.test/a b") is None
+
+
+def test_raw_numeric_mouse_report_is_filtered():
+    assert _is_raw_mouse_report("\x1b[0;12;34M") is True
+
+
+def test_non_mouse_numeric_csi_sequence_is_not_filtered():
+    assert _is_raw_mouse_report("\x1b[31m") is False
 
 
 def test_sensitive_prompt_masks_value_and_submits():

--- a/src/nooa/mcp/oauth.py
+++ b/src/nooa/mcp/oauth.py
@@ -106,7 +106,7 @@ def _system_browser_available() -> bool:
     the server config to force the out-of-band flow.
     """
     # Explicit sandbox/container signals must win over DISPLAY/WAYLAND_DISPLAY.
-    # NVIDIA sbx deliberately exports host display metadata for forwarding, but
+    # Container runtimes may export host display metadata for forwarding, but
     # SBX_NO_DISPLAY=1 means there is no browser/callback route into the sandbox.
     # Treating the forwarded WAYLAND_DISPLAY as usable makes OAuth launch on the
     # host and then strand the browser at a sandbox-local localhost callback.

--- a/src/nooa/mcp/oauth.py
+++ b/src/nooa/mcp/oauth.py
@@ -322,8 +322,14 @@ class OAuthHandler:
             auth_url = self._build_authorization_url(redirect_uri=manual_redirect)
             if not dynamic_client:
                 break
-            async with httpx.AsyncClient(follow_redirects=False) as client:
-                response = await client.get(auth_url, timeout=10.0)
+            try:
+                async with httpx.AsyncClient(follow_redirects=False) as client:
+                    response = await client.get(auth_url, timeout=10.0)
+            except httpx.RequestError as exc:
+                logger.warning(
+                    "Could not probe the OAuth authorization endpoint; continuing: %s", exc
+                )
+                break
             invalid_registration = (
                 response.status_code == 400 and "not registered for client" in response.text.lower()
             )

--- a/src/nooa/mcp/oauth.py
+++ b/src/nooa/mcp/oauth.py
@@ -47,6 +47,7 @@ class OAuthConfig:
         client_id: OAuth client ID, or None until dynamic registration completes
         redirect_uri: Redirect URI for OAuth callback
         scope: Optional OAuth scopes
+        resource: Optional RFC 8707 protected-resource identifier
         client_secret: Optional client secret (for dynamic registration)
         registration_endpoint: Optional OAuth dynamic client registration endpoint
     """
@@ -56,6 +57,7 @@ class OAuthConfig:
     client_id: str | None
     redirect_uri: str
     scope: str | None = None
+    resource: str | None = None
     client_secret: str | None = None
     registration_endpoint: str | None = None
     timeout: float = 300.0  # 5 minutes
@@ -103,11 +105,31 @@ def _system_browser_available() -> bool:
     won't trigger there. Such environments should set ``oauth_manual = true`` in
     the server config to force the out-of-band flow.
     """
+    # Explicit sandbox/container signals must win over DISPLAY/WAYLAND_DISPLAY.
+    # NVIDIA sbx deliberately exports host display metadata for forwarding, but
+    # SBX_NO_DISPLAY=1 means there is no browser/callback route into the sandbox.
+    # Treating the forwarded WAYLAND_DISPLAY as usable makes OAuth launch on the
+    # host and then strand the browser at a sandbox-local localhost callback.
+    no_display = os.environ.get("SBX_NO_DISPLAY", "").strip().lower()
+    if os.environ.get("SANDBOX_VM_ID") and no_display in {"1", "true", "yes", "on"}:
+        return False
+
+    # Check headless SSH before consulting webbrowser's process-global registry.
+    # A prior probe can register xdg-open, after which webbrowser.get() succeeds
+    # even though the launcher still cannot display anything in this session.
+    if (
+        os.name == "posix"
+        and os.environ.get("SSH_CONNECTION")
+        and not (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+    ):
+        return False
+
     try:
         webbrowser.get()
         return True
     except webbrowser.Error:
         pass
+
     # webbrowser.get() misses common launchers that DO open a host browser
     # (e.g. a sandbox's xdg-open that forwards to the host). If one is on PATH,
     # the loopback-callback flow can still complete — prefer it over OOB paste.
@@ -264,6 +286,8 @@ class OAuthHandler:
 
         if self.config.scope:
             params["scope"] = self.config.scope
+        if self.config.resource:
+            params["resource"] = self.config.resource
 
         query_string = urlencode(params)
         return f"{self.config.authorization_endpoint}?{query_string}"
@@ -272,14 +296,51 @@ class OAuthHandler:
         """Out-of-band authorization: show the URL, collect a pasted code.
 
         No local callback server is bound, so this works in headless/remote
-        environments (e.g. a docker sandbox). Uses the OOB redirect URI and the
-        host-provided ``code_prompt`` callback to read the code, never blocking
-        ``input()``.
+        environments (e.g. a docker sandbox). Dynamic clients register an OOB
+        redirect; pre-registered clients retain their configured redirect URI.
+        The host-provided ``code_prompt`` reads the resulting code/callback URL
+        without ever blocking on ``input()``.
         """
-        oob_redirect = "urn:ietf:wg:oauth:2.0:oob"
-        self._actual_redirect_uri = oob_redirect
-        await self._register_dynamic_client(oob_redirect)
-        auth_url = self._build_authorization_url(redirect_uri=oob_redirect)
+        # A pre-registered client can only use redirect URIs provisioned for
+        # that client. In a remote sandbox, keep its configured loopback URI:
+        # the browser may fail to load localhost, but the user can paste that
+        # callback URL into the secure prompt. Dynamic clients can register OOB.
+        dynamic_client = self.config.client_id is None and bool(self.config.registration_endpoint)
+        manual_redirect = (
+            "urn:ietf:wg:oauth:2.0:oob" if dynamic_client else self.config.redirect_uri
+        )
+        self._actual_redirect_uri = manual_redirect
+
+        # Some distributed OAuth gateways acknowledge dynamic registration on
+        # one backend before the client is visible to the authorization backend.
+        # Never hand the user a URL that already reports its redirect URI as
+        # unregistered: discard that client and register a fresh one first.
+        auth_url = ""
+        attempts = range(3) if dynamic_client else range(1)
+        for attempt in attempts:
+            await self._register_dynamic_client(manual_redirect)
+            auth_url = self._build_authorization_url(redirect_uri=manual_redirect)
+            if not dynamic_client:
+                break
+            async with httpx.AsyncClient(follow_redirects=False) as client:
+                response = await client.get(auth_url, timeout=10.0)
+            invalid_registration = (
+                response.status_code == 400 and "not registered for client" in response.text.lower()
+            )
+            if not invalid_registration:
+                break
+            logger.warning(
+                "OAuth authorization endpoint rejected newly registered client; retrying "
+                "dynamic registration (%s/3)",
+                attempt + 1,
+            )
+            self.config.client_id = None
+            self.config.client_secret = None
+        else:
+            raise RuntimeError(
+                "OAuth dynamic registration did not propagate to the authorization endpoint; "
+                "retry the connection later"
+            )
 
         if open_browser:
             with contextlib.suppress(Exception):
@@ -532,6 +593,8 @@ class OAuthHandler:
 
             if self.config.client_secret:
                 data["client_secret"] = self.config.client_secret
+            if self.config.resource:
+                data["resource"] = self.config.resource
 
             try:
                 response = await client.post(self.config.token_endpoint, data=data)
@@ -590,6 +653,8 @@ class OAuthHandler:
         }
         if self.config.scope:
             data["scope"] = self.config.scope
+        if self.config.resource:
+            data["resource"] = self.config.resource
 
         async with httpx.AsyncClient() as client:
             response = await client.post(self.config.token_endpoint, data=data, timeout=30.0)
@@ -842,6 +907,7 @@ async def _refresh_access_token(
     client_id: str,
     refresh_token: str,
     client_secret: str | None = None,
+    resource: str | None = None,
 ) -> OAuthToken | None:
     """Exchange a refresh token for a fresh access token, or None on failure."""
     data = {
@@ -851,6 +917,8 @@ async def _refresh_access_token(
     }
     if client_secret:
         data["client_secret"] = client_secret
+    if resource:
+        data["resource"] = resource
     try:
         async with httpx.AsyncClient() as client:
             response = await client.post(token_endpoint, data=data, timeout=10.0)
@@ -916,9 +984,13 @@ async def handle_mcp_oauth(
     token_endpoint = None
     registration_endpoint = None
     grant_types: list[str] = []
+    resource: str | None = None
 
     async with httpx.AsyncClient(follow_redirects=True) as client:
         resource_metadata = await _fetch_protected_resource_metadata(client, server_url)
+        advertised_resource = resource_metadata.get("resource")
+        if isinstance(advertised_resource, str) and advertised_resource:
+            resource = advertised_resource
         if scope is None:
             scopes = resource_metadata.get("scopes_supported") or []
             if all(isinstance(s, str) for s in scopes):
@@ -947,7 +1019,11 @@ async def handle_mcp_oauth(
         refresh_client_id = client_id or cached.client_id if cached else None
         if cached and cached.refresh_token and token_endpoint and refresh_client_id:
             refreshed = await _refresh_access_token(
-                token_endpoint, refresh_client_id, cached.refresh_token, cached.client_secret
+                token_endpoint,
+                refresh_client_id,
+                cached.refresh_token,
+                cached.client_secret,
+                resource,
             )
             if refreshed:
                 logger.info("Refreshed MCP OAuth token from cache")
@@ -977,6 +1053,7 @@ async def handle_mcp_oauth(
         client_secret=final_client_secret,
         redirect_uri=redirect_uri,
         scope=scope,
+        resource=resource,
         registration_endpoint=registration_endpoint,
         # Caller-supplied timeout overrides the OAuthConfig default (300s); this
         # is the single authoritative OAuth wait — the local callback server's

--- a/tests/test_mcp/test_browser_detection.py
+++ b/tests/test_mcp/test_browser_detection.py
@@ -82,8 +82,8 @@ def test_false_over_ssh_without_display_even_when_xdg_open_exists(monkeypatch):
     assert oauth._system_browser_available() is False
 
 
-def test_false_in_headless_nvidia_sandbox_even_with_forwarded_wayland(monkeypatch):
-    """sbx host-display metadata must not imply a reachable loopback browser."""
+def test_false_in_headless_container_even_with_forwarded_wayland(monkeypatch):
+    """Forwarded host-display metadata must not imply a reachable loopback browser."""
     monkeypatch.setattr(webbrowser, "get", lambda *a, **k: object())
     monkeypatch.setenv("SANDBOX_VM_ID", "agent-example")
     monkeypatch.setenv("SBX_NO_DISPLAY", "1")

--- a/tests/test_mcp/test_browser_detection.py
+++ b/tests/test_mcp/test_browser_detection.py
@@ -11,7 +11,16 @@ used instead.
 
 import webbrowser
 
+import pytest
+
 import nooa.mcp.oauth as oauth
+
+
+@pytest.fixture(autouse=True)
+def _clear_remote_runtime_signals(monkeypatch):
+    """Keep host runtime markers from leaking into browser-detection tests."""
+    for name in ("SANDBOX_VM_ID", "SBX_NO_DISPLAY", "SSH_CONNECTION"):
+        monkeypatch.delenv(name, raising=False)
 
 
 def test_uses_launcher_when_webbrowser_get_fails(monkeypatch):
@@ -20,6 +29,7 @@ def test_uses_launcher_when_webbrowser_get_fails(monkeypatch):
         raise webbrowser.Error("could not locate runnable browser")
 
     monkeypatch.setattr(webbrowser, "get", _raise)
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
     # Pretend xdg-open is on PATH.
     monkeypatch.setattr(
         oauth.shutil, "which", lambda name: "/usr/bin/xdg-open" if name == "xdg-open" else None
@@ -47,5 +57,37 @@ def test_false_when_no_browser_and_no_launcher(monkeypatch):
 
 
 def test_true_when_webbrowser_get_succeeds(monkeypatch):
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
     monkeypatch.setattr(webbrowser, "get", lambda: object())
     assert oauth._system_browser_available() is True
+
+
+def test_false_over_ssh_without_display_even_when_xdg_open_exists(monkeypatch):
+    """A bare xdg-open executable is not a browser in a headless SSH session."""
+
+    def _raise(*_a, **_k):
+        raise webbrowser.Error("could not locate runnable browser")
+
+    # Simulate xdg-open having already been registered by an earlier probe:
+    # the headless check must run before this apparent browser success.
+    monkeypatch.setattr(webbrowser, "get", lambda *a, **k: object())
+    monkeypatch.setattr(oauth.os, "name", "posix")
+    monkeypatch.setenv("SSH_CONNECTION", "client 123 server 22")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setattr(
+        oauth.shutil, "which", lambda name: "/usr/bin/xdg-open" if name == "xdg-open" else None
+    )
+
+    assert oauth._system_browser_available() is False
+
+
+def test_false_in_headless_nvidia_sandbox_even_with_forwarded_wayland(monkeypatch):
+    """sbx host-display metadata must not imply a reachable loopback browser."""
+    monkeypatch.setattr(webbrowser, "get", lambda *a, **k: object())
+    monkeypatch.setenv("SANDBOX_VM_ID", "agent-example")
+    monkeypatch.setenv("SBX_NO_DISPLAY", "1")
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
+
+    assert oauth._system_browser_available() is False

--- a/tests/test_mcp/test_oauth_discovery.py
+++ b/tests/test_mcp/test_oauth_discovery.py
@@ -377,6 +377,48 @@ async def test_manual_authorize_retries_delayed_dynamic_registration(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_manual_authorize_continues_when_registration_probe_fails(monkeypatch):
+    registrations: list[str] = []
+    prompted_urls: list[str] = []
+    original = httpx.AsyncClient
+
+    async def fake_register(self, redirect_uri):
+        registrations.append(redirect_uri)
+        self.config.client_id = "client-1"
+        self.config.client_secret = "secret-client-1"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("authorization endpoint unavailable", request=request)
+
+    async def code_prompt(auth_url: str) -> str:
+        prompted_urls.append(auth_url)
+        return "authorization-code"
+
+    monkeypatch.setattr(oauth.OAuthHandler, "_register_dynamic_client", fake_register)
+    monkeypatch.setattr(
+        oauth.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: original(transport=httpx.MockTransport(handler)),
+    )
+    config = oauth.OAuthConfig(
+        authorization_endpoint="https://maas.example/authorize",
+        token_endpoint="https://maas.example/token",
+        client_id=None,
+        redirect_uri="urn:ietf:wg:oauth:2.0:oob",
+        registration_endpoint="https://maas.example/register",
+    )
+
+    code = await oauth.OAuthHandler(config, manual=True, code_prompt=code_prompt).authorize(
+        open_browser=False
+    )
+
+    assert code == "authorization-code"
+    assert registrations == ["urn:ietf:wg:oauth:2.0:oob"]
+    assert len(prompted_urls) == 1
+    assert "client_id=client-1" in prompted_urls[0]
+
+
+@pytest.mark.asyncio
 async def test_manual_authorize_fails_after_registration_retry_limit(monkeypatch):
     registrations: list[str] = []
     original = httpx.AsyncClient

--- a/tests/test_mcp/test_oauth_discovery.py
+++ b/tests/test_mcp/test_oauth_discovery.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for RFC 9728 OAuth authorization-server discovery in mcp/oauth.py."""
 
+from urllib.parse import parse_qs, urlparse
+
 import httpx
 import pytest
 
@@ -267,8 +269,11 @@ async def test_handle_mcp_oauth_refreshes_expired_token(monkeypatch, tmp_path):
         ),
     )
 
-    async def fake_discover(client, server_url):
-        return ["https://maas.example/auth"]
+    async def fake_resource_metadata(client, server_url):
+        return {
+            "resource": "https://maas.example/mcp",
+            "authorization_servers": ["https://maas.example/auth"],
+        }
 
     async def fake_metadata(client, auth_server):
         return {
@@ -277,15 +282,18 @@ async def test_handle_mcp_oauth_refreshes_expired_token(monkeypatch, tmp_path):
             "registration_endpoint": f"{auth_server}/register",
         }
 
-    async def fake_refresh(token_endpoint, client_id, refresh_token, client_secret=None):
+    async def fake_refresh(
+        token_endpoint, client_id, refresh_token, client_secret=None, resource=None
+    ):
         assert client_id == "cached-client"
         assert client_secret == "cached-secret"
         assert refresh_token == "ref"
+        assert resource == "https://maas.example/mcp"
         return oauth.OAuthToken(
             access_token="new", refresh_token="ref2", expires_in=3600, obtained_at=oauth.time.time()
         )
 
-    monkeypatch.setattr(oauth, "_discover_authorization_servers", fake_discover)
+    monkeypatch.setattr(oauth, "_fetch_protected_resource_metadata", fake_resource_metadata)
     monkeypatch.setattr(oauth, "_fetch_authorization_server_metadata", fake_metadata)
     monkeypatch.setattr(oauth, "_refresh_access_token", fake_refresh)
 
@@ -293,6 +301,135 @@ async def test_handle_mcp_oauth_refreshes_expired_token(monkeypatch, tmp_path):
     assert token.access_token == "new"
     # Refreshed token is persisted.
     assert oauth._load_cached_token(url).access_token == "new"
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_includes_protected_resource(monkeypatch):
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(dict(httpx.QueryParams(request.content.decode())))
+        return httpx.Response(200, json={"access_token": "new-token"})
+
+    original = httpx.AsyncClient
+    monkeypatch.setattr(
+        oauth.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: original(transport=httpx.MockTransport(handler)),
+    )
+
+    token = await oauth._refresh_access_token(
+        "https://maas.example/token",
+        "client-id",
+        "refresh-token",
+        "client-secret",
+        "https://maas.example/mcp",
+    )
+
+    assert token is not None
+    assert token.access_token == "new-token"
+    assert captured["resource"] == "https://maas.example/mcp"
+
+
+@pytest.mark.asyncio
+async def test_manual_authorize_retries_delayed_dynamic_registration(monkeypatch):
+    registrations: list[str] = []
+    authorization_checks: list[str] = []
+    original = httpx.AsyncClient
+
+    async def fake_register(self, redirect_uri):
+        client_id = f"client-{len(registrations) + 1}"
+        registrations.append(client_id)
+        self.config.client_id = client_id
+        self.config.client_secret = f"secret-{client_id}"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        client_id = request.url.params["client_id"]
+        authorization_checks.append(client_id)
+        if client_id in {"client-1", "client-2"}:
+            return httpx.Response(400, text="redirect URI not registered for client")
+        return httpx.Response(200)
+
+    async def code_prompt(auth_url: str) -> str:
+        return "authorization-code"
+
+    monkeypatch.setattr(oauth.OAuthHandler, "_register_dynamic_client", fake_register)
+    monkeypatch.setattr(
+        oauth.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: original(transport=httpx.MockTransport(handler)),
+    )
+    config = oauth.OAuthConfig(
+        authorization_endpoint="https://maas.example/authorize",
+        token_endpoint="https://maas.example/token",
+        client_id=None,
+        redirect_uri="urn:ietf:wg:oauth:2.0:oob",
+        registration_endpoint="https://maas.example/register",
+    )
+
+    code = await oauth.OAuthHandler(config, manual=True, code_prompt=code_prompt).authorize(
+        open_browser=False
+    )
+
+    assert code == "authorization-code"
+    assert registrations == ["client-1", "client-2", "client-3"]
+    assert authorization_checks == registrations
+
+
+@pytest.mark.asyncio
+async def test_manual_authorize_fails_after_registration_retry_limit(monkeypatch):
+    registrations: list[str] = []
+    original = httpx.AsyncClient
+
+    async def fake_register(self, redirect_uri):
+        client_id = f"client-{len(registrations) + 1}"
+        registrations.append(client_id)
+        self.config.client_id = client_id
+        self.config.client_secret = f"secret-{client_id}"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="redirect URI not registered for client")
+
+    async def code_prompt(auth_url: str) -> str:
+        raise AssertionError("the prompt must not open for an invalid registration")
+
+    monkeypatch.setattr(oauth.OAuthHandler, "_register_dynamic_client", fake_register)
+    monkeypatch.setattr(
+        oauth.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: original(transport=httpx.MockTransport(handler)),
+    )
+    config = oauth.OAuthConfig(
+        authorization_endpoint="https://maas.example/authorize",
+        token_endpoint="https://maas.example/token",
+        client_id=None,
+        redirect_uri="urn:ietf:wg:oauth:2.0:oob",
+        registration_endpoint="https://maas.example/register",
+    )
+
+    with pytest.raises(RuntimeError, match="did not propagate"):
+        await oauth.OAuthHandler(config, manual=True, code_prompt=code_prompt).authorize(
+            open_browser=False
+        )
+
+    assert registrations == ["client-1", "client-2", "client-3"]
+
+
+def test_authorization_url_includes_protected_resource_indicator():
+    config = oauth.OAuthConfig(
+        authorization_endpoint="https://maas.example/auth/authorize",
+        token_endpoint="https://maas.example/auth/token",
+        client_id="client-id",
+        redirect_uri="urn:ietf:wg:oauth:2.0:oob",
+        scope="user_impersonation",
+        resource="https://maas.example/confluence/mcp",
+    )
+
+    url = oauth.OAuthHandler(config)._build_authorization_url()
+    params = parse_qs(urlparse(url).query)
+
+    assert params["resource"] == ["https://maas.example/confluence/mcp"]
+    assert params["scope"] == ["user_impersonation"]
 
 
 @pytest.mark.asyncio
@@ -304,6 +441,8 @@ async def test_manual_authorize_uses_oob_and_code_prompt(monkeypatch):
     def handler(request: httpx.Request) -> httpx.Response:
         import json as _json
 
+        if request.method == "GET":
+            return httpx.Response(200)
         body = _json.loads(request.content)
         registered.extend(body["redirect_uris"])
         return httpx.Response(201, json={"client_id": "oob-client"})
@@ -339,6 +478,31 @@ async def test_manual_authorize_uses_oob_and_code_prompt(monkeypatch):
     assert handler_obj._actual_redirect_uri == "urn:ietf:wg:oauth:2.0:oob"
 
 
+@pytest.mark.asyncio
+async def test_manual_authorize_preserves_registered_client_redirect(monkeypatch):
+    """A fixed client must not be switched to an unregistered OOB redirect."""
+    seen_url: list[str] = []
+
+    async def code_prompt(auth_url: str) -> str:
+        seen_url.append(auth_url)
+        return "pasted-code"
+
+    config = oauth.OAuthConfig(
+        authorization_endpoint="https://maas.example/auth/authorize",
+        token_endpoint="https://maas.example/auth/token",
+        client_id="registered-client",
+        redirect_uri="http://localhost:8090/callback",
+    )
+    handler_obj = oauth.OAuthHandler(config, manual=True, code_prompt=code_prompt)
+
+    code = await handler_obj.authorize(open_browser=False)
+
+    assert code == "pasted-code"
+    params = parse_qs(urlparse(seen_url[0]).query)
+    assert params["redirect_uri"] == ["http://localhost:8090/callback"]
+    assert handler_obj._actual_redirect_uri == "http://localhost:8090/callback"
+
+
 def test_extract_authorization_code_accepts_oob_callback_url():
     pasted = "urn:ietf:wg:oauth:2.0:oob?code=abc123&state=xyz"
 
@@ -359,9 +523,11 @@ def test_extract_authorization_code_preserves_raw_code():
 async def test_handle_mcp_oauth_defaults_scope_from_resource_metadata(monkeypatch, tmp_path):
     monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(tmp_path))
     seen_scopes: list[str | None] = []
+    seen_resources: list[str | None] = []
 
     async def fake_resource_metadata(client, server_url):
         return {
+            "resource": "https://maas.example/confluence/mcp",
             "authorization_servers": ["https://maas.example/auth"],
             "scopes_supported": ["READ", "WRITE"],
         }
@@ -375,6 +541,7 @@ async def test_handle_mcp_oauth_defaults_scope_from_resource_metadata(monkeypatc
 
     async def fake_complete_flow(self, open_browser=True):
         seen_scopes.append(self.config.scope)
+        seen_resources.append(self.config.resource)
         return oauth.OAuthToken(access_token="token")
 
     monkeypatch.setattr(oauth, "_fetch_protected_resource_metadata", fake_resource_metadata)
@@ -384,11 +551,12 @@ async def test_handle_mcp_oauth_defaults_scope_from_resource_metadata(monkeypatc
     await oauth.handle_mcp_oauth("https://maas.example/mcp", client_id="client-id")
 
     assert seen_scopes == ["READ WRITE"]
+    assert seen_resources == ["https://maas.example/confluence/mcp"]
 
 
 @pytest.mark.asyncio
 async def test_authorize_falls_back_to_manual_when_no_browser(monkeypatch):
-    """Headless sessions auto-use manual OOB when a code prompt is available."""
+    """Headless fixed clients use a secure prompt with their registered redirect."""
     monkeypatch.setattr(oauth, "_system_browser_available", lambda: False)
 
     config = oauth.OAuthConfig(
@@ -415,7 +583,7 @@ async def test_authorize_falls_back_to_manual_when_no_browser(monkeypatch):
 
     assert code == "pasted-code"
     assert seen and seen[0].startswith("https://maas.example/auth/authorize")
-    assert handler._actual_redirect_uri == "urn:ietf:wg:oauth:2.0:oob"
+    assert handler._actual_redirect_uri == "http://127.0.0.1:0/callback"
 
 
 @pytest.mark.asyncio
@@ -454,6 +622,9 @@ def test_system_browser_available_false_when_no_browser(monkeypatch):
 
 def test_system_browser_available_true_when_browser_present(monkeypatch):
     """Returns True when webbrowser.get() succeeds without raising."""
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
+    monkeypatch.delenv("SANDBOX_VM_ID", raising=False)
+    monkeypatch.delenv("SBX_NO_DISPLAY", raising=False)
     monkeypatch.setattr(oauth.webbrowser, "get", lambda *a, **k: object())
     assert oauth._system_browser_available() is True
 


### PR DESCRIPTION
Summary

 • detect headless SSH and container sessions before launching OAuth browsers
 • preserve fixed-client redirect URIs while supporting secure manual OAuth
 • propagate RFC 8707 protected-resource indicators through authorization, code exchange, refresh, and client-credentials grants
 • retry bounded dynamic registration when authorization backends lag registration
 • avoid leaking OSC-8 links in sensitive OAuth prompts

Validation

 • uv run --frozen pytest -q tests/test_mcp — 100 passed
 • focused OAuth/browser/sensitive-prompt tests — 55 passed
 • Ruff format/check — clean
 • git diff --check — clean

Notes

The broader TUI suite previously passed 846 tests with test_reflection_runner.py excluded because that test is contaminated by the live external
durable_recovery skill and closed-SQLite lifecycle behavior unrelated to this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth resource support across discovery, authorization, token refresh, and protected-resource metadata.
  * Improved authorization handling for pre-registered and dynamically registered clients, including retry support.
  * Added safe copy instructions for authorization links.

* **Bug Fixes**
  * Limited compact prompts to a bounded display height.
  * Improved detection of unavailable browsers in headless, sandboxed, and remote sessions.
  * Filtered additional raw mouse input before displaying prompt text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->