### PR TITLE
Speed up TUI startup 

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/__init__.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/__init__.py
@@ -2,11 +2,42 @@
 # SPDX-License-Identifier: Apache-2.0
 """Native terminal interface for NVIDIA Labs Object Oriented Agents (NOOA)."""
 
-from .agent import BaseTUIAgent, TUIAgent
-from .config import AgentConfig, Config, SummarizationConfig, TUIConfig
-from .console import TUIConsole
-from .input_handler import TUIInputHandler
-from .theme import CATPPUCCIN_THEME, COLORS
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .agent import BaseTUIAgent, TUIAgent
+    from .config import AgentConfig, Config, SummarizationConfig, TUIConfig
+    from .console import TUIConsole
+    from .input_handler import TUIInputHandler
+    from .theme import CATPPUCCIN_THEME, COLORS
+
+_EXPORTS = {
+    "BaseTUIAgent": ".agent",
+    "TUIAgent": ".agent",
+    "AgentConfig": ".config",
+    "Config": ".config",
+    "SummarizationConfig": ".config",
+    "TUIConfig": ".config",
+    "TUIConsole": ".console",
+    "TUIInputHandler": ".input_handler",
+    "CATPPUCCIN_THEME": ".theme",
+    "COLORS": ".theme",
+}
+
+
+def __getattr__(name: str):
+    """Lazy package exports keep ``import nooa_cli.tui.config`` lightweight."""
+    module_name = _EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    module = import_module(module_name, __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
 
 __all__ = [
     "AgentConfig",

--- a/packages/nooa-cli/src/nooa_cli/tui/bootstrap.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/bootstrap.py
@@ -335,15 +335,15 @@ async def bootstrap(
     from nooa.unifiedllm import FakeLLMClient
 
     if not isinstance(llm, FakeLLMClient):
-        from .health_check import probe_llm
+        from .health_check import HealthCheckResult
 
-        health = await probe_llm(llm)
-        if not health.ok:
-            messages.append(TextOutput(f"⚠️  {health.error_message}", "error"))
-            if health.fix_hint:
-                messages.append(TextOutput(health.fix_hint, "info"))
-            if health.blocking:
-                blocking_llm_health = health
+        blocking_llm_health = HealthCheckResult(
+            ok=False,
+            error_message=f"Checking LLM endpoint for model '{config.tui.default_model}'.",
+            fix_hint="Slash commands and !shell commands are available while the check runs.",
+            blocking=True,
+            pending=True,
+        )
 
     from nooa.storage.sqlite import SessionAlreadyActiveError
 
@@ -485,6 +485,13 @@ def build_startup_info(result: BootstrapResult) -> Output:
 
     config = result.config
     agent = result.agent
+    health = result.blocking_llm_health
+    if health is None:
+        llm_status = "ready"
+    elif getattr(health, "pending", False):
+        llm_status = "checking"
+    else:
+        llm_status = "unavailable"
     trace_dir: str | None = None
     if result.tracing_enabled and config.tui.trace_dir:
         from nooa.paths import get_project_dir
@@ -507,7 +514,8 @@ def build_startup_info(result: BootstrapResult) -> Output:
             if config.tui.agent_spec and not isinstance(agent, TUIAgent)
             else None
         ),
-        llm_ready=result.blocking_llm_health is None,
+        llm_ready=llm_status == "ready",
+        llm_status=llm_status,
     )
 
 

--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -498,6 +498,14 @@ class ModelCommand(Command):
         self.config.default_model = selected
         if self._registry is not None:
             self._registry.blocking_llm_health = None
+            startup_info = getattr(self._registry, "startup_info", None)
+            if startup_info is not None:
+                from nooa_cli.tui.session import _short_model_name
+
+                startup_info.model = selected
+                startup_info.short_model = _short_model_name(selected)
+                startup_info.llm_ready = True
+                startup_info.llm_status = "ready"
         try:
             settings_path = self._persist_tui_setting("default_model", selected)
         except Exception as e:

--- a/packages/nooa-cli/src/nooa_cli/tui/config.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/config.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field, field_validator
 if TYPE_CHECKING:
     from nooa.unifiedllm import CompletionClient
 
+
 # Default model — direct litellm-supported name. Override via config or --model.
 DEFAULT_MODEL = "claude-opus-4-8"
 

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -549,7 +549,8 @@ class TerminalFrontend:
         sapphire = COLORS["sapphire"]
         peach = COLORS["peach"]
 
-        if info.llm_ready:
+        llm_status = getattr(info, "llm_status", "ready" if info.llm_ready else "unavailable")
+        if llm_status in {"ready", "checking"}:
             title = f"[bold {COLORS['mauve']}]NOOA ready[/]"
         else:
             title = f"[bold {COLORS['red']}]NOOA — LLM unavailable[/]"

--- a/packages/nooa-cli/src/nooa_cli/tui/health_check.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/health_check.py
@@ -58,6 +58,9 @@ class HealthCheckResult:
     # user successfully changes models. Transient network/rate-limit failures
     # remain warnings so a real prompt may still succeed moments later.
     blocking: bool = False
+    # Startup can render before the real provider probe finishes. While pending,
+    # normal agent prompts stay blocked, but slash and shell commands remain usable.
+    pending: bool = False
 
 
 def _detect_provider(model: str) -> str | None:

--- a/packages/nooa-cli/src/nooa_cli/tui/output.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/output.py
@@ -147,6 +147,7 @@ class StartupInfo:
     trace_dir: str | None = None
     custom_agent: str | None = None
     llm_ready: bool = True
+    llm_status: str = "ready"
 
     def to_json(self) -> dict:
         return {
@@ -161,6 +162,7 @@ class StartupInfo:
             "trace_dir": self.trace_dir,
             "custom_agent": self.custom_agent,
             "llm_ready": self.llm_ready,
+            "llm_status": self.llm_status,
         }
 
 

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -557,6 +557,7 @@ class Session:
                 auto_connect_result = auto_connect_mcp()
                 if asyncio.iscoroutine(auto_connect_result):
                     self._fire_and_forget(auto_connect_result)
+            self._start_llm_health_check()
             await self._app.run_async()
         except (KeyboardInterrupt, EOFError):
             await self.frontend.render(
@@ -652,6 +653,72 @@ class Session:
 
         future = asyncio.run_coroutine_threadsafe(_render(), loop)
         await asyncio.wrap_future(future)
+
+    def _start_llm_health_check(self) -> None:
+        """Run the startup LLM probe without blocking first paint."""
+        health = getattr(self.registry, "blocking_llm_health", None)
+        if getattr(health, "pending", False) is not True:
+            return
+        self._set_llm_probe_status("probing LLM endpoint...")
+        llm = getattr(self.agent, "llm", None)
+        if llm is None:
+            self.registry.blocking_llm_health = None
+            self._set_llm_probe_status("")
+            self._invalidate_app()
+            return
+        model_at_start = getattr(llm, "model", None)
+
+        async def _probe() -> None:
+            from .health_check import probe_llm
+            from .output import TextOutput
+
+            result = await probe_llm(llm)
+            if getattr(self.agent, "llm", None) is not llm:
+                self._set_llm_probe_status("")
+                return
+            current_model = getattr(llm, "model", None)
+            if model_at_start is not None and current_model != model_at_start:
+                self._set_llm_probe_status("")
+                return
+            if result.ok:
+                self.registry.blocking_llm_health = None
+                startup_info = getattr(self.registry, "startup_info", None)
+                if startup_info is not None:
+                    startup_info.llm_ready = True
+                    startup_info.llm_status = "ready"
+                self._set_llm_probe_status("")
+                self._invalidate_app()
+                return
+
+            if result.blocking:
+                self.registry.blocking_llm_health = result
+            else:
+                self.registry.blocking_llm_health = None
+            startup_info = getattr(self.registry, "startup_info", None)
+            if startup_info is not None:
+                startup_info.llm_ready = not result.blocking
+                startup_info.llm_status = "unavailable" if result.blocking else "ready"
+            self._set_llm_probe_status("")
+            self._invalidate_app()
+
+            level = "error" if result.blocking else "warning"
+            await self.frontend.render(TextOutput(f"⚠️  {result.error_message}", level))
+            if result.fix_hint:
+                await self.frontend.render(TextOutput(result.fix_hint, "info"))
+
+        self._fire_and_forget(_probe())
+
+    def _invalidate_app(self) -> None:
+        app = getattr(self, "_app", None)
+        invalidate = getattr(app, "invalidate", None)
+        if callable(invalidate):
+            invalidate()
+
+    def _set_llm_probe_status(self, text: str) -> None:
+        app = getattr(self, "_app", None)
+        set_status = getattr(app, "set_llm_probe_status", None)
+        if callable(set_status):
+            set_status(text)
 
     def _restore_terminal(self) -> None:
         """Best-effort restoration of terminal state on exit.
@@ -990,6 +1057,20 @@ class Session:
         health = getattr(self.registry, "blocking_llm_health", None)
         if health is None or getattr(health, "blocking", False) is not True:
             return None
+        if getattr(health, "pending", False) is True:
+            lines = [
+                "Cannot send this message because the configured LLM is still being checked.",
+            ]
+            if health.error_message:
+                lines.append(health.error_message)
+            lines.extend(
+                (
+                    "",
+                    "Slash commands and !shell commands still work.",
+                    "Prompts will be enabled automatically if the check succeeds.",
+                )
+            )
+            return "\n".join(lines)
         lines = [
             "Cannot send this message because the configured LLM is unavailable.",
         ]

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -351,6 +351,7 @@ class TUIApplication:
         self._spinner_task: asyncio.Task | None = None
         self._command_status_text: str = ""
         self._command_queue_texts: list[str] = []
+        self._llm_probe_status_text: str = ""
 
         self._prompt_processor = BeforeInput(PROMPT_MARKER, style="class:prompt")
         self._agent_task: asyncio.Future | None = None
@@ -1161,16 +1162,16 @@ class TUIApplication:
         return task
 
     def _ensure_spinner_task(self) -> None:
-        """Start a background task cycling the spinner frame while the
-        agent is thinking. Invalidates the app each tick so the status
-        line redraws; exits when ``is_thinking()`` becomes False."""
+        """Start a background task cycling the spinner frame while live work
+        needs animation. Invalidates the app each tick so the status line
+        redraws; exits when the animated statuses clear."""
         if self._spinner_task is not None and not self._spinner_task.done():
             return
 
         async def _animate() -> None:
             i = 0
             try:
-                while self.is_thinking():
+                while self.is_thinking() or self._llm_probe_status_text:
                     self._spinner_frame = self._spinner_frames[i % len(self._spinner_frames)]
                     if self._app.is_running:
                         self._app.invalidate()
@@ -2846,6 +2847,15 @@ class TUIApplication:
         if app is not None and app.is_running:
             app.invalidate()
 
+    def set_llm_probe_status(self, text: str) -> None:
+        """Set transient LLM startup probe text in the dynamic status area."""
+        self._llm_probe_status_text = text
+        if text:
+            self._ensure_spinner_task()
+        app = getattr(self, "_app", None)
+        if app is not None and app.is_running:
+            app.invalidate()
+
     def status_text(self) -> str:
         """One-line status area text.
 
@@ -2861,6 +2871,8 @@ class TUIApplication:
             lines.append(f"{self._spinner_frame} cancelling agent turn...")
         elif self.is_thinking():
             lines.append(f"{self._spinner_frame} thinking...")
+        if self._llm_probe_status_text:
+            lines.append(f"{self._spinner_frame} {self._llm_probe_status_text}")
         reflection_frame = ""
         runner = self._reflection_runner()
         if runner is not None:
@@ -2881,3 +2893,9 @@ class TUIApplication:
     def set_session_label(self, label: str) -> None:
         """Set the bracketed label shown on the right of the status line."""
         self._session_label = label
+
+    def invalidate(self) -> None:
+        """Request a prompt/layout redraw after external state changes."""
+        app = getattr(self, "_app", None)
+        if app is not None and app.is_running:
+            app.invalidate()

--- a/packages/nooa-cli/tests/tui/test_startup_latency.py
+++ b/packages/nooa-cli/tests/tui/test_startup_latency.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Startup latency regressions for the native TUI."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, call
+
+import pytest
+
+
+def _configure_project(monkeypatch, tmp_path):
+    project_dir = tmp_path / ".nooa"
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project_dir))
+    import nooa_cli.tui.session_manager as session_manager
+
+    monkeypatch.setattr(session_manager, "SESSIONS_DIR", project_dir / "sessions")
+    return project_dir
+
+
+def test_tui_package_import_does_not_import_agent_stack() -> None:
+    code = (
+        "import sys\n"
+        "import nooa_cli.tui\n"
+        "print('nooa_cli.tui.agent' in sys.modules)\n"
+        "print('nooa_cli.coding.agent' in sys.modules)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.splitlines() == ["False", "False"]
+
+
+@pytest.mark.asyncio
+async def test_pending_llm_health_does_not_emit_durable_startup_status(tmp_path, monkeypatch):
+    from nooa_cli.tui.bootstrap import bootstrap
+    from nooa_cli.tui.config import Config
+
+    _configure_project(monkeypatch, tmp_path)
+    cfg = Config()
+    cfg.tui.default_model = "provider/model-a"
+    cfg.agent.summarization.policy = "none"
+    monkeypatch.setattr(
+        "nooa_cli.tui.config.get_llm",
+        lambda config: SimpleNamespace(model=config.tui.default_model),
+    )
+
+    result = await bootstrap(cfg)
+    try:
+        assert result.blocking_llm_health is not None
+        assert result.blocking_llm_health.pending is True
+        assert all(
+            "Checking LLM endpoint in the background"
+            not in str(getattr(output, "content", ""))
+            for output in result.messages
+        )
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_pending_llm_health_blocks_prompts_until_background_probe_succeeds(monkeypatch):
+    from nooa_cli.tui.health_check import HealthCheckResult
+    from nooa_cli.tui.session import Session
+
+    rendered = []
+    session = Session.__new__(Session)
+    session.agent = SimpleNamespace(llm=SimpleNamespace(model="model-a"))
+    session.registry = SimpleNamespace(
+        blocking_llm_health=HealthCheckResult(
+            ok=False,
+            error_message="Checking LLM endpoint for model 'model-a'.",
+            blocking=True,
+            pending=True,
+        ),
+        startup_info=SimpleNamespace(llm_ready=False, llm_status="checking"),
+    )
+    session.frontend = SimpleNamespace(
+        render=AsyncMock(side_effect=lambda output: rendered.append(output))
+    )
+    session._app = SimpleNamespace(invalidate=Mock(), set_llm_probe_status=Mock())
+    session._background_tasks = set()
+
+    monkeypatch.setattr(
+        "nooa_cli.tui.health_check.probe_llm",
+        AsyncMock(return_value=HealthCheckResult(ok=True)),
+    )
+
+    assert "still being checked" in session._llm_submission_error()
+
+    session._start_llm_health_check()
+    await asyncio_wait_for_background_tasks(session)
+
+    assert session.registry.blocking_llm_health is None
+    assert session.registry.startup_info.llm_ready is True
+    assert session.registry.startup_info.llm_status == "ready"
+    assert session._app.set_llm_probe_status.mock_calls == [
+        call("probing LLM endpoint..."),
+        call(""),
+    ]
+    session._app.invalidate.assert_called_once()
+    assert rendered == []
+    assert session._llm_submission_error() is None
+
+
+@pytest.mark.asyncio
+async def test_pending_llm_health_keeps_blocking_on_auth_failure(monkeypatch):
+    from nooa_cli.tui.health_check import HealthCheckResult
+    from nooa_cli.tui.session import Session
+
+    rendered = []
+    session = Session.__new__(Session)
+    session.agent = SimpleNamespace(llm=SimpleNamespace(model="model-a"))
+    session.registry = SimpleNamespace(
+        blocking_llm_health=HealthCheckResult(
+            ok=False,
+            error_message="Checking LLM endpoint for model 'model-a'.",
+            blocking=True,
+            pending=True,
+        ),
+        startup_info=SimpleNamespace(llm_ready=False, llm_status="checking"),
+    )
+    session.frontend = SimpleNamespace(
+        render=AsyncMock(side_effect=lambda output: rendered.append(output))
+    )
+    session._app = SimpleNamespace(invalidate=Mock(), set_llm_probe_status=Mock())
+    session._background_tasks = set()
+
+    failure = HealthCheckResult(
+        ok=False,
+        error_message="Authentication failed for model 'model-a'.",
+        fix_hint="export API_KEY",
+        blocking=True,
+    )
+    monkeypatch.setattr("nooa_cli.tui.health_check.probe_llm", AsyncMock(return_value=failure))
+
+    session._start_llm_health_check()
+    await asyncio_wait_for_background_tasks(session)
+
+    assert session.registry.blocking_llm_health is failure
+    assert session.registry.startup_info.llm_ready is False
+    assert session.registry.startup_info.llm_status == "unavailable"
+    assert session._app.set_llm_probe_status.mock_calls == [
+        call("probing LLM endpoint..."),
+        call(""),
+    ]
+    session._app.invalidate.assert_called_once()
+    assert "unavailable" in session._llm_submission_error()
+    assert any("Authentication failed" in output.content for output in rendered)
+    assert any("export API_KEY" in output.content for output in rendered)
+
+
+@pytest.mark.asyncio
+async def test_model_switch_clears_pending_startup_info(monkeypatch):
+    from nooa_cli.tui.commands import ModelCommand
+    from nooa_cli.tui.health_check import HealthCheckResult
+
+    candidate = SimpleNamespace(model="new/model")
+    agent = SimpleNamespace(
+        llm=SimpleNamespace(model="old/model"),
+        set_llm=lambda llm: setattr(agent, "llm", llm),
+    )
+    startup_info = SimpleNamespace(
+        model="old/model",
+        short_model="model",
+        llm_ready=False,
+        llm_status="checking",
+    )
+    registry = SimpleNamespace(
+        blocking_llm_health=HealthCheckResult(
+            ok=False,
+            error_message="Checking LLM endpoint for model 'old/model'.",
+            blocking=True,
+            pending=True,
+        ),
+        startup_info=startup_info,
+    )
+    config = SimpleNamespace(default_model="old/model")
+    command = ModelCommand(AsyncMock(), config, agent, registry=registry)
+    command._persist_tui_setting = lambda _key, _value: Path("settings.yaml")
+
+    async def _agent_run_async(fn):
+        return fn()
+
+    command._agent_run_async = _agent_run_async
+    monkeypatch.setattr("nooa_cli.tui.config.get_llm_for_model", lambda _model: candidate)
+    monkeypatch.setattr(
+        "nooa_cli.tui.health_check.probe_llm",
+        AsyncMock(return_value=HealthCheckResult(ok=True)),
+    )
+    monkeypatch.setattr("nooa.interactive.apply_model_limits", lambda _agent: None)
+
+    result = await command.execute(["new/model"])
+
+    assert result.success is True
+    assert registry.blocking_llm_health is None
+    assert startup_info.model == "new/model"
+    assert startup_info.short_model == "model"
+    assert startup_info.llm_ready is True
+    assert startup_info.llm_status == "ready"
+
+
+async def asyncio_wait_for_background_tasks(session) -> None:
+    import asyncio
+
+    pending = list(session._background_tasks)
+    if pending:
+        await asyncio.gather(*pending)

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -313,6 +313,16 @@ async def test_status_text_separates_thinking_and_command_status():
         h.app._agent_task.cancel()
 
 
+async def test_llm_probe_status_is_transient_status_line():
+    async with TUIHarness() as h:
+        h.app.set_llm_probe_status("probing LLM endpoint...")
+        await h.wait_for(lambda: "probing LLM endpoint..." in h.app.status_text())
+        assert "probing LLM endpoint..." in h.app.status_text()
+
+        h.app.set_llm_probe_status("")
+        assert "probing LLM endpoint..." not in h.app.status_text()
+
+
 async def test_baseline_command_queue_is_dynamic_not_scrollback():
     """Queued commands live in dynamic UI state, not transcript scrollback."""
     async with TUIHarness() as h:


### PR DESCRIPTION
 ## Summary

  This PR addresses two main startup latency sources in the TUI:

  1. The startup LLM health probe was blocking first paint.
  2. Some TUI imports pull in the heavier agent/LLM stack earlier than needed.

On my machine, the LLM probe averaged about **1.76s**, and it was happening synchronously before the TUI became usable. This PR moves that probe into the background. While the probe is running, we show a small spinner and prompts that require the LLM are temporarily blocked, but slash commands and `!shell` commands remain available. If the probe succeeds, the transient status simply disappears and prompts become available. If it fails with a blocking configuration/auth error, the TUI shows the existing actionable error and keeps LLM-backed prompts blocked until the user changes/fixes the model.


This PR also narrows part of the import path so importing `nooa_cli.tui` no longer immediately imports the coding agent stack. This reduces some avoidable startup/import work.

## Speedup (warm cache, on my machine)
  origin/dev/tui:          avg 4.78s, median 4.24s
  this branch: avg 2.14s, median 2.05s

  ## Important Limitation

  This does not fully eliminate the heavy import cost. In particular, `nooa_cli.tui.config` still imports `SummarizationConfig` from `nooa.interactive`, which pulls in the broader agent/strategy/LLM stack, including LiteLLM-related imports, that are super slow. I tested avoiding that import, and it was way faster, but the cleaner local workaround would have changed the `SummarizationConfig` type identity.   So this PR improves the startup path, but LiteLLM/core-agent import cost can still be visible, especially on cold starts.


  ## Validation

  - `ruff check`
  - Focused TUI tests: `100 passed`
  - Broader TUI subset: `189 passed`

