### PR TITLE
Add CI-controlled release gate

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,11 +69,12 @@ toolchain identity, check outcomes, capability scope/results, distribution
 checksums, and draft identity. Raw `.noo-eval.jsonl` files and traces are private
 artifacts and must not be copied into the public draft.
 
-Hard or infrastructure failure creates no draft. Fix the problem and start a
-new pipeline with the same tag and SHA. If draft creation failed after the gate,
-rerun: reconciliation updates an exact matching draft without duplication. If a
-draft has the wrong target or a release is already published, the runner stops
-instead of mutating it.
+Hard-gate failure or capability-infrastructure failure before draft creation
+creates no draft. Fix the problem and start a new pipeline with the same tag
+and SHA. A failure after `gh release create` or `gh release edit` may leave a
+draft requiring reconciliation; rerun to update an exact matching draft without
+duplication. If a draft has the wrong target or a release is already published,
+the runner stops instead of mutating it.
 
 Use the controller's one-model/one-run/one-sample rehearsal mode to exercise
 setup and reporting cheaply; rehearsals can never create a draft. Before first

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,76 +1,120 @@
 # Releasing
 
-`nooa`, `nooa-cli`, `nooa-memory` and `nooa-bench` release together from the
-same commit. **The version comes from the git tag** — there is no `version =`
-in any `pyproject.toml` and no bump step. On tag `v0.0.9` the wheels are
-`0.0.9`; between tags they are `0.0.9.devN`.
+`nooa`, `nooa-cli`, `nooa-memory`, and `nooa-bench` release together from one
+commit. The version comes from the Git tag: on `v0.0.10` the distributions are
+`0.0.10`; between tags they are development versions.
 
-## Cutting a release
+## Normal release path
+
+Releases are gated by a manually started pipeline on protected `main` in the
+private `interactive-agents/nooa-dev` GitLab project. Supply both:
+
+- `NOOA_RELEASE_TAG`: a new canonical `vX.Y.Z` version;
+- `NOOA_RELEASE_SHA`: the full 40-character SHA of a commit currently reachable
+  from public GitHub `main`.
+
+The controller freezes that SHA. A later push to `main` does not change the
+candidate under test. The job builds the internal NVIDIA model-alias wheel from
+the controller commit, clones this repository at the candidate, and calls
+`scripts/make_release.py --ci`. The public runner remains the implementation of
+the gate; GitLab YAML only provisions and invokes it.
+
+The strict gate performs:
+
+1. Ruff lint and formatting, SPDX checks, unit tests, and explicit OS sandbox
+   containment tests.
+2. Builds all four wheels and source distributions under a temporary local tag,
+   verifies their versions, and smoke-tests imports and `nooa --version` in a
+   clean environment.
+3. Runs the full capability suite for the candidate and previous release, fresh
+   and back-to-back: four gate models, three runs, full data, no response cache.
+4. Writes private results, traces, distributions, checksums, a JSON manifest,
+   and sanitized public notes to the GitLab job artifacts.
+5. After every hard gate passes, creates or safely updates one GitHub **draft**
+   targeting the exact tested SHA.
+
+The candidate and baseline environments receive the same explicit
+`nemo-oo-agents-nvidia` wheel. Strict CI never copies `.env`, discovers ambient
+packages, or reuses capability results from another candidate. Each sample,
+stalled run, and complete arm has a timeout; completed JSONL evidence remains
+available when a later sample fails.
+
+The stable-tier 60% floor, unusable/missing results, and an arm with more than
+50% errors are hard failures. Collapses, new errors, removed tests, and drops
+beyond the noise band are advisory: they are prominent in the draft but remain
+a human judgment when hard gates pass.
+
+## Human approval
+
+The GitLab job can create only a draft. It has no command that publishes a
+release or uploads to PyPI.
+
+- **Accept:** inspect the draft and private GitLab evidence, then click GitHub's
+  **Publish release** button.
+- **Reject:** delete the draft with its tag, or leave it unpublished until a
+  maintainer performs cleanup. A subsequent pipeline may reuse only a draft
+  whose target is the identical frozen SHA; any different target fails closed.
+
+Publishing is the single human approval. `.github/workflows/publish.yml` listens
+for `release: published` and automatically rebuilds, smoke-tests, and uploads
+all four packages to PyPI using Trusted Publishing. Despite their names, the
+current `pypi-*` GitHub Environments have no configured reviewer protection, so
+there is no second approval after **Publish release**.
+
+## Evidence and recovery
+
+GitLab retains the release evidence for 90 days. Start with `job-summary.md` and
+`release-manifest.json`; the latter indexes exact commits, lock/config hashes,
+toolchain identity, check outcomes, capability scope/results, distribution
+checksums, and draft identity. Raw `.noo-eval.jsonl` files and traces are private
+artifacts and must not be copied into the public draft.
+
+Hard or infrastructure failure creates no draft. Fix the problem and start a
+new pipeline with the same tag and SHA. If draft creation failed after the gate,
+rerun: reconciliation updates an exact matching draft without duplication. If a
+draft has the wrong target or a release is already published, the runner stops
+instead of mutating it.
+
+Use the controller's one-model/one-run/one-sample rehearsal mode to exercise
+setup and reporting cheaply; rehearsals can never create a draft. Before first
+production use, run the complete gate once with draft creation disabled and
+review all artifacts.
+
+## Publication rehearsal and artifact promotion
+
+A manual run of `publish.yml` always targets TestPyPI and is the safe way to
+rehearse its build, OIDC, and upload jobs without consuming a production PyPI
+version. The production trigger remains `release: published`; do not publish a
+throwaway GitHub release to test it because that event intentionally reaches
+real PyPI.
+
+The current first increment rebuilds after publication from the exact published
+tag. The candidate artifacts and checksums are retained for review, but they are
+not yet promoted. A follow-up should attach the checked artifacts to the draft
+and make `publish.yml` download and verify those exact files while preserving
+the existing PyPI OIDC identities.
+
+## Emergency local fallback
+
+If the private controller is unavailable, a trusted maintainer may run the
+public script from a clean, current `main` checkout:
 
 ```bash
-git checkout main && git pull
-uv run python scripts/make_release.py v0.0.9
+uv run python scripts/make_release.py v0.0.10
 ```
 
-The script runs everything in order and stops at two prompts — after the
-capability report, and after the draft notes:
+This is deliberately narrower than the old workflow: it may create a draft but
+cannot publish it. It retains local compatibility for model aliases, prompts
+before drafting advisory results, and still blocks the capability floor. Use it
+only for recovery, record the evidence separately, and publish only through the
+GitHub draft UI.
 
-| Step | Fails the run? |
-|---|---|
-| Preflight — on `main`, clean, in sync with origin, tag unused | yes |
-| Lint, SPDX headers, unit tests | yes |
-| Build 4 wheels, version == tag, smoke import | yes |
-| Capability diff vs the previous release, 4 models × 3 runs | only below the floor |
-| `gh release create --draft`, capability report appended | — |
-| `gh release edit --draft=false` → triggers `publish.yml` | — |
+## Trusted Publishing setup
 
-Publishing uploads to PyPI via Trusted Publishing. Each package waits on its
-`pypi-<package>` GitHub Environment, so a reviewer approves before upload.
+Each project needs a publisher configured for owner `NVIDIA-NeMo`, repository
+`labs-OO-Agents`, workflow `publish.yml`, and its distinct environment:
+`pypi-nooa`, `pypi-nooa-cli`, `pypi-nooa-memory`, or `pypi-nooa-bench`. Repeat
+with `testpypi-*` environments on TestPyPI.
 
-### Capability gate
-
-Both arms run fresh: HEAD in the working tree, the previous tag in a temporary
-worktree. Comparing against a stored baseline cannot tell a real regression
-from the endpoint behind a model alias changing.
-
-The only hard threshold is a **floor** on the stable tier (60%) — clearing it
-requires typing `OVERRIDE`. Everything else (collapses, new error types, drops
-beyond ±5 points) is reported for a human to judge. An arm where >50% of
-samples error is rejected as infrastructure failure rather than reported as a
-result. Results cache under `tmp/release-check/`, so aborting at a prompt does
-not mean paying for another run.
-
-### Flags
-
-| Flag | Use |
-|---|---|
-| `--checks-only` | run everything, print the report, touch nothing |
-| `--dry-run` | print the `gh` commands instead of running them |
-| `--skip-capability` | docs-only releases |
-| `--models` / `--runs` / `--limit` | cheap rehearsal; requires `--checks-only` |
-
-Rehearse without spending real money:
-
-```bash
-uv run python scripts/make_release.py v0.0.9 --checks-only \
-  --models claude-haiku --runs 1 --limit 1
-```
-
-Report logic is covered by `tests/test_make_release.py`.
-
-## One-time PyPI setup
-
-Each project needs a pending publisher at
-<https://pypi.org/manage/account/publishing/> — owner `NVIDIA-NeMo`, repo
-`labs-OO-Agents`, workflow `publish.yml`, and a **distinct environment per
-package**: `pypi-nooa`, `pypi-nooa-cli`, `pypi-nooa-memory`, `pypi-nooa-bench`.
-PyPI keys a pending publisher on (owner, repo, workflow, environment), so a
-shared environment makes the second registration fail. The matching GitHub
-Environments must exist too.
-
-Repeat on <https://test.pypi.org> with `testpypi-<package>` names. Running the
-**Publish** workflow manually always targets TestPyPI.
-
-> Every `uses:` in `publish.yml` must be an `actions/*` action. This org
-> enforces an allowlist, and a disallowed action fails the whole workflow at
-> startup — that is what left CI dead for eight days (PR #50).
+Every `uses:` entry in `publish.yml` must remain compatible with the NVIDIA
+organization's GitHub Actions allowlist.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -80,6 +80,13 @@ setup and reporting cheaply; rehearsals can never create a draft. Before first
 production use, run the complete gate once with draft creation disabled and
 review all artifacts.
 
+Before requesting review of coordinated release-process changes, the private
+controller may run an unmerged rehearsal against a canonical GitHub
+`refs/pull/<number>/head` ref and its exact SHA. That mode may relax only the
+candidate's reachability from GitHub `main`; it remains reduced-scope, requires
+the private controller to authenticate the pull ref, runs every deterministic,
+containment, build, smoke, and evidence check, and can never create a draft.
+
 ## Publication rehearsal and artifact promotion
 
 A manual run of `publish.yml` always targets TestPyPI and is the safe way to

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -1,12 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""One codified release path: check, diff capabilities, review, publish.
+"""One codified release gate: check, diff capabilities, and prepare a draft.
 
 Runs every pre-release check in a fixed order, prints a capability regression
-report against the previous release, and stops at two human gates before doing
-anything irreversible.
+report against the previous release, and can create a GitHub draft. It contains
+no publication operation: a reviewer publishes only in the GitHub UI.
 
     uv run python scripts/make_release.py v0.0.9
+
+Strict ``--ci`` mode is noninteractive, freezes an explicit candidate SHA,
+requires an explicit model-alias wheel, writes private evidence/manifests, and
+creates a draft only after deterministic, infrastructure, and hard capability
+gates pass. Advisory capability findings remain visible for human review.
 
 The capability step has one hard gate and everything else advisory. The gate is
 an absolute *floor* on the stable tier, not a delta threshold: LLM pass rates
@@ -25,7 +30,10 @@ delta is attributable to our code.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
+import platform
 import re
 import shutil
 import subprocess
@@ -35,7 +43,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import NoReturn
+from typing import Any, NoReturn
 
 REPO = Path(__file__).resolve().parent.parent
 
@@ -53,6 +61,15 @@ GATE_PARALLEL = 40
 CAPABILITY_CONFIG = Path("tests/capability/config.yaml")
 PACKAGES = ["nooa", "nooa-cli", "nooa-memory", "nooa-bench"]
 REPORT_PATH = REPO / "tmp" / "release-check" / "capability-report.md"
+GITHUB_REPO = "NVIDIA-NeMo/labs-OO-Agents"
+TAG_RE = re.compile(r"^v(?P<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+# CI bounds are deliberately explicit. The eval runner checkpoints every
+# completed result to JSONL, so an overall timeout still leaves useful evidence.
+CI_SAMPLE_TIMEOUT = 20 * 60
+CI_HANG_TIMEOUT = 25 * 60
+CI_ARM_TIMEOUT = 2 * 60 * 60 + 30 * 60
 
 # An absolute floor on the stable tier, mirroring the MR pipeline's gate. A
 # *floor* survives run-to-run LLM variance in a way a delta threshold cannot:
@@ -78,9 +95,12 @@ BOLD, DIM, RED, YELLOW, GREEN, RESET = (
 )
 
 
+class ReleaseError(RuntimeError):
+    """Expected release-gate failure, safe to show without a traceback."""
+
+
 def die(msg: str) -> NoReturn:
-    print(f"\n{RED}✗ {msg}{RESET}", file=sys.stderr)
-    sys.exit(1)
+    raise ReleaseError(msg)
 
 
 def step(msg: str) -> None:
@@ -96,18 +116,31 @@ def warn(msg: str) -> None:
 
 
 def run(
-    cmd: list[str], cwd: Path | None = None, check: bool = True, capture: bool = True
+    cmd: list[str],
+    cwd: Path | None = None,
+    check: bool = True,
+    capture: bool = True,
+    *,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
 ) -> subprocess.CompletedProcess:
     """Run a command, echoing it when output is not captured."""
     if not capture:
         print(f"  {DIM}$ {' '.join(cmd)}{RESET}")
-    proc = subprocess.run(
-        cmd,
-        cwd=cwd or REPO,
-        text=True,
-        capture_output=capture,
-        check=False,
-    )
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=cwd or REPO,
+            text=True,
+            capture_output=capture,
+            check=False,
+            env=env,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        die(f"required executable is unavailable: {cmd[0]} ({exc})")
+    except subprocess.TimeoutExpired:
+        die(f"command timed out after {timeout}s: {' '.join(cmd)}")
     if check and proc.returncode != 0:
         detail = (proc.stderr or proc.stdout or "").strip() if capture else ""
         die(f"command failed ({proc.returncode}): {' '.join(cmd)}\n{detail}")
@@ -125,22 +158,155 @@ def confirm(prompt: str) -> bool:
     return input(f"\n{BOLD}{prompt}{RESET} [y/N] ").strip().lower() in ("y", "yes")
 
 
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_tag(tag: str) -> str:
+    match = TAG_RE.fullmatch(tag)
+    if not match:
+        die(f"tag must be a canonical vX.Y.Z version, got {tag!r}")
+    return match.group("version")
+
+
+def validate_candidate_sha(sha: str) -> str:
+    if not SHA_RE.fullmatch(sha):
+        die("candidate SHA must be an exact 40-character lowercase hexadecimal commit SHA")
+    return sha
+
+
+def validate_https_url(value: str, label: str) -> str:
+    if not re.fullmatch(r"https://[A-Za-z0-9.-]+/[^\s]+", value) or "@" in value:
+        die(f"{label} must be an HTTPS URL without embedded credentials")
+    return value
+
+
+def release_for_tag(tag: str) -> dict[str, Any] | None:
+    """Return GitHub release metadata, including drafts, or None for 404."""
+    proc = run(
+        ["gh", "api", f"repos/{GITHUB_REPO}/releases/tags/{tag}"],
+        check=False,
+    )
+    if proc.returncode == 0:
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            die(f"GitHub returned invalid release metadata for {tag}")
+    # gh uses exit 1 for HTTP 404. Do not turn authentication/server failures
+    # into "unused tag": its stderr contains the HTTP status, never a token.
+    if "404" in proc.stderr or "release not found" in proc.stderr.lower():
+        return None
+    die(f"could not inspect GitHub release {tag}: {proc.stderr.strip()}")
+
+
+def validate_existing_release(tag: str, sha: str) -> dict[str, Any] | None:
+    """Allow only an idempotent draft already targeting this exact SHA."""
+    release = release_for_tag(tag)
+    remote_tag = run(
+        ["git", "ls-remote", "--tags", "origin", f"refs/tags/{tag}"], check=False
+    ).stdout.strip()
+    if release is None:
+        if remote_tag:
+            die(f"tag {tag} already exists on GitHub without a matching draft release")
+        return None
+    if not release.get("draft"):
+        die(f"release {tag} is already published; refusing to modify it")
+    target = str(release.get("target_commitish", "")).lower()
+    if target != sha:
+        die(f"draft {tag} targets {target or '<unknown>'}, not frozen candidate {sha}")
+    if remote_tag:
+        resolved = remote_tag.split()[0].removesuffix("^{}")
+        # Annotated tags report the tag object first. Resolve through the local
+        # fetched ref so exact-target checking remains correct in either case.
+        local = git("rev-parse", f"refs/tags/{tag}^{{commit}}", check=False)
+        if local:
+            resolved = local
+        if resolved.lower() != sha:
+            die(f"tag {tag} resolves to {resolved}, not frozen candidate {sha}")
+    return release
+
+
+@dataclass
+class ReleaseManifest:
+    """Incrementally written private evidence index for CI diagnosis."""
+
+    path: Path
+    data: dict[str, Any]
+
+    def write(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self.data, indent=2, sort_keys=True) + "\n")
+        tmp.replace(self.path)
+
+    def update(self, **values: Any) -> None:
+        self.data.update(values)
+        self.write()
+
+    def stage(self, name: str, outcome: str, detail: str | None = None) -> None:
+        stages = self.data.setdefault("deterministic_checks", {})
+        stages[name] = {"outcome": outcome}
+        if detail:
+            stages[name]["detail"] = detail
+        self.write()
+
+
+def tool_versions(image_digest: str | None) -> dict[str, str]:
+    versions = {
+        "runner_image": image_digest or "unknown",
+        "python": platform.python_version(),
+        "kernel": platform.release(),
+    }
+    for name, cmd in {
+        "uv": ["uv", "--version"],
+        "git": ["git", "--version"],
+        "rg": ["rg", "--version"],
+        "sha256sum": ["sha256sum", "--version"],
+        "base64": ["base64", "--version"],
+        "curl": ["curl", "--version"],
+        "gcc": ["gcc", "--version"],
+        "make": ["make", "--version"],
+        "gh": ["gh", "--version"],
+    }.items():
+        proc = run(cmd, check=False)
+        versions[name] = (
+            (proc.stdout or proc.stderr).splitlines()[0].strip()
+            if (proc.stdout or proc.stderr).strip()
+            else "unavailable"
+        )
+    return versions
+
+
 # ---------------------------------------------------------------------------
 # 1. Preflight
 # ---------------------------------------------------------------------------
 
 
-def preflight(tag: str, allow_dirty: bool) -> tuple[str, str]:
+def preflight(
+    tag: str,
+    allow_dirty: bool,
+    *,
+    candidate_sha: str | None = None,
+    ci: bool = False,
+) -> tuple[str, str, str, dict[str, Any] | None]:
     """Validate repo state. Returns (head_sha, previous_version_tag)."""
     step(f"Preflight for {tag}")
 
-    if not tag.startswith("v"):
-        die(f"tag must look like v0.0.9, got {tag!r}")
+    validate_tag(tag)
+    if ci:
+        if candidate_sha is None:
+            die("--candidate-sha is required in CI mode")
+        candidate_sha = validate_candidate_sha(candidate_sha)
 
     branch = git("rev-parse", "--abbrev-ref", "HEAD")
-    if branch != "main":
+    if not ci and branch != "main":
         die(f"on branch {branch!r}, releases are cut from main")
-    ok("on main")
+    if not ci:
+        ok("on main")
 
     dirty = git("status", "--porcelain")
     if dirty and not allow_dirty:
@@ -150,27 +316,42 @@ def preflight(tag: str, allow_dirty: bool) -> tuple[str, str]:
     else:
         ok("working tree clean")
 
-    git("fetch", "--tags", "origin", check=False)
+    fetch = run(["git", "fetch", "--force", "--tags", "origin", "main"], check=False)
+    if fetch.returncode != 0:
+        die(f"could not fetch public main and version tags: {fetch.stderr.strip()}")
     head = git("rev-parse", "HEAD")
-    remote = git("rev-parse", "origin/main", check=False)
-    if remote and head != remote:
-        die("HEAD differs from origin/main — push or pull first")
-    ok("in sync with origin/main")
-
-    existing = git("tag", "-l", tag)
-    if existing:
-        die(f"tag {tag} already exists locally")
-    remote_tag = run(["git", "ls-remote", "--tags", "origin", tag]).stdout.strip()
-    if remote_tag:
-        die(f"tag {tag} already exists on origin")
-    ok(f"{tag} is unused")
+    remote = git("rev-parse", "origin/main")
+    if ci:
+        assert candidate_sha is not None
+        if head != candidate_sha:
+            die(f"checked-out HEAD is {head}, not frozen candidate {candidate_sha}")
+        exists = run(["git", "cat-file", "-e", f"{candidate_sha}^{{commit}}"], check=False)
+        if exists.returncode != 0:
+            die(f"candidate {candidate_sha} does not exist in the fetched public repository")
+        reachable = run(["git", "merge-base", "--is-ancestor", candidate_sha, remote], check=False)
+        if reachable.returncode != 0:
+            die(f"candidate {candidate_sha} is not reachable from GitHub main ({remote})")
+        ok(f"frozen candidate is reachable from current GitHub main ({remote[:12]})")
+        existing_release = validate_existing_release(tag, candidate_sha)
+        ok(f"{tag} has a matching reusable draft" if existing_release else f"{tag} is unused")
+    else:
+        if head != remote:
+            die("HEAD differs from origin/main — push or pull first")
+        ok("in sync with origin/main")
+        existing_release = validate_existing_release(tag, head)
+        ok(f"{tag} has a matching reusable draft" if existing_release else f"{tag} is unused")
 
     prev = git("describe", "--tags", "--abbrev=0", "--match", VERSION_TAG_GLOB, check=False)
+    if prev == tag:
+        prev = git(
+            "describe", "--tags", "--abbrev=0", "--match", VERSION_TAG_GLOB, f"{tag}^", check=False
+        )
     if not prev:
         die("no previous version tag found — cannot compute a capability diff")
-    ok(f"previous release: {prev}")
+    prev_sha = git("rev-parse", f"{prev}^{{commit}}")
+    ok(f"previous release: {prev} ({prev_sha[:12]})")
 
-    return head, prev
+    return head, prev, prev_sha, existing_release
 
 
 # ---------------------------------------------------------------------------
@@ -178,7 +359,9 @@ def preflight(tag: str, allow_dirty: bool) -> tuple[str, str]:
 # ---------------------------------------------------------------------------
 
 
-def fast_checks() -> None:
+def fast_checks(
+    manifest: ReleaseManifest | None = None, *, verify_containment: bool = False
+) -> None:
     """Everything cheap, before spending money on LLM calls."""
     step("Fast checks (lint, headers, unit tests)")
     for label, cmd in [
@@ -189,9 +372,42 @@ def fast_checks() -> None:
     ]:
         proc = run(cmd, check=False)
         if proc.returncode != 0:
+            if manifest:
+                manifest.stage(label, "failed")
             print(proc.stdout[-4000:])
             print(proc.stderr[-2000:], file=sys.stderr)
             die(f"{label} failed")
+        if manifest:
+            manifest.stage(label, "passed")
+        ok(label)
+
+    if verify_containment:
+        # These prove the worker is a separate process and that both filesystem
+        # and network containment are enforceable. A green run with skipped
+        # kernel guard tests is not acceptable for the credential-bearing job.
+        label = "sandbox containment"
+        cmd = [
+            "uv",
+            "run",
+            "pytest",
+            "-q",
+            "-m",
+            "sandbox",
+            "-rs",
+            "tests/runtime/sandbox/test_codeact_sandbox.py::test_sandbox_cell_runs_in_a_separate_process",
+            "tests/runtime/sandbox/test_guards.py::test_file_read_closed_with_sandbox",
+            "tests/runtime/sandbox/test_guards.py::test_network_closed_with_sandbox",
+        ]
+        proc = run(cmd, check=False)
+        output = f"{proc.stdout}\n{proc.stderr}"
+        if proc.returncode != 0 or re.search(r"\bskipped\b", output, re.IGNORECASE):
+            if manifest:
+                manifest.stage(label, "failed", "required containment test failed or skipped")
+            print(proc.stdout[-4000:])
+            print(proc.stderr[-2000:], file=sys.stderr)
+            die("sandbox containment is unavailable or a required containment test skipped")
+        if manifest:
+            manifest.stage(label, "passed")
         ok(label)
 
 
@@ -209,14 +425,22 @@ def temporary_tag(tag: str, sha: str):
     publish. The tag is removed again on the way out — `gh release create`
     creates the real one, at this same commit.
     """
-    git("tag", tag, sha)
+    existing = git("rev-parse", f"refs/tags/{tag}^{{commit}}", check=False)
+    created = not existing
+    if existing and existing != sha:
+        die(f"local tag {tag} resolves to {existing}, not candidate {sha}")
+    if created:
+        git("tag", tag, sha)
     try:
         yield
     finally:
-        git("tag", "-d", tag, check=False)
+        if created:
+            git("tag", "-d", tag, check=False)
 
 
-def build_and_smoke(tag: str, sha: str) -> None:
+def build_and_smoke(
+    tag: str, sha: str, manifest: ReleaseManifest | None = None
+) -> list[dict[str, str]]:
     step("Build wheels and smoke test")
     expected = tag.lstrip("v")
     dist = REPO / "dist"
@@ -225,10 +449,14 @@ def build_and_smoke(tag: str, sha: str) -> None:
         if dist.exists():
             shutil.rmtree(dist)
         for pkg in PACKAGES:
-            run(
+            proc = run(
                 ["uv", "build", "--no-sources", "--package", pkg, "--out-dir", "dist"],
-                capture=True,
+                check=False,
             )
+            if proc.returncode != 0:
+                if manifest:
+                    manifest.stage("build", "failed", pkg)
+                die(f"build failed for {pkg}: {(proc.stderr or proc.stdout)[-2000:]}")
         ok(f"built {len(PACKAGES)} packages")
 
         wheels = sorted(dist.glob("*.whl"))
@@ -266,6 +494,24 @@ def build_and_smoke(tag: str, sha: str) -> None:
             if proc.returncode != 0:
                 die(f"smoke import failed:\n{proc.stderr}")
             ok(f"smoke import OK ({proc.stdout.strip()})")
+            cli = run([str(venv / "bin" / "nooa"), "--version"], check=False)
+            if cli.returncode != 0 or expected not in cli.stdout:
+                die(
+                    f"CLI smoke test failed or reported the wrong version: {cli.stdout}{cli.stderr}"
+                )
+            ok(f"CLI version OK ({cli.stdout.strip()})")
+
+    artifacts = [
+        {"path": str(path.relative_to(REPO)), "sha256": sha256(path)}
+        for path in sorted(dist.iterdir())
+        if path.is_file()
+    ]
+    if manifest:
+        manifest.stage("build", "passed")
+        manifest.stage("wheel versions", "passed", expected)
+        manifest.stage("clean wheel smoke", "passed")
+        manifest.update(distributions=artifacts)
+    return artifacts
 
 
 # ---------------------------------------------------------------------------
@@ -289,6 +535,8 @@ class ArmResults:
     output_tokens: int = 0
     total_tokens: int = 0
     errored: int = 0
+    result_path: str | None = None
+    lock_sha256: str | None = None
 
     def error_rate(self) -> float:
         _, total = self.counts()
@@ -407,28 +655,69 @@ def run_capability_arm(
     models: list[str],
     runs: int,
     limit: int | None,
+    *,
+    strict_ci: bool = False,
+    internal_wheel: Path | None = None,
+    output_root: Path | None = None,
+    sample_timeout: float | None = None,
+    hang_timeout: float | None = None,
+    overall_timeout: float | None = None,
 ) -> ArmResults:
-    """Run the capability suite in `tree`, reusing cached results when present.
+    """Run the capability suite in `tree`, with cache only for local fallback.
 
-    The script has two human gates and a run takes a while; without a cache,
-    aborting at the review prompt costs another full paid run to get back. The
-    signature covers models/runs/limit so a cheap smoke run never gets mistaken
-    for a real gate run.
+    Local review can reuse a paid run after aborting at its prompt. Strict CI
+    always runs fresh. The signature covers models/runs/limit so a cheap smoke
+    run never gets mistaken for a real gate run.
     """
-    out_dir = REPO / "tmp" / "release-check" / cache_key
+    out_dir = (output_root or REPO / "tmp" / "release-check") / cache_key
     out_dir.mkdir(parents=True, exist_ok=True)
     marker = out_dir / "run.json"
     signature = {"models": sorted(models), "runs": runs, "limit": limit}
 
     existing = newest_eval(out_dir)
-    if existing and marker.exists() and json.loads(marker.read_text()) == signature:
+    if (
+        not strict_ci
+        and existing
+        and marker.exists()
+        and json.loads(marker.read_text()) == signature
+    ):
         ok(f"{label}: reusing cached results ({existing.name})")
         return parse_results(existing, label)
 
     scope = f"{len(models)} models × {runs} runs" + (f" × {limit} samples" if limit else "")
     print(f"  {DIM}{label}: full suite × {scope}{RESET}")
 
-    if tree != REPO:
+    if strict_ci:
+        if internal_wheel is None:
+            die(f"{label}: strict CI requires an explicit internal model wheel")
+        print(f"  {DIM}syncing a fresh locked environment for {label}...{RESET}")
+        run(
+            ["uv", "sync", "--frozen", "--all-extras", "--no-extra", "sandbox"],
+            cwd=tree,
+        )
+        venv_python = tree / ".venv" / "bin" / "python"
+        run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "--python",
+                str(venv_python),
+                "--no-deps",
+                str(internal_wheel),
+            ],
+            cwd=tree,
+        )
+        # Resolve every alias through the entry-point registry. This fails
+        # before any paid call and does not print model endpoints or secrets.
+        alias_check = (
+            "from nooa.unifiedllm.registry import get_registry_config; "
+            f"names={models!r}; missing=[n for n in names if not get_registry_config(n)]; "
+            "assert not missing, 'missing model aliases: '+','.join(missing)"
+        )
+        run([str(venv_python), "-c", alias_check], cwd=tree)
+        ok(f"{label}: explicit internal wheel installed and all model aliases resolved")
+    elif tree != REPO:
         # A worktree is a clean git checkout, so gitignored local config does
         # not come with it. Without .env the baseline arm has no credentials and
         # every sample fails with "Missing credentials" — which reads as a
@@ -494,14 +783,34 @@ def run_capability_arm(
         "--output-dir",
         str(out_dir),
     ]
+    if strict_ci:
+        cmd += ["--no-cache", "--trace-files"]
+    if sample_timeout:
+        cmd += ["--timeout", str(sample_timeout)]
+    if hang_timeout:
+        cmd += ["--hang-timeout", str(hang_timeout)]
     if limit:
         cmd += ["--limit", str(limit)]
-    run(cmd, cwd=tree, capture=False)
+    child_env = os.environ.copy()
+    if strict_ci:
+        # The evaluator always starts its own headless backend. Prevent an
+        # inherited endpoint from duplicating private traces externally.
+        child_env.pop("OTLP_ENDPOINT", None)
+    run(
+        cmd,
+        cwd=tree,
+        capture=False,
+        env=child_env,
+        timeout=overall_timeout,
+    )
 
     produced = newest_eval(out_dir)
     if not produced:
         die(f"{label}: eval produced no .noo-eval.jsonl under {out_dir}")
     arm = parse_results(produced, label)
+    arm.result_path = str(produced)
+    lock = tree / "uv.lock"
+    arm.lock_sha256 = sha256(lock) if lock.exists() else None
     # The eval CLI exits 0 even when every sample errors, so these two checks are
     # the only thing standing between an infrastructure outage and a meaningless
     # report. A broken BASELINE arm is the dangerous case: it reads as a huge
@@ -550,6 +859,10 @@ class Diff:
     models_changed: list[str] = field(default_factory=list)
     floor_breach: str | None = None
     markdown: str = ""
+
+    @property
+    def hard_gate_passed(self) -> bool:
+        return self.floor_breach is None
 
     @property
     def clean(self) -> bool:
@@ -650,7 +963,9 @@ def compare(
     # LLM variance while still catching catastrophe; the delta stays advisory.
     stable_p, stable_t = tiers_head.get("stable", (0, 0))
     stable_rate = stable_p / stable_t if stable_t else 0.0
-    if stable_t and stable_rate < STABLE_FLOOR:
+    if not stable_t:
+        diff.floor_breach = "candidate produced no stable-tier samples"
+    elif stable_rate < STABLE_FLOOR:
         diff.floor_breach = f"stable tier at {stable_rate:.1%}, floor is {STABLE_FLOOR:.0%}"
 
     # ---- markdown ----------------------------------------------------------
@@ -834,75 +1149,223 @@ def compare(
 
 
 def capability_diff(
-    prev_tag: str, sha: str, models: list[str], runs: int, limit: int | None
-) -> Diff:
+    prev_tag: str,
+    sha: str,
+    models: list[str],
+    runs: int,
+    limit: int | None,
+    *,
+    strict_ci: bool = False,
+    internal_wheel: Path | None = None,
+    artifact_dir: Path | None = None,
+    sample_timeout: float | None = None,
+    hang_timeout: float | None = None,
+    overall_timeout: float | None = None,
+) -> tuple[Diff, ArmResults, ArmResults]:
     step(f"Capability diff vs {prev_tag} (both arms run fresh)")
     # The cache key carries the scope, so a `--limit 1` smoke run and a real
     # gate run never share a directory.
     scope = f"m{len(models)}r{runs}" + (f"l{limit}" if limit else "")
-    head_arm = run_capability_arm(
-        REPO, f"HEAD ({sha[:8]})", f"{sha[:12]}-{scope}", models, runs, limit
-    )
-    with worktree_at(prev_tag) as tree:
-        base_arm = run_capability_arm(
-            tree, prev_tag, f"{prev_tag.replace('/', '_')}-{scope}", models, runs, limit
+    output_root = (artifact_dir / "capability") if artifact_dir else None
+    common = {
+        "strict_ci": strict_ci,
+        "internal_wheel": internal_wheel,
+        "output_root": output_root,
+        "sample_timeout": sample_timeout,
+        "hang_timeout": hang_timeout,
+        "overall_timeout": overall_timeout,
+    }
+    if strict_ci:
+        # Run both sides from disposable worktrees so neither arm can inherit a
+        # project environment. They receive the same explicit adapter wheel.
+        with worktree_at(sha) as head_tree:
+            head_arm = run_capability_arm(
+                head_tree,
+                f"candidate ({sha[:8]})",
+                f"candidate-{sha[:12]}-{scope}",
+                models,
+                runs,
+                limit,
+                **common,
+            )
+        with worktree_at(prev_tag) as base_tree:
+            base_arm = run_capability_arm(
+                base_tree,
+                prev_tag,
+                f"baseline-{prev_tag.replace('/', '_')}-{scope}",
+                models,
+                runs,
+                limit,
+                **common,
+            )
+    else:
+        head_arm = run_capability_arm(
+            REPO, f"HEAD ({sha[:8]})", f"{sha[:12]}-{scope}", models, runs, limit
         )
+        with worktree_at(prev_tag) as tree:
+            base_arm = run_capability_arm(
+                tree, prev_tag, f"{prev_tag.replace('/', '_')}-{scope}", models, runs, limit
+            )
     diff = compare(base_arm, head_arm, prev_tag, sha, runs)
-    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    REPORT_PATH.write_text(diff.markdown)
-    print(f"\n  {DIM}markdown report: {REPORT_PATH}{RESET}")
-    return diff
+    report_path = artifact_dir / "capability-report.md" if artifact_dir else REPORT_PATH
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(diff.markdown)
+    print(f"\n  {DIM}markdown report: {report_path}{RESET}")
+    return diff, base_arm, head_arm
+
+
+def arm_summary(arm: ArmResults) -> dict[str, Any]:
+    passed, total = arm.counts()
+    return {
+        "label": arm.label,
+        "passed": passed,
+        "total": total,
+        "sample_count": total,
+        "success_rate": arm.overall(),
+        "error_rate": arm.error_rate(),
+        "tiers": {
+            tier: {"passed": counts[0], "total": counts[1]}
+            for tier, counts in sorted(arm.tier_counts().items())
+        },
+        "models": dict(sorted(arm.per_model().items())),
+        "result_path": arm.result_path,
+        "uv_lock_sha256": arm.lock_sha256,
+    }
 
 
 # ---------------------------------------------------------------------------
-# 5. Release
+# 5. Draft release (publication is intentionally not implemented here)
 # ---------------------------------------------------------------------------
 
 
-def create_draft(tag: str, sha: str, report: str) -> None:
-    step(f"Creating draft release {tag}")
-    run(
+def sanitize_public_text(text: str) -> str:
+    """Conservative last-line defense before private evidence becomes public."""
+    text = re.sub(r"\x1b\[[0-9;]*m", "", text)
+    text = re.sub(
+        r"(?i)\b(api[_-]?key|authorization|token|secret)\b\s*[:=]\s*\S+",
+        r"\1=[REDACTED]",
+        text,
+    )
+    text = re.sub(r"https?://[^\s/@]+:[^\s/@]+@", "https://[REDACTED]@", text)
+    text = re.sub(r"(?<![\w])/(?:home|builds|tmp)/[^\s`|)]+", "[private-path]", text)
+    return "".join(ch for ch in text if ch in "\n\t" or ord(ch) >= 32)
+
+
+def generated_change_notes(tag: str, sha: str, prev_tag: str) -> str:
+    proc = run(
         [
             "gh",
-            "release",
-            "create",
-            tag,
-            "--target",
-            sha,
-            "--title",
-            f"NOOA {tag.lstrip('v')}",
-            "--generate-notes",
-            "--draft",
+            "api",
+            "--method",
+            "POST",
+            f"repos/{GITHUB_REPO}/releases/generate-notes",
+            "-f",
+            f"tag_name={tag}",
+            "-f",
+            f"target_commitish={sha}",
+            "-f",
+            f"previous_tag_name={prev_tag}",
         ],
-        capture=False,
+        check=False,
     )
-    if report:
-        # Append the capability report to the generated notes, so each release
-        # carries the evidence it was cut on. `--generate-notes` has already
-        # written the changelog; read it back and extend rather than replace.
-        notes = run(["gh", "release", "view", tag, "--json", "body", "-q", ".body"]).stdout
-        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
-            fh.write(f"{notes.rstrip()}\n\n---\n\n{report}\n")
-            notes_path = fh.name
-        try:
-            run(["gh", "release", "edit", tag, "--notes-file", notes_path])
-            ok("capability report appended to the release notes")
-        finally:
-            Path(notes_path).unlink(missing_ok=True)
-    url = run(["gh", "release", "view", tag, "--json", "url", "-q", ".url"]).stdout.strip()
-    ok(f"draft created: {url}")
+    if proc.returncode != 0:
+        die(f"could not generate GitHub change notes: {proc.stderr.strip()}")
+    try:
+        return str(json.loads(proc.stdout).get("body", "")).strip()
+    except json.JSONDecodeError:
+        die("GitHub returned invalid generated release notes")
 
 
-def publish(tag: str) -> None:
-    step(f"Publishing {tag}")
-    run(["gh", "release", "edit", tag, "--draft=false"], capture=False)
-    ok(f"{tag} published — publish.yml will build and upload to PyPI")
-    print(f"  {DIM}each package waits on its pypi-<name> environment approval{RESET}")
+def build_public_notes(
+    *,
+    tag: str,
+    sha: str,
+    prev_tag: str,
+    diff: Diff,
+    change_notes: str,
+    pipeline_url: str,
+    distributions: list[dict[str, str]],
+) -> str:
+    advisory_count = (
+        len(diff.regressions) + len(diff.new_errors) + len(diff.beyond_noise) + len(diff.removed)
+    )
+    verdict = "PASS — all automated hard gates passed"
+    checksum_lines = [
+        f"- `{Path(item['path']).name}` — `{item['sha256']}`" for item in distributions
+    ]
+    sections = [
+        "# Unpublished NOOA release candidate",
+        "",
+        "> **This draft is not published. Publishing it is the sole human release approval and immediately starts automatic PyPI publication.**",
+        "",
+        f"- Version: `{tag}`",
+        f"- Immutable candidate: `{sha}`",
+        f"- Previous release: `{prev_tag}`",
+        f"- Automated hard-gate verdict: **{verdict}**",
+        f"- Advisory findings: **{advisory_count}** (review the open sections below)",
+        f"- Private pipeline evidence: {pipeline_url}",
+        "",
+        sanitize_public_text(diff.markdown),
+        "",
+        "## Changes",
+        "",
+        sanitize_public_text(change_notes) or "No generated change notes were returned.",
+        "",
+        "## Candidate build provenance",
+        "",
+        *checksum_lines,
+        "",
+        "The candidate pipeline built and smoke-tested these artifacts. The current publication workflow rebuilds from this exact tag; artifact promotion remains a follow-up.",
+        "",
+        "## Reviewer checklist",
+        "",
+        f"- Confirm the candidate SHA is exactly `{sha}`.",
+        "- Review advisory findings and the private GitLab evidence/traces.",
+        "- **Accept:** click GitHub’s **Publish release** button. This immediately triggers `publish.yml` and automatic PyPI publication.",
+        "- **Reject:** delete this draft (including its tag) or leave it for the documented cleanup procedure.",
+    ]
+    return sanitize_public_text("\n".join(sections).rstrip() + "\n")
 
 
-def main() -> int:
+def create_or_update_draft(
+    tag: str,
+    sha: str,
+    notes_path: Path,
+) -> tuple[str, int]:
+    """Create exactly one draft, or update the matching unpublished draft."""
+    # Re-read immediately before mutation. A reviewer may have published a
+    # pre-existing draft while this multi-hour gate was running; in that case
+    # validate_existing_release fails before `gh release edit` can unpublish it.
+    current = validate_existing_release(tag, sha)
+    step(f"{'Updating' if current else 'Creating'} draft release {tag}")
+    common = [
+        "--repo",
+        GITHUB_REPO,
+        "--target",
+        sha,
+        "--title",
+        f"NOOA {tag.lstrip('v')}",
+        "--notes-file",
+        str(notes_path),
+        "--draft",
+    ]
+    if current:
+        cmd = ["gh", "release", "edit", tag, *common]
+    else:
+        cmd = ["gh", "release", "create", tag, *common]
+    run(cmd, capture=False)
+    release = validate_existing_release(tag, sha)
+    if release is None:
+        die(f"GitHub did not return the draft after {'update' if current else 'creation'}")
+    url = str(release.get("html_url", ""))
+    release_id = int(release["id"])
+    ok(f"draft ready: {url}")
+    return url, release_id
+
+
+def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Run the full pre-release check, then create and publish a GitHub Release."
+        description="Run the release gate and optionally create/update a GitHub draft."
     )
     parser.add_argument("tag", help="release tag, e.g. v0.0.9")
     parser.add_argument(
@@ -934,14 +1397,250 @@ def main() -> int:
         action="store_true",
         help="print the gh release commands instead of running them",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--ci",
+        action="store_true",
+        help="strict, noninteractive CI mode (never discovers ambient extras or copies .env)",
+    )
+    parser.add_argument("--candidate-sha", help="exact 40-character public candidate SHA")
+    parser.add_argument("--internal-wheel", type=Path, help="explicit internal model-alias wheel")
+    parser.add_argument("--controller-sha", help="exact nooa-dev commit that built the wheel")
+    parser.add_argument("--artifact-dir", type=Path, help="private CI evidence output directory")
+    parser.add_argument(
+        "--create-draft",
+        action="store_true",
+        help="after a production-strength CI gate passes, create/update the GitHub draft",
+    )
+    parser.add_argument("--pipeline-url", default="", help="private GitLab pipeline URL")
+    parser.add_argument("--job-url", default="", help="private GitLab job URL")
+    parser.add_argument("--image-digest", default="", help="immutable runner image reference")
+    parser.add_argument(
+        "--sample-timeout", type=float, default=CI_SAMPLE_TIMEOUT, help=argparse.SUPPRESS
+    )
+    parser.add_argument(
+        "--hang-timeout", type=float, default=CI_HANG_TIMEOUT, help=argparse.SUPPRESS
+    )
+    parser.add_argument("--arm-timeout", type=float, default=CI_ARM_TIMEOUT, help=argparse.SUPPRESS)
+    return parser
+
+
+def _copy_distributions(artifact_dir: Path) -> list[dict[str, str]]:
+    target = artifact_dir / "dist"
+    target.mkdir(parents=True, exist_ok=True)
+    records = []
+    for source in sorted((REPO / "dist").iterdir()):
+        if not source.is_file():
+            continue
+        destination = target / source.name
+        shutil.copy2(source, destination)
+        records.append({"path": str(destination), "sha256": sha256(destination)})
+    checksum_file = artifact_dir / "CHECKSUMS.sha256"
+    checksum_file.write_text(
+        "".join(f"{item['sha256']}  {Path(item['path']).name}\n" for item in records)
+    )
+    return records
+
+
+def _write_job_summary(artifact_dir: Path, manifest: ReleaseManifest) -> None:
+    data = manifest.data
+    cap = data.get("capability", {})
+    lines = [
+        "# NOOA release gate summary",
+        "",
+        f"- Status: **{data.get('status', 'running')}**",
+        f"- Version: `{data.get('requested_version', '')}`",
+        f"- Candidate: `{data.get('candidate_sha', '')}`",
+        f"- Previous: `{data.get('previous_release_tag', '')}`",
+        f"- Capability hard gate: **{cap.get('hard_gate_outcome', 'not run')}**",
+    ]
+    if data.get("github_draft_url"):
+        lines.append(f"- GitHub draft: {data['github_draft_url']}")
+    if data.get("failure"):
+        lines.append(f"- Failure: {data['failure']}")
+    (artifact_dir / "job-summary.md").write_text("\n".join(lines) + "\n")
+
+
+def ci_main(args: argparse.Namespace) -> int:
+    if args.allow_dirty or args.skip_capability or args.dry_run:
+        die("--ci forbids --allow-dirty, --skip-capability, and --dry-run")
+    if not args.candidate_sha or not args.controller_sha:
+        die("--ci requires --candidate-sha and --controller-sha")
+    candidate_sha = validate_candidate_sha(args.candidate_sha)
+    controller_sha = validate_candidate_sha(args.controller_sha)
+    if args.internal_wheel is None or not args.internal_wheel.is_file():
+        die("--ci requires an existing --internal-wheel")
+    internal_wheel = args.internal_wheel.resolve()
+    if internal_wheel.suffix != ".whl" or "nemo_oo_agents_nvidia" not in internal_wheel.name:
+        die("--internal-wheel must be the nemo-oo-agents-nvidia wheel")
+    if args.artifact_dir is None:
+        die("--ci requires --artifact-dir")
+    if not os.getenv("NVIDIA_INTERNAL_API_KEY"):
+        die("NVIDIA_INTERNAL_API_KEY is required for the live capability gate")
+    if not os.getenv("GH_TOKEN"):
+        die("GH_TOKEN is required in CI to inspect and reconcile release state")
+    validate_https_url(args.pipeline_url, "pipeline URL")
+    validate_https_url(args.job_url, "job URL")
+    if not re.search(r"@sha256:[0-9a-f]{64}$", args.image_digest):
+        die("--image-digest must identify an image pinned by an immutable sha256 digest")
+    for value, name in [
+        (args.sample_timeout, "sample timeout"),
+        (args.hang_timeout, "hang timeout"),
+        (args.arm_timeout, "arm timeout"),
+    ]:
+        if value <= 0:
+            die(f"{name} must be positive")
+
+    artifact_dir = args.artifact_dir.resolve()
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    manifest = ReleaseManifest(
+        artifact_dir / "release-manifest.json",
+        {
+            "schema_version": 1,
+            "status": "running",
+            "requested_version": args.tag,
+            "candidate_sha": candidate_sha,
+            "nooa_dev_sha": controller_sha,
+            "internal_model_wheel": {
+                "filename": internal_wheel.name,
+                "sha256": sha256(internal_wheel),
+            },
+            "pipeline_url": args.pipeline_url,
+            "job_url": args.job_url,
+            "environment": {"runner_image": args.image_digest},
+            "capability": {"hard_gate_outcome": "not_run"},
+            "github_draft_url": None,
+            "github_release_database_id": None,
+        },
+    )
+    manifest.write()
+    try:
+        manifest.update(environment=tool_versions(args.image_digest))
+        models = args.models.split(",") if args.models else GATE_MODELS
+        if any(not model.strip() for model in models):
+            die("--models contains an empty alias")
+        rehearsal = bool(args.limit) or args.runs != GATE_RUNS or models != GATE_MODELS
+        if args.runs < 1 or (args.limit is not None and args.limit < 1):
+            die("--runs and --limit must be positive")
+        if rehearsal and args.create_draft:
+            die("a reduced rehearsal can never create a draft")
+        if args.checks_only and args.create_draft:
+            die("--checks-only can never be combined with --create-draft")
+
+        head_sha, prev_tag, prev_sha, existing = preflight(
+            args.tag, False, candidate_sha=candidate_sha, ci=True
+        )
+        manifest.update(
+            previous_release_tag=prev_tag,
+            previous_release_sha=prev_sha,
+            existing_matching_draft=bool(existing),
+            capability_config_sha256=sha256(REPO / CAPABILITY_CONFIG),
+            capability_scope={
+                "models": models,
+                "runs": args.runs,
+                "sample_limit": args.limit,
+                "parallelism": GATE_PARALLEL,
+                "sample_timeout_seconds": args.sample_timeout,
+                "hang_timeout_seconds": args.hang_timeout,
+                "arm_timeout_seconds": args.arm_timeout,
+                "fresh_arms": True,
+                "response_cache": False,
+            },
+        )
+
+        fast_checks(manifest, verify_containment=True)
+        build_and_smoke(args.tag, head_sha, manifest)
+        distributions = _copy_distributions(artifact_dir)
+        manifest.update(distributions=distributions)
+
+        manifest.update(capability={"hard_gate_outcome": "running"})
+        try:
+            diff, baseline, candidate = capability_diff(
+                prev_tag,
+                head_sha,
+                models,
+                args.runs,
+                args.limit,
+                strict_ci=True,
+                internal_wheel=internal_wheel,
+                artifact_dir=artifact_dir,
+                sample_timeout=args.sample_timeout,
+                hang_timeout=args.hang_timeout,
+                overall_timeout=args.arm_timeout,
+            )
+        except ReleaseError as exc:
+            manifest.update(
+                capability={
+                    "hard_gate_outcome": "infrastructure_failed",
+                    "hard_gate_detail": sanitize_public_text(str(exc)),
+                }
+            )
+            raise
+        hard_gate = "passed" if diff.hard_gate_passed else "failed"
+        capability = {
+            "hard_gate_outcome": hard_gate,
+            "hard_gate_detail": diff.floor_breach,
+            "advisory": {
+                "collapses": diff.regressions,
+                "new_errors": diff.new_errors,
+                "aggregate_drops": diff.beyond_noise,
+                "removed_tests": diff.removed,
+                "models_changed": diff.models_changed,
+            },
+            "baseline": arm_summary(baseline),
+            "candidate": arm_summary(candidate),
+        }
+        manifest.update(
+            capability=capability,
+            public_uv_lock_sha256={
+                "candidate": candidate.lock_sha256,
+                "previous": baseline.lock_sha256,
+            },
+        )
+        if diff.floor_breach:
+            die(f"capability hard gate failed: {diff.floor_breach}")
+
+        change_notes = generated_change_notes(args.tag, head_sha, prev_tag)
+        notes = build_public_notes(
+            tag=args.tag,
+            sha=head_sha,
+            prev_tag=prev_tag,
+            diff=diff,
+            change_notes=change_notes,
+            pipeline_url=args.pipeline_url,
+            distributions=distributions,
+        )
+        notes_path = artifact_dir / "public-release-notes.md"
+        notes_path.write_text(notes)
+        manifest.update(public_release_notes_sha256=sha256(notes_path))
+
+        if args.create_draft:
+            url, release_id = create_or_update_draft(args.tag, head_sha, notes_path)
+            manifest.update(
+                github_draft_url=url,
+                github_release_database_id=release_id,
+            )
+        else:
+            warn("checks-only CI run complete; GitHub draft creation was disabled")
+        manifest.update(status="passed", rehearsal=rehearsal)
+        _write_job_summary(artifact_dir, manifest)
+        return 0
+    except ReleaseError as exc:
+        message = sanitize_public_text(str(exc))
+        manifest.update(status="failed", failure=message)
+        _write_job_summary(artifact_dir, manifest)
+        raise
+
+
+def local_main(args: argparse.Namespace) -> int:
+    if args.create_draft or args.candidate_sha or args.internal_wheel or args.artifact_dir:
+        die("CI-only arguments require --ci")
 
     models = args.models.split(",") if args.models else GATE_MODELS
     rehearsal = args.limit or args.runs != GATE_RUNS or models != GATE_MODELS
     if rehearsal and not args.checks_only and not args.dry_run:
         die("--models/--runs/--limit reduce the gate's power; pair them with --checks-only")
 
-    head_sha, prev_tag = preflight(args.tag, args.allow_dirty)
+    head_sha, prev_tag, _prev_sha, existing = preflight(args.tag, args.allow_dirty)
     fast_checks()
     build_and_smoke(args.tag, head_sha)
 
@@ -949,18 +1648,14 @@ def main() -> int:
     if args.skip_capability:
         warn("capability diff SKIPPED — no evidence this release is free of regressions")
     else:
-        diff = capability_diff(prev_tag, head_sha, models, args.runs, args.limit)
+        diff, _baseline, _candidate = capability_diff(
+            prev_tag, head_sha, models, args.runs, args.limit
+        )
         report = diff.markdown
         if args.checks_only:
-            return 0 if diff.clean else 1
-        # The floor is the one place the script takes a position. Everything
-        # else is advisory; a stable tier under the floor needs the override to
-        # be typed out, not answered with a reflexive "y".
+            return 0 if not diff.floor_breach else 1
         if diff.floor_breach:
-            print(f"\n{RED}{diff.floor_breach}{RESET}")
-            if input(f"{BOLD}Type OVERRIDE to release anyway:{RESET} ").strip() != "OVERRIDE":
-                print("Aborted. Cached eval results kept under tmp/release-check/.")
-                return 1
+            die(f"capability hard gate failed: {diff.floor_breach}")
         elif not confirm(f"Accept these capability results and draft {args.tag}?"):
             print("Aborted. Cached eval results kept under tmp/release-check/.")
             return 1
@@ -971,29 +1666,46 @@ def main() -> int:
     if args.dry_run:
         step("Dry run — the release steps that would follow")
         print(
-            f"  {DIM}$ gh release create {args.tag} --target {head_sha[:12]} "
-            f"--title 'NOOA {args.tag.lstrip('v')}' --generate-notes --draft{RESET}"
+            f"  {DIM}$ gh release create {args.tag} --repo {GITHUB_REPO} "
+            f"--target {head_sha} --title 'NOOA {args.tag.lstrip('v')}' "
+            f"--notes-file <review notes> --draft{RESET}"
         )
-        print(
-            f"  {DIM}$ gh release edit {args.tag} --notes-file <notes + capability report>{RESET}"
-        )
-        print(f"  {DIM}$ gh release edit {args.tag} --draft=false{RESET}")
         ok("dry run complete — nothing was created")
         return 0
 
-    create_draft(args.tag, head_sha, report)
-    print(f"\n{DIM}Review the generated notes in the browser before continuing.{RESET}")
-    if not confirm(f"Publish {args.tag} to GitHub and PyPI?"):
-        # --cleanup-tag: plain `gh release delete` leaves the tag behind, and a
-        # stray v0.0.9 tag makes the next attempt fail preflight ("tag already
-        # exists on origin"). Harmless if the draft never created a tag.
-        print(
-            f"Aborted. The draft remains; delete with: gh release delete {args.tag} --cleanup-tag"
-        )
-        return 1
-
-    publish(args.tag)
+    change_notes = generated_change_notes(args.tag, head_sha, prev_tag)
+    diff = diff if report else Diff(markdown="Capability comparison skipped.")
+    notes = build_public_notes(
+        tag=args.tag,
+        sha=head_sha,
+        prev_tag=prev_tag,
+        diff=diff,
+        change_notes=change_notes,
+        pipeline_url="Local emergency fallback; no private CI evidence URL.",
+        distributions=[
+            {"path": str(path), "sha256": sha256(path)}
+            for path in sorted((REPO / "dist").iterdir())
+            if path.is_file()
+        ],
+    )
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
+        fh.write(notes)
+        notes_path = Path(fh.name)
+    try:
+        url, _release_id = create_or_update_draft(args.tag, head_sha, notes_path)
+    finally:
+        notes_path.unlink(missing_ok=True)
+    print(f"\nReview {url}. Accept only by clicking GitHub's Publish release button.")
     return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        return ci_main(args) if args.ci else local_main(args)
+    except ReleaseError as exc:
+        print(f"\n{RED}✗ {exc}{RESET}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -378,12 +378,24 @@ def fast_checks(
 ) -> None:
     """Everything cheap, before spending money on LLM calls."""
     step("Fast checks (lint, headers, unit tests)")
-    for label, cmd in [
+    checks = [
         ("ruff lint", ["uv", "run", "ruff", "check", "."]),
         ("ruff format", ["uv", "run", "ruff", "format", "--check", "."]),
         ("license headers", ["uv", "run", "python", "scripts/check_license_headers.py"]),
         ("unit tests", ["uv", "run", "pytest", "-q", "-m", "not integration and not stress"]),
-    ]:
+    ]
+    if verify_containment:
+        # Match public CI exactly. The release clone starts without a virtual
+        # environment, and `uv run` alone does not install optional test extras.
+        checks.insert(
+            0,
+            (
+                "locked environment sync",
+                ["uv", "sync", "--frozen", "--all-extras", "--no-extra", "sandbox"],
+            ),
+        )
+
+    for label, cmd in checks:
         proc = run(cmd, check=False)
         if proc.returncode != 0:
             if manifest:

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -64,6 +64,7 @@ REPORT_PATH = REPO / "tmp" / "release-check" / "capability-report.md"
 GITHUB_REPO = "NVIDIA-NeMo/labs-OO-Agents"
 TAG_RE = re.compile(r"^v(?P<version>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))$")
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+PR_REF_RE = re.compile(r"^refs/pull/[1-9]\d*/head$")
 
 # CI bounds are deliberately explicit. The eval runner checkpoints every
 # completed result to JSONL, so an overall timeout still leaves useful evidence.
@@ -179,6 +180,12 @@ def validate_candidate_sha(sha: str) -> str:
     return sha
 
 
+def validate_candidate_ref(ref: str) -> str:
+    if not PR_REF_RE.fullmatch(ref):
+        die("candidate ref must be a canonical refs/pull/<number>/head ref")
+    return ref
+
+
 def validate_https_url(value: str, label: str) -> str:
     if not re.fullmatch(r"https://[A-Za-z0-9.-]+/[^\s]+", value) or "@" in value:
         die(f"{label} must be an HTTPS URL without embedded credentials")
@@ -292,6 +299,7 @@ def preflight(
     *,
     candidate_sha: str | None = None,
     ci: bool = False,
+    allow_unmerged_candidate: bool = False,
 ) -> tuple[str, str, str, dict[str, Any] | None]:
     """Validate repo state. Returns (head_sha, previous_version_tag)."""
     step(f"Preflight for {tag}")
@@ -328,12 +336,18 @@ def preflight(
         exists = run(["git", "cat-file", "-e", f"{candidate_sha}^{{commit}}"], check=False)
         if exists.returncode != 0:
             die(f"candidate {candidate_sha} does not exist in the fetched public repository")
-        reachable = run(["git", "merge-base", "--is-ancestor", candidate_sha, remote], check=False)
-        if reachable.returncode != 0:
-            die(f"candidate {candidate_sha} is not reachable from GitHub main ({remote})")
-        ok(f"frozen candidate is reachable from current GitHub main ({remote[:12]})")
-        existing_release = validate_existing_release(tag, candidate_sha)
-        ok(f"{tag} has a matching reusable draft" if existing_release else f"{tag} is unused")
+        if allow_unmerged_candidate:
+            existing_release = None
+            ok(f"frozen unmerged rehearsal candidate: {candidate_sha[:12]}")
+        else:
+            reachable = run(
+                ["git", "merge-base", "--is-ancestor", candidate_sha, remote], check=False
+            )
+            if reachable.returncode != 0:
+                die(f"candidate {candidate_sha} is not reachable from GitHub main ({remote})")
+            ok(f"frozen candidate is reachable from current GitHub main ({remote[:12]})")
+            existing_release = validate_existing_release(tag, candidate_sha)
+            ok(f"{tag} has a matching reusable draft" if existing_release else f"{tag} is unused")
     else:
         if head != remote:
             die("HEAD differs from origin/main — push or pull first")
@@ -1403,6 +1417,11 @@ def _parser() -> argparse.ArgumentParser:
         help="strict, noninteractive CI mode (never discovers ambient extras or copies .env)",
     )
     parser.add_argument("--candidate-sha", help="exact 40-character public candidate SHA")
+    parser.add_argument(
+        "--candidate-ref",
+        default="",
+        help="canonical refs/pull/<number>/head ref authenticated by the private controller",
+    )
     parser.add_argument("--internal-wheel", type=Path, help="explicit internal model-alias wheel")
     parser.add_argument("--controller-sha", help="exact nooa-dev commit that built the wheel")
     parser.add_argument("--artifact-dir", type=Path, help="private CI evidence output directory")
@@ -1474,9 +1493,25 @@ def ci_main(args: argparse.Namespace) -> int:
         die("--internal-wheel must be the nemo-oo-agents-nvidia wheel")
     if args.artifact_dir is None:
         die("--ci requires --artifact-dir")
+    candidate_ref = validate_candidate_ref(args.candidate_ref) if args.candidate_ref else None
+    unmerged_candidate = candidate_ref is not None
+    models = args.models.split(",") if args.models else GATE_MODELS
+    if any(not model.strip() for model in models):
+        die("--models contains an empty alias")
+    rehearsal = bool(args.limit) or args.runs != GATE_RUNS or models != GATE_MODELS
+    if args.runs < 1 or (args.limit is not None and args.limit < 1):
+        die("--runs and --limit must be positive")
+    if rehearsal and args.create_draft:
+        die("a reduced rehearsal can never create a draft")
+    if unmerged_candidate and not rehearsal:
+        die("--candidate-ref requires a reduced rehearsal")
+    if unmerged_candidate and args.create_draft:
+        die("an unmerged candidate can never create a draft")
+    if args.checks_only and args.create_draft:
+        die("--checks-only can never be combined with --create-draft")
     if not os.getenv("NVIDIA_INTERNAL_API_KEY"):
         die("NVIDIA_INTERNAL_API_KEY is required for the live capability gate")
-    if not os.getenv("GH_TOKEN"):
+    if not unmerged_candidate and not os.getenv("GH_TOKEN"):
         die("GH_TOKEN is required in CI to inspect and reconcile release state")
     validate_https_url(args.pipeline_url, "pipeline URL")
     validate_https_url(args.job_url, "job URL")
@@ -1499,6 +1534,10 @@ def ci_main(args: argparse.Namespace) -> int:
             "status": "running",
             "requested_version": args.tag,
             "candidate_sha": candidate_sha,
+            "candidate_ref": candidate_ref,
+            "candidate_source": (
+                "canonical_github_pull_ref" if unmerged_candidate else "github_main"
+            ),
             "nooa_dev_sha": controller_sha,
             "internal_model_wheel": {
                 "filename": internal_wheel.name,
@@ -1515,19 +1554,12 @@ def ci_main(args: argparse.Namespace) -> int:
     manifest.write()
     try:
         manifest.update(environment=tool_versions(args.image_digest))
-        models = args.models.split(",") if args.models else GATE_MODELS
-        if any(not model.strip() for model in models):
-            die("--models contains an empty alias")
-        rehearsal = bool(args.limit) or args.runs != GATE_RUNS or models != GATE_MODELS
-        if args.runs < 1 or (args.limit is not None and args.limit < 1):
-            die("--runs and --limit must be positive")
-        if rehearsal and args.create_draft:
-            die("a reduced rehearsal can never create a draft")
-        if args.checks_only and args.create_draft:
-            die("--checks-only can never be combined with --create-draft")
-
         head_sha, prev_tag, prev_sha, existing = preflight(
-            args.tag, False, candidate_sha=candidate_sha, ci=True
+            args.tag,
+            False,
+            candidate_sha=candidate_sha,
+            ci=True,
+            allow_unmerged_candidate=unmerged_candidate,
         )
         manifest.update(
             previous_release_tag=prev_tag,
@@ -1621,7 +1653,11 @@ def ci_main(args: argparse.Namespace) -> int:
             )
         else:
             warn("checks-only CI run complete; GitHub draft creation was disabled")
-        manifest.update(status="passed", rehearsal=rehearsal)
+        manifest.update(
+            status="passed",
+            rehearsal=rehearsal,
+            unmerged_candidate=unmerged_candidate,
+        )
         _write_job_summary(artifact_dir, manifest)
         return 0
     except ReleaseError as exc:
@@ -1632,7 +1668,13 @@ def ci_main(args: argparse.Namespace) -> int:
 
 
 def local_main(args: argparse.Namespace) -> int:
-    if args.create_draft or args.candidate_sha or args.internal_wheel or args.artifact_dir:
+    if (
+        args.create_draft
+        or args.candidate_sha
+        or args.candidate_ref
+        or args.internal_wheel
+        or args.artifact_dir
+    ):
         die("CI-only arguments require --ci")
 
     models = args.models.split(",") if args.models else GATE_MODELS

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -149,7 +149,13 @@ def run(
 
 
 def git(*args: str, cwd: Path | None = None, check: bool = True) -> str:
-    return run(["git", *args], cwd=cwd, check=check).stdout.strip()
+    proc = run(["git", *args], cwd=cwd, check=check)
+    # Some Git commands echo an unresolved argument to stdout on failure.
+    # Callers using check=False treat an empty result as "not found", so never
+    # let diagnostic stdout masquerade as a resolved ref or tag.
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
 
 
 def confirm(prompt: str) -> bool:

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -1308,6 +1308,17 @@ def generated_change_notes(tag: str, sha: str, prev_tag: str) -> str:
         die("GitHub returned invalid generated release notes")
 
 
+def local_change_notes(sha: str, prev_tag: str) -> str:
+    """Generate rehearsal-only notes without requiring GitHub credentials."""
+    proc = run(
+        ["git", "log", "--format=- %s (`%h`)", f"{prev_tag}..{sha}"],
+        check=False,
+    )
+    if proc.returncode != 0:
+        die(f"could not generate local rehearsal change notes: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
 def build_public_notes(
     *,
     tag: str,
@@ -1649,7 +1660,11 @@ def ci_main(args: argparse.Namespace) -> int:
         if diff.floor_breach:
             die(f"capability hard gate failed: {diff.floor_breach}")
 
-        change_notes = generated_change_notes(args.tag, head_sha, prev_tag)
+        change_notes = (
+            local_change_notes(head_sha, prev_tag)
+            if unmerged_candidate
+            else generated_change_notes(args.tag, head_sha, prev_tag)
+        )
         notes = build_public_notes(
             tag=args.tag,
             sha=head_sha,

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -285,6 +285,9 @@ def tool_versions(image_digest: str | None) -> dict[str, str]:
         "make": ["make", "--version"],
         "gh": ["gh", "--version"],
     }.items():
+        if shutil.which(cmd[0]) is None:
+            versions[name] = "unavailable"
+            continue
         proc = run(cmd, check=False)
         versions[name] = (
             (proc.stdout or proc.stderr).splitlines()[0].strip()
@@ -307,7 +310,11 @@ def preflight(
     ci: bool = False,
     allow_unmerged_candidate: bool = False,
 ) -> tuple[str, str, str, dict[str, Any] | None]:
-    """Validate repo state. Returns (head_sha, previous_version_tag)."""
+    """Validate repo state.
+
+    Returns (head_sha, previous_version_tag, previous_version_sha,
+    existing_draft_release_or_None).
+    """
     step(f"Preflight for {tag}")
 
     validate_tag(tag)
@@ -1328,11 +1335,17 @@ def build_public_notes(
     change_notes: str,
     pipeline_url: str,
     distributions: list[dict[str, str]],
+    capability_gate_ran: bool,
 ) -> str:
     advisory_count = (
         len(diff.regressions) + len(diff.new_errors) + len(diff.beyond_noise) + len(diff.removed)
     )
-    verdict = "PASS — all automated hard gates passed"
+    if not capability_gate_ran:
+        verdict = "NOT RUN — the capability gate was skipped for this candidate"
+    elif diff.hard_gate_passed:
+        verdict = "PASS — all automated hard gates passed"
+    else:
+        verdict = f"FAIL — {diff.floor_breach}"
     checksum_lines = [
         f"- `{Path(item['path']).name}` — `{item['sha256']}`" for item in distributions
     ]
@@ -1673,6 +1686,7 @@ def ci_main(args: argparse.Namespace) -> int:
             change_notes=change_notes,
             pipeline_url=args.pipeline_url,
             distributions=distributions,
+            capability_gate_ran=True,
         )
         notes_path = artifact_dir / "public-release-notes.md"
         notes_path.write_text(notes)
@@ -1762,6 +1776,7 @@ def local_main(args: argparse.Namespace) -> int:
             for path in sorted((REPO / "dist").iterdir())
             if path.is_file()
         ],
+        capability_gate_ran=not args.skip_capability,
     )
     with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
         fh.write(notes)

--- a/tests/test_make_release.py
+++ b/tests/test_make_release.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from collections.abc import Sequence
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -248,3 +250,366 @@ def test_markdown_report_has_the_expected_sections(mr, tmp_path):
     for section in ("Per-tier breakdown", "Per-test breakdown", "| Tests Passed |", "Total Tokens"):
         assert section in md
     assert md.rstrip().endswith("*2 models × 3 runs* | *both arms run fresh*")
+
+
+@pytest.mark.parametrize(
+    "tag",
+    ["0.0.10", "v1.2", "v01.2.3", "v1.02.3", "v1.2.03", "v1.2.3-rc1", "v1.2.3;bad"],
+)
+def test_release_tag_validation_fails_closed(mr, tag):
+    with pytest.raises(mr.ReleaseError):
+        mr.validate_tag(tag)
+
+
+def test_exact_sha_validation(mr):
+    sha = "a" * 40
+    assert mr.validate_candidate_sha(sha) == sha
+    for invalid in ("a" * 39, "A" * 40, "g" * 40, "a" * 40 + ";echo"):
+        with pytest.raises(mr.ReleaseError):
+            mr.validate_candidate_sha(invalid)
+
+
+def test_ci_candidate_remains_valid_when_main_advances(mr, monkeypatch):
+    candidate = "1" * 40
+    advanced_main = "2" * 40
+    previous = "3" * 40
+
+    def fake_git(*args, **_kwargs):
+        if args == ("rev-parse", "--abbrev-ref", "HEAD"):
+            return "HEAD"
+        if args == ("status", "--porcelain"):
+            return ""
+        if args == ("rev-parse", "HEAD"):
+            return candidate
+        if args == ("rev-parse", "origin/main"):
+            return advanced_main
+        if args[0] == "describe":
+            return "v0.0.9"
+        if args == ("rev-parse", "v0.0.9^{commit}"):
+            return previous
+        raise AssertionError(args)
+
+    commands = []
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(mr, "git", fake_git)
+    monkeypatch.setattr(mr, "run", fake_run)
+    monkeypatch.setattr(mr, "validate_existing_release", lambda *_args: None)
+
+    head, _tag, _prev, _release = mr.preflight("v0.0.10", False, candidate_sha=candidate, ci=True)
+
+    assert head == candidate
+    assert ["git", "merge-base", "--is-ancestor", candidate, advanced_main] in commands
+
+
+def test_existing_release_must_be_matching_unpublished_draft(mr, monkeypatch):
+    sha = "a" * 40
+    monkeypatch.setattr(
+        mr, "run", lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "", "")
+    )
+    monkeypatch.setattr(
+        mr, "release_for_tag", lambda _tag: {"draft": True, "target_commitish": sha}
+    )
+    assert mr.validate_existing_release("v1.2.3", sha)["draft"]
+
+    monkeypatch.setattr(
+        mr, "release_for_tag", lambda _tag: {"draft": False, "target_commitish": sha}
+    )
+    with pytest.raises(mr.ReleaseError, match="already published"):
+        mr.validate_existing_release("v1.2.3", sha)
+
+    monkeypatch.setattr(
+        mr, "release_for_tag", lambda _tag: {"draft": True, "target_commitish": "b" * 40}
+    )
+    with pytest.raises(mr.ReleaseError, match="not frozen candidate"):
+        mr.validate_existing_release("v1.2.3", sha)
+
+
+def test_strict_arm_uses_explicit_wheel_without_env_or_ambient_extras(mr, tmp_path, monkeypatch):
+    tree = tmp_path / "tree"
+    tree.mkdir()
+    (tree / "uv.lock").write_text("locked")
+    wheel = tmp_path / "nemo_oo_agents_nvidia-0.1.0-py3-none-any.whl"
+    wheel.write_bytes(b"wheel")
+    output_root = tmp_path / "evidence"
+    commands = []
+    eval_env = None
+
+    def forbidden_extras():
+        raise AssertionError("strict CI must not inspect the ambient environment")
+
+    def fake_run(cmd, **kwargs):
+        nonlocal eval_env
+        commands.append(cmd)
+        if "eval_pipeline" in cmd:
+            eval_env = kwargs["env"]
+            result_dir = output_root / "candidate" / "run"
+            result_dir.mkdir(parents=True)
+            write_eval(
+                result_dir / "result.noo-eval.jsonl",
+                [("model-a", "test-a", "case-a", "stable", True, None)],
+            )
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(mr, "run", fake_run)
+    monkeypatch.setattr(mr, "env_extras", forbidden_extras)
+    monkeypatch.setenv("OTLP_ENDPOINT", "https://viewer.invalid/v1/traces")
+
+    arm = mr.run_capability_arm(
+        tree,
+        "candidate",
+        "candidate",
+        ["model-a"],
+        1,
+        1,
+        strict_ci=True,
+        internal_wheel=wheel,
+        output_root=output_root,
+        sample_timeout=10,
+        hang_timeout=20,
+        overall_timeout=30,
+    )
+
+    assert arm.counts() == (1, 1)
+    assert ["uv", "sync", "--frozen", "--all-extras", "--no-extra", "sandbox"] in commands
+    assert any(str(wheel) in cmd and "pip" in cmd for cmd in commands)
+    eval_cmd = next(cmd for cmd in commands if "eval_pipeline" in cmd)
+    assert "--no-cache" in eval_cmd and "--trace-files" in eval_cmd
+    assert "--timeout" in eval_cmd and "--hang-timeout" in eval_cmd
+    assert "OTLP_ENDPOINT" not in eval_env
+    assert not (tree / ".env").exists()
+
+
+def test_strict_capability_installs_same_wheel_in_both_fresh_arms(mr, tmp_path, monkeypatch):
+    wheel = tmp_path / "nemo_oo_agents_nvidia-0.1.0-py3-none-any.whl"
+    wheel.write_bytes(b"wheel")
+    calls = []
+
+    @contextmanager
+    def fake_worktree(ref):
+        tree = tmp_path / ref.replace("/", "_")
+        tree.mkdir(exist_ok=True)
+        yield tree
+
+    def fake_arm(tree, label, cache_key, models, runs, limit, **kwargs):
+        calls.append((tree, kwargs["internal_wheel"], kwargs["strict_ci"]))
+        arm = mr.ArmResults(label)
+        arm.by_case["case"] = [True]
+        arm.case_tier["case"] = "stable"
+        arm.by_test[(models[0], "test")] = [True]
+        arm.lock_sha256 = "f" * 64
+        return arm
+
+    monkeypatch.setattr(mr, "worktree_at", fake_worktree)
+    monkeypatch.setattr(mr, "run_capability_arm", fake_arm)
+    diff, _base, _head = mr.capability_diff(
+        "v0.0.9",
+        "a" * 40,
+        ["model-a"],
+        1,
+        1,
+        strict_ci=True,
+        internal_wheel=wheel,
+        artifact_dir=tmp_path / "artifacts",
+    )
+
+    assert diff.hard_gate_passed
+    assert len(calls) == 2
+    assert all(call[1:] == (wheel, True) for call in calls)
+    assert calls[0][0] != calls[1][0]
+
+
+def test_advisories_do_not_become_hard_gate_failures(mr):
+    diff = mr.Diff(regressions=["collapse"], beyond_noise=["overall -6 pts"])
+    assert not diff.clean
+    assert diff.hard_gate_passed
+    diff.floor_breach = "stable floor"
+    assert not diff.hard_gate_passed
+
+
+@pytest.mark.parametrize("existing", [None, {"id": 7, "draft": True}])
+def test_draft_command_targets_full_sha_and_is_idempotent(mr, tmp_path, monkeypatch, existing):
+    sha = "a" * 40
+    notes = tmp_path / "notes.md"
+    notes.write_text("safe")
+    commands = []
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(mr, "run", fake_run)
+    release = {
+        "id": 7,
+        "draft": True,
+        "target_commitish": sha,
+        "html_url": "https://draft",
+    }
+    responses = iter([existing, release])
+    monkeypatch.setattr(mr, "validate_existing_release", lambda *_args: next(responses))
+    url, release_id = mr.create_or_update_draft("v1.2.3", sha, notes)
+
+    cmd = commands[0]
+    assert cmd[:3] == ["gh", "release", "edit" if existing else "create"]
+    assert cmd[cmd.index("--target") + 1] == sha
+    assert "--draft" in cmd
+    assert not any("draft=false" in part for part in cmd)
+    assert (url, release_id) == ("https://draft", 7)
+
+
+def test_draft_is_rechecked_before_mutation(mr, tmp_path, monkeypatch):
+    notes = tmp_path / "notes.md"
+    notes.write_text("safe")
+    commands = []
+    monkeypatch.setattr(
+        mr,
+        "validate_existing_release",
+        lambda *_args: (_ for _ in ()).throw(mr.ReleaseError("already published")),
+    )
+    monkeypatch.setattr(mr, "run", lambda cmd, **_kwargs: commands.append(cmd))
+    with pytest.raises(mr.ReleaseError, match="already published"):
+        mr.create_or_update_draft("v1.2.3", "a" * 40, notes)
+    assert commands == []
+
+
+def test_public_report_sanitization(mr):
+    unsafe = (
+        "api_key=supersecret\nAuthorization: Bearer-token\n"
+        "https://alice:password@internal.example/path\n/home/alice/private/trace.jsonl\n"
+    )
+    safe = mr.sanitize_public_text(unsafe)
+    assert "supersecret" not in safe
+    assert "Bearer-token" not in safe
+    assert "alice:password" not in safe
+    assert "/home/alice" not in safe
+    assert "[REDACTED]" in safe and "[private-path]" in safe
+
+
+def _ci_args(mr, tmp_path):
+    wheel = tmp_path / "nemo_oo_agents_nvidia-0.1.0-py3-none-any.whl"
+    wheel.write_bytes(b"wheel")
+    return mr._parser().parse_args(
+        [
+            "v1.2.3",
+            "--ci",
+            "--candidate-sha",
+            "a" * 40,
+            "--controller-sha",
+            "b" * 40,
+            "--internal-wheel",
+            str(wheel),
+            "--artifact-dir",
+            str(tmp_path / "artifacts"),
+            "--pipeline-url",
+            "https://gitlab.example/pipelines/1",
+            "--job-url",
+            "https://gitlab.example/jobs/2",
+            "--image-digest",
+            "registry.example/release@sha256:" + "c" * 64,
+            "--create-draft",
+        ]
+    )
+
+
+@pytest.mark.parametrize("failure_point", ["deterministic", "infrastructure", "hard-gate"])
+def test_ci_never_creates_draft_after_gate_failure(mr, tmp_path, monkeypatch, failure_point):
+    args = _ci_args(mr, tmp_path)
+    monkeypatch.setenv("NVIDIA_INTERNAL_API_KEY", "masked")
+    monkeypatch.setenv("GH_TOKEN", "masked")
+    monkeypatch.setattr(mr, "tool_versions", lambda _image: {})
+    monkeypatch.setattr(
+        mr,
+        "preflight",
+        lambda *_args, **_kwargs: ("a" * 40, "v1.2.2", "d" * 40, None),
+    )
+    monkeypatch.setattr(mr, "sha256", lambda _path: "e" * 64)
+    monkeypatch.setattr(mr, "build_and_smoke", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(mr, "_copy_distributions", lambda _path: [])
+    draft_calls = []
+    monkeypatch.setattr(mr, "create_or_update_draft", lambda *_args: draft_calls.append(True))
+
+    if failure_point == "deterministic":
+        monkeypatch.setattr(
+            mr,
+            "fast_checks",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(mr.ReleaseError("lint")),
+        )
+    else:
+        monkeypatch.setattr(mr, "fast_checks", lambda *_args, **_kwargs: None)
+        if failure_point == "infrastructure":
+            monkeypatch.setattr(
+                mr,
+                "capability_diff",
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(mr.ReleaseError("endpoint")),
+            )
+        else:
+            base = mr.ArmResults("base")
+            head = mr.ArmResults("head")
+            blocked = mr.Diff(floor_breach="stable floor", markdown="blocked")
+            monkeypatch.setattr(
+                mr, "capability_diff", lambda *_args, **_kwargs: (blocked, base, head)
+            )
+
+    with pytest.raises(mr.ReleaseError):
+        mr.ci_main(args)
+    assert draft_calls == []
+    manifest = json.loads((tmp_path / "artifacts" / "release-manifest.json").read_text())
+    assert manifest["status"] == "failed"
+
+
+def test_noninteractive_ci_drafts_when_only_advisories_exist(mr, tmp_path, monkeypatch):
+    args = _ci_args(mr, tmp_path)
+    monkeypatch.setenv("NVIDIA_INTERNAL_API_KEY", "masked")
+    monkeypatch.setenv("GH_TOKEN", "masked")
+    monkeypatch.setattr(mr, "tool_versions", lambda _image: {})
+    monkeypatch.setattr(
+        mr,
+        "preflight",
+        lambda *_args, **_kwargs: ("a" * 40, "v1.2.2", "d" * 40, None),
+    )
+    monkeypatch.setattr(mr, "sha256", lambda _path: "e" * 64)
+    monkeypatch.setattr(mr, "fast_checks", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mr, "build_and_smoke", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(mr, "_copy_distributions", lambda _path: [])
+    base = mr.ArmResults("base")
+    head = mr.ArmResults("head")
+    for arm in (base, head):
+        arm.by_case["case"] = [True]
+        arm.case_tier["case"] = "stable"
+        arm.by_test[("model", "test")] = [True]
+        arm.lock_sha256 = "f" * 64
+    advisory = mr.Diff(regressions=["collapse"], markdown="advisory report")
+    monkeypatch.setattr(mr, "capability_diff", lambda *_args, **_kwargs: (advisory, base, head))
+    monkeypatch.setattr(mr, "generated_change_notes", lambda *_args: "changes")
+    draft_calls = []
+
+    def fake_draft(*call_args):
+        draft_calls.append(call_args)
+        return "https://github.example/draft", 42
+
+    monkeypatch.setattr(mr, "create_or_update_draft", fake_draft)
+
+    assert mr.ci_main(args) == 0
+    assert len(draft_calls) == 1
+    manifest = json.loads((tmp_path / "artifacts" / "release-manifest.json").read_text())
+    assert manifest["status"] == "passed"
+    assert manifest["capability"]["hard_gate_outcome"] == "passed"
+    assert manifest["capability"]["advisory"]["collapses"] == ["collapse"]
+    assert manifest["github_release_database_id"] == 42
+
+
+def test_release_runner_contains_no_publish_operation(mr):
+    source = (REPO / "scripts/make_release.py").read_text()
+    assert "--draft=false" not in source
+    assert "def publish(" not in source
+
+
+def test_existing_publication_workflow_still_uses_published_release_trigger():
+    workflow = (REPO / ".github/workflows/publish.yml").read_text()
+    assert "release:" in workflow
+    assert "types: [published]" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "if: github.event_name == 'release'" in workflow

--- a/tests/test_make_release.py
+++ b/tests/test_make_release.py
@@ -269,6 +269,15 @@ def test_exact_sha_validation(mr):
             mr.validate_candidate_sha(invalid)
 
 
+@pytest.mark.parametrize(
+    "candidate_ref",
+    ["refs/heads/topic", "refs/pull/0/head", "refs/pull/163/merge", "refs/pull/1/head:evil"],
+)
+def test_candidate_ref_validation_is_limited_to_pull_heads(mr, candidate_ref):
+    with pytest.raises(mr.ReleaseError):
+        mr.validate_candidate_ref(candidate_ref)
+
+
 def test_ci_candidate_remains_valid_when_main_advances(mr, monkeypatch):
     candidate = "1" * 40
     advanced_main = "2" * 40
@@ -303,6 +312,53 @@ def test_ci_candidate_remains_valid_when_main_advances(mr, monkeypatch):
 
     assert head == candidate
     assert ["git", "merge-base", "--is-ancestor", candidate, advanced_main] in commands
+
+
+def test_ci_unmerged_rehearsal_skips_only_main_reachability(mr, monkeypatch):
+    candidate = "1" * 40
+    advanced_main = "2" * 40
+    previous = "3" * 40
+
+    def fake_git(*args, **_kwargs):
+        if args == ("rev-parse", "--abbrev-ref", "HEAD"):
+            return "HEAD"
+        if args == ("status", "--porcelain"):
+            return ""
+        if args == ("rev-parse", "HEAD"):
+            return candidate
+        if args == ("rev-parse", "origin/main"):
+            return advanced_main
+        if args[0] == "describe":
+            return "v0.0.9"
+        if args == ("rev-parse", "v0.0.9^{commit}"):
+            return previous
+        raise AssertionError(args)
+
+    commands = []
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(mr, "git", fake_git)
+    monkeypatch.setattr(mr, "run", fake_run)
+    monkeypatch.setattr(
+        mr,
+        "validate_existing_release",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("release state is production-only")),
+    )
+
+    head, _tag, _prev, existing = mr.preflight(
+        "v0.0.10",
+        False,
+        candidate_sha=candidate,
+        ci=True,
+        allow_unmerged_candidate=True,
+    )
+
+    assert head == candidate
+    assert existing is None
+    assert not any("merge-base" in command for command in commands)
 
 
 def test_existing_release_must_be_matching_unpublished_draft(mr, monkeypatch):
@@ -512,6 +568,45 @@ def _ci_args(mr, tmp_path):
             "--create-draft",
         ]
     )
+
+
+def test_unmerged_candidate_requires_reduced_scope_and_never_drafts(mr, tmp_path, monkeypatch):
+    args = _ci_args(mr, tmp_path)
+    args.candidate_ref = "refs/pull/163/head"
+    args.create_draft = False
+    monkeypatch.setenv("NVIDIA_INTERNAL_API_KEY", "disposable-test-key")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    with pytest.raises(mr.ReleaseError, match="requires a reduced rehearsal"):
+        mr.ci_main(args)
+
+    args.models = "claude-haiku"
+    args.runs = 1
+    args.limit = 1
+    args.create_draft = True
+    with pytest.raises(mr.ReleaseError, match="can never create a draft"):
+        mr.ci_main(args)
+
+
+def test_unmerged_rehearsal_does_not_require_github_token(mr, tmp_path, monkeypatch):
+    args = _ci_args(mr, tmp_path)
+    args.candidate_ref = "refs/pull/163/head"
+    args.create_draft = False
+    args.models = "claude-haiku"
+    args.runs = 1
+    args.limit = 1
+    monkeypatch.setenv("NVIDIA_INTERNAL_API_KEY", "disposable-test-key")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr(mr, "tool_versions", lambda _image: {})
+    monkeypatch.setattr(mr, "sha256", lambda _path: "e" * 64)
+    monkeypatch.setattr(
+        mr,
+        "preflight",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(mr.ReleaseError("reached preflight")),
+    )
+
+    with pytest.raises(mr.ReleaseError, match="reached preflight"):
+        mr.ci_main(args)
 
 
 @pytest.mark.parametrize("failure_point", ["deterministic", "infrastructure", "hard-gate"])

--- a/tests/test_make_release.py
+++ b/tests/test_make_release.py
@@ -637,11 +637,31 @@ def test_unmerged_rehearsal_does_not_require_github_token(mr, tmp_path, monkeypa
     monkeypatch.setattr(
         mr,
         "preflight",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(mr.ReleaseError("reached preflight")),
+        lambda *_args, **_kwargs: ("a" * 40, "v1.2.2", "d" * 40, None),
+    )
+    monkeypatch.setattr(mr, "fast_checks", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mr, "build_and_smoke", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(mr, "_copy_distributions", lambda _path: [])
+    base = mr.ArmResults("base")
+    head = mr.ArmResults("head")
+    for arm in (base, head):
+        arm.by_case["case"] = [True]
+        arm.case_tier["case"] = "stable"
+        arm.by_test[("model", "test")] = [True]
+        arm.lock_sha256 = "f" * 64
+    clean = mr.Diff(markdown="clean")
+    monkeypatch.setattr(mr, "capability_diff", lambda *_args, **_kwargs: (clean, base, head))
+    monkeypatch.setattr(mr, "local_change_notes", lambda *_args: "local changes")
+    monkeypatch.setattr(
+        mr,
+        "generated_change_notes",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("unmerged rehearsal called GitHub")),
     )
 
-    with pytest.raises(mr.ReleaseError, match="reached preflight"):
-        mr.ci_main(args)
+    assert mr.ci_main(args) == 0
+    manifest = json.loads((tmp_path / "artifacts" / "release-manifest.json").read_text())
+    assert manifest["status"] == "passed"
+    assert manifest["unmerged_candidate"] is True
 
 
 @pytest.mark.parametrize("failure_point", ["deterministic", "infrastructure", "hard-gate"])

--- a/tests/test_make_release.py
+++ b/tests/test_make_release.py
@@ -269,6 +269,17 @@ def test_exact_sha_validation(mr):
             mr.validate_candidate_sha(invalid)
 
 
+def test_git_returns_empty_when_an_allowed_failure_echoes_the_unresolved_ref(mr, monkeypatch):
+    unresolved = "refs/tags/v0.0.10^{commit}"
+    monkeypatch.setattr(
+        mr,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 128, unresolved + "\n", ""),
+    )
+
+    assert mr.git("rev-parse", unresolved, check=False) == ""
+
+
 @pytest.mark.parametrize(
     "candidate_ref",
     ["refs/heads/topic", "refs/pull/0/head", "refs/pull/163/merge", "refs/pull/1/head:evil"],

--- a/tests/test_make_release.py
+++ b/tests/test_make_release.py
@@ -280,6 +280,23 @@ def test_git_returns_empty_when_an_allowed_failure_echoes_the_unresolved_ref(mr,
     assert mr.git("rev-parse", unresolved, check=False) == ""
 
 
+def test_tool_versions_records_missing_diagnostic_tools(mr, monkeypatch):
+    monkeypatch.setattr(mr.shutil, "which", lambda _executable: None)
+    monkeypatch.setattr(
+        mr,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("missing diagnostic tool was executed")
+        ),
+    )
+
+    versions = mr.tool_versions("release-image@sha256:digest")
+
+    assert versions["runner_image"] == "release-image@sha256:digest"
+    for tool in ("uv", "git", "rg", "sha256sum", "base64", "curl", "gcc", "make", "gh"):
+        assert versions[tool] == "unavailable"
+
+
 @pytest.mark.parametrize(
     "candidate_ref",
     ["refs/heads/topic", "refs/pull/0/head", "refs/pull/163/merge", "refs/pull/1/head:evil"],
@@ -577,6 +594,32 @@ def test_public_report_sanitization(mr):
     assert "alice:password" not in safe
     assert "/home/alice" not in safe
     assert "[REDACTED]" in safe and "[private-path]" in safe
+
+
+@pytest.mark.parametrize(
+    ("capability_gate_ran", "diff", "expected", "unexpected"),
+    [
+        (False, None, "NOT RUN — the capability gate was skipped", "PASS"),
+        (True, None, "PASS — all automated hard gates passed", "NOT RUN"),
+        (True, "stable floor", "FAIL — stable floor", "PASS"),
+    ],
+)
+def test_public_notes_report_the_actual_capability_gate_state(
+    mr, capability_gate_ran, diff, expected, unexpected
+):
+    notes = mr.build_public_notes(
+        tag="v1.2.3",
+        sha="a" * 40,
+        prev_tag="v1.2.2",
+        diff=mr.Diff(floor_breach=diff, markdown="capability report"),
+        change_notes="changes",
+        pipeline_url="https://gitlab.example/pipelines/1",
+        distributions=[],
+        capability_gate_ran=capability_gate_ran,
+    )
+
+    assert expected in notes
+    assert unexpected not in notes
 
 
 def _ci_args(mr, tmp_path):

--- a/tests/test_make_release.py
+++ b/tests/test_make_release.py
@@ -384,6 +384,30 @@ def test_existing_release_must_be_matching_unpublished_draft(mr, monkeypatch):
         mr.validate_existing_release("v1.2.3", sha)
 
 
+def test_strict_fast_checks_sync_all_public_ci_dependencies_first(mr, monkeypatch):
+    commands = []
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(mr, "run", fake_run)
+
+    mr.fast_checks(verify_containment=True)
+
+    assert commands[0] == [
+        "uv",
+        "sync",
+        "--frozen",
+        "--all-extras",
+        "--no-extra",
+        "sandbox",
+    ]
+    assert commands.index(["uv", "run", "ruff", "check", "."]) < commands.index(
+        ["uv", "run", "pytest", "-q", "-m", "not integration and not stress"]
+    )
+
+
 def test_strict_arm_uses_explicit_wheel_without_env_or_ambient_extras(mr, tmp_path, monkeypatch):
     tree = tmp_path / "tree"
     tree.mkdir()


### PR DESCRIPTION
## Summary
- add a strict, noninteractive release gate with exact-SHA validation
- allow draft-free pre-merge rehearsals against an authenticated GitHub pull ref
- run fresh capability arms with the explicit internal model wheel

## Validation
- 41 focused release tests pass
- Ruff, formatting, and SPDX checks pass