### PR TITLE
fix(eval): authenticate OTLP eval-span uploads

### DIFF
--- a/util/eval_pipeline/src/eval_pipeline/trace_eval_span.py
+++ b/util/eval_pipeline/src/eval_pipeline/trace_eval_span.py
@@ -165,11 +165,13 @@ def post_eval_span_to_otlp(
         ]
     }
     try:
+        from nooa.tracing._viewer_auth import apply_viewer_auth
+
         data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
         req = urllib.request.Request(
             endpoint,
             data=data,
-            headers={"Content-Type": "application/json"},
+            headers=apply_viewer_auth({"Content-Type": "application/json"}),
             method="POST",
         )
         with urllib.request.urlopen(req, timeout=5) as resp:

--- a/util/eval_pipeline/tests/test_trace_eval_span.py
+++ b/util/eval_pipeline/tests/test_trace_eval_span.py
@@ -26,7 +26,7 @@ def _read_first_span_from_otlp_file(trace_file: Path) -> tuple[str, dict]:
 
 def test_post_eval_span_applies_viewer_auth(monkeypatch: pytest.MonkeyPatch):
     """Remote eval-span posts include the configured viewer bearer token."""
-    captured: dict[str, str | None] = {}
+    captured: dict[str, object] = {}
 
     class Response:
         status = 200
@@ -39,7 +39,7 @@ def test_post_eval_span_applies_viewer_auth(monkeypatch: pytest.MonkeyPatch):
 
     def fake_urlopen(request, timeout):
         captured["authorization"] = request.get_header("Authorization")
-        captured["timeout"] = str(timeout)
+        captured["timeout"] = timeout
         return Response()
 
     monkeypatch.setenv("NOOA_VIEWER_AUTH_TOKEN", "viewer-secret")
@@ -57,7 +57,7 @@ def test_post_eval_span_applies_viewer_auth(monkeypatch: pytest.MonkeyPatch):
         scores={},
         endpoint="http://viewer.example/v1/traces",
     )
-    assert captured == {"authorization": "Bearer viewer-secret", "timeout": "5"}
+    assert captured == {"authorization": "Bearer viewer-secret", "timeout": 5}
 
 
 class TestWriteEvalSpanToTrace:

--- a/util/eval_pipeline/tests/test_trace_eval_span.py
+++ b/util/eval_pipeline/tests/test_trace_eval_span.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from eval_pipeline.eval_types import ScoreDetail
-from eval_pipeline.trace_eval_span import write_eval_span_to_trace
+from eval_pipeline.trace_eval_span import post_eval_span_to_otlp, write_eval_span_to_trace
 from tests.otlp_helpers import _otlp_attrs_to_dict
 
 
@@ -22,6 +22,42 @@ def _read_first_span_from_otlp_file(trace_file: Path) -> tuple[str, dict]:
     span = scope["spans"][0]
     attrs = _otlp_attrs_to_dict(span.get("attributes", []))
     return span.get("name", ""), attrs
+
+
+def test_post_eval_span_applies_viewer_auth(monkeypatch: pytest.MonkeyPatch):
+    """Remote eval-span posts include the configured viewer bearer token."""
+    captured: dict[str, str | None] = {}
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+    def fake_urlopen(request, timeout):
+        captured["authorization"] = request.get_header("Authorization")
+        captured["timeout"] = str(timeout)
+        return Response()
+
+    monkeypatch.setenv("NOOA_VIEWER_AUTH_TOKEN", "viewer-secret")
+    monkeypatch.setattr("eval_pipeline.trace_eval_span.urllib.request.urlopen", fake_urlopen)
+
+    assert post_eval_span_to_otlp(
+        session_id="session-1",
+        experiment="experiment-1",
+        test_id="test-1",
+        passed=True,
+        weighted_score=1.0,
+        model="model-1",
+        agent_class="Agent",
+        method="run",
+        scores={},
+        endpoint="http://viewer.example/v1/traces",
+    )
+    assert captured == {"authorization": "Bearer viewer-secret", "timeout": "5"}
 
 
 class TestWriteEvalSpanToTrace:


### PR DESCRIPTION
## What does this PR do?

- Applies the configured `NOOA_VIEWER_AUTH_TOKEN` bearer token when posting eval-result spans to a remote OTLP viewer.
- Aligns direct eval-span uploads with the existing authenticated journal and trace exporters.
- Adds regression coverage verifying that the Authorization header is present.

Previously, execution spans reached authenticated remote viewers, but eval-result spans were rejected. The viewer therefore contained the underlying sessions while its eval page returned "Experiment not found."

## Related issues

None.

## Validation

- `uv run --no-sync pytest util/eval_pipeline/tests/test_trace_eval_span.py -q` — 7 passed.
- Commit-time Ruff, formatting, whitespace, SPDX, and conflict checks passed.

## Checklist

- [x] Code follows the project style.
- [x] Tests added/updated and passing.
- [x] Documentation is not required; this corrects existing authenticated-viewer behavior without changing the public API.
- [x] No new source files were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eval-span submissions now include the appropriate viewer authentication, allowing authenticated remote requests to complete successfully.
  * Existing request behavior, including timeout handling and error reporting, remains unchanged.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->