### PR TITLE
Fix nooa-bench OTLP trace usage extraction

### DIFF
--- a/packages/nooa-bench/src/nooa_bench/trace_analyzer.py
+++ b/packages/nooa-bench/src/nooa_bench/trace_analyzer.py
@@ -20,6 +20,115 @@ from nooa_bench.protocol import (
 logger = logging.getLogger(__name__)
 
 
+_MODEL_ATTRS = (
+    "llm.model_name",
+    "llm.model",
+    "gen_ai.request.model",
+    "gen_ai.response.model",
+    "model",
+)
+_PROMPT_TOKEN_ATTRS = (
+    "llm.token_count.prompt",
+    "gen_ai.usage.input_tokens",
+    "gen_ai.usage.prompt_tokens",
+    "input_tokens",
+)
+_COMPLETION_TOKEN_ATTRS = (
+    "llm.token_count.completion",
+    "gen_ai.usage.output_tokens",
+    "gen_ai.usage.completion_tokens",
+    "output_tokens",
+)
+_TOTAL_TOKEN_ATTRS = (
+    "llm.token_count.total",
+    "gen_ai.usage.total_tokens",
+    "total_tokens",
+)
+
+
+def _extract_any_value(value_obj: dict[str, Any]) -> Any:
+    """Extract a Python value from an OTLP AnyValue object."""
+    if "stringValue" in value_obj:
+        return value_obj["stringValue"]
+    if "intValue" in value_obj:
+        return int(value_obj["intValue"])
+    if "doubleValue" in value_obj:
+        return float(value_obj["doubleValue"])
+    if "boolValue" in value_obj:
+        return value_obj["boolValue"]
+    if "bytesValue" in value_obj:
+        return value_obj["bytesValue"]
+    if "arrayValue" in value_obj:
+        return [_extract_any_value(v) for v in value_obj["arrayValue"].get("values", [])]
+    if "kvlistValue" in value_obj:
+        return {
+            kv["key"]: _extract_any_value(kv.get("value", {}))
+            for kv in value_obj["kvlistValue"].get("values", [])
+        }
+    return None
+
+
+def _otlp_attrs_to_dict(attrs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Convert OTLP ``[{key, value}]`` attributes to a flat dict."""
+    result: dict[str, Any] = {}
+    for attr in attrs:
+        key = attr.get("key", "")
+        if key:
+            result[key] = _extract_any_value(attr.get("value", {}))
+    return result
+
+
+def _parse_time_ns(value: Any) -> int:
+    """Parse a timestamp value in nanoseconds, returning 0 when absent."""
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _first_attr(attrs: dict[str, Any], names: tuple[str, ...], default: Any = None) -> Any:
+    """Return the first present attribute from ``names``."""
+    for name in names:
+        value = attrs.get(name)
+        if value is not None:
+            return value
+    return default
+
+
+def _iter_trace_spans(doc: dict[str, Any]):
+    """Yield trace spans from current OTLP envelopes and legacy flat JSONL."""
+    if "resourceSpans" in doc:
+        for resource_spans in doc.get("resourceSpans", []):
+            for scope_spans in resource_spans.get("scopeSpans", []):
+                for span in scope_spans.get("spans", []):
+                    yield {
+                        "name": span.get("name", ""),
+                        "start_ns": _parse_time_ns(span.get("startTimeUnixNano")),
+                        "end_ns": _parse_time_ns(span.get("endTimeUnixNano")),
+                        "attributes": _otlp_attrs_to_dict(span.get("attributes", [])),
+                    }
+        return
+
+    attrs = doc.get("attributes", {})
+    if isinstance(attrs, list):
+        attrs = _otlp_attrs_to_dict(attrs)
+    elif not isinstance(attrs, dict):
+        attrs = {}
+
+    yield {
+        "name": doc.get("name", ""),
+        "start_ns": _parse_time_ns(
+            doc.get("start_time_unix_nano", doc.get("startTimeUnixNano", doc.get("start_time")))
+        ),
+        "end_ns": _parse_time_ns(
+            doc.get("end_time_unix_nano", doc.get("endTimeUnixNano", doc.get("end_time")))
+        ),
+        "attributes": attrs,
+    }
+
+
 class TraceAnalyzer:
     """
     Analyzes OTel traces to extract usage statistics.
@@ -56,74 +165,79 @@ class TraceAnalyzer:
 
         # Track stats per model
         model_stats: dict[str, ModelUsageStats] = {}
-        trace_start_time: float | None = None
-        trace_end_time: float | None = None
+        trace_start_ns: int | None = None
+        trace_end_ns: int | None = None
         total_llm_calls = 0
 
         with open(path) as f:
             for line in f:
+                line = line.strip()
+                if not line:
+                    continue
                 try:
-                    span = json.loads(line.strip())
+                    doc = json.loads(line)
 
-                    # Track overall trace timing
-                    start_time = span.get("start_time_unix_nano", 0) / 1e9
-                    end_time = span.get("end_time_unix_nano", 0) / 1e9
+                    for span in _iter_trace_spans(doc):
+                        start_ns = span["start_ns"]
+                        end_ns = span["end_ns"]
 
-                    if trace_start_time is None or start_time < trace_start_time:
-                        trace_start_time = start_time
-                    if trace_end_time is None or end_time > trace_end_time:
-                        trace_end_time = end_time
+                        # Track overall trace timing
+                        if start_ns > 0 and (trace_start_ns is None or start_ns < trace_start_ns):
+                            trace_start_ns = start_ns
+                        if end_ns > 0 and (trace_end_ns is None or end_ns > trace_end_ns):
+                            trace_end_ns = end_ns
 
-                    # Look for LLM spans
-                    attrs = span.get("attributes", {})
-                    span_name = span.get("name", "")
+                        # Look for LLM spans
+                        attrs = span["attributes"]
+                        span_name = span["name"]
 
-                    # Check if this is an LLM call span
-                    if self._is_llm_span(span_name, attrs):
-                        total_llm_calls += 1
+                        # Check if this is an LLM call span
+                        if self._is_llm_span(span_name, attrs):
+                            total_llm_calls += 1
 
-                        # Extract model name
-                        model_name = attrs.get(
-                            "llm.model", attrs.get("gen_ai.request.model", "unknown")
-                        )
+                            # Extract model name
+                            model_name = _first_attr(attrs, _MODEL_ATTRS, "unknown")
 
-                        # Initialize model stats if not seen before
-                        if model_name not in model_stats:
-                            model_stats[model_name] = ModelUsageStats(model_name=model_name)
+                            # Initialize model stats if not seen before
+                            if model_name not in model_stats:
+                                model_stats[model_name] = ModelUsageStats(model_name=model_name)
 
-                        stats = model_stats[model_name]
+                            stats = model_stats[model_name]
 
-                        # Extract token counts with validation
-                        prompt_tokens = attrs.get(
-                            "llm.token_count.prompt", attrs.get("gen_ai.usage.input_tokens", 0)
-                        )
-                        completion_tokens = attrs.get(
-                            "llm.token_count.completion", attrs.get("gen_ai.usage.output_tokens", 0)
-                        )
+                            # Extract token counts with validation
+                            prompt_tokens = _first_attr(attrs, _PROMPT_TOKEN_ATTRS, 0)
+                            completion_tokens = _first_attr(attrs, _COMPLETION_TOKEN_ATTRS, 0)
+                            total_tokens = _first_attr(attrs, _TOTAL_TOKEN_ATTRS, None)
 
-                        # Validate and parse token counts
-                        prompt_count = self._parse_token_count(prompt_tokens, "prompt_tokens", path)
-                        completion_count = self._parse_token_count(
-                            completion_tokens, "completion_tokens", path
-                        )
+                            # Validate and parse token counts
+                            prompt_count = self._parse_token_count(
+                                prompt_tokens, "prompt_tokens", path
+                            )
+                            completion_count = self._parse_token_count(
+                                completion_tokens, "completion_tokens", path
+                            )
+                            total_count = self._parse_token_count(
+                                total_tokens, "total_tokens", path
+                            )
+                            combined_count = prompt_count + completion_count
 
-                        stats.prompt_tokens += prompt_count
-                        stats.completion_tokens += completion_count
-                        stats.total_tokens += prompt_count + completion_count
-                        stats.call_count += 1
+                            stats.prompt_tokens += prompt_count
+                            stats.completion_tokens += completion_count
+                            stats.total_tokens += combined_count or total_count
+                            stats.call_count += 1
 
-                        # Calculate latency in milliseconds
-                        if start_time > 0 and end_time > 0:
-                            latency_ms = (end_time - start_time) * 1000
-                            stats.latencies_ms.append(latency_ms)
+                            # Calculate latency in milliseconds
+                            if start_ns > 0 and end_ns > 0:
+                                latency_ms = (end_ns - start_ns) / 1e6
+                                stats.latencies_ms.append(latency_ms)
 
                 except json.JSONDecodeError:
                     continue
 
         # Calculate total runtime
         runtime_seconds = 0.0
-        if trace_start_time and trace_end_time:
-            runtime_seconds = trace_end_time - trace_start_time
+        if trace_start_ns and trace_end_ns:
+            runtime_seconds = (trace_end_ns - trace_start_ns) / 1e9
 
         return TaskUsageStats(
             task_id=path.stem,
@@ -141,12 +255,16 @@ class TraceAnalyzer:
 
         # Check for LLM-related attributes
         llm_attrs = [
+            "llm.model_name",
             "llm.model",
             "llm.token_count.prompt",
             "llm.token_count.completion",
+            "llm.token_count.total",
             "gen_ai.request.model",
+            "gen_ai.response.model",
             "gen_ai.usage.input_tokens",
             "gen_ai.usage.output_tokens",
+            "gen_ai.usage.total_tokens",
         ]
         return any(attr in attributes for attr in llm_attrs)
 

--- a/packages/nooa-bench/tests/test_trace_analyzer.py
+++ b/packages/nooa-bench/tests/test_trace_analyzer.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for nooa-bench trace usage extraction."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nooa_bench.trace_analyzer import TraceAnalyzer
+
+
+def _attr(key: str, value: object) -> dict:
+    if isinstance(value, bool):
+        otlp_value = {"boolValue": value}
+    elif isinstance(value, int):
+        otlp_value = {"intValue": str(value)}
+    elif isinstance(value, float):
+        otlp_value = {"doubleValue": value}
+    else:
+        otlp_value = {"stringValue": str(value)}
+    return {"key": key, "value": otlp_value}
+
+
+def _write_jsonl(path: Path, *records: dict) -> None:
+    path.write_text("".join(json.dumps(record) + "\n" for record in records))
+
+
+def test_current_otlp_jsonl_extracts_usage(tmp_path: Path) -> None:
+    trace_path = tmp_path / "current_otlp.jsonl"
+    _write_jsonl(
+        trace_path,
+        {
+            "resourceSpans": [
+                {
+                    "scopeSpans": [
+                        {
+                            "spans": [
+                                {
+                                    "name": "completion",
+                                    "startTimeUnixNano": "1000000000",
+                                    "endTimeUnixNano": "1500000000",
+                                    "attributes": [
+                                        _attr("llm.model_name", "model-a"),
+                                        _attr("llm.token_count.prompt", 10),
+                                        _attr("llm.token_count.completion", 5),
+                                    ],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+    )
+
+    stats = TraceAnalyzer().analyze_trace(str(trace_path))
+
+    assert stats.total_runtime_seconds == 0.5
+    assert stats.total_llm_calls == 1
+    assert len(stats.models_used) == 1
+    model_stats = stats.models_used[0]
+    assert model_stats.model_name == "model-a"
+    assert model_stats.prompt_tokens == 10
+    assert model_stats.completion_tokens == 5
+    assert model_stats.total_tokens == 15
+    assert model_stats.call_count == 1
+    assert model_stats.latencies_ms == [500.0]
+
+
+def test_current_otlp_jsonl_aggregates_multiple_batches_and_models(tmp_path: Path) -> None:
+    trace_path = tmp_path / "multi_batch.jsonl"
+    _write_jsonl(
+        trace_path,
+        {
+            "resourceSpans": [
+                {
+                    "scopeSpans": [
+                        {
+                            "spans": [
+                                {
+                                    "name": "acompletion",
+                                    "startTimeUnixNano": "1000000000",
+                                    "endTimeUnixNano": "1200000000",
+                                    "attributes": [
+                                        _attr("llm.model_name", "model-a"),
+                                        _attr("llm.token_count.prompt", 3),
+                                        _attr("llm.token_count.completion", 2),
+                                    ],
+                                },
+                                {
+                                    "name": "tool",
+                                    "startTimeUnixNano": "1250000000",
+                                    "endTimeUnixNano": "1300000000",
+                                    "attributes": [_attr("tool.name", "shell")],
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resourceSpans": [
+                {
+                    "scopeSpans": [
+                        {
+                            "spans": [
+                                {
+                                    "name": "responses",
+                                    "startTimeUnixNano": "2000000000",
+                                    "endTimeUnixNano": "2400000000",
+                                    "attributes": [
+                                        _attr("llm.model", "model-a"),
+                                        _attr("gen_ai.usage.input_tokens", 7),
+                                        _attr("gen_ai.usage.output_tokens", 4),
+                                    ],
+                                },
+                                {
+                                    "name": "inference",
+                                    "startTimeUnixNano": "3000000000",
+                                    "endTimeUnixNano": "3100000000",
+                                    "attributes": [
+                                        _attr("gen_ai.response.model", "model-b"),
+                                        _attr("llm.token_count.total", 9),
+                                    ],
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+    )
+
+    stats = TraceAnalyzer().analyze_trace(str(trace_path))
+    by_model = {model.model_name: model for model in stats.models_used}
+
+    assert stats.total_runtime_seconds == 2.1
+    assert stats.total_llm_calls == 3
+    assert by_model["model-a"].prompt_tokens == 10
+    assert by_model["model-a"].completion_tokens == 6
+    assert by_model["model-a"].total_tokens == 16
+    assert by_model["model-a"].call_count == 2
+    assert by_model["model-a"].latencies_ms == [200.0, 400.0]
+    assert by_model["model-b"].prompt_tokens == 0
+    assert by_model["model-b"].completion_tokens == 0
+    assert by_model["model-b"].total_tokens == 9
+    assert by_model["model-b"].call_count == 1
+
+
+def test_legacy_flat_jsonl_still_extracts_usage(tmp_path: Path) -> None:
+    trace_path = tmp_path / "legacy_flat.jsonl"
+    _write_jsonl(
+        trace_path,
+        {
+            "name": "completion",
+            "start_time_unix_nano": 1000000000,
+            "end_time_unix_nano": 1500000000,
+            "attributes": {
+                "llm.model": "legacy-model",
+                "llm.token_count.prompt": 10,
+                "llm.token_count.completion": 5,
+            },
+        },
+    )
+
+    stats = TraceAnalyzer().analyze_trace(str(trace_path))
+
+    assert stats.total_runtime_seconds == 0.5
+    assert stats.total_llm_calls == 1
+    assert stats.models_used[0].model_name == "legacy-model"
+    assert stats.models_used[0].total_tokens == 15
+
+
+def test_missing_trace_returns_empty_stats(tmp_path: Path) -> None:
+    trace_path = tmp_path / "missing.jsonl"
+
+    stats = TraceAnalyzer().analyze_trace(str(trace_path))
+
+    assert stats.task_id == "missing"
+    assert stats.total_runtime_seconds == 0.0
+    assert stats.total_llm_calls == 0
+    assert stats.models_used == []


### PR DESCRIPTION
## What does this PR do?

Fixes `nooa_bench.trace_analyzer.TraceAnalyzer` so benchmark usage accounting works with the current OTLP JSONL trace format.

Current trace files are written as OTLP `TracesData` envelopes (`resourceSpans -> scopeSpans -> spans`), but the analyzer only understood the older flat JSONL span shape. That made current traces report zero LLM calls, zero tokens, and zero runtime even when LLM spans were present.

This change:

- unwraps current OTLP JSONL envelopes into individual spans
- converts OTLP attribute arrays into flat Python dictionaries
- preserves legacy flat JSONL compatibility
- recognizes the model/token attribute names used by current trace surfaces
- keeps total-token-only spans useful when prompt/completion breakdowns are absent
- adds focused regression coverage for OTLP, legacy flat traces, multi-batch aggregation, multiple models, and missing trace files

## Related issues

Closes #153

## Validation

- Reproduced the issue on current `origin/main` (`498d5b0`): current OTLP JSONL returned `0` calls, `0` runtime, and no model stats while equivalent legacy flat JSONL returned `1` call, `0.5s`, and `15` tokens.
- Re-ran the same repro after the patch: both current OTLP and legacy flat JSONL returned `1` call, `0.5s`, and `15` tokens.
- `uv run pytest -q packages/nooa-bench/tests/test_trace_analyzer.py`
- `uv run pytest -q packages/nooa-bench/tests/test_trace_analyzer.py packages/nooa-bench/tests/test_bench_agent.py tests/performance/test_client_creation_overhead.py util/eval_pipeline/tests/test_eval_types.py util/eval_pipeline/tests/test_pipeline.py`
- `uv run ruff check packages/nooa-bench/src/nooa_bench/trace_analyzer.py packages/nooa-bench/tests/test_trace_analyzer.py`
- `uv run ruff format --check packages/nooa-bench/src/nooa_bench/trace_analyzer.py packages/nooa-bench/tests/test_trace_analyzer.py`
- `uv run pyright packages/nooa-bench/src/nooa_bench/trace_analyzer.py packages/nooa-bench/tests/test_trace_analyzer.py`
- `uv run python scripts/check_license_headers.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for analyzing both OTLP and legacy trace formats.
  * Trace reports now include model names, runtime, latency, LLM call counts, and token totals.
  * Token totals can be calculated from prompt and completion counts when available.
  * Results aggregate data across batches and multiple models.

* **Bug Fixes**
  * Improved handling of missing files, blank lines, varied timestamps, and alternate trace attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->