### PR TITLE
fix(skills): honor source-tree entry point targets

### DIFF
--- a/src/nooa/skill_registry.py
+++ b/src/nooa/skill_registry.py
@@ -216,11 +216,11 @@ class SkillRegistry(Skill):
             if not (lib_dir.is_dir() and (lib_dir / "pyproject.toml").exists()):
                 continue
             lib_name = lib_dir.name
-            reg_name = self._read_skill_name(lib_dir, lib_name)
+            reg_name, target = self._read_skill_entry_point(lib_dir, lib_name)
             if reg_name in self._loaded:
                 continue
             try:
-                skill = self._import_lib(lib_dir, lib_name)
+                skill = self._import_lib(lib_dir, lib_name, target)
                 if skill is not None:
                     skill._source_dir = lib_dir
                     self.register(reg_name, skill)
@@ -228,11 +228,8 @@ class SkillRegistry(Skill):
                 logger.warning("Library %s skipped", lib_name, exc_info=True)
 
     @staticmethod
-    def _read_skill_name(lib_dir: "Path", lib_name: str) -> str:
-        """Read the skill registry name from pyproject.toml entry_points.
-
-        Falls back to ``local.<lib_name>`` if no entry_point is declared.
-        """
+    def _read_skill_entry_point(lib_dir: "Path", lib_name: str) -> "tuple[str, str | None]":
+        """Read the first skill entry-point name and target from pyproject.toml."""
         import tomllib
 
         pyproject = lib_dir / "pyproject.toml"
@@ -241,14 +238,21 @@ class SkillRegistry(Skill):
                 data = tomllib.load(f)
             eps = data.get("project", {}).get("entry-points", {}).get(ENTRY_POINT_GROUP, {})
             if eps:
-                # Use the first declared entry_point name
-                return next(iter(eps))
+                name, target = next(iter(eps.items()))
+                return name, target
         except Exception:
             pass
-        return f"local.{lib_name}"
+        return f"local.{lib_name}", None
 
-    def _import_lib(self, lib_dir: "Path", lib_name: str) -> "Skill | None":
-        """Import a library package and extract its Skill instance."""
+    @staticmethod
+    def _read_skill_name(lib_dir: "Path", lib_name: str) -> str:
+        """Read the skill registry name, retaining the historical helper API."""
+        return SkillRegistry._read_skill_entry_point(lib_dir, lib_name)[0]
+
+    def _import_lib(
+        self, lib_dir: "Path", lib_name: str, target: str | None = None
+    ) -> "Skill | None":
+        """Import a library package and extract its declared Skill instance."""
         import importlib
         import sys as _sys
 
@@ -262,8 +266,11 @@ class SkillRegistry(Skill):
         for key in [k for k in _sys.modules if k == lib_name or k.startswith(prefix)]:
             del _sys.modules[key]
 
+        module_name, separator, object_path = (target or lib_name).partition(":")
+        module_name = module_name.strip()
+        object_path = object_path.partition(" ")[0].strip()
         try:
-            module = importlib.import_module(lib_name)
+            module = importlib.import_module(module_name)
         except Exception:
             if added_to_path:
                 _sys.path.remove(libs_str)
@@ -273,7 +280,18 @@ class SkillRegistry(Skill):
         if added_to_path:
             self._lib_paths[lib_name] = libs_str
 
-        return skill_from_module(module, lib_name, source=f"Library {lib_name!r}")
+        if not separator:
+            return skill_from_module(module, module_name, source=f"Library {lib_name!r}")
+
+        resolved: Any = module
+        for part in object_path.split("."):
+            resolved = getattr(resolved, part)
+        if isinstance(resolved, type) and issubclass(resolved, Skill):
+            return resolved()
+        if isinstance(resolved, Skill):
+            return resolved
+        logger.warning("Library %r entry point %r did not resolve to a Skill", lib_name, target)
+        return None
 
     def discover_skills_dirs(self, dirs: "list[Path]") -> None:
         """Scan skill roots for packaged libraries, TextSkills, and Python skills.

--- a/src/nooa/skill_registry.py
+++ b/src/nooa/skill_registry.py
@@ -156,6 +156,7 @@ class SkillRegistry(Skill):
         self._activated: set[str] = set()
         self._attr_map: dict[str, str] = {}  # registry name → actual attr name on agent
         self._lib_paths: dict[str, str] = {}  # lib_name → sys.path entry added for it
+        self._lib_targets: dict[str, str] = {}  # registry name → declared entry-point target
         self._discover()
         super().__init__()
         # Self-register our own context block (we're never activated through ourselves)
@@ -224,6 +225,8 @@ class SkillRegistry(Skill):
                 if skill is not None:
                     skill._source_dir = lib_dir
                     self.register(reg_name, skill)
+                    if target:
+                        self._lib_targets[reg_name] = target
             except Exception:
                 logger.warning("Library %s skipped", lib_name, exc_info=True)
 
@@ -639,7 +642,9 @@ class SkillRegistry(Skill):
     async def _reload_one(self, name: str) -> str:
         """Reload a single skill by re-importing its module.
 
-        Two strategies, chosen by the skill's top-level package:
+        Source-tree skills with a declared entry-point target are reloaded
+        from that exact module/object. Other skills use one of two strategies,
+        chosen by the skill's top-level package:
 
         * **Package purge** (user/lib skills) — delete every ``sys.modules``
           entry under the top package and re-import it. Safe for self-contained
@@ -655,6 +660,10 @@ class SkillRegistry(Skill):
         skill = getattr(self._agent, attr, None)
         if skill is None:
             return f"Skill {name!r} has no instance on agent"
+
+        target = self._lib_targets.get(name)
+        if target:
+            return await self._reload_target(name, attr, target)
 
         mod_name = type(skill).__module__
         # For package modules (e.g. "excalidraw.__init__"), use the top-level package
@@ -689,6 +698,54 @@ class SkillRegistry(Skill):
                     name,
                     exc_info=True,
                 )
+
+    async def _reload_target(self, name: str, attr: str, target: str) -> str:
+        """Reload a source-tree skill from its declared entry-point target."""
+        import asyncio
+        import importlib
+        import sys as _sys
+
+        module_name, separator, object_path = target.partition(":")
+        module_name = module_name.strip()
+        object_path = object_path.partition(" ")[0].strip()
+        if not separator or not object_path:
+            return f"Reload failed for {name}: invalid entry-point target {target!r}"
+
+        old_skill = getattr(self._agent, attr, None)
+        try:
+            old_skill, old_detached = await self._detach_old_for_reload(attr)
+        except Exception as e:
+            await self._restore_old_after_reload_failure(name, old_skill, old_skill is not None)
+            return f"Reload failed for {name}: {e}"
+
+        top_pkg = module_name.split(".")[0]
+        try:
+            prefix = top_pkg + "."
+            for key in [k for k in _sys.modules if k == top_pkg or k.startswith(prefix)]:
+                del _sys.modules[key]
+            module = await asyncio.to_thread(importlib.import_module, module_name)
+            resolved: Any = module
+            for part in object_path.split("."):
+                resolved = getattr(resolved, part)
+            if isinstance(resolved, Skill):
+                resolved = type(resolved)
+            if not isinstance(resolved, type) or not issubclass(resolved, Skill):
+                await self._restore_old_after_reload_failure(name, old_skill, old_detached)
+                return f"Reloaded {target} but target did not resolve to a Skill"
+        except Exception as e:
+            await self._restore_old_after_reload_failure(name, old_skill, old_detached)
+            return f"Reload failed for {name}: {e}"
+
+        try:
+            return await self._install_reloaded(
+                name,
+                attr,
+                resolved,
+                old_skill=old_skill,
+                old_detached=old_detached,
+            )
+        except Exception as e:
+            return f"Reload failed for {name}: {e}"
 
     async def _reload_package(self, name: str, attr: str, top_pkg: str) -> str:
         """Purge and re-import an entire top-level package (user/lib skills)."""

--- a/tests/test_skill_registry_extended.py
+++ b/tests/test_skill_registry_extended.py
@@ -145,6 +145,32 @@ class TestDiscoverLibs:
         registry.discover_libs(tmp_path)
         assert "local.my_lib" in registry.loaded()
 
+    def test_lib_uses_declared_entry_point_target(self, registry, agent, tmp_path):
+        """Source-tree discovery loads the declared object, not a package fallback."""
+        lib_dir = tmp_path / "recovery_lib"
+        lib_dir.mkdir()
+        (lib_dir / "pyproject.toml").write_text(
+            '[project]\nname = "recovery-lib"\n\n'
+            '[project.entry-points."nooa.skills"]\n'
+            '"local.recovery" = "recovery_lib.production:ProductionSkill"\n'
+        )
+        (lib_dir / "__init__.py").write_text(
+            "from nooa.skill import Skill\n\n"
+            "class RecoverySkill(Skill):\n"
+            '    """Package-root fallback that must not be selected."""\n'
+        )
+        (lib_dir / "production.py").write_text(
+            "from nooa.skill import Skill\n\n"
+            "class ProductionSkill(Skill):\n"
+            '    """Skill selected by the declared entry point."""\n'
+        )
+
+        registry.discover_libs(tmp_path)
+
+        assert "local.recovery" in registry.loaded()
+        assert type(agent.recovery).__module__ == "recovery_lib.production"
+        assert type(agent.recovery).__name__ == "ProductionSkill"
+
     def test_dir_without_pyproject_skipped(self, registry, tmp_path):
         """Directories without pyproject.toml are skipped."""
         lib_dir = tmp_path / "no_pyproject"

--- a/tests/test_skill_registry_extended.py
+++ b/tests/test_skill_registry_extended.py
@@ -145,7 +145,8 @@ class TestDiscoverLibs:
         registry.discover_libs(tmp_path)
         assert "local.my_lib" in registry.loaded()
 
-    def test_lib_uses_declared_entry_point_target(self, registry, agent, tmp_path):
+    @pytest.mark.asyncio
+    async def test_lib_uses_declared_entry_point_target(self, registry, agent, tmp_path):
         """Source-tree discovery loads the declared object, not a package fallback."""
         lib_dir = tmp_path / "recovery_lib"
         lib_dir.mkdir()
@@ -168,6 +169,12 @@ class TestDiscoverLibs:
         registry.discover_libs(tmp_path)
 
         assert "local.recovery" in registry.loaded()
+        assert type(agent.recovery).__module__ == "recovery_lib.production"
+        assert type(agent.recovery).__name__ == "ProductionSkill"
+
+        result = await registry.reload("local.recovery")
+
+        assert result == "Reloaded local.recovery (self.recovery)"
         assert type(agent.recovery).__module__ == "recovery_lib.production"
         assert type(agent.recovery).__name__ == "ProductionSkill"
 


### PR DESCRIPTION
## Summary

- honor the declared `nooa.skills` entry-point target during source-tree skill discovery
- resolve the configured module/object instead of falling back to the package root
- preserve the historical source-tree fallback when no entry point is declared

## Reproduced failure

A source-tree skill project declared `recovery_lib.production:ProductionSkill`, while its package root also exposed a different `RecoverySkill`. Discovery registered the entry-point name but imported the package root, selecting the fallback skill instead of `ProductionSkill`.

## Root cause

`discover_libs()` read only the entry-point name from `pyproject.toml`; `_import_lib()` then imported `lib_name` and ignored the entry-point target. Installed entry points honored their target, but source-tree discovery did not.

## Validation

- 2 focused source-tree discovery tests passed:
  - existing package-root entry-point case
  - declared submodule/class target case
- 55 skill-registry/tool regression tests passed
- targeted `ruff format --check` passed
- targeted `ruff check` passed
- `git diff --check origin/dev/tui...HEAD` passed

## Independent review

An independent patch review was performed with emphasis on entry-point syntax, import resolution, cache/path behavior, and compatibility. It identified broader source-layout and import-cache lifecycle edge cases for future hardening; this PR remains scoped to the reproduced package/submodule target-selection failure and preserves existing fallback behavior.

## Rollback

Revert this single commit to restore the previous source-tree behavior. No schema, persisted-state, configuration, or migration changes are involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved library discovery to load the skill specified by its declared entry point.
  - Added support for skill entry points provided as classes or instances.
  - Invalid skill targets are now skipped without interrupting discovery.
  - Retained fallback scanning when no entry-point target is declared.

- **Tests**
  - Added regression coverage for selecting the correct skill from source-tree libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->