### PR TITLE
feat(tui): clear input on first Ctrl-C

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -941,6 +941,7 @@ class TUIApplication:
             # running it also requests cancellation; at an idle prompt it arms
             # the existing second-C-c-to-exit confirmation.
             event.current_buffer.reset()
+            self._history_cursor = None
             if self.request_agent_cancel(source="ctrl-c"):
                 self._arm_ctrl_c_exit()
                 return

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -937,8 +937,10 @@ class TUIApplication:
                 event.app.exit()
                 return
 
-            # While an agent is running, the first C-c requests cancellation
-            # and keeps the input buffer. At an idle prompt it only arms exit.
+            # The first C-c always clears the composer. While an agent is
+            # running it also requests cancellation; at an idle prompt it arms
+            # the existing second-C-c-to-exit confirmation.
+            event.current_buffer.reset()
             if self.request_agent_cancel(source="ctrl-c"):
                 self._arm_ctrl_c_exit()
                 return

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -142,6 +142,7 @@ async def test_baseline_ctrl_d_exits():
 async def test_baseline_ctrl_c_clears_input_and_requires_confirmation():
     async with TUIHarness() as h:
         await h.type_keys("discard this command")
+        await h.wait_input_equals("discard this command")
         await h.press("c-c")
         await h.wait_input_equals("")
         await h.wait_for(lambda: "Press Ctrl+C again to exit" in h.capture_status())
@@ -316,6 +317,19 @@ async def test_input_history_up_on_empty_buffer():
         await h.wait_input_equals("")
         await h.press("up")
         await h.wait_input_equals("first")
+
+
+async def test_ctrl_c_resets_history_navigation_to_most_recent():
+    """Clearing a recalled entry makes the next Up start at newest history."""
+    async with TUIHarness() as h:
+        h.app._history.extend(["first", "second"])
+        await h.press("up")
+        await h.wait_input_equals("second")
+
+        await h.press("c-c")
+        await h.wait_input_equals("")
+        await h.press("up")
+        await h.wait_input_equals("second")
 
 
 async def test_input_cursor_home_and_end():
@@ -638,6 +652,7 @@ async def test_hard_ctrl_c_interrupts_and_clears_buffer():
         await h.submit_async("first")
         await h.wait_for(lambda: h.app.is_thinking())
         await h.type_keys("in-progress")
+        await h.wait_input_equals("in-progress")
         await h.press("c-c")
         # Agent gets cancelled and the in-progress input is discarded.
         await h.wait_for(lambda: not h.app.is_thinking())

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -139,9 +139,11 @@ async def test_baseline_ctrl_d_exits():
         await h.wait_for(lambda: not h.app.is_running)
 
 
-async def test_baseline_ctrl_c_requires_confirmation_then_exits_cleanly():
+async def test_baseline_ctrl_c_clears_input_and_requires_confirmation():
     async with TUIHarness() as h:
+        await h.type_keys("discard this command")
         await h.press("c-c")
+        await h.wait_input_equals("")
         await h.wait_for(lambda: "Press Ctrl+C again to exit" in h.capture_status())
         assert h.app.is_running
 
@@ -629,17 +631,17 @@ async def test_cancelled_agent_run_async_propagates_to_agent_loop():
 # ╚══════════════════════════════════════════════════════════════════════╝
 
 
-async def test_hard_ctrl_c_interrupts_and_preserves_buffer():
-    """C-c while the agent is working cancels the agent but keeps the buffer."""
+async def test_hard_ctrl_c_interrupts_and_clears_buffer():
+    """C-c while the agent is working cancels the agent and clears the buffer."""
     agent = _blocking_agent()
     async with TUIHarness(agent=agent) as h:
         await h.submit_async("first")
         await h.wait_for(lambda: h.app.is_thinking())
         await h.type_keys("in-progress")
         await h.press("c-c")
-        # Agent gets cancelled; buffer contents survive.
+        # Agent gets cancelled and the in-progress input is discarded.
         await h.wait_for(lambda: not h.app.is_thinking())
-        assert h.capture_input() == "in-progress"
+        assert h.capture_input() == ""
 
 
 async def test_hard_agent_error_shown_in_output():


### PR DESCRIPTION
## Summary

- clear the TUI input composer on the first Ctrl-C press
- preserve active-turn cancellation and the existing second-Ctrl-C exit confirmation
- update idle and active-turn regression coverage

## Validation

- `uv run pytest -q packages/nooa-cli/tests/tui/test_tui_app_behavior.py packages/nooa-cli/tests/tui/test_input_handler.py` — 75 passed
- Ruff format/check passed for changed files
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pressing Ctrl+C now consistently clears the input composer.
  - When an agent is active, Ctrl+C clears in-progress input before requesting cancellation.
  - A second Ctrl+C is still required to confirm exiting the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->