### PR TITLE
fix(tui): restore active skills before resume event

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/bootstrap.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/bootstrap.py
@@ -534,6 +534,51 @@ def build_registry(result: BootstrapResult, frontend: Frontend) -> CommandRegist
         )
         result.agent.skills.activate(["nemo.mcp"])  # type: ignore[union-attr]
 
+    skills = getattr(result.agent, "skills", None)
+    if skills is not None:
+        discover_dirs = getattr(skills, "discover_skills_dirs", None)
+        if result.config.tui.active_skills and callable(discover_dirs):
+            try:
+                discover_dirs(result.config.tui.skills_dirs)
+            except Exception as exc:
+                result.messages.append(
+                    TextOutput(f"Could not discover configured skills: {exc}", "warning")
+                )
+
+        discovered = set(skills.discovered())
+        for skill_name in result.config.tui.active_skills:
+            if skill_name not in discovered:
+                result.messages.append(
+                    TextOutput(f"Configured skill not found: {skill_name}", "warning")
+                )
+                continue
+            try:
+                skills.activate([skill_name])
+            except Exception as exc:
+                result.messages.append(
+                    TextOutput(f"Could not activate skill {skill_name}: {exc}", "warning")
+                )
+                continue
+            if skill_name not in skills.activated():
+                result.messages.append(
+                    TextOutput(f"Could not activate skill {skill_name}", "warning")
+                )
+
+        for skill_name in result.config.tui.inactive_skills:
+            if skill_name not in skills.activated():
+                continue
+            try:
+                skills.deactivate([skill_name])
+            except Exception as exc:
+                result.messages.append(
+                    TextOutput(f"Could not deactivate skill {skill_name}: {exc}", "warning")
+                )
+                continue
+            if skill_name in skills.activated():
+                result.messages.append(
+                    TextOutput(f"Could not deactivate skill {skill_name}", "warning")
+                )
+
     if result.session_id is not None:
         try:
             result.agent.event_manager.add(

--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -279,9 +279,14 @@ class Command(abc.ABC):
         return True, None
 
     def _persist_tui_setting(self, key: str, value: object) -> Path:
+        return self._persist_tui_settings({key: value})
+
+    def _persist_tui_settings(self, updates: dict[str, object]) -> Path:
         from .settings import write_settings_updates
 
-        path, _data = write_settings_updates({("tui", key): value})
+        path, _data = write_settings_updates(
+            {("tui", key): value for key, value in updates.items()}
+        )
         return path
 
 
@@ -1187,9 +1192,22 @@ class SkillsCommand(Command):
                 return CommandResult.err(f"Skill `{skill_id}` not found. Use /skills list.")
             try:
                 registry.activate([skill_id])
-                return CommandResult.ok(TextOutput(f"Skill `{skill_id}` activated", "success"))
             except Exception as e:
                 return CommandResult.err(f"Failed to activate `{skill_id}`: {e}")
+            if skill_id not in registry.activated():
+                return CommandResult.err(f"Failed to activate `{skill_id}`")
+            active = list(dict.fromkeys([*self.config.active_skills, skill_id]))
+            inactive = [name for name in self.config.inactive_skills if name != skill_id]
+            self.config.active_skills = active
+            self.config.inactive_skills = inactive
+            try:
+                self._persist_tui_settings({"active_skills": active, "inactive_skills": inactive})
+            except Exception as exc:
+                return CommandResult.ok(
+                    TextOutput(f"Skill `{skill_id}` activated", "success"),
+                    TextOutput(f"Could not save skill activation: {exc}", "warning"),
+                )
+            return CommandResult.ok(TextOutput(f"Skill `{skill_id}` activated", "success"))
 
         # deactivate
         skill_id = subargs[0]
@@ -1197,9 +1215,22 @@ class SkillsCommand(Command):
             return CommandResult.err(f"`{skill_id}` not active. Use /skills list.")
         try:
             registry.deactivate([skill_id])
-            return CommandResult.ok(TextOutput(f"Skill `{skill_id}` deactivated", "success"))
         except Exception as e:
             return CommandResult.err(f"Failed to deactivate `{skill_id}`: {e}")
+        if skill_id in registry.activated():
+            return CommandResult.err(f"Failed to deactivate `{skill_id}`")
+        active = [name for name in self.config.active_skills if name != skill_id]
+        inactive = list(dict.fromkeys([*self.config.inactive_skills, skill_id]))
+        self.config.active_skills = active
+        self.config.inactive_skills = inactive
+        try:
+            self._persist_tui_settings({"active_skills": active, "inactive_skills": inactive})
+        except Exception as exc:
+            return CommandResult.ok(
+                TextOutput(f"Skill `{skill_id}` deactivated", "success"),
+                TextOutput(f"Could not save skill deactivation: {exc}", "warning"),
+            )
+        return CommandResult.ok(TextOutput(f"Skill `{skill_id}` deactivated", "success"))
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nooa-cli/src/nooa_cli/tui/config.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/config.py
@@ -90,6 +90,13 @@ class TUIConfig(BaseModel):
     # Extra roots explicitly added with ``/skills add``. Unlike
     # ``skills_dirs`` (the computed runtime search path), these are persisted.
     additional_skills_dirs: list[Path] = Field(default_factory=list)
+    # Skills explicitly activated with ``/skills activate``. Persisting this
+    # separately from discovery lets lifecycle skills attach before the resume
+    # event on the next process start.
+    active_skills: list[str] = Field(default_factory=list)
+    # Skills explicitly deactivated with ``/skills deactivate``. This negative
+    # override is needed for skills that an agent activates in its constructor.
+    inactive_skills: list[str] = Field(default_factory=list)
 
     # Default LLM model (from unifiedllm registry)
     default_model: str = DEFAULT_MODEL

--- a/packages/nooa-cli/src/nooa_cli/tui/settings.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/settings.py
@@ -54,6 +54,8 @@ _COERCE: dict[str, Any] = {
     "tui.mcp_file": lambda v: Path(v),
     "tui.trace_dir": lambda v: Path(v) if v is not None else None,
     "tui.additional_skills_dirs": lambda v: [Path(item) for item in (v or [])],
+    "tui.active_skills": lambda v: [str(item) for item in (v or [])],
+    "tui.inactive_skills": lambda v: [str(item) for item in (v or [])],
 }
 
 
@@ -300,6 +302,8 @@ tui:
   # Additional skill roots. Prefer /skills add <directory> so these are
   # discovered immediately and saved here for future TUI runs.
   # additional_skills_dirs: []
+  # active_skills: []    # re-activate these before SessionResumed hooks run
+  # inactive_skills: []  # keep explicitly deactivated skills inactive on restart
 
   # Write trace files here (relative to project root, or ":project:").
   # trace_dir: .nooa/traces

--- a/packages/nooa-cli/tests/tui/test_display_commands.py
+++ b/packages/nooa-cli/tests/tui/test_display_commands.py
@@ -69,9 +69,7 @@ async def test_skills_commands_lists_extensions_without_requiring_skill_registry
     result = await command.execute(["commands"])
 
     assert result.success is True
-    assert result.outputs[0].rows == [
-        ["/project-operation", "<target>", "Operate on this project"]
-    ]
+    assert result.outputs[0].rows == [["/project-operation", "<target>", "Operate on this project"]]
 
 
 @pytest.mark.asyncio
@@ -121,3 +119,82 @@ async def test_skills_add_discovers_immediately_and_persists(tmp_path, monkeypat
     assert "review-code" in registry._user_skills
     saved = yaml.safe_load((project_dir / "settings.yaml").read_text())
     assert saved["tui"]["additional_skills_dirs"] == [str(skills_root.resolve())]
+
+
+@pytest.mark.asyncio
+async def test_skills_activate_and_deactivate_are_persisted(tmp_path, monkeypatch) -> None:
+    from nooa.skill_registry import SkillRegistry
+
+    project_dir = tmp_path / ".nooa"
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project_dir))
+    agent = SimpleNamespace(context_manager=MagicMock(), cwd=tmp_path)
+    agent.skills = SkillRegistry(agent)
+    agent.skills.register("local.reconnect", SimpleNamespace())
+    config = TUIConfig(active_skills=[], inactive_skills=["local.reconnect"])
+    command = SkillsCommand(MagicMock(), config, agent, skills_dirs=[])
+
+    activated = await command.execute(["activate", "local.reconnect"])
+
+    assert activated.success is True
+    assert config.active_skills == ["local.reconnect"]
+    assert config.inactive_skills == []
+    saved = yaml.safe_load((project_dir / "settings.yaml").read_text())
+    assert saved["tui"]["active_skills"] == ["local.reconnect"]
+    assert saved["tui"]["inactive_skills"] == []
+
+    deactivated = await command.execute(["deactivate", "local.reconnect"])
+
+    assert deactivated.success is True
+    assert config.active_skills == []
+    assert config.inactive_skills == ["local.reconnect"]
+    saved = yaml.safe_load((project_dir / "settings.yaml").read_text())
+    assert saved["tui"]["active_skills"] == []
+    assert saved["tui"]["inactive_skills"] == ["local.reconnect"]
+
+
+@pytest.mark.asyncio
+async def test_skills_does_not_persist_an_activation_that_did_not_take_effect(
+    tmp_path, monkeypatch
+) -> None:
+    from nooa.skill_registry import SkillRegistry
+
+    project_dir = tmp_path / ".nooa"
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project_dir))
+    agent = SimpleNamespace(context_manager=MagicMock(), cwd=tmp_path)
+    agent.skills = SkillRegistry(agent)
+    agent.skills.register("local.broken", SimpleNamespace())
+    monkeypatch.setattr(agent.skills, "activate", lambda _patterns: None)
+    config = TUIConfig(active_skills=[])
+    command = SkillsCommand(MagicMock(), config, agent, skills_dirs=[])
+
+    result = await command.execute(["activate", "local.broken"])
+
+    assert result.success is False
+    assert result.outputs[0].content == "Failed to activate `local.broken`"
+    assert config.active_skills == []
+    assert not (project_dir / "settings.yaml").exists()
+
+
+@pytest.mark.asyncio
+async def test_skills_does_not_persist_a_deactivation_that_did_not_take_effect(
+    tmp_path, monkeypatch
+) -> None:
+    from nooa.skill_registry import SkillRegistry
+
+    project_dir = tmp_path / ".nooa"
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project_dir))
+    agent = SimpleNamespace(context_manager=MagicMock(), cwd=tmp_path)
+    agent.skills = SkillRegistry(agent)
+    agent.skills.register("local.stuck", SimpleNamespace())
+    agent.skills.activate(["local.stuck"])
+    monkeypatch.setattr(agent.skills, "deactivate", lambda _patterns: None)
+    config = TUIConfig(active_skills=["local.stuck"], inactive_skills=[])
+    command = SkillsCommand(MagicMock(), config, agent, skills_dirs=[])
+
+    result = await command.execute(["deactivate", "local.stuck"])
+
+    assert result.success is False
+    assert result.outputs[0].content == "Failed to deactivate `local.stuck`"
+    assert config.active_skills == ["local.stuck"]
+    assert config.inactive_skills == []
+    assert not (project_dir / "settings.yaml").exists()

--- a/packages/nooa-cli/tests/tui/test_session_resumed_event.py
+++ b/packages/nooa-cli/tests/tui/test_session_resumed_event.py
@@ -109,3 +109,103 @@ async def test_resume_without_snapshot_emits_restored_false(tmp_path, monkeypatc
     assert captured[0].restored is False
     await resumed.agent.close()
     resumed.session_manager.close()
+
+
+def test_configured_skills_activate_before_session_resumed_event() -> None:
+    """Resume hooks exist only when configured skills attach before the event."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from nooa_cli.tui.bootstrap import BootstrapResult, build_registry
+
+    config = Config()
+    config.tui.active_skills = ["nvzurich.agent_mesh"]
+    agent = MagicMock()
+    agent.skills.discovered.return_value = ["nvzurich.agent_mesh"]
+    agent.skills.activated.return_value = ["nvzurich.agent_mesh"]
+    result = BootstrapResult(
+        config=config,
+        agent=agent,
+        session_manager=None,
+        tracing_enabled=False,
+        resumed=True,
+        restored=True,
+        session_id="session-1",
+    )
+
+    def record_event(_event):
+        agent.skills.activate.assert_any_call(["nvzurich.agent_mesh"])
+
+    agent.event_manager.add.side_effect = record_event
+    build_registry(result, SimpleNamespace())
+
+    agent.skills.discover_skills_dirs.assert_called_once_with(config.tui.skills_dirs)
+    agent.skills.activate.assert_any_call(["nvzurich.agent_mesh"])
+    agent.event_manager.add.assert_called_once()
+
+
+def test_failed_configured_skill_activation_warns_before_session_resumed() -> None:
+    """A registry load failure must not be reported as a successful restore."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from nooa_cli.tui.bootstrap import BootstrapResult, build_registry
+
+    config = Config()
+    config.tui.active_skills = ["local.broken"]
+    agent = MagicMock()
+    agent.skills.discovered.return_value = ["local.broken"]
+    agent.skills.activated.return_value = []
+    result = BootstrapResult(
+        config=config,
+        agent=agent,
+        session_manager=None,
+        tracing_enabled=False,
+        resumed=True,
+        restored=True,
+        session_id="session-1",
+    )
+
+    build_registry(result, SimpleNamespace())
+
+    agent.skills.activate.assert_any_call(["local.broken"])
+    assert [output.content for output in result.messages] == [
+        "Could not activate skill local.broken"
+    ]
+    agent.event_manager.add.assert_called_once()
+
+
+def test_configured_deactivation_happens_before_session_resumed_event() -> None:
+    """A constructor-default skill stays inactive when a session starts."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from nooa_cli.tui.bootstrap import BootstrapResult, build_registry
+
+    config = Config()
+    config.tui.inactive_skills = ["nemo.repo"]
+    agent = MagicMock()
+    active = {"nemo.repo"}
+    agent.skills.discovered.return_value = ["nemo.repo"]
+    agent.skills.activated.side_effect = lambda: sorted(active)
+    agent.skills.deactivate.side_effect = lambda names: active.difference_update(names)
+    result = BootstrapResult(
+        config=config,
+        agent=agent,
+        session_manager=None,
+        tracing_enabled=False,
+        resumed=False,
+        restored=False,
+        session_id="session-1",
+    )
+
+    def record_event(_event):
+        agent.skills.deactivate.assert_called_once_with(["nemo.repo"])
+
+    agent.event_manager.add.side_effect = record_event
+    build_registry(result, SimpleNamespace())
+
+    agent.skills.discover_skills_dirs.assert_not_called()
+    agent.skills.deactivate.assert_called_once_with(["nemo.repo"])
+    agent.event_manager.add.assert_called_once()
+    assert result.messages == []

--- a/packages/nooa-cli/tests/tui/test_settings.py
+++ b/packages/nooa-cli/tests/tui/test_settings.py
@@ -57,6 +57,8 @@ class TestRoundTrip:
         original.tui.default_model = "my-model"
         original.tui.vi_mode = True
         original.tui.toolbar_items = ["model", "cwd", "session"]
+        original.tui.active_skills = ["nvzurich.agent_mesh"]
+        original.tui.inactive_skills = ["nemo.repo"]
         original.agent.working_dir = "/tmp"
         original.agent.summarization.preserve_recent = 123
         (user_dir / "settings.yaml").write_text(dump_settings(original))
@@ -64,6 +66,8 @@ class TestRoundTrip:
         assert loaded.tui.default_model == "my-model"
         assert loaded.tui.vi_mode is True
         assert loaded.tui.toolbar_items == ["model", "cwd", "session"]
+        assert loaded.tui.active_skills == ["nvzurich.agent_mesh"]
+        assert loaded.tui.inactive_skills == ["nemo.repo"]
         assert loaded.agent.working_dir == "/tmp"
         assert loaded.agent.summarization.preserve_recent == 123
 


### PR DESCRIPTION
## Summary

- persist skills explicitly activated and deactivated through `/skills`
- restore activation overrides during TUI startup before `SessionResumed`, so lifecycle hooks can reconnect correctly
- preserve explicit deactivation of skills that an agent activates by default
- discover configured skill roots before restoring requested activations
- verify activation/deactivation postconditions and warn without aborting startup when restoration cannot be applied
- persist positive and negative overrides atomically

## Validation

- focused changed-feature suite — **30 passed**
- broader skill/bootstrap/settings suite — **85 passed** (30 focused + 55 adjacent)
- full TUI suite — **1153 passed, 2 failed**; both failures reproduce unchanged on exact `origin/dev/tui` (`6975d1d`) and are unrelated macOS `/var` vs `/private/var` path issues:
  - `test_loud_handler_diagnostics.py::TestBangShell::test_get_bang_shell_syncs_cwd`
  - `test_model_catalog.py::test_connect_prompts_for_missing_secret_and_saves_it`
- targeted Ruff check — passed
- targeted Ruff format check — passed
- targeted Pyright — passed (0 errors, 0 warnings)
- `git diff --check origin/dev/tui...HEAD` — passed

## Review notes

The refreshed branch is one signed commit directly on current `dev/tui`. Review found and fixed three bounded correctness gaps:

1. `SkillRegistry.activate()` can log and swallow a load failure, so callers verify that requested state actually took effect before persisting or reporting success.
2. A positive-only activation list could not preserve `/skills deactivate` for constructor-default skills. `inactive_skills` records that negative override and startup applies it before `SessionResumed`.
3. `SkillRegistry.deactivate()` can no-op, so the command verifies the postcondition before changing config or persisted settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent configuration for activated and deactivated TUI skills.
  * Configured active skills are restored when the TUI starts.
  * Configured inactive skills remain disabled across restarts.
  * Skill activation and deactivation now update settings automatically.

* **Bug Fixes**
  * Added warnings for skill discovery, activation, deactivation, and persistence failures without interrupting startup.
  * Failed or ineffective skill changes no longer alter saved configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->