### PR TITLE
fix(release): use Git excludes for SPDX scan

### DIFF
--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -6,12 +6,16 @@ Run locally with ``uv run python scripts/check_license_headers.py``; the CI
 ``lint`` job runs it on every merge request. Empty ``__init__.py`` package
 markers (0 bytes) are exempt — they hold no copyrightable content.
 
-Walks the filesystem (no ``git`` dependency, so it runs in the minimal CI lint
-image), skipping virtualenvs, caches, build output, and vendored trees.
+Uses Git's file and exclude handling as the source of truth: tracked Python
+files and untracked, nonignored Python files are checked. Files excluded by
+``.gitignore``, ``.git/info/exclude``, or the user's global Git excludes are
+not repository source and are not scanned.
 """
 
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -19,37 +23,27 @@ REQUIRED = "SPDX-License-Identifier"
 # Only the first few lines are checked (header sits above any docstring, after
 # an optional shebang/coding line).
 HEAD_LINES = 5
-# Directory names to skip anywhere in the tree.
-SKIP_DIRS = {
-    ".git",
-    ".venv",
-    "venv",
-    "__pycache__",
-    "node_modules",
-    "dist",
-    "build",
-    ".uv-cache",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    "site-packages",
-    ".scratch",
-    "htmlcov",
-    # Local git worktrees are separate checkouts of other branches. Scanning
-    # them makes this check fail on someone else's in-progress work — and on
-    # vendored trees that branch happens to contain. CI never has them, so the
-    # failure only ever hits developers running the check locally.
-    ".worktrees",
-}
 
 
 def source_python_files(root: Path) -> list[Path]:
-    files: list[Path] = []
-    for path in root.rglob("*.py"):
-        if any(part in SKIP_DIRS for part in path.relative_to(root).parts):
-            continue
-        files.append(path)
-    return files
+    """Return tracked and untracked, nonignored Python files under *root*."""
+    result = subprocess.run(
+        [
+            "git",
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--",
+            "*.py",
+        ],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+    relative_paths = (os.fsdecode(raw) for raw in result.stdout.split(b"\0") if raw)
+    return sorted(root / relative for relative in relative_paths)
 
 
 def main() -> int:

--- a/tests/test_check_license_headers.py
+++ b/tests/test_check_license_headers.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the repository SPDX header scanner."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts.check_license_headers import source_python_files
+
+
+def _python_file(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("print('test')\n")
+    return path
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=root, check=True, capture_output=True)
+
+
+def test_source_files_follow_standard_git_excludes(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    (tmp_path / ".gitignore").write_text("/tmp/\n")
+    with (tmp_path / ".git" / "info" / "exclude").open("a") as exclude:
+        exclude.write("\n.codex/\n")
+
+    tracked_source = _python_file(tmp_path / "src" / "tracked.py")
+    untracked_source = _python_file(tmp_path / "src" / "new.py")
+    ignored_by_gitignore = _python_file(tmp_path / "tmp" / "generated.py")
+    ignored_by_info_exclude = _python_file(tmp_path / ".codex" / "external.py")
+    _git(tmp_path, "add", ".gitignore", "src/tracked.py")
+
+    found = set(source_python_files(tmp_path))
+
+    assert tracked_source in found
+    assert untracked_source in found
+    assert ignored_by_gitignore not in found
+    assert ignored_by_info_exclude not in found
+
+
+def test_source_files_include_tracked_files_that_match_ignore_rules(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    tracked_source = _python_file(tmp_path / "generated" / "tracked.py")
+    _git(tmp_path, "add", "generated/tracked.py")
+    (tmp_path / ".gitignore").write_text("/generated/\n")
+
+    assert tracked_source in source_python_files(tmp_path)


### PR DESCRIPTION
## Summary

- use Git file discovery as the single source of truth for the SPDX scan
- check tracked Python files plus untracked, nonignored Python files
- honor .gitignore, .git/info/exclude, and global Git excludes through git ls-files --exclude-standard
- add regression tests for ignored, untracked, and tracked-but-ignored files

## Why

The filesystem walk scanned ignored Codex-managed skills and generated tmp artifacts as repository source. Those files are not tracked and should not receive NVIDIA license headers. Delegating inclusion to Git avoids a second hardcoded exclusion policy while still catching new untracked source files.

## Testing

- uv run ruff check .
- uv run ruff format --check .
- uv run python scripts/check_license_headers.py
- uv run pytest -q tests/test_check_license_headers.py tests/test_make_release.py (13 passed)
- uv run pytest -q -m "not integration and not stress" (6674 passed, 4 skipped, 236 deselected)