### PR TITLE
fix(tui): stabilize native scrollback rendering

### DIFF
--- a/packages/nooa-cli/pyproject.toml
+++ b/packages/nooa-cli/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pyyaml>=6.0",
     "prompt-toolkit>=3.0.41,<3.1.0",
     "pydantic>=2.5.0",
-    "rich>=13.0.0",
+    "rich>=14.3.3",
 ]
 
 [project.urls]

--- a/packages/nooa-cli/src/nooa_cli/tui/config.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/config.py
@@ -118,7 +118,7 @@ class TUIConfig(BaseModel):
     reflection_debounce_s: float = 10.0
     reflection_grace_s: float = 0.5
 
-    # Native scrollback with clear+rewrite transcript replay on resize.
+    # Native scrollback with debounced clear+rewrite replay on width resize.
     full_screen: bool = True
 
     # Ordered, structured toolbar providers. Third-party packages can register

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -50,7 +50,7 @@ def render_history_replay_to_ansi(output: HistoryReplay, width: int) -> str:
     dim = COLORS["overlay1"]
     user_color = COLORS["subtext1"]
 
-    render_width = max(int(width), 20)
+    render_width = max(int(width), 1)
     buf = io.StringIO()
     # Rich ignores ``width=`` for force_terminal consoles when it can read the
     # real terminal size.  Supplying COLUMNS pins the semantic replay width.
@@ -256,6 +256,15 @@ class TerminalFrontend:
         """Dispatch *output* to the appropriate Rich rendering call."""
         handler = self._renderers.get(type(output))
         if handler is not None:
+            # The live Console is long-lived, but terminal width is not.  Keep
+            # every structured render inside the native-scrollback safe width
+            # instead of retaining the constructor's arbitrary 120 columns.
+            stream = getattr(self._console.console, "file", None)
+            replay_width = getattr(stream, "replay_width", None)
+            if callable(replay_width):
+                self._console.console.width = max(
+                    int(replay_width(self._console.console.width or 80)), 1
+                )
             handler(output)
 
     def batch_render(self):

--- a/packages/nooa-cli/src/nooa_cli/tui/input_handler.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/input_handler.py
@@ -18,6 +18,7 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.styles import Style
 
 from .completer import _MENTION_PATTERN, Completer
+from .terminal_safety import sanitize_live_text
 from .theme import COLORS
 
 if TYPE_CHECKING:
@@ -44,6 +45,11 @@ class SlashCommandCompleter(PtCompleter):
             return
 
         for item in self._completer.complete(text):
+            # Completion labels are presentation data, not terminal input.
+            # Keep dynamic filenames/plugin help on one inert menu row while
+            # leaving ``item.text`` unchanged for insertion.
+            display = sanitize_live_text(item.display).replace("\n", r"\n")
+            description = sanitize_live_text(item.description).replace("\n", r"\n")
             # Calculate how much text to replace: the item.text is the full
             # replacement, so we insert the suffix after what's already typed.
             suffix = item.text[len(text) :] if item.text.startswith(text) else item.text
@@ -54,15 +60,15 @@ class SlashCommandCompleter(PtCompleter):
                 yield Completion(
                     "",
                     start_position=0,
-                    display=item.display,
-                    display_meta=item.description,
+                    display=display,
+                    display_meta=description,
                 )
                 continue
             yield Completion(
                 suffix if item.text.startswith(text) else item.text,
                 start_position=0 if item.text.startswith(text) else -len(text),
-                display=item.display,
-                display_meta=item.description,
+                display=display,
+                display_meta=description,
             )
 
 

--- a/packages/nooa-cli/src/nooa_cli/tui/resize_reflow.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resize_reflow.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""State machine for source-backed transcript replay after terminal resize."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+TRANSCRIPT_REFLOW_DEBOUNCE_SECONDS = 0.075
+
+
+@dataclass(frozen=True)
+class ResizeObservation:
+    """Result of sampling the terminal geometry."""
+
+    changed: bool
+    should_debounce: bool
+
+
+@dataclass(frozen=True)
+class ResizeReplayRequest:
+    """A replay that is valid only for one settled resize generation."""
+
+    width: int
+    generation: int
+    required: bool = False
+
+
+class TranscriptResizeState:
+    """Track observed geometry separately from the width actually replayed.
+
+    Transcript wrapping depends on columns, not rows. Row-only changes are still
+    observed so they extend the quiet period for an already-pending width replay,
+    but they never initiate a destructive scrollback rebuild on their own.
+    """
+
+    def __init__(self) -> None:
+        self.observed_size: tuple[int, int] | None = None
+        self.replayed_width: int | None = None
+        self.pending_width: int | None = None
+        self.replay_required = False
+        self.generation = 0
+
+    def observe(self, size: tuple[int, int]) -> ResizeObservation:
+        """Record a geometry sample and report whether to restart the debounce."""
+        width, rows = (int(size[0]), int(size[1]))
+        current = (width, rows)
+        previous = self.observed_size
+        if previous is None:
+            self.observed_size = current
+            self.replayed_width = width
+            return ResizeObservation(changed=True, should_debounce=False)
+        if current == previous:
+            return ResizeObservation(changed=False, should_debounce=False)
+
+        self.observed_size = current
+        self.generation += 1
+        if width != previous[0]:
+            self.pending_width = width
+
+        return ResizeObservation(
+            changed=True,
+            should_debounce=self.pending_width is not None,
+        )
+
+    def prepare_replay(self) -> ResizeReplayRequest | None:
+        """Build a request once quiet without consuming work before success."""
+        width = self.pending_width
+        if width is None:
+            return None
+        if width == self.replayed_width and not self.replay_required:
+            self.pending_width = None
+            return None
+        return ResizeReplayRequest(
+            width=width,
+            generation=self.generation,
+            required=self.replay_required,
+        )
+
+    def request_replay(self) -> bool:
+        """Require a rebuild at the observed width even when it did not change.
+
+        This is reserved for recovery after prompt_toolkit had to compress its
+        non-full-screen live region below the previously rendered height.  It
+        is intentionally distinct from ordinary row observations, which stay
+        cheap and never initiate transcript replay.
+        """
+        if self.observed_size is None:
+            return False
+        width = self.observed_size[0]
+        if self.pending_width == width and self.replay_required:
+            return False
+        self.generation += 1
+        self.pending_width = width
+        self.replay_required = True
+        return True
+
+    def is_current(self, request: ResizeReplayRequest) -> bool:
+        """Return whether a queued replay still matches the latest geometry."""
+        return (
+            request.generation == self.generation
+            and self.observed_size is not None
+            and request.width == self.observed_size[0]
+            and request.width == self.pending_width
+            and request.required == self.replay_required
+        )
+
+    def mark_replayed(self, request: ResizeReplayRequest) -> None:
+        """Remember the width whose transcript was actually rebuilt."""
+        self.replayed_width = request.width
+        if (
+            self.observed_size is not None
+            and self.observed_size[0] == request.width
+            and self.pending_width == request.width
+        ):
+            self.pending_width = None
+            self.replay_required = False
+
+    @property
+    def has_pending_replay(self) -> bool:
+        return self.pending_width is not None

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -24,8 +24,15 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from rich.cells import chop_cells, set_cell_size
 from rich.console import Console as RichConsole
 from rich.text import Text
+
+from .terminal_safety import (
+    fallback_transcript_columns,
+    normalize_transcript_block,
+    sanitize_live_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -98,14 +105,14 @@ def _effective_slash_output_to_agent(agent: Any, slash_result: Any) -> bool:
 
 
 def _build_user_bar(text: str, app: "TUIApplication", colors: dict) -> str:
-    """Build a full-width highlighted user-message bar as raw ANSI.
+    """Build a highlighted user-message bar as safe raw ANSI.
 
     Bypasses Rich because reconciling Rich's wrap/crop/overflow logic
     with manual ``ljust`` padding is brittle across Rich versions and
     terminal emulators — direct CSI emission always renders the full
     width-spanning highlighted row the spec asks for.
 
-    Each input line becomes one bar row:
+    Each input line becomes one bar row (or more when it wraps):
       ``ESC[fg;bg m{prefix}{line}{padding}{ ESC[0m}\\n``
     where the first row carries the ``❯`` prompt glyph and
     continuation rows start flush-left.
@@ -115,15 +122,14 @@ def _build_user_bar(text: str, app: "TUIApplication", colors: dict) -> str:
     # terminal_cols helper if the app output can't report.
     cols: int
     try:
-        cols = app.output_columns(minimum=20)
+        cols = app.transcript_columns()
     except Exception:
         try:
-            cols = app._app.output.get_size().columns  # type: ignore[attr-defined]
+            cols = max(int(app._app.output.get_size().columns) - 1, 1)  # type: ignore[attr-defined]
         except Exception:
             from .tui_application import terminal_cols
 
-            cols = terminal_cols(minimum=40)
-    cols = max(cols, 20)
+            cols = max(terminal_cols(minimum=1) - 1, 1)
 
     fg = _hex_to_ansi256(colors["text"])
     bg = _hex_to_ansi256(colors["surface2"])
@@ -131,14 +137,13 @@ def _build_user_bar(text: str, app: "TUIApplication", colors: dict) -> str:
     off = "\x1b[0m"
 
     rows: list[str] = []
-    for i, line in enumerate(text.split("\n")):
+    for i, line in enumerate(sanitize_live_text(text).split("\n")):
         shown = f" ❯ {line} " if i == 0 else f" {line} "
-        # Clamp to cols so an overlong line becomes multiple bar rows
-        # rather than wrapping chaotically at the terminal's edge.
-        while len(shown) > cols:
-            rows.append(f"{on}{shown[:cols]}{off}")
-            shown = shown[cols:]
-        rows.append(f"{on}{shown.ljust(cols)}{off}")
+        # Rich's cell helpers preserve grapheme clusters and measure wide
+        # glyphs correctly.  Every row is exactly the safe content width,
+        # which is one cell narrower than the physical terminal.
+        chunks = chop_cells(shown, cols) or [""]
+        rows.extend(f"{on}{set_cell_size(chunk, cols)}{off}" for chunk in chunks)
     return "\n".join(rows) + "\n"
 
 
@@ -298,7 +303,6 @@ class Session:
         self._app: TUIApplication | None = None
         self._renderer: AgentEventRenderer | None = None
         self._unsub_activity: Callable[[], None] | None = None
-        self._emit_console: RichConsole | None = None
         self._loud_handler_reentrant: bool = False
         # Own ShellTools for bang (!) commands — avoids cross-loop issues
         # when the agent's shell was created on a different event loop.
@@ -350,7 +354,6 @@ class Session:
 
     def _dump_exit_diagnostics(self) -> None:
         """Print pending tasks, threads, and subprocesses on exit for debugging hangs."""
-        import sys
         import threading
 
         lines: list[str] = []
@@ -386,11 +389,8 @@ class Session:
                 lines.append(f"  - {t.get_name()}")
 
         if lines:
-            sys.stderr.write("\n\033[2m[exit diagnostics]\n")
-            for line in lines:
-                sys.stderr.write(f"  {line}\n")
-            sys.stderr.write("\033[0m\n")
-            sys.stderr.flush()
+            body = "".join(f"  {line}\n" for line in lines)
+            self._write_terminal_fallback(f"\n\033[2m[exit diagnostics]\n{body}\033[0m\n")
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -425,16 +425,6 @@ class Session:
                 self._saved_termios = termios.tcgetattr(sys.stdin.fileno())
         except (ImportError, OSError):
             pass
-
-        # The block-rendering Rich Console: re-used across ``_emit_text``
-        # calls with width reset per-call to track live terminal width.
-        self._emit_console = RichConsole(
-            file=io.StringIO(),
-            force_terminal=True,
-            color_system="256",
-            width=120,
-            theme=CATPPUCCIN_THEME,
-        )
 
         self._app = TUIApplication(
             agent=self.agent,
@@ -515,7 +505,7 @@ class Session:
                 RichConsole(
                     file=_EmitStream(
                         self._app.emit_block,
-                        replay_width=lambda app=self._app: app.output_columns(minimum=40),
+                        replay_width=lambda app=self._app: app.transcript_columns(),
                         clear=self._app.clear_transcript,
                     ),  # type: ignore[arg-type]
                     force_terminal=True,
@@ -709,16 +699,33 @@ class Session:
                 tag = ""
         else:
             tag = ""
-        suffix = f" — {tag}" if tag else ""
-        sys.stderr.write(f"\n\x1b[2mGoodbye! Stay vibing.{suffix}\x1b[0m\n")
+        safe_tag = sanitize_live_text(tag).replace("\n", " ")
+        suffix = f" — {safe_tag}" if safe_tag else ""
+        message = f"\n\x1b[2mGoodbye! Stay vibing.{suffix}\x1b[0m\n"
         if sm is not None and short:
-            sys.stderr.write(
-                f"\x1b[2mResume this session with \x1b[0m\x1b[1mnooa tui -c {short}\x1b[0m\n"
-            )
+            message += f"\x1b[2mResume this session with \x1b[0m\x1b[1mnooa tui -c {short}\x1b[0m\n"
+        self._write_terminal_fallback(message)
+
+    def _write_terminal_fallback(self, value: str, stream: Any = None) -> None:
+        """Write degraded-path diagnostics through transcript safety rules."""
+        target = stream if stream is not None else sys.stderr
+        try:
+            app = getattr(self, "_app", None)
+            if app is not None:
+                candidate = app.transcript_columns()
+                columns = candidate if isinstance(candidate, int) else fallback_transcript_columns()
+            else:
+                columns = fallback_transcript_columns()
+            target.write(normalize_transcript_block(value, columns=max(int(columns), 1)))
+            target.flush()
+        except Exception:
+            # This is the last-resort path used while the UI itself is failing.
+            # Never recurse through the asyncio exception handler from here.
+            pass
 
     # ------------------------------------------------------------------
     # Handlers — driven by TUIApplication, called in run()'s event loop.
-    # Each closes over ``self._app`` / ``self._renderer`` / ``self._emit_console``
+    # Each closes over ``self._app`` / ``self._renderer``
     # set up in ``run()``. Don't call any of these before ``run()`` has
     # started; calling an assertion-gated attribute access ("``self._app``
     # is None") raises a descriptive error.
@@ -734,17 +741,25 @@ class Session:
 
     def _render_to_ansi(self, renderable: Any) -> str:
         """Render a Rich renderable using the current terminal width."""
-        assert self._emit_console is not None
+        from .theme import CATPPUCCIN_THEME
         from .tui_application import terminal_cols
 
         try:
-            width = self._app.output_columns(minimum=40)  # type: ignore[union-attr]
+            width = self._app.transcript_columns()  # type: ignore[union-attr]
         except Exception:
-            width = terminal_cols(minimum=40)
-        self._emit_console.width = max(int(width), 40)
+            width = max(terminal_cols(minimum=1) - 1, 1)
+        # Live agent output and resize replay may render concurrently on two
+        # loops. A per-call console keeps width and destination local instead
+        # of coupling those threads through mutable Rich Console state.
         buf = io.StringIO()
-        self._emit_console.file = buf
-        self._emit_console.print(renderable)
+        console = RichConsole(
+            file=buf,
+            force_terminal=True,
+            color_system="256",
+            width=max(int(width), 1),
+            theme=CATPPUCCIN_THEME,
+        )
+        console.print(renderable)
         return buf.getvalue()
 
     def _emit_text(
@@ -758,7 +773,7 @@ class Session:
         """Render a Rich renderable → ANSI → enqueue to the block queue.
 
         In fullscreen mode, also retain a replay callback that re-renders the
-        same semantic Rich/Markdown object at the current width on resize.
+        same semantic Rich/Markdown object after a settled width resize.
         """
         assert self._app is not None
 
@@ -835,6 +850,7 @@ class Session:
                 self._session_title_requested = False
             finally:
                 self._app._session_transitioning = False
+
         async def _render_result_outputs() -> None:
             frontend = getattr(self, "frontend", None)
             render = getattr(frontend, "render", None)
@@ -1077,8 +1093,7 @@ class Session:
             if self._loud_handler_reentrant:
                 err = sys.__stderr__
                 if err is not None:
-                    err.write(diag_msg)
-                    err.flush()
+                    self._write_terminal_fallback(diag_msg, err)
             else:
                 self._loud_handler_reentrant = True
                 try:
@@ -1088,8 +1103,7 @@ class Session:
                     # fall back to stderr so the diagnostic isn't lost.
                     err = sys.__stderr__
                     if err is not None:
-                        err.write(diag_msg)
-                        err.flush()
+                        self._write_terminal_fallback(diag_msg, err)
                 finally:
                     self._loud_handler_reentrant = False
             # Fall through to normal handler for the full traceback
@@ -1143,11 +1157,7 @@ class Session:
         if self._loud_handler_reentrant:
             err = sys.__stderr__
             if err is not None:
-                try:
-                    err.write(line)
-                    err.flush()
-                except Exception:
-                    pass
+                self._write_terminal_fallback(line, err)
             return
         self._loud_handler_reentrant = True
         try:
@@ -1155,11 +1165,10 @@ class Session:
         except Exception as inner:
             err = sys.__stderr__
             if err is not None:
-                try:
-                    err.write(f"[loud_handler fallback] {inner}\n{line}")
-                    err.flush()
-                except Exception:
-                    pass
+                self._write_terminal_fallback(
+                    f"[loud_handler fallback] {inner}\n{line}",
+                    err,
+                )
         finally:
             self._loud_handler_reentrant = False
 

--- a/packages/nooa-cli/src/nooa_cli/tui/stream_forwarder.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/stream_forwarder.py
@@ -27,17 +27,15 @@ buffer is set, i.e. exactly the stray-write case we care about.
 
 from __future__ import annotations
 
-import re
 import threading
 from collections.abc import Callable
 from typing import IO, Any
 
-# Strip ANSI escape sequences for pattern matching.
-_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
-
-
-def _strip_ansi(s: str) -> str:
-    return _ANSI_RE.sub("", s)
+from .terminal_safety import (
+    fallback_transcript_columns,
+    normalize_transcript_block,
+    sanitize_live_text,
+)
 
 
 class _StrayStreamForwarder:
@@ -124,8 +122,12 @@ class _StrayStreamForwarder:
 
     def _emit_line(self, line: str) -> None:
         """Wrap a single line in the configured ANSI style and emit it."""
+        # Even the fallback below can write to the real terminal.  Normalize
+        # before dedup/styling so subprocess cursor controls, BEL, CR, OSC,
+        # and malformed CSI can never escape by making ``emit_block`` fail.
+        line = sanitize_live_text(line).replace("\n", "\\n")
         # Suppress purely empty/whitespace lines.
-        stripped = _strip_ansi(line).strip()
+        stripped = line.strip()
         if not stripped:
             return
 
@@ -147,26 +149,32 @@ class _StrayStreamForwarder:
         self._repeat_count = 1
 
         styled = f"\x1b[{self._ansi_color}m{self._prefix}{line}\x1b[0m\n"
+        self._emit_styled(styled)
+
+        self._notify_stray(stripped, "emitted")
+
+    def _emit_styled(self, styled: str) -> None:
+        """Use the transcript pipeline, with one normalized terminal fallback."""
         try:
             self._emit_block(styled)
         except Exception:
             try:
-                self._original.write(styled)
+                self._original.write(
+                    normalize_transcript_block(
+                        styled,
+                        columns=fallback_transcript_columns(),
+                    )
+                )
                 self._original.flush()
             except Exception:
                 pass
-
-        self._notify_stray(stripped, "emitted")
 
     def _flush_dedup(self) -> None:
         """Emit a repeat summary if the last line was seen more than once."""
         if self._repeat_count > 1:
             summary = f"{self._last_line} (×{self._repeat_count - 1} more)"
             styled = f"\x1b[{self._ansi_color}m{self._prefix}{summary}\x1b[0m\n"
-            try:
-                self._emit_block(styled)
-            except Exception:
-                pass
+            self._emit_styled(styled)
         self._last_stripped = ""
         self._last_line = ""
         self._repeat_count = 0

--- a/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Terminal-output normalization shared by the native-scrollback TUI.
+
+The transcript accepts ANSI produced by Rich, but it must never accept terminal
+*commands* from user, model, subprocess, exception, or server text.  Styling
+(SGR) and hyperlinks (OSC 8) are harmless presentation metadata; cursor moves,
+screen erases, scroll-region changes, device queries, BEL, CR, and every other
+control can invalidate prompt_toolkit's idea of the live-region origin.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+
+from rich.cells import split_graphemes
+
+_ESC = "\x1b"
+
+# This expression is used only after ``sanitize_transcript_ansi`` has reduced
+# the language to SGR and OSC-8.  It deliberately recognizes both OSC
+# terminators because Rich versions differ between BEL and ST.
+_SAFE_ANSI_RE = re.compile(
+    r"\x1b\[[0-?]*[ -/]*m|\x1b\]8;[^\x07\x1b\r\n]*;(?:[^\x07\x1b\r\n]*)(?:\x07|\x1b\\)"
+)
+
+
+def _visible_control(codepoint: int) -> str:
+    width = 2 if codepoint <= 0xFF else 4
+    prefix = "x" if width == 2 else "u"
+    return f"\\{prefix}{codepoint:0{width}x}"
+
+
+def _find_csi_end(value: str, start: int) -> int | None:
+    """Return the index of a CSI final byte, or ``None`` when incomplete."""
+    for index in range(start, len(value)):
+        codepoint = ord(value[index])
+        if 0x40 <= codepoint <= 0x7E:
+            return index
+        if not 0x20 <= codepoint <= 0x3F:
+            return None
+    return None
+
+
+def _find_osc_end(value: str, start: int) -> tuple[int, int] | None:
+    """Return ``(payload_end, sequence_end)`` for BEL/ST-terminated OSC."""
+    index = start
+    while index < len(value):
+        character = value[index]
+        if character == "\x07":
+            return index, index + 1
+        if character == _ESC and index + 1 < len(value) and value[index + 1] == "\\":
+            return index, index + 2
+        codepoint = ord(character)
+        if (
+            character in "\r\n"
+            or codepoint < 0x20
+            or codepoint == 0x7F
+            or 0x80 <= codepoint <= 0x9F
+        ):
+            return None
+        index += 1
+    return None
+
+
+def sanitize_transcript_ansi(value: str) -> str:
+    """Keep printable text, newlines, SGR, and OSC-8; expose other controls.
+
+    Unsupported escape sequences are rendered visibly (for example,
+    ``ESC[2J`` becomes ``\\x1b[2J``), so diagnostic/code output remains useful
+    without being allowed to clear or reposition the real terminal.
+    """
+    value = str(value)
+    output: list[str] = []
+    index = 0
+    while index < len(value):
+        character = value[index]
+        codepoint = ord(character)
+
+        if character == _ESC:
+            # CSI: retain only Select Graphic Rendition's numeric parameter
+            # grammar. Some private xterm commands also end in ``m``.
+            if index + 1 < len(value) and value[index + 1] == "[":
+                end = _find_csi_end(value, index + 2)
+                if end is not None:
+                    sequence = value[index : end + 1]
+                    sgr_parameters = value[index + 2 : end]
+                    if value[end] == "m" and all(
+                        character.isdigit() or character in ":;" for character in sgr_parameters
+                    ):
+                        output.append(sequence)
+                    else:
+                        output.append("\\x1b" + sequence[1:])
+                    index = end + 1
+                    continue
+
+            # OSC: retain only well-formed hyperlinks.  Clipboard writes and
+            # title changes intentionally remain outside the transcript path.
+            if index + 1 < len(value) and value[index + 1] == "]":
+                end_info = _find_osc_end(value, index + 2)
+                if end_info is not None:
+                    payload_end, sequence_end = end_info
+                    payload = value[index + 2 : payload_end]
+                    sequence = value[index:sequence_end]
+                    if payload.startswith("8;") and payload.count(";") >= 2:
+                        output.append(sequence)
+                    else:
+                        terminator = "\\x07" if value[payload_end] == "\x07" else "\\x1b\\\\"
+                        output.append("\\x1b]" + payload + terminator)
+                    index = sequence_end
+                    continue
+
+            output.append("\\x1b")
+            index += 1
+            continue
+
+        if character == "\r":
+            if index + 1 < len(value) and value[index + 1] == "\n":
+                output.append("\n")
+                index += 2
+            else:
+                output.append("\\r")
+                index += 1
+            continue
+        if character == "\n":
+            output.append(character)
+        elif character == "\t":
+            output.append("    ")
+        elif codepoint < 0x20 or codepoint == 0x7F or 0x80 <= codepoint <= 0x9F:
+            output.append(_visible_control(codepoint))
+        else:
+            output.append(character)
+        index += 1
+    return "".join(output)
+
+
+def strip_safe_ansi(value: str) -> str:
+    """Strip the presentation escapes accepted by ``sanitize_transcript_ansi``."""
+    return _SAFE_ANSI_RE.sub("", value)
+
+
+def fallback_transcript_columns(default: int = 120) -> int:
+    """Safe native-scrollback width when no prompt_toolkit Output exists."""
+    try:
+        physical = shutil.get_terminal_size((default, 24)).columns
+    except Exception:
+        physical = default
+    return max(int(physical) - 1, 1)
+
+
+def _wrap_safe_ansi(value: str, columns: int) -> str:
+    """Hard-wrap sanitized ANSI without splitting styles or graphemes.
+
+    ``value`` must already contain only printable text, newlines, SGR, and
+    OSC-8.  Explicit newlines keep every physical line at or below ``columns``
+    cells, avoiding the terminal's delayed-autowrap state at the last column.
+    """
+    columns = max(int(columns), 1)
+    output: list[str] = []
+    line_cells = 0
+    index = 0
+    while index < len(value):
+        if value[index] == _ESC:
+            match = _SAFE_ANSI_RE.match(value, index)
+            if match is not None:
+                output.append(match.group(0))
+                index = match.end()
+                continue
+            # The sanitizer should make this unreachable.  Keep the fallback
+            # visibly inert if this helper is ever called independently.
+            output.append(r"\x1b")
+            index += 1
+            continue
+        if value[index] == "\n":
+            output.append("\n")
+            line_cells = 0
+            index += 1
+            continue
+
+        next_escape = value.find(_ESC, index)
+        next_newline = value.find("\n", index)
+        ends = [end for end in (next_escape, next_newline) if end >= 0]
+        end = min(ends) if ends else len(value)
+        text = value[index:end]
+        spans, _cell_count = split_graphemes(text)
+        for start, stop, cell_size in spans:
+            grapheme = text[start:stop]
+            if cell_size > columns:
+                # A two-cell grapheme cannot be rendered without touching the
+                # reserved last column of a two-column terminal.
+                grapheme = "�"
+                cell_size = 1
+            if line_cells and line_cells + cell_size > columns:
+                output.append("\n")
+                line_cells = 0
+            output.append(grapheme)
+            line_cells += max(cell_size, 0)
+        index = end
+    return "".join(output)
+
+
+def normalize_transcript_block(value: str, *, columns: int | None = None) -> str:
+    """Return one safe, style-contained block ending at a line boundary.
+
+    When ``columns`` is provided, this is also the sole native-scrollback
+    width boundary: every printable line is explicitly cell-wrapped before it
+    can reach the terminal.
+    """
+    normalized = sanitize_transcript_ansi(value)
+    visible = strip_safe_ansi(normalized)
+    if visible and not visible.endswith("\n"):
+        normalized += "\n"
+    # Replay concatenates retained blocks without a prompt_toolkit reset in
+    # between.  Contain every producer's styling even when it forgot SGR 0.
+    if "\x1b]8;" in normalized:
+        # A producer may provide a valid opening hyperlink without its closing
+        # OSC-8.  Contain that presentation state to this block.
+        normalized += "\x1b]8;;\x1b\\"
+    if "\x1b[" in normalized and not normalized.endswith("\x1b[0m"):
+        normalized += "\x1b[0m"
+    if columns is not None:
+        normalized = _wrap_safe_ansi(normalized, columns)
+    return normalized
+
+
+def sanitize_live_text(value: str) -> str:
+    """Make plain prompt_toolkit text safe without interpreting ANSI styles."""
+    # Run the strict scanner first, then expose even the two presentation
+    # sequence families: FormattedTextControl receives styles separately.
+    return strip_safe_ansi(sanitize_transcript_ansi(value))

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2181,6 +2181,23 @@ class TUIApplication:
     def _retain_transcript_block(self, block: TranscriptBlock) -> None:
         block.transcript_epoch = self._transcript_epoch
         self._transcript_blocks.append(block)
+        if not block.keep and block.event_id is None and not block.tags:
+            self._trim_untagged_transcript_tail()
+
+    def _trim_untagged_transcript_tail(self) -> None:
+        """Bound source retention even when no resize replay has run yet."""
+        untagged_indexes = [
+            index
+            for index, block in enumerate(self._transcript_blocks)
+            if not block.keep and block.event_id is None and not block.tags
+        ]
+        excess = len(untagged_indexes) - self._untagged_replay_tail
+        if excess <= 0:
+            return
+        discard = set(untagged_indexes[:excess])
+        self._transcript_blocks = [
+            block for index, block in enumerate(self._transcript_blocks) if index not in discard
+        ]
 
     def _enqueue_transcript_block(self, block: TranscriptBlock) -> None:
         rendered = self._render_replay_source(block.source)
@@ -2697,18 +2714,19 @@ class TUIApplication:
         if not self._transcript_blocks:
             return
         active_ids, active_ranges = self._active_replay_identity()
-        if not active_ids and not active_ranges:
-            return
+        has_active_identity = bool(active_ids or active_ranges)
         keep_indexes: set[int] = set()
         untagged_indexes: list[int] = []
         for i, block in enumerate(self._transcript_blocks):
             if block.keep:
                 keep_indexes.add(i)
             elif block.event_id is not None:
-                if block.event_id in active_ids:
+                if not has_active_identity or block.event_id in active_ids:
                     keep_indexes.add(i)
             elif block.tags:
-                if any(self._tag_is_active(tag, active_ranges) for tag in block.tags):
+                if not has_active_identity or any(
+                    self._tag_is_active(tag, active_ranges) for tag in block.tags
+                ):
                     keep_indexes.add(i)
             else:
                 untagged_indexes.append(i)

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -45,8 +45,19 @@ from prompt_toolkit.layout.processors import BeforeInput
 from prompt_toolkit.mouse_events import MouseEvent, MouseEventType
 
 from .completer import expand_mentions
-from .input_handler import create_prompt_style
+from .input_handler import _set_completions_sync, create_prompt_style
+from .resize_reflow import (
+    TRANSCRIPT_REFLOW_DEBOUNCE_SECONDS,
+    ResizeReplayRequest,
+    TranscriptResizeState,
+)
 from .subapp import InAppSubview, normalize_key_result
+from .terminal_safety import (
+    normalize_transcript_block,
+    sanitize_live_text,
+    sanitize_transcript_ansi,
+    strip_safe_ansi,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,14 +103,8 @@ class _SubviewControl(FormattedTextControl):
         return super().mouse_handler(mouse_event)
 
 
-# CSI + OSC stripper for the plain-text view of output_buffer. We keep
-# the original ANSI in _output_ansi; tests that assert on buffer text
-# don't want escape sequences in their comparisons.
-_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*\x07")
-
-
 def _strip_ansi(text: str) -> str:
-    return _ANSI_RE.sub("", text)
+    return strip_safe_ansi(text)
 
 
 def terminal_cols(default: int = 120, minimum: int = 20) -> int:
@@ -129,7 +134,11 @@ def format_session_rule(cols: int, label: str = "") -> list[tuple[str, str]]:
     "resize clutter" bug). Reserving the last column keeps the rule on one row so
     the erase stays correct across resizes.
     """
+    from rich.cells import cell_len, set_cell_size
+
     width = max(cols - 1, 1)
+    label = sanitize_live_text(label).replace("\n", " ")
+    label_width = cell_len(label)
     if label:
         # Clamp the whole line (fill + space + label) to ``width`` so an
         # over-long label can't push the rule into the final column and
@@ -138,10 +147,12 @@ def format_session_rule(cols: int, label: str = "") -> list[tuple[str, str]]:
         # width - 2``; otherwise (including ``len(label) == width - 1``, where
         # ``max(..., 1)`` would silently round the fill back up and re-bleed to
         # the final column) fall straight through to truncation, keeping the
-        # label tail (the context-usage / id that matters most).
-        if len(label) > width - 2:
-            return [("class:rule.label", label[-width:])]
-        dashes = width - len(label) - 1  # >= 1 by the guard above
+        # label text.
+        if label_width > width - 2:
+            # Keep grapheme clusters intact. Reversing code points to preserve
+            # the tail can detach combining marks and ZWJ emoji sequences.
+            return [("class:rule.label", set_cell_size(label, width).rstrip())]
+        dashes = width - label_width - 1  # >= 1 by the guard above
         return [
             ("class:rule", "─" * dashes + " "),
             ("class:rule.label", label),
@@ -151,15 +162,29 @@ def format_session_rule(cols: int, label: str = "") -> list[tuple[str, str]]:
 
 PROMPT_MARKER = "❯ "
 _CTRL_C_EXIT_WINDOW_SECONDS = 2.0
+_TRANSCRIPT_CLEAR_SEQUENCE = "\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H"
 
 
 @dataclass
-class ReplayBlock:
-    raw: str
+class TranscriptBlock:
+    source: str
     replay: Callable[[], str] | None = None
     event_id: str | None = None
     tags: frozenset[str] = frozenset()
     keep: bool = False
+    transcript_epoch: int = 0
+
+
+@dataclass(frozen=True)
+class _ResizeReplayQueueItem:
+    request: ResizeReplayRequest
+    transcript_blocks: tuple[TranscriptBlock, ...]
+    transcript_epoch: int
+
+
+@dataclass(frozen=True)
+class _ClearTranscriptQueueItem:
+    transcript_epoch: int
 
 
 def _coalesce_string_into_queue(inq: Any, text: str) -> None:
@@ -235,8 +260,8 @@ class TUIApplication:
             completer: Optional prompt_toolkit ``Completer`` for Tab
                 completion. When omitted no completion is offered.
             full_screen: Native-scrollback mode. Transcript output is written to
-                the terminal scrollback; resize only redraws prompt_toolkit's
-                live input/status region.
+                terminal scrollback; settled width changes rebuild retained
+                transcript output before prompt_toolkit redraws its live region.
             submission_guard: Returns an actionable error when plain agent-bound
                 input must be rejected. Slash and bang commands remain available.
 
@@ -271,16 +296,14 @@ class TUIApplication:
                 qm.set_notify_callback(self._on_queue_notify)
         self.full_screen = full_screen
 
-        # Output scrollback. Two parallel stores:
-        #   * ``output_buffer`` — plain-text view, used by tests and by
-        #     callers that want a printable transcript. ANSI stripped.
-        #   * ``_output_ansi`` — raw ANSI chunks rendered into the live
-        #     TUI via FormattedTextControl so Rich styling survives.
+        # ``output_buffer`` is the ANSI-stripped logical transcript used by
+        # tests and printable-transcript callers. Source-bearing blocks below
+        # are the single retained representation used for terminal replay.
         self.output_buffer = Buffer(read_only=False)
-        self._output_ansi: list[str] = []
         # Retained transcript replay units. On resize we intentionally clear
         # the visible screen + terminal scrollback, then rewrite these blocks.
-        self._replay_blocks: list[ReplayBlock] = []
+        self._transcript_blocks: list[TranscriptBlock] = []
+        self._transcript_epoch = 0
         self._untagged_replay_tail = 200
 
         # In-app subview host. These are modal views inside the single
@@ -349,18 +372,34 @@ class TUIApplication:
         self._keep_going_tasks: set[asyncio.Task[Any]] = set()
         self._keep_going_generation: int = 0
 
-        # Single producer-many-consumers path for transcript content:
+        # Many-producer, single-consumer path for transcript content:
         # emit_block() enqueues one ANSI chunk; a single background task
         # (started in run_async) drains the queue in order and writes
         # each chunk via run_in_terminal → sys.__stdout__. Everything
         # that used to have its own scheduling (patch_stdout proxy,
         # direct run_in_terminal in _render_message, etc.) now funnels
         # through this one queue — no races.
-        self._block_queue: asyncio.Queue[str] | None = None
+        self._block_queue: (
+            asyncio.Queue[TranscriptBlock | _ResizeReplayQueueItem | _ClearTranscriptQueueItem]
+            | None
+        ) = None
         self._consumer_task: asyncio.Task | None = None
-        # Diagnostic/test counter for fullscreen clear+rewrite replays.
+        # Diagnostic/test counter for fullscreen clear+rewrite replays. Resize
+        # state distinguishes transient geometry observations from the width
+        # that actually rebuilt scrollback.
         self._fullscreen_invalidate_count = 0
-        self._last_rendered_size: tuple[int, int] | None = None
+        self._resize_reflow = TranscriptResizeState()
+        self._resize_replay_timer: asyncio.TimerHandle | None = None
+        self._resize_replay_schedule_generation = 0
+        self._queued_resize_replay_generation: int | None = None
+        self._resize_replay_failure_generation: int | None = None
+        # A real height shrink can compress the non-full-screen live region
+        # below its preferred height.  prompt_toolkit erases using a cursor
+        # offset captured before SIGWINCH, so one rebuild is required after the
+        # normal layout fits again even though transcript wrapping did not
+        # change.
+        self._height_compaction_needs_replay = False
+        self._resize_replays_enabled = False
         self._replay_columns_override: int | None = None
         # Captured in run_async; used by emit_block for thread-safe
         # enqueue without calling the deprecated asyncio.get_event_loop().
@@ -377,8 +416,9 @@ class TUIApplication:
         kb = self._build_key_bindings()
 
         # Transcript output lives in terminal scrollback. In full_screen mode we
-        # still use native scrollback during steady state, but on resize we clear
-        # the visible screen and replay the retained transcript at the new width.
+        # still use native scrollback during steady state, but after a settled
+        # width resize we clear the visible screen and replay the retained
+        # transcript at the new width.
         self._output_window = None
 
         # Queue window: shown whenever the agent has unconsumed messages
@@ -402,9 +442,9 @@ class TUIApplication:
                 rows.append(f"│ {len(command_queue)} {noun} queued")
                 for index, text in enumerate(command_queue):
                     branch = "└─" if index == len(command_queue) - 1 else "├─"
-                    rows.append(f"{branch} {text}")
+                    rows.append(f"{branch} {sanitize_live_text(text)}")
             for text in _queue_pending():
-                for line in str(text).split("\n"):
+                for line in sanitize_live_text(str(text)).split("\n"):
                     rows.append(f"│ {line}")
             if not rows:
                 return []
@@ -430,24 +470,31 @@ class TUIApplication:
             style=input_style,
         )
         self._input_window = input_window
+        optional_row = Dimension(min=0, preferred=1, max=1)
         self._input_container = HSplit(
             [
-                Window(height=1, char=" ", style=input_style),
+                Window(height=optional_row, char=" ", style=input_style),
                 input_window,
-                Window(height=1, char=" ", style=input_style),
+                Window(height=optional_row, char=" ", style=input_style),
             ],
             style=input_style,
+            # The children above have a one-row aggregate minimum.  Keep a
+            # blank final fallback as a belt-and-suspenders guard for terminal
+            # implementations that briefly report zero rows.
+            window_too_small=Window(),
         )
 
         # Status line at the bottom — shows spinner + session label.
         def _status_formatted():
-            text = self.status_text()
+            text = sanitize_live_text(self.status_text())
             return [("class:status", text)] if text else []
 
         def _status_height() -> Dimension:
             lines = self.status_text().splitlines()
             height = max(1, len(lines))
-            return Dimension(min=height, max=height, preferred=height)
+            # Status is useful chrome, not a reason to replace the entire UI
+            # with prompt_toolkit's emergency "Window too small" window.
+            return Dimension(min=0, max=height, preferred=height)
 
         status_window = Window(
             FormattedTextControl(_status_formatted, focusable=False),
@@ -460,10 +507,13 @@ class TUIApplication:
         # Rule) so it re-measures with the live terminal width.
         def _session_rule_formatted():
             label = self._session_label_fn() if self._session_label_fn is not None else ""
-            return format_session_rule(terminal_cols(minimum=20), label)
+            current = self._read_terminal_size()
+            columns = current[0] if current is not None else terminal_cols(minimum=1)
+            return format_session_rule(columns, label)
 
         session_rule = Window(
-            FormattedTextControl(_session_rule_formatted, focusable=False), height=1
+            FormattedTextControl(_session_rule_formatted, focusable=False),
+            height=optional_row,
         )
 
         # Completion menu as a real layout region below the input.
@@ -480,12 +530,15 @@ class TUIApplication:
         def _completions_height() -> Dimension:
             state = self.input_buffer.complete_state
             n = len(state.completions) if state is not None else 0
-            exact = min(max(n, 1), _COMPLETION_MAX)
+            exact = min(n, _COMPLETION_MAX)
             # Exact, not a range. Dimension(min=1, max=12) lets HSplit
             # inflate the window when extra space is available — which
             # is exactly what causes growing blank gaps between the
             # prompt and the menu as completions narrow.
-            return Dimension(min=exact, max=exact, preferred=exact)
+            # A large completion set consumes only rows left after the input's
+            # one-row minimum; it can shrink all the way to zero instead of
+            # forcing HSplit's "Window too small" fallback.
+            return Dimension(min=0, max=exact, preferred=exact)
 
         completions_window = ConditionalContainer(
             Window(
@@ -495,7 +548,12 @@ class TUIApplication:
                 dont_extend_height=True,
                 right_margins=[ScrollbarMargin(display_arrows=True)],
             ),
-            filter=Condition(lambda: self.input_buffer.complete_state is not None),
+            filter=Condition(
+                lambda: (
+                    self.input_buffer.complete_state is not None
+                    and bool(self.input_buffer.complete_state.completions)
+                )
+            ),
         )
 
         # Active bottom region (top → bottom):
@@ -512,7 +570,9 @@ class TUIApplication:
                 self._input_container,
                 completions_window,
             ],
+            window_too_small=Window(),
         )
+        self._main_container = main_container
 
         def _subview_formatted():
             view = self._active_subview
@@ -523,7 +583,11 @@ class TUIApplication:
                 width, height = int(size.columns), int(size.rows)
             except Exception:
                 width, height = terminal_cols(minimum=80), 24
-            return ANSI(view.render(width, height))
+            # Subviews intentionally return SGR-colored ANSI, but their rows
+            # also contain session names, model output, server text, and other
+            # untrusted data.  Apply the same allowlist as transcript blocks
+            # before prompt_toolkit explodes it into screen cells.
+            return ANSI(sanitize_transcript_ansi(view.render(width, height)))
 
         self._subview_control = _SubviewControl(
             _subview_formatted,
@@ -735,6 +799,8 @@ class TUIApplication:
                 pass
             if self._app.is_running:
                 self._app.invalidate()
+            if self._resize_reflow.has_pending_replay:
+                self._schedule_resize_replay()
 
     def _prefill_input(self, text: str) -> None:
         self.input_buffer.text = text
@@ -958,7 +1024,9 @@ class TUIApplication:
             # advance on repeat presses — complete_next does both.
             buf = event.current_buffer
             if buf.complete_state is None:
-                buf.start_completion(select_first=True)
+                _set_completions_sync(buf)
+                if buf.complete_state is not None and buf.complete_state.completions:
+                    buf.complete_next()
             else:
                 buf.complete_next()
 
@@ -1993,9 +2061,29 @@ class TUIApplication:
 
     def clear_transcript(self) -> None:
         """Clear live transcript buffers and fullscreen resize replay retention."""
-        self._output_ansi.clear()
-        self._replay_blocks.clear()
+        loop = self._loop
+        if loop is not None:
+            try:
+                on_ui_loop = asyncio.get_running_loop() is loop
+            except RuntimeError:
+                on_ui_loop = False
+            if not on_ui_loop:
+                try:
+                    loop.call_soon_threadsafe(self._clear_transcript_on_ui_loop)
+                except RuntimeError:
+                    # The UI loop has already closed; there is no live prompt
+                    # buffer left to update.
+                    pass
+                return
+        self._clear_transcript_on_ui_loop()
+
+    def _clear_transcript_on_ui_loop(self) -> None:
+        self._transcript_epoch += 1
+        self._transcript_blocks.clear()
         self.output_buffer.set_document(Document(""), bypass_readonly=True)
+        queue = self._block_queue
+        if queue is not None:
+            queue.put_nowait(_ClearTranscriptQueueItem(self._transcript_epoch))
 
     def _on_stray_output(self, content: str, disposition: str) -> None:
         """Record stray stdout/stderr intercepts as hidden runtime events."""
@@ -2029,35 +2117,33 @@ class TUIApplication:
         task drains the queue and writes each block in FIFO order via
         ``run_in_terminal`` → ``sys.__stdout__``. No races.
 
-        Thread-safe: any mutation of prompt_toolkit state (``Buffer``
-        document, which fires callbacks synchronously) is routed through
-        ``call_soon_threadsafe`` so it always runs on the loop thread.
-        ``list.append`` on ``_output_ansi`` is already GIL-safe.
+        Thread-safe: retention, prompt_toolkit state, and terminal-queue
+        insertion are committed together on the UI loop. This keeps the replay
+        snapshot order identical to the terminal write order.
         """
         if not text:
             return
 
-        # GIL-safe: list.append is atomic. Reading from off-thread is fine.
-        self._output_ansi.append(text)
-        self._replay_blocks.append(
-            ReplayBlock(
-                raw=text,
-                replay=replay,
-                event_id=str(event_id) if event_id is not None else None,
-                tags=frozenset(str(t) for t in (tags or ())),
-                keep=keep,
-            )
+        block = TranscriptBlock(
+            source=text,
+            replay=replay,
+            event_id=str(event_id) if event_id is not None else None,
+            tags=frozenset(str(t) for t in (tags or ())),
+            keep=keep,
         )
 
         # Before the consumer is up (pre-run_async) we're single-threaded
         # by construction — safe to touch the buffer directly + emit to
         # stdout. After run_async, route everything via the loop.
-        if self._block_queue is None or self._loop is None:
-            self._append_stripped_to_buffer(text)
+        loop = self._loop
+        if self._block_queue is None or loop is None:
+            rendered = self._render_replay_source(block.source)
+            self._retain_transcript_block(block)
+            self._append_stripped_to_buffer(rendered)
             import sys as _sys
 
             try:
-                _sys.stdout.write(text)
+                _sys.stdout.write(rendered)
                 _sys.stdout.flush()
             except Exception:
                 pass
@@ -2067,19 +2153,56 @@ class TUIApplication:
         # inspect ``output_buffer.text`` right after a call see the
         # update without waiting for a loop tick.
         try:
-            on_thread = asyncio.get_running_loop() is self._loop
+            on_thread = asyncio.get_running_loop() is loop
         except RuntimeError:
             on_thread = False
         if on_thread:
-            self._append_stripped_to_buffer(text)
-            self._block_queue.put_nowait(text)
+            self._enqueue_transcript_block(block)
             return
 
-        # Off-thread: route everything through the loop so off-thread
-        # producers (e.g. background workers, OTEL exporter) never touch
-        # prompt_toolkit state directly.
-        self._loop.call_soon_threadsafe(self._append_stripped_to_buffer, text)
-        self._loop.call_soon_threadsafe(self._block_queue.put_nowait, text)
+        # Off-thread: use one callback so retention order and queue order cannot
+        # diverge, and replay cannot observe a block before the queue does.
+        try:
+            loop.call_soon_threadsafe(self._enqueue_transcript_block, block)
+        except RuntimeError:
+            # Teardown won the race with a late producer. prompt_toolkit no
+            # longer owns the terminal, so preserve the diagnostic directly.
+            rendered = self._render_replay_source(block.source)
+            import sys as _sys
+
+            out = _sys.__stdout__
+            if out is not None:
+                try:
+                    out.write(rendered)
+                    out.flush()
+                except Exception:
+                    pass
+
+    def _retain_transcript_block(self, block: TranscriptBlock) -> None:
+        block.transcript_epoch = self._transcript_epoch
+        self._transcript_blocks.append(block)
+
+    def _enqueue_transcript_block(self, block: TranscriptBlock) -> None:
+        rendered = self._render_replay_source(block.source)
+        self._retain_transcript_block(block)
+        self._append_stripped_to_buffer(rendered)
+        queue = self._block_queue
+        if queue is not None:
+            queue.put_nowait(block)
+            return
+
+        # A call_soon_threadsafe callback can outlive the queue during
+        # teardown. The terminal is no longer owned by prompt_toolkit then, so
+        # deliver the already-retained block directly instead of dropping it.
+        import sys as _sys
+
+        out = _sys.__stdout__
+        if out is not None:
+            try:
+                out.write(rendered)
+                out.flush()
+            except Exception:
+                pass
 
     def _append_stripped_to_buffer(self, text: str) -> None:
         """Append the ANSI-stripped transcript text to ``output_buffer``.
@@ -2105,6 +2228,7 @@ class TUIApplication:
         # any thread without calling the deprecated get_event_loop().
         self._loop = asyncio.get_running_loop()
         self._block_queue = asyncio.Queue()
+        self._resize_replays_enabled = True
         self._consumer_task = asyncio.ensure_future(self._consume_blocks())
 
         # Route stray sys.stdout / sys.stderr writes (aiohttp warnings,
@@ -2127,6 +2251,10 @@ class TUIApplication:
             # swallows every other diagnostic field.
             await self._app.run_async(set_exception_handler=False)
         finally:
+            # No resize callback or queued replay may clear the terminal after
+            # prompt_toolkit gives up ownership of it.
+            self._resize_replays_enabled = False
+            self._cancel_resize_replay_work()
             self._clear_ctrl_c_exit()
             # Restore sys.stdout / sys.stderr FIRST so any post-exit
             # prints from teardown code (spinner cleanup, snapshot save,
@@ -2150,26 +2278,24 @@ class TUIApplication:
             except Exception:
                 logger.debug("queue manager shutdown during TUI teardown failed", exc_info=True)
 
-            # Drain any blocks queued during teardown (e.g. 'Goodbye!
-            # Stay vibing.' from /exit) straight to the real stdout —
-            # the consumer task's run_in_terminal no longer works once
-            # the app has exited.
+            # Stop the remaining producer thread before the final output drain;
+            # otherwise it can enqueue after the consumer has been cancelled.
+            await self._stop_agent_loop()
+
+            # Let the single consumer finish ordinary blocks queued during
+            # teardown (e.g. 'Goodbye! Stay vibing.' from /exit). Once the
+            # prompt_toolkit app has exited, run_in_terminal executes its
+            # callable directly, so preserving the FIFO is both safe and less
+            # lossy than racing a manual drain against an in-flight consumer.
             import sys as _sys
 
             q = self._block_queue
-            if q is not None:
-                while not q.empty():
-                    try:
-                        chunk = q.get_nowait()
-                    except asyncio.QueueEmpty:
-                        break
-                    out = _sys.__stdout__
-                    if out is not None:
-                        try:
-                            out.write(chunk)
-                            out.flush()
-                        except Exception:
-                            pass
+            if q is not None and self._consumer_task is not None:
+                await asyncio.sleep(0)
+                try:
+                    await asyncio.wait_for(q.join(), timeout=1.0)
+                except TimeoutError:
+                    logger.debug("timed out draining TUI output during teardown")
             if self._consumer_task is not None:
                 self._consumer_task.cancel()
                 try:
@@ -2178,6 +2304,34 @@ class TUIApplication:
                     pass
                 except BaseException:
                     pass
+            # Later UI-loop cleanup callbacks bypass the retired queue and use
+            # emit_block's direct-output path. Keep the local q for the final
+            # fallback drain below.
+            self._block_queue = None
+
+            # A timed-out or exceptionally stopped consumer can leave queued
+            # ordinary blocks behind. Flush those directly, but deliberately
+            # discard resize barriers now that replay is disabled.
+            if q is not None:
+                while not q.empty():
+                    try:
+                        item = q.get_nowait()
+                    except asyncio.QueueEmpty:
+                        break
+                    try:
+                        if (
+                            isinstance(item, TranscriptBlock)
+                            and item.transcript_epoch == self._transcript_epoch
+                        ):
+                            out = _sys.__stdout__
+                            if out is not None:
+                                try:
+                                    out.write(self._render_replay_source(item.source))
+                                    out.flush()
+                                except Exception:
+                                    pass
+                    finally:
+                        q.task_done()
             if self._spinner_task is not None and not self._spinner_task.done():
                 self._spinner_task.cancel()
                 # Await so the spinner's finally block runs (invalidate())
@@ -2187,10 +2341,10 @@ class TUIApplication:
                     await self._spinner_task
                 except (asyncio.CancelledError, BaseException):
                     pass
-            await self._stop_agent_loop()
             self._consumer_task = None
             self._spinner_task = None
-            self._block_queue = None
+            self._queued_resize_replay_generation = None
+            self._replay_columns_override = None
             self._loop = None
 
     async def _consume_blocks(self) -> None:
@@ -2208,25 +2362,39 @@ class TUIApplication:
 
         assert self._block_queue is not None
         while True:
-            text = await self._block_queue.get()
-
-            def _write(t: str = text) -> None:
-                out = _sys.__stdout__
-                if out is not None:
-                    out.write(t)
-                    out.flush()
+            item = await self._block_queue.get()
 
             try:
-                await run_in_terminal(_write)
+                if isinstance(item, TranscriptBlock):
+
+                    def _write(block: TranscriptBlock = item) -> None:
+                        if block.transcript_epoch != self._transcript_epoch:
+                            return
+                        out = _sys.__stdout__
+                        if out is not None:
+                            # A block may have waited behind another terminal
+                            # operation while the pane narrowed. Enforce the
+                            # physical-width invariant at the actual write,
+                            # not only when the item entered the FIFO.
+                            out.write(self._render_replay_source(block.source))
+                            out.flush()
+
+                    await run_in_terminal(_write)
+                elif isinstance(item, _ResizeReplayQueueItem):
+                    await self._consume_resize_replay(item)
+                else:
+                    await self._consume_clear_transcript(item)
             except asyncio.CancelledError:
                 raise
             except Exception:
                 # Best-effort — a single failed write shouldn't wedge
                 # the consumer. Fall through and pick up the next block.
                 continue
+            finally:
+                self._block_queue.task_done()
 
     def output_columns(self, minimum: int = 20) -> int:
-        """Current transcript render width, including forced resize replays."""
+        """Current transcript render width, including an active resize replay."""
         if self._replay_columns_override is not None:
             return max(int(self._replay_columns_override), minimum)
         try:
@@ -2234,23 +2402,256 @@ class TUIApplication:
         except Exception:
             return terminal_cols(minimum=minimum)
 
+    def transcript_columns(self) -> int:
+        """Safe printable width for native-scrollback blocks.
+
+        Direct terminal output runs with autowrap enabled.  Reserving the last
+        physical column avoids the delayed-wrap ambiguity where a subsequent
+        newline can create an extra row and move prompt_toolkit's live-region
+        origin.  Unlike ``output_columns``, this never inflates a genuinely
+        narrow terminal to an arbitrary rendering minimum.
+        """
+        if self._replay_columns_override is not None:
+            physical = int(self._replay_columns_override)
+        else:
+            current = self._read_terminal_size()
+            physical = current[0] if current is not None else terminal_cols(minimum=1)
+        return max(physical - 1, 1)
+
+    def _render_replay_source(self, source: str) -> str:
+        """Normalize source text at the terminal's current safe width."""
+        return normalize_transcript_block(source, columns=self.transcript_columns())
+
     def _before_render(self, _app) -> None:
-        """Replay retained transcript when fullscreen mode sees a terminal resize."""
+        """Observe terminal geometry before prompt_toolkit renders a frame."""
         if not self.full_screen:
             return
+        current = self._read_terminal_size()
+        if current is None:
+            return
+        self._observe_terminal_size(current)
+
+    def _read_terminal_size(self) -> tuple[int, int] | None:
         try:
             size = self._app.output.get_size()
-            current = (int(size.columns), int(size.rows))
+            return int(size.columns), int(size.rows)
         except Exception:
+            return None
+
+    def _observe_terminal_size(
+        self,
+        size: tuple[int, int],
+    ) -> None:
+        previous_size = self._resize_reflow.observed_size
+        observation = self._resize_reflow.observe(size)
+        recovery_requested = False
+        if self._active_subview is None:
+            compressed = self._main_layout_is_compressed(size)
+            rows_changed = previous_size is not None and previous_size[1] != size[1]
+            if rows_changed and compressed:
+                self._height_compaction_needs_replay = True
+            elif self._height_compaction_needs_replay and not compressed:
+                recovery_requested = self._resize_reflow.request_replay()
+                self._height_compaction_needs_replay = False
+        if observation.changed:
+            self._resize_replay_failure_generation = None
+        replay_is_queued = self._queued_resize_replay_generation == self._resize_reflow.generation
+        replay_failed = self._resize_replay_failure_generation == self._resize_reflow.generation
+        should_schedule = (
+            recovery_requested
+            or observation.should_debounce
+            or (
+                self._resize_reflow.has_pending_replay
+                and self._resize_replay_timer is None
+                and not replay_is_queued
+                and not replay_failed
+            )
+        )
+        if self._active_subview is None and should_schedule:
+            self._schedule_resize_replay()
+
+    def _main_layout_is_compressed(self, size: tuple[int, int]) -> bool:
+        """Return whether optional main-view rows cannot all fit."""
+        if self._active_subview is not None:
+            return False
+        columns, rows = size
+        try:
+            preferred = self._main_container.preferred_height(columns, rows).preferred
+        except Exception:
+            # The fixed normal chrome is status + rule + padded input.  This
+            # fallback is only for a broken third-party dimension callback.
+            preferred = 5
+        return preferred > rows
+
+    def _schedule_resize_replay(self) -> None:
+        loop = self._loop
+        if loop is None or loop.is_closed():
             return
-        if self._last_rendered_size is None:
-            self._last_rendered_size = current
+        if self._resize_replay_timer is not None:
+            self._resize_replay_timer.cancel()
+        self._resize_replay_schedule_generation += 1
+        schedule_generation = self._resize_replay_schedule_generation
+        self._resize_replay_timer = loop.call_later(
+            TRANSCRIPT_REFLOW_DEBOUNCE_SECONDS,
+            self._start_resize_replay,
+            schedule_generation,
+        )
+
+    def _start_resize_replay(
+        self,
+        schedule_generation: int,
+    ) -> None:
+        if schedule_generation != self._resize_replay_schedule_generation:
             return
-        if current != self._last_rendered_size:
-            self._last_rendered_size = current
+        self._resize_replay_timer = None
+        if not self._resize_replays_enabled:
+            return
+        current = self._read_terminal_size()
+        if current is None:
+            # Keep the pending width. A later successful before_render sample
+            # will schedule it again without retrying a broken Output.
+            return
+        observation = self._resize_reflow.observe(current)
+        if observation.should_debounce:
+            self._schedule_resize_replay()
+            return
+
+        if self._active_subview is not None:
+            return
+
+        request = self._resize_reflow.prepare_replay()
+        if request is None:
+            return
+
+        queue = self._block_queue
+        if queue is None:
+            return
+        if self._queued_resize_replay_generation is not None:
+            # Keep at most one replay barrier in the FIFO. If this one is stale,
+            # its consumer schedules the latest pending width after removing it.
+            return
+
+        # Replay is a barrier in the same FIFO as ordinary terminal writes. The
+        # snapshot is taken at the barrier's exact queue position, so later
+        # blocks are written once after the rebuilt prefix instead of appearing
+        self._prune_transcript_blocks_for_active_events()
+        self._queued_resize_replay_generation = request.generation
+        queue.put_nowait(
+            _ResizeReplayQueueItem(
+                request=request,
+                transcript_blocks=tuple(self._transcript_blocks),
+                transcript_epoch=self._transcript_epoch,
+            )
+        )
+
+    async def _consume_clear_transcript(self, item: _ClearTranscriptQueueItem) -> None:
+        from prompt_toolkit.application import run_in_terminal
+
+        await run_in_terminal(lambda: self._clear_terminal_if_current(item))
+
+    def _clear_terminal_if_current(self, item: _ClearTranscriptQueueItem) -> bool:
+        if not self._resize_replays_enabled or item.transcript_epoch != self._transcript_epoch:
+            return False
+        import sys as _sys
+
+        out = _sys.__stdout__
+        if out is None:
+            return False
+        try:
+            out.write(_TRANSCRIPT_CLEAR_SEQUENCE)
+            out.flush()
+            self._height_compaction_needs_replay = False
+            return True
+        except Exception:
+            return False
+
+    async def _consume_resize_replay(self, item: _ResizeReplayQueueItem) -> None:
+        schedule_latest_pending = False
+        try:
+            if (
+                not self._resize_replays_enabled
+                or item.transcript_epoch != self._transcript_epoch
+                or not self._resize_reflow.is_current(item.request)
+            ):
+                schedule_latest_pending = self._resize_reflow.has_pending_replay
+                return
             if self._active_subview is not None:
                 return
-            self._replay_fullscreen_transcript()
+            if not item.transcript_blocks and not item.request.required:
+                self._resize_reflow.mark_replayed(item.request)
+                self._resize_replay_failure_generation = None
+                return
+
+            from prompt_toolkit.application import run_in_terminal
+
+            self._replay_columns_override = item.request.width
+            try:
+                replayed = await run_in_terminal(lambda: self._replay_queue_item_if_current(item))
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                replayed = False
+            finally:
+                self._replay_columns_override = None
+
+            if replayed:
+                self._resize_reflow.mark_replayed(item.request)
+                self._resize_replay_failure_generation = None
+                self._height_compaction_needs_replay = False
+                # Some terminal stacks report final geometry only after the
+                # replay-triggered prompt_toolkit redraw.
+                self._schedule_resize_replay()
+            elif (
+                item.transcript_epoch != self._transcript_epoch
+                or not self._resize_reflow.is_current(item.request)
+            ):
+                schedule_latest_pending = self._resize_reflow.has_pending_replay
+            elif self._resize_replay_failure_generation != item.request.generation:
+                # One automatic retry recovers a transient stdout failure but
+                # cannot spin forever on a permanently broken terminal.
+                self._resize_replay_failure_generation = item.request.generation
+                schedule_latest_pending = self._resize_reflow.has_pending_replay
+        finally:
+            if self._queued_resize_replay_generation == item.request.generation:
+                self._queued_resize_replay_generation = None
+            if (
+                schedule_latest_pending
+                and self._resize_replays_enabled
+                and self._active_subview is None
+                and self._resize_replay_timer is None
+            ):
+                self._schedule_resize_replay()
+
+    def _replay_queue_item_if_current(self, item: _ResizeReplayQueueItem) -> bool:
+        if (
+            not self._resize_replays_enabled
+            or self._active_subview is not None
+            or item.transcript_epoch != self._transcript_epoch
+            or not self._resize_reflow.is_current(item.request)
+            or not self._resize_output_width_is_current(item)
+        ):
+            return False
+        return self._replay_fullscreen_transcript(
+            item.transcript_blocks,
+            clear_even_if_empty=item.request.required,
+            still_current=lambda: (
+                self._resize_replays_enabled
+                and self._active_subview is None
+                and item.transcript_epoch == self._transcript_epoch
+                and self._resize_reflow.is_current(item.request)
+                and self._resize_output_width_is_current(item)
+            ),
+        )
+
+    def _resize_output_width_is_current(self, item: _ResizeReplayQueueItem) -> bool:
+        current = self._read_terminal_size()
+        return current is not None and current[0] == item.request.width
+
+    def _cancel_resize_replay_work(self) -> None:
+        self._resize_replay_schedule_generation += 1
+        if self._resize_replay_timer is not None:
+            self._resize_replay_timer.cancel()
+            self._resize_replay_timer = None
 
     @staticmethod
     def _tag_range(tag: str) -> tuple[int, int] | None:
@@ -2292,15 +2693,15 @@ class TUIApplication:
             for active_start, active_end in active_ranges
         )
 
-    def _prune_replay_blocks_for_active_events(self) -> None:
-        if not self._replay_blocks:
+    def _prune_transcript_blocks_for_active_events(self) -> None:
+        if not self._transcript_blocks:
             return
         active_ids, active_ranges = self._active_replay_identity()
         if not active_ids and not active_ranges:
             return
         keep_indexes: set[int] = set()
         untagged_indexes: list[int] = []
-        for i, block in enumerate(self._replay_blocks):
+        for i, block in enumerate(self._transcript_blocks):
             if block.keep:
                 keep_indexes.add(i)
             elif block.event_id is not None:
@@ -2312,35 +2713,53 @@ class TUIApplication:
             else:
                 untagged_indexes.append(i)
         keep_indexes.update(untagged_indexes[-self._untagged_replay_tail :])
-        self._replay_blocks = [
-            block for i, block in enumerate(self._replay_blocks) if i in keep_indexes
+        self._transcript_blocks = [
+            block for i, block in enumerate(self._transcript_blocks) if i in keep_indexes
         ]
 
-    def _replay_fullscreen_transcript(self) -> None:
-        if not self.full_screen or not self._replay_blocks:
-            return
+    def _replay_fullscreen_transcript(
+        self,
+        transcript_blocks: tuple[TranscriptBlock, ...] | None = None,
+        *,
+        clear_even_if_empty: bool = False,
+        still_current: Callable[[], bool] | None = None,
+    ) -> bool:
+        if not self.full_screen:
+            return False
         import sys as _sys
 
         out = _sys.__stdout__
         if out is None:
-            return
-        self._prune_replay_blocks_for_active_events()
+            return False
+        if transcript_blocks is None:
+            self._prune_transcript_blocks_for_active_events()
+            transcript_blocks = tuple(self._transcript_blocks)
+        if not transcript_blocks and not clear_even_if_empty:
+            return False
         chunks: list[str] = []
-        for block in self._replay_blocks:
-            if block.replay is None:
-                chunks.append(block.raw)
-                continue
+        for block in transcript_blocks:
             try:
-                chunks.append(block.replay())
+                # Semantic callbacks and retained sources cross the same
+                # trust/width boundary at replay time. Re-normalizing sources
+                # is what makes arbitrary diagnostics and stream
+                # output safe after a narrower resize too.
+                source = block.replay() if block.replay is not None else block.source
             except Exception:
-                chunks.append(block.raw)
+                source = block.source
+            chunks.append(self._render_replay_source(source))
+        if still_current is not None and not still_current():
+            return False
         try:
-            out.write("\x1b[H\x1b[2J\x1b[3J")
+            # Reset scroll region + style state before clearing. Homing again
+            # after the purge gives prompt_toolkit a stable origin for its live
+            # input/status redraw when run_in_terminal returns.
+            out.write(_TRANSCRIPT_CLEAR_SEQUENCE)
             out.write("".join(chunks))
             out.flush()
             self._fullscreen_invalidate_count += 1
+            return True
         except Exception:
-            return
+            return False
 
     def exit(self) -> None:
         if self._app.is_running:
@@ -2444,23 +2863,3 @@ class TUIApplication:
     def set_session_label(self, label: str) -> None:
         """Set the bracketed label shown on the right of the status line."""
         self._session_label = label
-
-    def handle_resize(self, cols: int, rows: int) -> None:
-        """Hint the app to re-layout for a new terminal size.
-
-        prompt_toolkit handles real resize events internally; this hook
-        exists for tests (and callers that want to force a redraw after
-        a non-SIGWINCH layout change).
-        """
-        if self.full_screen:
-            size = (int(cols), int(rows))
-            if self._last_rendered_size != size:
-                self._last_rendered_size = size
-                if self._active_subview is None:
-                    self._replay_columns_override = int(cols)
-                    try:
-                        self._replay_fullscreen_transcript()
-                    finally:
-                        self._replay_columns_override = None
-        if self._app.is_running:
-            self._app.invalidate()

--- a/packages/nooa-cli/tests/tui/test_input_handler.py
+++ b/packages/nooa-cli/tests/tui/test_input_handler.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from nooa_cli.tui.input_handler import TUIInputHandler, create_key_bindings
+from nooa_cli.tui.input_handler import SlashCommandCompleter, TUIInputHandler, create_key_bindings
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -60,6 +60,39 @@ class TestPromptContinuation:
             result = await handler.get_input("❯ ")
 
         assert result == "hello world"
+
+
+def test_completion_presentation_is_single_line_and_control_safe(mock_registry) -> None:
+    from nooa_cli.tui.completer import CompletionItem
+    from prompt_toolkit.completion import CompleteEvent
+    from prompt_toolkit.document import Document
+    from prompt_toolkit.formatted_text import fragment_list_to_text
+
+    adapter = SlashCommandCompleter(mock_registry)
+    adapter._completer.complete = MagicMock(
+        return_value=[
+            CompletionItem(
+                text="/unsafe",
+                display="unsafe\nlabel\x1b[2J",
+                description="help\r\nnext\x07",
+            )
+        ]
+    )
+
+    [completion] = list(
+        adapter.get_completions(
+            Document("/u", cursor_position=2),
+            CompleteEvent(completion_requested=True),
+        )
+    )
+    display = fragment_list_to_text(completion.display)
+    meta = fragment_list_to_text(completion.display_meta)
+    assert "\n" not in display
+    assert "\n" not in meta
+    assert "\x1b[2J" not in display
+    assert "\x07" not in meta
+    assert r"unsafe\nlabel\x1b[2J" == display
+    assert r"help\nnext\x07" == meta
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nooa-cli/tests/tui/test_resize_reflow_state.py
+++ b/packages/nooa-cli/tests/tui/test_resize_reflow_state.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from nooa_cli.tui.resize_reflow import TranscriptResizeState
+
+
+def test_first_observation_establishes_replayed_width_without_rebuild() -> None:
+    state = TranscriptResizeState()
+
+    observation = state.observe((120, 40))
+
+    assert observation.changed is True
+    assert observation.should_debounce is False
+    assert state.replayed_width == 120
+    assert state.has_pending_replay is False
+
+
+def test_height_only_resize_does_not_schedule_transcript_replay() -> None:
+    state = TranscriptResizeState()
+    state.observe((120, 40))
+
+    observation = state.observe((120, 24))
+
+    assert observation.changed is True
+    assert observation.should_debounce is False
+    assert state.prepare_replay() is None
+
+
+def test_explicit_recovery_replays_at_the_same_width() -> None:
+    state = TranscriptResizeState()
+    state.observe((120, 40))
+    state.observe((120, 4))
+    state.observe((120, 40))
+
+    assert state.request_replay() is True
+    request = state.prepare_replay()
+
+    assert request is not None
+    assert request.width == 120
+    assert request.required is True
+    assert state.is_current(request) is True
+
+    state.mark_replayed(request)
+    assert state.has_pending_replay is False
+    assert state.replay_required is False
+
+
+def test_height_change_extends_an_already_pending_width_resize() -> None:
+    state = TranscriptResizeState()
+    state.observe((120, 40))
+    state.observe((80, 40))
+
+    observation = state.observe((80, 24))
+
+    assert observation.should_debounce is True
+    request = state.prepare_replay()
+    assert request is not None
+    assert request.width == 80
+
+
+def test_transient_width_that_returns_to_replayed_width_needs_no_rebuild() -> None:
+    state = TranscriptResizeState()
+    state.observe((120, 40))
+    state.observe((80, 24))
+
+    observation = state.observe((120, 40))
+
+    assert observation.should_debounce is True
+    assert state.prepare_replay() is None
+
+
+def test_queued_replay_becomes_stale_when_geometry_changes_again() -> None:
+    state = TranscriptResizeState()
+    state.observe((120, 40))
+    state.observe((80, 24))
+    request = state.prepare_replay()
+    assert request is not None
+
+    state.observe((90, 24))
+
+    assert state.is_current(request) is False
+
+
+def test_row_change_while_replay_is_in_flight_preserves_width_repair() -> None:
+    state = TranscriptResizeState()
+    state.observe((120, 40))
+    state.observe((80, 24))
+    first_request = state.prepare_replay()
+    assert first_request is not None
+
+    observation = state.observe((80, 20))
+
+    assert observation.should_debounce is True
+    assert state.is_current(first_request) is False
+    replacement_request = state.prepare_replay()
+    assert replacement_request is not None
+    assert replacement_request.width == 80
+
+
+def test_mark_replayed_commits_the_width_that_was_physically_written() -> None:
+    state = TranscriptResizeState()
+    state.observe((120, 40))
+    state.observe((80, 24))
+    request = state.prepare_replay()
+    assert request is not None
+
+    state.mark_replayed(request)
+
+    assert state.replayed_width == 80
+    assert state.has_pending_replay is False
+    assert state.is_current(request) is False
+
+
+def test_successful_stale_replay_records_physical_width_and_repairs_latest_width() -> None:
+    state = TranscriptResizeState()
+    state.observe((120, 40))
+    state.observe((80, 24))
+    request = state.prepare_replay()
+    assert request is not None
+
+    state.observe((120, 40))
+    state.mark_replayed(request)
+
+    assert state.replayed_width == 80
+    replacement_request = state.prepare_replay()
+    assert replacement_request is not None
+    assert replacement_request.width == 120
+
+
+def test_row_change_during_successful_replay_does_not_require_second_rebuild() -> None:
+    state = TranscriptResizeState()
+    state.observe((120, 40))
+    state.observe((80, 24))
+    request = state.prepare_replay()
+    assert request is not None
+
+    state.observe((80, 20))
+    state.mark_replayed(request)
+
+    assert state.replayed_width == 80
+    assert state.has_pending_replay is False

--- a/packages/nooa-cli/tests/tui/test_resize_reflow_state.py
+++ b/packages/nooa-cli/tests/tui/test_resize_reflow_state.py
@@ -45,6 +45,25 @@ def test_explicit_recovery_replays_at_the_same_width() -> None:
     assert state.replay_required is False
 
 
+def test_recovery_replay_is_ignored_before_the_first_observation() -> None:
+    state = TranscriptResizeState()
+
+    assert state.request_replay() is False
+    assert state.has_pending_replay is False
+
+
+def test_duplicate_recovery_request_preserves_the_pending_request() -> None:
+    state = TranscriptResizeState()
+    state.observe((120, 40))
+    assert state.request_replay() is True
+    request = state.prepare_replay()
+    assert request is not None
+
+    assert state.request_replay() is False
+    assert state.generation == request.generation
+    assert state.is_current(request) is True
+
+
 def test_height_change_extends_an_already_pending_width_resize() -> None:
     state = TranscriptResizeState()
     state.observe((120, 40))

--- a/packages/nooa-cli/tests/tui/test_resume_replay.py
+++ b/packages/nooa-cli/tests/tui/test_resume_replay.py
@@ -144,7 +144,7 @@ class TestBatchRendering:
         from nooa_cli.tui.frontend import TerminalFrontend
 
         # Create a mock console
-        mock_file = MagicMock()
+        mock_file = MagicMock(spec=["write", "flush"])
         mock_console = MagicMock()
         mock_console.console.width = 80
         mock_console.console.file = mock_file
@@ -173,6 +173,22 @@ class TestBatchRendering:
         assert "hello" in written
         assert "world" in written
         assert "bye" in written
+
+    def test_history_renderer_honors_pathologically_narrow_width(self):
+        from nooa_cli.tui.frontend import render_history_replay_to_ansi
+        from nooa_cli.tui.terminal_safety import strip_safe_ansi
+        from rich.cells import cell_len
+
+        replay = HistoryReplay(
+            turns=[HistoryTurn(role="agent", content="abcdefghij")],
+            session_id="narrow",
+            show_header=False,
+            show_footer=False,
+        )
+
+        rendered = render_history_replay_to_ansi(replay, 3)
+
+        assert all(cell_len(line) <= 3 for line in strip_safe_ansi(rendered).splitlines())
 
     def test_history_replay_on_emit_stream_keeps_semantic_replay_callback(self):
         """Live TUI rendering stores resumed HistoryReplay as a reflowable block."""

--- a/packages/nooa-cli/tests/tui/test_session_plumbing.py
+++ b/packages/nooa-cli/tests/tui/test_session_plumbing.py
@@ -191,7 +191,7 @@ def test_print_exit_message_includes_name_and_short_hash(capsys) -> None:
     assert "my-debug-run [abc12345]" in err
 
 
-def test_print_exit_message_exposes_controls_in_session_name(capsys) -> None:
+def test_print_exit_message_neutralizes_controls_in_session_name(capsys) -> None:
     from unittest.mock import Mock
 
     from nooa_cli.tui.session import Session

--- a/packages/nooa-cli/tests/tui/test_session_plumbing.py
+++ b/packages/nooa-cli/tests/tui/test_session_plumbing.py
@@ -17,11 +17,62 @@ these components don't need an ``Application`` to be testable.
 from __future__ import annotations
 
 import asyncio
+import threading
 
 from nooa_cli.tui.console import TUIConsole
 from nooa_cli.tui.session import _EmitStream
 from rich.console import Console
 from rich.table import Table
+
+
+def test_session_semantic_render_uses_isolated_consoles_across_threads(
+    monkeypatch,
+) -> None:
+    """Resize replay and live rendering must not share mutable Console state."""
+    from types import SimpleNamespace
+
+    import nooa_cli.tui.session as session_module
+    from nooa_cli.tui.session import Session
+
+    first_inside_print = threading.Event()
+    release_first = threading.Event()
+    second_finished = threading.Event()
+
+    class BlockingConsole:
+        def __init__(self, *, file, **_kwargs) -> None:
+            self.file = file
+
+        def print(self, renderable) -> None:
+            if renderable == "first":
+                first_inside_print.set()
+                assert release_first.wait(timeout=1)
+            self.file.write(renderable)
+
+    monkeypatch.setattr(session_module, "RichConsole", BlockingConsole)
+    session = Session.__new__(Session)
+    session._app = SimpleNamespace(transcript_columns=lambda: 79)
+    rendered: dict[str, str] = {}
+
+    first = threading.Thread(
+        target=lambda: rendered.setdefault("first", session._render_to_ansi("first"))
+    )
+
+    def render_second() -> None:
+        rendered["second"] = session._render_to_ansi("second")
+        second_finished.set()
+
+    second = threading.Thread(target=render_second)
+    first.start()
+    assert first_inside_print.wait(timeout=1)
+    second.start()
+    assert second_finished.wait(timeout=1)
+    second.join(timeout=1)
+    assert second.is_alive() is False
+    release_first.set()
+    first.join(timeout=1)
+
+    assert first.is_alive() is False
+    assert rendered == {"first": "first", "second": "second"}
 
 
 def test_emit_stream_coalesces_one_print_into_one_emit_call() -> None:
@@ -138,6 +189,26 @@ def test_print_exit_message_includes_name_and_short_hash(capsys) -> None:
     err = capsys.readouterr().err
     assert "Goodbye! Stay vibing." in err
     assert "my-debug-run [abc12345]" in err
+
+
+def test_print_exit_message_exposes_controls_in_session_name(capsys) -> None:
+    from unittest.mock import Mock
+
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session._app = None
+    session._session_manager = Mock(
+        session_id="abc1234567890def",
+        name="unsafe\x1b[2J\r\x07",
+    )
+
+    session._print_exit_message()
+
+    err = capsys.readouterr().err
+    assert "\x1b[2J" not in err
+    assert "\x07" not in err
+    assert r"unsafe\x1b[2J\r\x07" in err
 
 
 def test_print_exit_message_short_hash_only_when_name_missing(capsys) -> None:

--- a/packages/nooa-cli/tests/tui/test_session_rule_width.py
+++ b/packages/nooa-cli/tests/tui/test_session_rule_width.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import pytest
 from nooa_cli.tui.tui_application import format_session_rule
+from rich.cells import cell_len
 
 
 def _rendered_width(fragments: list[tuple[str, str]]) -> int:
@@ -69,3 +70,13 @@ def test_rule_label_is_preserved() -> None:
     frags = format_session_rule(120, label)
     rendered = "".join(text for _style, text in frags)
     assert label in rendered
+
+
+def test_rule_is_cell_aware_and_cannot_emit_terminal_controls() -> None:
+    cols = 40
+    fragments = format_session_rule(cols, "wide 界\x1b[2J\r")
+    rendered = "".join(text for _style, text in fragments)
+
+    assert cell_len(rendered) <= cols - 1
+    assert "\x1b[2J" not in rendered
+    assert r"\x1b[2J\r" in rendered

--- a/packages/nooa-cli/tests/tui/test_stream_forwarder.py
+++ b/packages/nooa-cli/tests/tui/test_stream_forwarder.py
@@ -136,6 +136,20 @@ class TestEmitBlockFailureSafety:
         fw.write("critical\n")
         assert "critical" in original.getvalue()
 
+    def test_fallback_exposes_terminal_controls_instead_of_executing_them(self):
+        original = io.StringIO()
+
+        def broken_emit(_: str) -> None:
+            raise RuntimeError("block queue exploded")
+
+        fw = _StrayStreamForwarder(original, broken_emit, prefix="! ", ansi_color="31")
+        fw.write("oops\x1b[2J\r\x07\n")
+        rendered = original.getvalue()
+
+        assert "\x1b[2J" not in rendered
+        assert "\x07" not in rendered
+        assert r"\x1b[2J\r\x07" in rendered
+
 
 class TestInstallUninstall:
     def test_install_replaces_both_streams_uninstall_restores(self):

--- a/packages/nooa-cli/tests/tui/test_terminal_safety.py
+++ b/packages/nooa-cli/tests/tui/test_terminal_safety.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from nooa_cli.tui.session import _build_user_bar
+from nooa_cli.tui.terminal_safety import (
+    normalize_transcript_block,
+    sanitize_transcript_ansi,
+    strip_safe_ansi,
+)
+from rich.cells import cell_len
+
+
+def test_transcript_normalizer_allows_style_but_exposes_terminal_commands() -> None:
+    raw = "\x1b[31mred\x1b[0m\x1b[2J\x1b]52;c;Y2xpcGJvYXJk\x07\r\x07\x08"
+
+    normalized = normalize_transcript_block(raw)
+
+    assert "\x1b[31m" in normalized
+    assert "\x1b[2J" not in normalized
+    assert "\x1b]52;" not in normalized
+    assert "\x07" not in normalized
+    assert "\x08" not in normalized
+    visible = strip_safe_ansi(normalized)
+    assert r"\x1b[2J" in visible
+    assert r"\x1b]52;c;Y2xpcGJvYXJk\x07" in visible
+    assert r"\r\x07\x08" in visible
+    assert visible.endswith("\n")
+
+
+def test_transcript_normalizer_preserves_well_formed_hyperlinks() -> None:
+    hyperlink = "\x1b]8;;https://example.com\x1b\\example\x1b]8;;\x1b\\\n"
+    normalized = normalize_transcript_block(hyperlink)
+    assert hyperlink in normalized
+    assert normalized.endswith("\x1b]8;;\x1b\\")
+
+
+def test_hyperlink_cannot_smuggle_a_c1_string_terminator() -> None:
+    smuggled = "\x1b]8;;https://example.com\x9c\x1b[2Jowned\x07"
+    normalized = normalize_transcript_block(smuggled)
+
+    assert "\x1b]8;" not in normalized
+    assert "\x9c" not in normalized
+    assert "\x1b[2J" not in normalized
+    assert r"\x9c\x1b[2J" in normalized
+
+
+def test_private_csi_ending_in_m_is_not_mistaken_for_graphic_rendition() -> None:
+    # XTMODKEYS uses final byte ``m`` but changes terminal input behavior; only
+    # the ordinary numeric/semicolon/colon SGR grammar is presentation-safe.
+    normalized = normalize_transcript_block("before\x1b[>4;2mafter")
+
+    assert "\x1b[>4;2m" not in normalized
+    assert r"\x1b[>4;2m" in normalized
+
+
+def test_transcript_normalizer_wraps_ansi_and_graphemes_inside_safe_width() -> None:
+    normalized = normalize_transcript_block(
+        "\x1b[31mab界cafe\N{COMBINING ACUTE ACCENT}👨‍👩‍👧‍👦z\x1b[0m",
+        columns=5,
+    )
+
+    visible_lines = strip_safe_ansi(normalized).splitlines()
+    assert "".join(visible_lines) == "ab界café👨‍👩‍👧‍👦z"
+    assert all(cell_len(line) <= 5 for line in visible_lines)
+
+
+def test_grapheme_wider_than_pathological_safe_width_is_replaced() -> None:
+    normalized = normalize_transcript_block("界", columns=1)
+
+    assert strip_safe_ansi(normalized) == "�\n"
+
+
+def test_user_bar_is_control_safe_cell_aware_and_reserves_final_column() -> None:
+    class _App:
+        @staticmethod
+        def transcript_columns() -> int:
+            return 9  # ten physical columns, with one deliberately reserved
+
+    colors = {"text": "#cdd6f4", "surface2": "#585b70"}
+    bar = _build_user_bar("wide 界\x1b[2J\r", _App(), colors)  # type: ignore[arg-type]
+
+    assert "\x1b[2J" not in bar
+    visible_lines = strip_safe_ansi(sanitize_transcript_ansi(bar)).splitlines()
+    assert visible_lines
+    assert all(cell_len(line) == 9 for line in visible_lines)

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -76,6 +76,38 @@ async def test_pre_run_emit_uses_the_same_normalized_block_as_replay(
     assert app._transcript_blocks[0].source == "bootstrap\x1b[2J\r\x07"
 
 
+async def test_untagged_transcript_retention_is_bounded_before_resize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    monkeypatch.setattr("sys.stdout", io.StringIO())
+    app = TUIApplication()
+
+    for index in range(app._untagged_replay_tail + 5):
+        app.emit_block(f"block {index}\n")
+
+    assert len(app._transcript_blocks) == app._untagged_replay_tail
+    assert app._transcript_blocks[0].source == "block 5\n"
+
+
+async def test_no_active_identity_preserves_tagged_blocks_but_caps_untagged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    monkeypatch.setattr("sys.stdout", io.StringIO())
+    app = TUIApplication()
+    app.emit_block("tagged\n", event_id="event-without-manager")
+    for index in range(app._untagged_replay_tail + 1):
+        app.emit_block(f"untagged {index}\n")
+
+    app._prune_transcript_blocks_for_active_events()
+
+    assert app._transcript_blocks[0].source == "tagged\n"
+    assert len(app._transcript_blocks) == app._untagged_replay_tail + 1
+
+
 async def test_input_composer_has_blank_row_above_and_below_input():
     """The default composer is three rows and expands for multiline input."""
     async with TUIHarness() as h:
@@ -1515,7 +1547,15 @@ async def test_permanent_replay_failure_stops_after_one_retry(
 
         for _ in range(5):
             h.app._app.invalidate()
-            await asyncio.sleep(0.03)
+            await asyncio.sleep(0)
+
+        await h.wait_for(
+            lambda: (
+                h.app._resize_replay_timer is None
+                and h.app._queued_resize_replay_generation is None
+            )
+        )
+        await asyncio.sleep(0)
 
         assert capture.attempts == 2
         assert h.app._resize_reflow.has_pending_replay is True
@@ -1711,7 +1751,14 @@ async def test_fullscreen_transient_resize_back_to_replayed_width_is_ignored() -
             max(observed[1] - 10, 1),
         )
         await h.resize_from_terminal(*observed)
-        await asyncio.sleep(0.15)
+        await h.wait_for(
+            lambda: (
+                h.app._resize_replay_timer is None
+                and h.app._queued_resize_replay_generation is None
+                and not h.app._resize_reflow.has_pending_replay
+            )
+        )
+        await asyncio.sleep(0)
 
         assert h.app._fullscreen_invalidate_count == 0
         assert h.app._resize_replay_timer is None
@@ -1735,7 +1782,7 @@ async def test_pending_resize_is_cancelled_before_terminal_teardown(
         assert observed is not None
         await h.resize_from_terminal(max(observed[0] - 10, 20), observed[1])
 
-    await asyncio.sleep(0.15)
+    await asyncio.sleep(0)
 
     assert app is not None
     assert app._fullscreen_invalidate_count == 0

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -24,14 +24,27 @@ from __future__ import annotations
 
 import asyncio
 import io
+import threading
 
 import pytest
 
-from .tui_app_harness import FakeAgent, ThreadGate, TUIHarness
+from .tui_app_harness import FakeAgent, MutableRecordingOutput, ThreadGate, TUIHarness
 
 XFAIL = pytest.mark.xfail(strict=True, reason="not yet implemented in Plan-C TUIApplication")
 
 pytestmark = pytest.mark.asyncio
+
+
+def _last_screen_text(app) -> str:
+    screen = app._app.renderer.last_rendered_screen
+    if screen is None:
+        return ""
+    rows: list[str] = []
+    for y in range(screen.height):
+        row = screen.data_buffer[y]
+        end = max(row, default=-1)
+        rows.append("".join(row[x].char for x in range(end + 1)))
+    return "\n".join(rows)
 
 
 # ╔══════════════════════════════════════════════════════════════════════╗
@@ -45,6 +58,24 @@ async def test_baseline_prompt_visible_at_startup():
         await h.wait_for(lambda: h.app.prompt_char_visible())  # new API
 
 
+async def test_pre_run_emit_uses_the_same_normalized_block_as_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    capture = io.StringIO()
+    monkeypatch.setattr("sys.stdout", capture)
+    app = TUIApplication()
+
+    app.emit_block("bootstrap\x1b[2J\r\x07")
+
+    written = capture.getvalue()
+    assert "\x1b[2J" not in written
+    assert "\x07" not in written
+    assert r"bootstrap\x1b[2J\r\x07" in written
+    assert app._transcript_blocks[0].source == "bootstrap\x1b[2J\r\x07"
+
+
 async def test_input_composer_has_blank_row_above_and_below_input():
     """The default composer is three rows and expands for multiline input."""
     async with TUIHarness() as h:
@@ -53,12 +84,14 @@ async def test_input_composer_has_blank_row_above_and_below_input():
         assert len(composer.children) == 3
 
         one_line = composer.preferred_height(80, 24)
-        assert one_line.min == 3
+        # Padding is preferred at ordinary sizes but optional when the terminal
+        # is short.  The input row is the only hard minimum.
+        assert one_line.min == 1
         assert one_line.preferred == 3
 
         h.app.input_buffer.text = "first\nsecond"
         two_lines = composer.preferred_height(80, 24)
-        assert two_lines.min == 3
+        assert two_lines.min == 1
         assert two_lines.preferred == 4
 
 
@@ -694,8 +727,9 @@ async def test_hard_spinner_and_session_label_in_status():
 
 
 async def test_hard_terminal_resize_does_not_crash():
-    async with TUIHarness() as h:
-        h.app.handle_resize(cols=40, rows=20)
+    output = MutableRecordingOutput()
+    async with TUIHarness(output=output) as h:
+        await h.resize_from_terminal(40, 20)
         await h.type_keys("still works")
         await h.wait_input_equals("still works")
 
@@ -933,19 +967,42 @@ async def test_prompt_toolkit_resize_polling_disabled_to_avoid_delayed_double_re
         assert h.app._app.terminal_size_polling_interval is None
 
 
-async def test_resize_with_active_subview_redraws_once_without_transcript_replay() -> None:
+async def test_row_only_resize_in_subview_needs_no_transcript_replay() -> None:
+    output = MutableRecordingOutput()
     view = _DummySubview()
-    async with TUIHarness(full_screen=True) as h:
-        h.app.emit_block("transcript behind subview\n")
-        await h.wait_output_contains("transcript behind subview")
+    async with TUIHarness(full_screen=True, output=output) as h:
+        observed = h.app._resize_reflow.observed_size
+        assert observed is not None
         task = asyncio.create_task(h.app.open_subview(view))
         await h.wait_for(lambda: h.app.active_subview is view)
 
-        h.app.handle_resize(cols=40, rows=20)
+        await h.resize_from_terminal(observed[0], max(observed[1] - 1, 1))
+
+        assert h.app._resize_reflow.has_pending_replay is False
         assert h.app._fullscreen_invalidate_count == 0
+        await h.press("q")
+        await asyncio.wait_for(task, timeout=1)
+
+
+async def test_production_width_resize_waits_for_subview_to_close() -> None:
+    output = MutableRecordingOutput()
+    view = _DummySubview()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("transcript behind subview\n")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        task = asyncio.create_task(h.app.open_subview(view))
+        await h.wait_for(lambda: h.app.active_subview is view)
+
+        await h.resize_from_terminal(60, 30)
+        await h.wait_for(lambda: h.app._resize_replay_timer is None)
+        assert h.app._fullscreen_invalidate_count == 0
+        assert h.app._resize_reflow.has_pending_replay is True
 
         await h.press("q")
         await asyncio.wait_for(task, timeout=1)
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+        assert h.app._resize_reflow.replayed_width == 60
 
 
 async def test_fullscreen_mode_rewrites_scrollback_on_resize() -> None:
@@ -956,31 +1013,34 @@ async def test_fullscreen_mode_rewrites_scrollback_on_resize() -> None:
         self.emit_message("A long traceback-ish line in native scrollback")
 
     agent.queue(step)
-    async with TUIHarness(agent=agent, full_screen=True) as h:
+    output = MutableRecordingOutput()
+    async with TUIHarness(agent=agent, full_screen=True, output=output) as h:
         assert h.app.full_screen is True
         assert h.app._app.full_screen is False
         assert h.app._output_window is None
         await h.submit_async("trigger")
         await h.wait_output_contains("traceback-ish line")
         assert h.app._fullscreen_invalidate_count == 0
-        h.app.handle_resize(cols=40, rows=20)
-        assert h.app._fullscreen_invalidate_count == 1
+        await h.resize_from_terminal(40, 20)
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
 
 
 async def test_fullscreen_streaming_output_rewrites_scrollback_on_resize() -> None:
-    async with TUIHarness(full_screen=True) as h:
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
         for i in range(25):
             h.app.emit_block(f"chunk {i}\n")
         await h.wait_output_contains("chunk 24")
         assert h.app._fullscreen_invalidate_count == 0
-        h.app.handle_resize(cols=50, rows=20)
-        assert h.app._fullscreen_invalidate_count == 1
+        await h.resize_from_terminal(50, 20)
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
 
 
 async def test_fullscreen_resize_replays_semantic_callbacks_and_clears_scrollback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async with TUIHarness(full_screen=True) as h:
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
         calls = 0
 
         def replay() -> str:
@@ -990,38 +1050,760 @@ async def test_fullscreen_resize_replays_semantic_callbacks_and_clears_scrollbac
 
         h.app.emit_block("old width\n", replay=replay)
         await h.wait_output_contains("old width")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
         capture = io.StringIO()
         monkeypatch.setattr("sys.__stdout__", capture)
 
-        h.app.handle_resize(cols=50, rows=20)
+        await h.resize_from_terminal(50, 20)
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
 
         rewritten = capture.getvalue()
         assert calls == 1
-        assert rewritten.startswith("\x1b[H\x1b[2J\x1b[3J")
+        assert rewritten.startswith("\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H")
         assert "reflowed width=50" in rewritten
         assert "old width" not in rewritten
         assert h.app._fullscreen_invalidate_count == 1
 
 
+async def test_semantic_replay_cannot_inject_terminal_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block(
+            "safe initial\n",
+            replay=lambda: "semantic\x1b[2J\r\x07",
+        )
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        capture = io.StringIO()
+        monkeypatch.setattr("sys.__stdout__", capture)
+
+        await h.resize_from_terminal(50, 20)
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+
+        rewritten = capture.getvalue()
+        # The one clear sequence belongs to the replay engine.  The callback's
+        # erase/CR/BEL are represented as printable diagnostics.
+        assert rewritten.count("\x1b[2J") == 1
+        assert "semantic\\x1b[2J\\r\\x07" in rewritten
+        assert "\x07" not in rewritten
+
+
 async def test_clear_screen_resets_rewritten_scrollback_replay(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async with TUIHarness(full_screen=True) as h:
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
         h.app.emit_block("before clear\n")
         await h.wait_output_contains("before clear")
         h.app.clear_transcript()
         h.app.emit_block("after clear\n")
         await h.wait_output_contains("after clear")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
         capture = io.StringIO()
         monkeypatch.setattr("sys.__stdout__", capture)
 
-        h.app.handle_resize(cols=50, rows=20)
+        await h.resize_from_terminal(50, 20)
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
 
         replayed = capture.getvalue()
-        assert replayed.startswith("\x1b[H\x1b[2J\x1b[3J")
+        assert replayed.startswith("\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H")
         assert "after clear" in replayed
         assert "before clear" not in replayed
         assert h.app._fullscreen_invalidate_count == 1
+
+
+async def test_prompt_toolkit_row_only_resize_redraws_without_rewriting_scrollback() -> None:
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("stable transcript\n")
+        await h.wait_output_contains("stable transcript")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        observed = h.app._resize_reflow.observed_size
+        assert observed is not None
+        prior_render_count = h.app._app.render_counter
+        output.events.clear()
+
+        await h.resize_from_terminal(observed[0], max(observed[1] - 1, 1))
+
+        assert h.app._app.render_counter > prior_render_count
+        assert ("erase_down",) in output.events
+        assert h.app._resize_reflow.observed_size == (observed[0], max(observed[1] - 1, 1))
+        assert h.app._resize_replay_timer is None
+        assert h.app._resize_reflow.has_pending_replay is False
+        assert h.app._fullscreen_invalidate_count == 0
+
+
+async def test_tiny_height_never_uses_window_too_small_and_recovers_once() -> None:
+    output = MutableRecordingOutput(columns=80, rows=40)
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("stable transcript\n")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+
+        await h.resize_from_terminal(80, 4)
+
+        assert "Window too small" not in _last_screen_text(h.app)
+        assert h.app._height_compaction_needs_replay is True
+        assert h.app._fullscreen_invalidate_count == 0
+
+        await h.resize_from_terminal(80, 40)
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+
+        assert "Window too small" not in _last_screen_text(h.app)
+        assert h.app._height_compaction_needs_replay is False
+        assert h.app._resize_reflow.has_pending_replay is False
+
+
+async def test_oversized_completion_menu_shrinks_instead_of_replacing_layout() -> None:
+    from prompt_toolkit.buffer import CompletionState
+    from prompt_toolkit.completion import Completion
+
+    output = MutableRecordingOutput(columns=80, rows=6)
+    async with TUIHarness(full_screen=True, output=output) as h:
+        before = h.app._app.render_counter
+        h.app.input_buffer.complete_state = CompletionState(
+            h.app.input_buffer.document,
+            [Completion(f"/command-{index}") for index in range(20)],
+        )
+        h.app._app.invalidate()
+        await h.wait_for(lambda: h.app._app.render_counter > before)
+
+        assert "Window too small" not in _last_screen_text(h.app)
+        assert h.app._fullscreen_invalidate_count == 0
+        assert h.app._height_compaction_needs_replay is False
+
+        before = h.app._app.render_counter
+        h.app.input_buffer.complete_state = None
+        h.app._app.invalidate()
+        await h.wait_for(lambda: h.app._app.render_counter > before)
+        assert h.app._fullscreen_invalidate_count == 0
+
+
+async def test_fullscreen_resize_coalesces_transient_sizes_to_final_width() -> None:
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        replay_widths: list[int] = []
+
+        def replay() -> str:
+            replay_widths.append(h.app.output_columns())
+            return "stable transcript\n"
+
+        h.app.emit_block("stable transcript\n", replay=replay)
+        await h.wait_output_contains("stable transcript")
+
+        await h.resize_from_terminal(40, 18)
+        await h.resize_from_terminal(50, 20)
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+
+        assert replay_widths == [50]
+
+
+async def test_production_before_render_path_debounces_to_latest_width() -> None:
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        replay_widths: list[int] = []
+        observed = h.app._resize_reflow.observed_size
+        assert observed is not None
+
+        def replay() -> str:
+            replay_widths.append(h.app.output_columns())
+            return "stable transcript\n"
+
+        h.app.emit_block("stable transcript\n", replay=replay)
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+
+        first = (max(observed[0] - 10, 30), max(observed[1] - 2, 1))
+        final = (max(observed[0] - 20, 20), max(observed[1] - 4, 1))
+        await h.resize_from_terminal(*first)
+        first_timer = h.app._resize_replay_timer
+        assert first_timer is not None
+        await h.resize_from_terminal(*final)
+
+        assert first_timer.cancelled() is True
+        assert h.app._fullscreen_invalidate_count == 0
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+
+        assert replay_widths == [final[0]]
+
+
+async def test_stale_resize_timer_cannot_enqueue_before_latest_quiet_period() -> None:
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("stable transcript\n")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+
+        await h.resize_from_terminal(70, 38)
+        stale_generation = h.app._resize_replay_schedule_generation
+        await h.resize_from_terminal(60, 36)
+        latest_generation = h.app._resize_replay_schedule_generation
+        assert latest_generation > stale_generation
+
+        # A cancelled TimerHandle may already be in the loop's ready queue.
+        # Its generation check must still make it harmless.
+        h.app._start_resize_replay(stale_generation)
+        assert h.app._fullscreen_invalidate_count == 0
+
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+        assert h.app._resize_reflow.replayed_width == 60
+
+
+async def test_slow_output_keeps_at_most_one_resize_barrier_queued(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = MutableRecordingOutput()
+    first_write_started = asyncio.Event()
+    release_first_write = asyncio.Event()
+    calls = 0
+
+    async def controlled_run_in_terminal(callback):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_write_started.set()
+            await release_first_write.wait()
+        return callback()
+
+    monkeypatch.setattr(
+        "prompt_toolkit.application.run_in_terminal",
+        controlled_run_in_terminal,
+    )
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("slow first block\n")
+        await asyncio.wait_for(first_write_started.wait(), timeout=1)
+
+        await h.resize_from_terminal(70, 38)
+        await h.wait_for(lambda: h.app._queued_resize_replay_generation is not None)
+        await h.resize_from_terminal(60, 36)
+        await h.wait_for(lambda: h.app._resize_replay_timer is None)
+
+        assert h.app._block_queue is not None
+        assert h.app._block_queue.qsize() == 1
+
+        release_first_write.set()
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+        await h.app._block_queue.join()
+        assert h.app._resize_reflow.replayed_width == 60
+
+
+async def test_row_change_replaces_a_queued_width_barrier_without_extra_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = MutableRecordingOutput()
+    first_write_started = asyncio.Event()
+    release_first_write = asyncio.Event()
+    calls = 0
+
+    async def controlled_run_in_terminal(callback):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_write_started.set()
+            await release_first_write.wait()
+        return callback()
+
+    monkeypatch.setattr(
+        "prompt_toolkit.application.run_in_terminal",
+        controlled_run_in_terminal,
+    )
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("slow first block\n")
+        await asyncio.wait_for(first_write_started.wait(), timeout=1)
+
+        await h.resize_from_terminal(70, 38)
+        await h.wait_for(lambda: h.app._queued_resize_replay_generation is not None)
+        first_barrier_generation = h.app._queued_resize_replay_generation
+        await h.resize_from_terminal(70, 30)
+        assert h.app._resize_reflow.generation > first_barrier_generation
+
+        release_first_write.set()
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+
+        assert h.app._resize_reflow.replayed_width == 70
+        assert h.app._resize_reflow.observed_size == (70, 30)
+        assert h.app._resize_reflow.has_pending_replay is False
+
+
+async def test_clear_invalidates_a_queued_resize_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = MutableRecordingOutput()
+    first_write_started = asyncio.Event()
+    release_first_write = asyncio.Event()
+    calls = 0
+
+    async def controlled_run_in_terminal(callback):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_write_started.set()
+            await release_first_write.wait()
+        return callback()
+
+    monkeypatch.setattr(
+        "prompt_toolkit.application.run_in_terminal",
+        controlled_run_in_terminal,
+    )
+    capture = io.StringIO()
+    monkeypatch.setattr("sys.__stdout__", capture)
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("A cleared transcript\n")
+        await asyncio.wait_for(first_write_started.wait(), timeout=1)
+
+        await h.resize_from_terminal(70, 38)
+        await h.wait_for(lambda: h.app._queued_resize_replay_generation is not None)
+        h.app.clear_transcript()
+        h.app.emit_block("B after clear\n")
+        release_first_write.set()
+
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+
+        after_last_clear = capture.getvalue().split("\x1b[3J")[-1]
+        assert "A cleared transcript" not in after_last_clear
+        assert after_last_clear.count("B after clear") == 1
+        assert [block.source for block in h.app._transcript_blocks] == ["B after clear\n"]
+
+
+async def test_clear_invalidates_an_inflight_ordinary_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_started = asyncio.Event()
+    release_write = asyncio.Event()
+
+    async def controlled_run_in_terminal(callback):
+        write_started.set()
+        await release_write.wait()
+        return callback()
+
+    monkeypatch.setattr(
+        "prompt_toolkit.application.run_in_terminal",
+        controlled_run_in_terminal,
+    )
+    capture = io.StringIO()
+    monkeypatch.setattr("sys.__stdout__", capture)
+    async with TUIHarness(full_screen=True) as h:
+        h.app.emit_block("must stay cleared\n")
+        await asyncio.wait_for(write_started.wait(), timeout=1)
+
+        h.app.clear_transcript()
+        release_write.set()
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+
+        assert "must stay cleared" not in capture.getvalue()
+        assert "\x1b[3J" in capture.getvalue()
+        assert h.app._transcript_blocks == []
+        assert h.capture_output() == ""
+
+
+async def test_clear_physically_purges_a_stale_resize_with_no_later_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = MutableRecordingOutput()
+    first_write_started = asyncio.Event()
+    release_first_write = asyncio.Event()
+    calls = 0
+
+    async def controlled_run_in_terminal(callback):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_write_started.set()
+            await release_first_write.wait()
+        return callback()
+
+    monkeypatch.setattr(
+        "prompt_toolkit.application.run_in_terminal",
+        controlled_run_in_terminal,
+    )
+    capture = io.StringIO()
+    monkeypatch.setattr("sys.__stdout__", capture)
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("A before empty clear\n")
+        await asyncio.wait_for(first_write_started.wait(), timeout=1)
+
+        await h.resize_from_terminal(70, 38)
+        await h.wait_for(lambda: h.app._queued_resize_replay_generation is not None)
+        h.app.clear_transcript()
+        release_first_write.set()
+
+        await h.wait_for(
+            lambda: (
+                h.app._resize_replay_timer is None
+                and h.app._queued_resize_replay_generation is None
+                and not h.app._resize_reflow.has_pending_replay
+            )
+        )
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+
+        assert "\x1b[3J" in capture.getvalue()
+        assert "A before empty clear" not in capture.getvalue().split("\x1b[3J")[-1]
+        assert h.app._transcript_blocks == []
+
+
+async def test_transient_replay_write_failure_retries_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailFirstReplay(io.StringIO):
+        def __init__(self) -> None:
+            super().__init__()
+            self.failed = False
+
+        def write(self, text: str) -> int:
+            if not self.failed and "\x1b[3J" in text:
+                self.failed = True
+                raise OSError("transient terminal write failure")
+            return super().write(text)
+
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("stable transcript\n")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        capture = FailFirstReplay()
+        monkeypatch.setattr("sys.__stdout__", capture)
+
+        await h.resize_from_terminal(70, 38)
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+
+        assert capture.failed is True
+        assert h.app._resize_reflow.replayed_width == 70
+        assert h.app._resize_reflow.has_pending_replay is False
+
+
+async def test_permanent_replay_failure_stops_after_one_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class AlwaysFailReplay(io.StringIO):
+        def __init__(self) -> None:
+            super().__init__()
+            self.attempts = 0
+
+        def write(self, text: str) -> int:
+            if "\x1b[3J" in text:
+                self.attempts += 1
+                raise OSError("permanent terminal write failure")
+            return super().write(text)
+
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("stable transcript\n")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        capture = AlwaysFailReplay()
+        monkeypatch.setattr("sys.__stdout__", capture)
+
+        await h.resize_from_terminal(70, 38)
+        await h.wait_for(
+            lambda: (
+                capture.attempts == 2
+                and h.app._resize_replay_timer is None
+                and h.app._queued_resize_replay_generation is None
+            )
+        )
+
+        for _ in range(5):
+            h.app._app.invalidate()
+            await asyncio.sleep(0.03)
+
+        assert capture.attempts == 2
+        assert h.app._resize_reflow.has_pending_replay is True
+
+
+async def test_ordinary_block_uses_width_at_physical_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = MutableRecordingOutput(columns=20, rows=40)
+    write_waiting = asyncio.Event()
+    release_write = asyncio.Event()
+
+    async def gated_run_in_terminal(callback):
+        write_waiting.set()
+        await release_write.wait()
+        return callback()
+
+    monkeypatch.setattr(
+        "prompt_toolkit.application.run_in_terminal",
+        gated_run_in_terminal,
+    )
+    capture = io.StringIO()
+    monkeypatch.setattr("sys.__stdout__", capture)
+    async with TUIHarness(full_screen=False, output=output) as h:
+        h.app.emit_block("abcdefghijklmnop\n")
+        await asyncio.wait_for(write_waiting.wait(), timeout=1)
+        output.set_size(6, 40)
+        release_write.set()
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+
+        from nooa_cli.tui.terminal_safety import strip_safe_ansi
+        from rich.cells import cell_len
+
+        visible_lines = strip_safe_ansi(capture.getvalue()).splitlines()
+        assert "".join(visible_lines) == "abcdefghijklmnop"
+        assert all(cell_len(line) <= 5 for line in visible_lines)
+
+
+async def test_resize_replay_barrier_orders_ui_and_off_thread_output_exactly_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("before barrier\n")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        capture = io.StringIO()
+        monkeypatch.setattr("sys.__stdout__", capture)
+
+        observed = h.app._resize_reflow.observed_size
+        assert observed is not None
+        target = (max(observed[0] - 10, 20), observed[1])
+        output.set_size(*target)
+        h.app._resize_reflow.observe(target)
+        h.app._resize_replay_schedule_generation += 1
+        generation = h.app._resize_replay_schedule_generation
+        h.app._start_resize_replay(generation)
+
+        h.app.emit_block("after barrier ui\n")
+        producer = threading.Thread(
+            target=h.app.emit_block,
+            args=("after barrier thread\n",),
+        )
+        producer.start()
+        producer.join(timeout=1)
+        assert producer.is_alive() is False
+
+        await asyncio.sleep(0)
+        await h.app._block_queue.join()
+
+        rendered = capture.getvalue()
+        assert rendered.count("before barrier") == 1
+        assert rendered.count("after barrier ui") == 1
+        assert rendered.count("after barrier thread") == 1
+        assert rendered.index("before barrier") < rendered.index("after barrier ui")
+        assert rendered.index("after barrier ui") < rendered.index("after barrier thread")
+
+
+async def test_output_committed_before_resize_barrier_is_in_replayed_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("A before resize\n")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        capture = io.StringIO()
+        monkeypatch.setattr("sys.__stdout__", capture)
+
+        # B occupies the FIFO before the replay marker, so the marker's source
+        # snapshot must contain both A and B.
+        h.app.emit_block("B before barrier\n")
+        observed = h.app._resize_reflow.observed_size
+        assert observed is not None
+        target = (max(observed[0] - 10, 20), observed[1])
+        output.set_size(*target)
+        h.app._resize_reflow.observe(target)
+        h.app._resize_replay_schedule_generation += 1
+        generation = h.app._resize_replay_schedule_generation
+        h.app._start_resize_replay(generation)
+        await h.app._block_queue.join()
+
+        after_last_clear = capture.getvalue().split("\x1b[3J")[-1]
+        assert after_last_clear.count("A before resize") == 1
+        assert after_last_clear.count("B before barrier") == 1
+        assert after_last_clear.index("A before resize") < after_last_clear.index(
+            "B before barrier"
+        )
+
+
+async def test_semantic_replay_emission_is_queued_after_immutable_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        callback_count = 0
+
+        def replay() -> str:
+            nonlocal callback_count
+            callback_count += 1
+            if callback_count == 1:
+                h.app.emit_block("C emitted during replay\n")
+            return "A semantic replay\n"
+
+        h.app.emit_block("A original\n", replay=replay)
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        capture = io.StringIO()
+        monkeypatch.setattr("sys.__stdout__", capture)
+
+        observed = h.app._resize_reflow.observed_size
+        assert observed is not None
+        await h.resize_from_terminal(max(observed[0] - 10, 20), observed[1])
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+        await h.app._block_queue.join()
+
+        after_last_clear = capture.getvalue().split("\x1b[3J")[-1]
+        assert after_last_clear.count("A semantic replay") == 1
+        assert after_last_clear.count("C emitted during replay") == 1
+        assert [block.source for block in h.app._transcript_blocks] == [
+            "A original\n",
+            "C emitted during replay\n",
+        ]
+
+
+async def test_size_change_during_semantic_render_aborts_stale_replay() -> None:
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        observed = h.app._resize_reflow.observed_size
+        assert observed is not None
+        narrow = (max(observed[0] - 20, 20), observed[1])
+        replay_widths: list[int] = []
+
+        def replay() -> str:
+            replay_widths.append(h.app.output_columns())
+            if len(replay_widths) == 1:
+                # Model a physical tmux pane change while synchronous semantic
+                # rendering owns the UI loop. SIGWINCH cannot update Nooa's
+                # state until the callback returns, so the final physical-width
+                # guard must catch this directly from the Output.
+                output.set_size(*observed)
+            return "stable transcript\n"
+
+        h.app.emit_block("stable transcript\n", replay=replay)
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+
+        await h.resize_from_terminal(*narrow)
+        await h.wait_for(
+            lambda: (
+                h.app._resize_replay_timer is None
+                and h.app._queued_resize_replay_generation is None
+                and not h.app._resize_reflow.has_pending_replay
+            )
+        )
+
+        assert replay_widths == [narrow[0]]
+        assert h.app._fullscreen_invalidate_count == 0
+        assert h.app._resize_reflow.replayed_width == observed[0]
+
+
+async def test_fullscreen_transient_resize_back_to_replayed_width_is_ignored() -> None:
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("stable transcript\n")
+        await h.wait_output_contains("stable transcript")
+        observed = h.app._resize_reflow.observed_size
+        assert observed is not None
+
+        await h.resize_from_terminal(
+            max(observed[0] - 20, 20),
+            max(observed[1] - 10, 1),
+        )
+        await h.resize_from_terminal(*observed)
+        await asyncio.sleep(0.15)
+
+        assert h.app._fullscreen_invalidate_count == 0
+        assert h.app._resize_replay_timer is None
+        assert h.app._resize_reflow.has_pending_replay is False
+
+
+async def test_pending_resize_is_cancelled_before_terminal_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capture = io.StringIO()
+    monkeypatch.setattr("sys.__stdout__", capture)
+    app = None
+
+    output = MutableRecordingOutput()
+    async with TUIHarness(full_screen=True, output=output) as h:
+        app = h.app
+        h.app.emit_block("stable transcript\n")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        observed = h.app._resize_reflow.observed_size
+        assert observed is not None
+        await h.resize_from_terminal(max(observed[0] - 10, 20), observed[1])
+
+    await asyncio.sleep(0.15)
+
+    assert app is not None
+    assert app._fullscreen_invalidate_count == 0
+    assert app._resize_replay_timer is None
+    assert "\x1b[3J" not in capture.getvalue()
+
+
+async def test_inflight_resize_barrier_cannot_clear_after_app_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = MutableRecordingOutput()
+    replay_started = asyncio.Event()
+    release_replay = asyncio.Event()
+    capture = io.StringIO()
+    monkeypatch.setattr("sys.__stdout__", capture)
+
+    async def gated_run_in_terminal(callback):
+        replay_started.set()
+        await release_replay.wait()
+        return callback()
+
+    monkeypatch.setattr(
+        "prompt_toolkit.application.run_in_terminal",
+        gated_run_in_terminal,
+    )
+    app = None
+    async with TUIHarness(full_screen=True, output=output) as h:
+        app = h.app
+        h.app.emit_block("stable transcript\n")
+        await asyncio.wait_for(replay_started.wait(), timeout=1)
+        release_replay.set()
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+
+        replay_started.clear()
+        release_replay.clear()
+        await h.resize_from_terminal(60, 36)
+        await asyncio.wait_for(replay_started.wait(), timeout=1)
+        asyncio.get_running_loop().call_later(0.05, release_replay.set)
+
+    assert app is not None
+    assert app._fullscreen_invalidate_count == 0
+    assert "\x1b[3J" not in capture.getvalue()
+
+
+async def test_inflight_clear_cannot_purge_terminal_after_app_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_started = asyncio.Event()
+    release_clear = asyncio.Event()
+    capture = io.StringIO()
+    monkeypatch.setattr("sys.__stdout__", capture)
+
+    async def gated_run_in_terminal(callback):
+        clear_started.set()
+        await release_clear.wait()
+        return callback()
+
+    monkeypatch.setattr(
+        "prompt_toolkit.application.run_in_terminal",
+        gated_run_in_terminal,
+    )
+    async with TUIHarness(full_screen=True) as h:
+        h.app.clear_transcript()
+        await asyncio.wait_for(clear_started.wait(), timeout=1)
+        asyncio.get_running_loop().call_later(0.05, release_clear.set)
+
+    assert "\x1b[3J" not in capture.getvalue()
 
 
 async def test_non_fullscreen_keeps_native_scrollback_path() -> None:

--- a/packages/nooa-cli/tests/tui/tui_app_harness.py
+++ b/packages/nooa-cli/tests/tui/tui_app_harness.py
@@ -12,14 +12,14 @@ Usage::
 The harness owns:
 
 - a ``PipeInput`` — bytes written with ``send_text()`` look like keystrokes
-- a ``DummyOutput`` — swallows rendering but the app still thinks it has a TTY
+- a prompt_toolkit ``Output`` — ``DummyOutput`` by default, or a mutable
+  recording output for production resize-path tests
 - a background task running ``app.run_async()``
 - a scriptable ``FakeAgent`` that yields controllable responses
 
-Assertions read the app's *logical* state (input/output buffer text, queue
-messages, status line) rather than parsed terminal output — terminal-level
-correctness is covered by manual smoke, and tying unit tests to rendered
-ANSI bytes is brittle.
+Most assertions read the app's *logical* state (input/output buffer text,
+queue messages, status line). Resize tests additionally record prompt_toolkit
+redraw operations and the transcript bytes written around a replay barrier.
 
 Timing model: writing to the pipe is synchronous, but prompt_toolkit
 parses input on the event loop. Every driver method ends with an
@@ -37,8 +37,9 @@ from contextlib import AbstractAsyncContextManager
 from typing import TYPE_CHECKING, Any
 
 from prompt_toolkit.application import create_app_session
+from prompt_toolkit.data_structures import Size
 from prompt_toolkit.input import create_pipe_input
-from prompt_toolkit.output import DummyOutput
+from prompt_toolkit.output import DummyOutput, Output
 
 if TYPE_CHECKING:
     from nooa_cli.tui.tui_application import TUIApplication
@@ -219,6 +220,39 @@ async def _maybe_await(value: Any) -> Any:
 # ── the harness itself -------------------------------------------------------
 
 
+class MutableRecordingOutput(DummyOutput):
+    """A prompt_toolkit output whose terminal geometry tests can change.
+
+    ``DummyOutput`` always reports 80×40, which means calling the real
+    prompt_toolkit resize callback cannot exercise Nooa's geometry observer.
+    This small test output keeps DummyOutput's no-op terminal behavior while
+    recording enough of the redraw path to prove a resize reached the renderer.
+    """
+
+    def __init__(self, columns: int = 80, rows: int = 40) -> None:
+        self._size = Size(rows=int(rows), columns=int(columns))
+        self.events: list[tuple[Any, ...]] = []
+
+    def get_size(self) -> Size:
+        self.events.append(("get_size", self._size.columns, self._size.rows))
+        return self._size
+
+    def get_rows_below_cursor_position(self) -> int:
+        return self._size.rows
+
+    def set_size(self, columns: int, rows: int) -> None:
+        self._size = Size(rows=int(rows), columns=int(columns))
+
+    def erase_down(self) -> None:
+        self.events.append(("erase_down",))
+
+    def reset_attributes(self) -> None:
+        self.events.append(("reset_attributes",))
+
+    def flush(self) -> None:
+        self.events.append(("flush",))
+
+
 class TUIHarness(AbstractAsyncContextManager["TUIHarness"]):
     """Drive a ``TUIApplication`` from tests.
 
@@ -227,11 +261,16 @@ class TUIHarness(AbstractAsyncContextManager["TUIHarness"]):
     """
 
     def __init__(
-        self, agent: FakeAgent | None = None, config: Any = None, full_screen: bool | None = None
+        self,
+        agent: FakeAgent | None = None,
+        config: Any = None,
+        full_screen: bool | None = None,
+        output: Output | None = None,
     ) -> None:
         self.agent = agent or FakeAgent()
         self._config = config
         self._full_screen = full_screen
+        self.output = output or DummyOutput()
         self._pipe_ctx: Any = None
         self._session_ctx: Any = None
         self._run_task: asyncio.Task | None = None
@@ -240,7 +279,7 @@ class TUIHarness(AbstractAsyncContextManager["TUIHarness"]):
     async def __aenter__(self) -> TUIHarness:
         self._pipe_ctx = create_pipe_input()
         pipe = self._pipe_ctx.__enter__()
-        self._session_ctx = create_app_session(input=pipe, output=DummyOutput())
+        self._session_ctx = create_app_session(input=pipe, output=self.output)
         self._session_ctx.__enter__()
 
         # Import locally so the stub can evolve without breaking harness
@@ -316,6 +355,19 @@ class TUIHarness(AbstractAsyncContextManager["TUIHarness"]):
         self._pipe.send_text(_key_sequence(key))
         await asyncio.sleep(0)
 
+    async def resize_from_terminal(self, columns: int, rows: int) -> None:
+        """Drive prompt_toolkit's production SIGWINCH callback at a new size."""
+        output = self.output
+        if not isinstance(output, MutableRecordingOutput):
+            raise TypeError("resize_from_terminal requires MutableRecordingOutput")
+        assert self.app is not None
+        output.set_size(columns, rows)
+        previous_render = self.app._app.render_counter
+        self.app._app._on_resize()
+        await asyncio.sleep(0)
+        if self.app._app.render_counter <= previous_render:
+            raise AssertionError("prompt_toolkit did not redraw after resize")
+
     async def submit_async(self, text: str) -> None:
         """Type ``text`` and press Enter. Doesn't wait for any side-effect."""
         await self.type_keys(text)
@@ -357,10 +409,9 @@ class TUIHarness(AbstractAsyncContextManager["TUIHarness"]):
         return self.app.output_buffer.text
 
     def capture_output_ansi(self) -> str:
-        """Raw (ANSI-bearing) output. ``capture_output`` strips ANSI; this
-        preserves it so ``\\x1b[`` round-trip tests can assert styling."""
+        """Raw retained sources for ANSI round-trip assertions."""
         assert self.app is not None
-        return "".join(self.app._output_ansi)
+        return "".join(block.source for block in self.app._transcript_blocks)
 
     def capture_queued(self) -> list[str]:
         """Return queued items (pending user messages) in submission order.

--- a/packages/nooa-cli/tests/tui/tui_app_harness.py
+++ b/packages/nooa-cli/tests/tui/tui_app_harness.py
@@ -230,6 +230,7 @@ class MutableRecordingOutput(DummyOutput):
     """
 
     def __init__(self, columns: int = 80, rows: int = 40) -> None:
+        super().__init__()
         self._size = Size(rows=int(rows), columns=int(columns))
         self.events: list[tuple[Any, ...]] = []
 
@@ -356,17 +357,17 @@ class TUIHarness(AbstractAsyncContextManager["TUIHarness"]):
         await asyncio.sleep(0)
 
     async def resize_from_terminal(self, columns: int, rows: int) -> None:
-        """Drive prompt_toolkit's production SIGWINCH callback at a new size."""
+        """Change terminal geometry and drive the supported redraw path."""
         output = self.output
         if not isinstance(output, MutableRecordingOutput):
             raise TypeError("resize_from_terminal requires MutableRecordingOutput")
         assert self.app is not None
+        previous_size_reads = sum(event[0] == "get_size" for event in output.events)
         output.set_size(columns, rows)
-        previous_render = self.app._app.render_counter
-        self.app._app._on_resize()
-        await asyncio.sleep(0)
-        if self.app._app.render_counter <= previous_render:
-            raise AssertionError("prompt_toolkit did not redraw after resize")
+        self.app._app.invalidate()
+        await self.wait_for(
+            lambda: sum(event[0] == "get_size" for event in output.events) > previous_size_reads
+        )
 
     async def submit_async(self, text: str) -> None:
         """Type ``text`` and press Enter. Doesn't wait for any side-effect."""

--- a/uv.lock
+++ b/uv.lock
@@ -1538,7 +1538,7 @@ requires-dist = [
     { name = "prompt-toolkit", specifier = ">=3.0.41,<3.1.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "rich", specifier = ">=13.0.0" },
+    { name = "rich", specifier = ">=14.3.3" },
     { name = "scikit-learn", marker = "extra == 'datascience'", specifier = ">=1.3.0" },
     { name = "scipy", marker = "extra == 'datascience'", specifier = ">=1.10.0" },
     { name = "tree-sitter", marker = "extra == 'ast'", specifier = ">=0.23.0" },


### PR DESCRIPTION
  ## What does this PR do? 

Stabilizes native-scrollback rendering in the TUI. - replaces the `Window too small` failure path with a 
responsive layout - safely rebuilds scrollback after settled resizes - serializes transcript writes, clears, and replay barriers - 
sanitizes terminal controls and enforces cell-safe wrapping - hardens completions, fallbacks, teardown, and concurrent rendering - 
simplifies resize state and removes the unused forced-resize path 

## Related issues 

None. 

## Checklist 

- [x] Code follows the project style (`ruff check` and `ruff format --check` pass) 
- [x] Tests added/updated and passing 
- [x] Docs updated if behavior or public APIs changed (N/A: internal renderer fix; configuration and public APIs are unchanged)
- [x] New source files carry an SPDX license header


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved terminal resizing and transcript reflow, including narrow-window support and debounced replay.
  - Added safer handling for terminal output, control characters, ANSI styling, hyperlinks, and grapheme-aware text wrapping.
  - Improved completion display readability by flattening and sanitizing labels and descriptions.

- **Bug Fixes**
  - Prevented malformed or unsafe terminal text from disrupting display.
  - Improved output ordering, fallback rendering, and teardown behavior during concurrent operations.
  - Fixed rendering issues during resize, replay, and session shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->