### PR TITLE
feat(cli): add the shared coding TUI

### DIFF
--- a/packages/nooa-cli/README.md
+++ b/packages/nooa-cli/README.md
@@ -1,6 +1,6 @@
 # nooa-cli
 
-CLI for [nemo-oo-agents](https://github.com/NVIDIA-NeMo/labs-OO-Agents). Ships the `nooa` command with subcommands for running evaluations, browsing traces, and managing config.
+CLI for [nemo-oo-agents](https://github.com/NVIDIA-NeMo/labs-OO-Agents). Ships the `nooa` command, including the native coding-agent TUI.
 
 ## Install
 
@@ -17,13 +17,14 @@ uv add "nooa-cli[datascience]"
 
 ```bash
 nooa --help
-nooa start-dev        # launch the trace viewer
-nooa eval ...         # eval pipeline runner
-nooa traces ...       # inspect/manage trace files
+nooa start-dev            # launch the trace viewer
+nooa eval ...             # eval pipeline runner
+nooa traces ...           # inspect/manage trace files
+nooa tui                  # interactive coding agent
 ```
 
 Install the separate `nooa-acp` package to add the `nooa acp` plugin command and
-run the NOOA coding agent from an ACP-compatible client:
+run the same coding agent from an ACP-compatible client instead of the TUI:
 
 ```bash
 uv add nooa-acp
@@ -31,6 +32,124 @@ export NOOA_MODEL=nvidia_nim/nvidia/nemotron-3-super-120b-a12b
 export NVIDIA_API_KEY=nvapi-...
 uv run nooa-acp
 ```
+
+## TUI configuration
+
+The TUI reads layered `settings.yaml` files from the user config directory and
+the current project's `.nooa/` directory. It also honors `AGENTS.md` files from
+the repository root down to the current working directory.
+
+Agent Skills are discovered from installed `nooa.skills` entry points and from
+conventional `.agents/skills`, `.claude/skills`, and `.cursor/skills`
+directories. Discovered workflow skills are loaded but remain model-inactive
+until `/skills activate <id>` or explicit invocation. Operations marked with
+`@slash_command` still appear as TUI slash commands. This is the extension path
+for project-specific workflows; they are not hard-coded into the terminal host.
+
+### Extending the coding agent
+
+The default `nooa_cli.coding.CodingAgent` is shared infrastructure for
+interactive hosts. An internal package can subclass it and select the subclass
+without forking the TUI:
+
+```python
+from nooa_cli.coding import CodingAgent
+
+
+class InternalCodingAgent(CodingAgent):
+    pass
+```
+
+```bash
+nooa tui --agent internal_agents:InternalCodingAgent
+```
+
+The TUI passes `llm`, durable `storage`, `cwd`, and `skills_dirs` when those
+parameters are declared by the custom class. Installed Python skills should be
+published through the `nooa.skills` entry-point group. Toolbar extensions can
+similarly publish named providers through `nooa_cli.tui.toolbar_items`; users
+select their order with `/toolbar set <item> ...`.
+
+Keep-going mode is an explicit opt-in. It audits a completed turn with a
+separate judge model and sends an internal continuation only when autonomous
+work remains:
+
+```text
+/keep-going model nemotron3-nano-30b
+/keep-going on
+```
+
+Use `/keep-going off` to disable it. New user input supersedes and cancels an
+in-flight audit.
+
+Long-term memory and idle reflection are also explicit opt-ins:
+
+```text
+/memory on        # project-wide store shared across sessions
+/memory local     # sidecar store for only this session
+/memories         # browse, forget, or complete stored memories
+/reflection on    # consolidate new memories while the agent is idle
+/reflection now   # run a consolidation pass immediately
+```
+
+`/memory off` detaches memory from the current agent. `/reflection off` stops
+idle consolidation without deleting stored memories. Project memory lives at
+`.nooa/memory/memory.sqlite` by default; session memory lives beside the
+session database. Both choices are persisted per agent in `settings.yaml`.
+
+### MCP servers
+
+Use the TUI commands for the common lifecycle:
+
+```text
+/mcp list
+/mcp add docs https://docs.example.com/mcp
+/mcp approve docs
+/mcp approve docs <confirmation-code>
+/mcp connect docs
+/mcp disconnect docs
+/mcp remove docs
+```
+
+`/mcp add` writes an HTTP URL or a single stdio command to the project
+`.nooa/settings.yaml`. Configuration is discovery, not trust: the TUI shows a
+secret-safe fingerprint review and requires the user to repeat its confirmation
+code before any transport or local process starts. Any configuration change
+invalidates that approval. Environment placeholders are resolved only after
+approval. `/mcp remove` removes inline project servers and revokes their stored
+approvals without disturbing sibling settings. Servers sourced from an external
+`.mcp.json` must be removed from that file.
+
+For a richer server definition—stdio arguments, environment mappings, headers,
+or OAuth settings—use `/mcp-add <the details you have>`. That user-invocable
+skill asks the coding agent to edit the same project settings without embedding
+secret values, then directs you back through the user-owned review and approval
+flow. Removal is always `/mcp remove <name>` (or an edit to the source
+`.mcp.json` for externally defined servers).
+
+For stdio arguments, environment variables, headers, or OAuth options, use the
+full settings form:
+
+```yaml
+tui:
+  mcp_servers:
+    local-tools:
+      command: uvx
+      args: [my-mcp-server]
+      env:
+        LOG_LEVEL: info
+    hosted-tools:
+      url: https://tools.example.com/mcp
+      transport: streamable-http
+      oauth_client_id: my-client-id
+      oauth_scope: "tools.read tools.write"
+```
+
+Keep secret values in the host environment and use literal `${VAR}` placeholders
+in repository config. First-time OAuth consent remains a human browser step;
+manual codes are collected in a masked in-app prompt. Cached credentials are
+reused by later `/mcp connect` calls after the exact server definition remains
+approved.
 
 See the main repo [README](https://github.com/NVIDIA-NeMo/labs-OO-Agents/blob/main/README.md) for the framework documentation.
 

--- a/packages/nooa-cli/pyproject.toml
+++ b/packages/nooa-cli/pyproject.toml
@@ -10,10 +10,13 @@ dependencies = [
     # Floor reflects the actual minimum-compatible core (bump when the cli
     # starts to require a newer core API). No auto-lockstep — published
     # wheels declare what they actually need, not what was co-released.
-    "nooa",
+    "nooa[mcp,memory]",
     "click>=8.1.0",
     # CLI config files
     "pyyaml>=6.0",
+    "prompt-toolkit>=3.0.41,<3.1.0",
+    "pydantic>=2.5.0",
+    "rich>=13.0.0",
 ]
 
 [project.urls]

--- a/packages/nooa-cli/src/nooa_cli/commands/tui.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/tui.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Launch the TUI through the ``nooa tui`` subcommand.
+
+Usage:
+    nooa tui --model gpt-4o
+
+Loaded on every ``nooa`` invocation, including ``nooa --help`` — keep this
+module's imports light and defer the TUI machinery into the handler.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import click
+
+_RESUME_LAST = "__last__"
+
+
+@click.command()
+@click.option(
+    "--model",
+    "-m",
+    help="LLM model to use (overrides config default)",
+)
+@click.option(
+    "--agent",
+    "agent_spec",
+    default=None,
+    metavar="MODULE:CLASS",
+    help=(
+        "Custom agent class instead of TUIAgent. "
+        "Format: 'module.path:ClassName' or './file.py:ClassName'. "
+        "CodingAgent subclasses receive the configured workspace and skills."
+    ),
+)
+@click.option(
+    "--working-dir",
+    "-w",
+    "-d",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=str),
+    default=".",
+    help="Working directory for bash commands",
+)
+@click.option(
+    "--mcp-file",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=str),
+    default=None,
+    help="MCP config file (default: .mcp.json in cwd)",
+)
+@click.option(
+    "--no-splash",
+    is_flag=True,
+    help="Skip the splash screen",
+)
+@click.option(
+    "--skills-dir",
+    multiple=True,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=str),
+    help="Skills directory (can be specified multiple times)",
+)
+@click.option(
+    "--context-limit",
+    type=int,
+    help="Context limit for summarization",
+)
+@click.option(
+    "--no-trace",
+    is_flag=True,
+    help="Disable tracing",
+)
+@click.option(
+    "--vi",
+    is_flag=True,
+    help="Enable vi keybindings in the input prompt",
+)
+@click.option(
+    "--python",
+    is_flag=True,
+    help="Show agent Python code execution panels",
+)
+@click.option(
+    "--continue",
+    "-c",
+    "continue_session",
+    is_flag=False,
+    flag_value=_RESUME_LAST,
+    default=None,
+    help="Resume a session: -c (last session) or -c <short-hash>",
+)
+def command(
+    model: str | None,
+    agent_spec: str | None,
+    working_dir: str,
+    mcp_file: str | None,
+    no_splash: bool,
+    skills_dir: tuple[str, ...],
+    context_limit: int | None,
+    no_trace: bool,
+    vi: bool,
+    python: bool,
+    continue_session: str | None,
+):
+    """Launch the NVIDIA OO Agents TUI (Text User Interface).
+
+    Interactive REPL for chatting with agents, running commands, and managing
+    skills and MCP servers.
+
+    Invoke as `nooa tui`.
+
+    Examples:
+        nooa tui
+        nooa tui --model gpt-4o
+        nooa tui --working-dir /path/to/project
+        nooa tui --mcp-file .mcp.json
+        nooa tui --agent internal_agents:CodingAgent
+        nooa tui --vi
+    """
+    # Lazy imports preserve the fast path for every other ``nooa`` command.
+    from nooa_cli.tui.config import Config
+    from nooa_cli.tui.main import main as tui_main
+
+    config = Config.load(
+        model=model,
+        agent=agent_spec,
+        working_dir=working_dir,
+        mcp_file=Path(mcp_file) if mcp_file else None,
+        no_splash=no_splash,
+        skills_dir=list(skills_dir) if skills_dir else None,
+        context_limit=context_limit,
+        no_trace=no_trace,
+        vi=vi,
+        python=python,
+    )
+
+    continue_last = continue_session == _RESUME_LAST
+    resume_session_id = (
+        continue_session if continue_session and continue_session != _RESUME_LAST else None
+    )
+
+    try:
+        asyncio.run(
+            tui_main(
+                config=config, continue_last=continue_last, resume_session_id=resume_session_id
+            )
+        )
+    except KeyboardInterrupt:
+        sys.exit(0)
+
+
+# ``python -m nooa_cli.commands.tui`` remains a script-free fallback.
+if __name__ == "__main__":
+    command()

--- a/packages/nooa-cli/src/nooa_cli/sessions/__init__.py
+++ b/packages/nooa-cli/src/nooa_cli/sessions/__init__.py
@@ -4,6 +4,8 @@
 
 from nooa_cli.sessions.events import (
     SESSION_EVENT_TYPES,
+    SessionCleared,
+    SessionResumed,
     SessionStarted,
     SessionTitleUpdated,
     SessionUserMessage,
@@ -20,9 +22,11 @@ from nooa_cli.sessions.store import (
 __all__ = [
     "InvalidSessionIdError",
     "SESSION_EVENT_TYPES",
+    "SessionCleared",
     "SessionHandle",
     "SessionInfo",
     "SessionNotFoundError",
+    "SessionResumed",
     "SessionStarted",
     "SessionStore",
     "SessionTitleUpdated",

--- a/packages/nooa-cli/src/nooa_cli/sessions/events.py
+++ b/packages/nooa-cli/src/nooa_cli/sessions/events.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Durable metadata for interactive coding-agent sessions."""
+"""Durable metadata and transient lifecycle events for coding-agent sessions."""
 
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
-from nooa.context_blocks import Metadata
+from pydantic import Field
+
+from nooa.context_blocks import EventBase, Metadata
 from nooa.context_blocks.roles import Role
 
 
@@ -36,6 +38,33 @@ class SessionUserMessage(Metadata):
     content: str = ""
 
 
+class SessionResumed(EventBase):  # type: ignore[misc]
+    """An interactive agent has been restored or initialized for a session."""
+
+    _role: ClassVar[Role] = Role.RUNTIME_EVENT
+    handler_aliases: ClassVar[tuple[str, ...]] = ("TuiSessionResumed",)
+
+    session_id: Annotated[str, Field(description="The resumed or started session ID")]
+    restored: Annotated[
+        bool,
+        Field(description="Whether a snapshot was restored into the agent"),
+    ]
+
+
+class SessionCleared(EventBase):  # type: ignore[misc]
+    """An interactive agent's working state has been reset."""
+
+    _role: ClassVar[Role] = Role.RUNTIME_EVENT
+    handler_aliases: ClassVar[tuple[str, ...]] = ("TuiSessionCleared",)
+
+    session_id: Annotated[
+        str | None,
+        Field(default=None, description="The new post-clear session ID, when known"),
+    ]
+
+
+# Transient lifecycle events are deliberately absent here: this tuple is the
+# set persisted with the session, and those two are runtime-only.
 SESSION_EVENT_TYPES: tuple[type[Metadata], ...] = (
     SessionStarted,
     SessionTitleUpdated,

--- a/packages/nooa-cli/src/nooa_cli/tui/__init__.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/__init__.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Native terminal interface for NVIDIA NeMo OO Agents."""
+
+from .agent import BaseTUIAgent, TUIAgent
+from .config import AgentConfig, Config, SummarizationConfig, TUIConfig
+from .console import TUIConsole
+from .input_handler import TUIInputHandler
+from .theme import CATPPUCCIN_THEME, COLORS
+
+__all__ = [
+    "AgentConfig",
+    "BaseTUIAgent",
+    "Config",
+    "SummarizationConfig",
+    "TUIAgent",
+    "TUIConfig",
+    "TUIConsole",
+    "TUIInputHandler",
+    "CATPPUCCIN_THEME",
+    "COLORS",
+]

--- a/packages/nooa-cli/src/nooa_cli/tui/__main__.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/__main__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run the same Click command as ``nooa tui``."""
+
+from nooa_cli.commands.tui import command
+
+if __name__ == "__main__":
+    command()

--- a/packages/nooa-cli/src/nooa_cli/tui/activity_overlay.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/activity_overlay.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Full-screen in-app overlay for the /activity command."""
+
+from __future__ import annotations
+
+import io
+import textwrap
+from collections.abc import Iterable
+
+from rich.console import Console as RichConsole
+from rich.syntax import Syntax
+from rich.table import Table
+from rich.text import Text
+
+from .output import CodeExecution, Output, TableOutput, TextOutput
+from .subapp import SubviewKeyResult
+from .theme import COLORS
+
+_BAR_STYLE = "\x1b[48;5;236;38;5;252m"
+
+
+def _style_bar(text: str, *, ansi: bool) -> str:
+    if not ansi:
+        return text
+    return f"{_BAR_STYLE}{text}\x1b[0m"
+
+
+def _plain_wrap(text: str, width: int) -> list[str]:
+    lines: list[str] = []
+    for raw in text.splitlines() or [""]:
+        if raw == "":
+            lines.append("")
+        else:
+            lines.extend(
+                textwrap.wrap(
+                    raw,
+                    width=max(width, 1),
+                    replace_whitespace=False,
+                    drop_whitespace=False,
+                    break_long_words=True,
+                    break_on_hyphens=False,
+                )
+                or [""]
+            )
+    return lines or [""]
+
+
+def _render_rich_lines(renderables: Iterable[object], width: int) -> list[str]:
+    render_width = max(int(width), 20)
+    buf = io.StringIO()
+    console = RichConsole(
+        file=buf,
+        force_terminal=True,
+        color_system="256",
+        width=render_width,
+        _environ={"COLUMNS": str(render_width), "LINES": "25"},
+    )
+    for renderable in renderables:
+        console.print(renderable)
+    return buf.getvalue().splitlines() or [""]
+
+
+def _table_lines(output: TableOutput, width: int, *, ansi: bool) -> list[str]:
+    if ansi:
+        table = Table(
+            title=output.title or None,
+            show_header=output.show_header,
+            box=None,
+            expand=True,
+        )
+        for column in output.columns:
+            table.add_column(column)
+        for row in output.rows:
+            table.add_row(*[str(cell) for cell in row])
+        lines = _render_rich_lines([table], width)
+        if output.footer:
+            lines.append("")
+            lines.extend(_render_rich_lines([Text(output.footer, style=COLORS["subtext1"])], width))
+        return lines
+
+    rows = output.rows
+    if not rows:
+        return []
+    left_width = min(max(len(str(row[0])) for row in rows), max(width // 3, 12))
+    lines: list[str] = []
+    if output.title:
+        lines.append(output.title)
+        lines.append("")
+    if output.show_header and output.columns:
+        lines.append(
+            f"{output.columns[0]:<{left_width}}  {output.columns[1] if len(output.columns) > 1 else ''}"
+        )
+    for row in rows:
+        left = str(row[0]) if row else ""
+        right = str(row[1]) if len(row) > 1 else ""
+        prefix = f"{left:<{left_width}}  "
+        wrapped = _plain_wrap(right, max(width - len(prefix), 1))
+        lines.append(prefix + wrapped[0])
+        for extra in wrapped[1:]:
+            lines.append(" " * len(prefix) + extra)
+    if output.footer:
+        lines.append("")
+        lines.extend(_plain_wrap(output.footer, width))
+    return lines
+
+
+def _code_lines(output: CodeExecution, width: int, *, ansi: bool) -> list[str]:
+    lines: list[str] = []
+    if output.code:
+        code = output.code.rstrip() if output.start_line > 1 else output.code.strip()
+        if ansi:
+            highlight = {output.highlight_line} if output.highlight_line is not None else None
+            lines.extend(
+                _render_rich_lines(
+                    [
+                        Syntax(
+                            code,
+                            "python",
+                            theme="monokai",
+                            line_numbers=True,
+                            word_wrap=True,
+                            start_line=output.start_line,
+                            highlight_lines=highlight,
+                        )
+                    ],
+                    width,
+                )
+            )
+        else:
+            lines.extend(_plain_wrap(code, width))
+    output_parts = [
+        part for part in (output.stdout, output.stderr, output.error, output.value) if part
+    ]
+    if output_parts:
+        if lines:
+            lines.append("")
+        for part in output_parts:
+            lines.extend(_plain_wrap(str(part), width))
+    return lines or ["(no source available)"]
+
+
+def _output_lines(output: Output, width: int, *, ansi: bool) -> list[str]:
+    if isinstance(output, TextOutput):
+        return _plain_wrap(output.content, width)
+    if isinstance(output, TableOutput):
+        return _table_lines(output, width, ansi=ansi)
+    if isinstance(output, CodeExecution):
+        return _code_lines(output, width, ansi=ansi)
+    return _plain_wrap(str(output), width)
+
+
+class ActivityOverlayView:
+    """Static activity snapshot shown as a full-screen in-app overlay."""
+
+    title = "activity"
+
+    def __init__(self, outputs: list[Output]) -> None:
+        self.outputs = outputs
+        self.offset = 0
+        self._last_line_count = 0
+        self._last_visible_lines = 0
+
+    def render(self, width: int, height: int) -> str:
+        return render_activity_overlay(self, width, height, ansi=True)
+
+    def handle_key(self, action: str, value: str = "") -> SubviewKeyResult:
+        if action in {"quit", "escape", "enter"}:
+            return "close"
+        if action in {"down", "j", "scroll_down"}:
+            self.scroll(+3 if action == "scroll_down" else +1)
+            return "handled"
+        if action in {"up", "k", "scroll_up"}:
+            self.scroll(-3 if action == "scroll_up" else -1)
+            return "handled"
+        if action == "page_down":
+            self.scroll(max(self._last_visible_lines, 1))
+            return "handled"
+        if action == "page_up":
+            self.scroll(-max(self._last_visible_lines, 1))
+            return "handled"
+        if action == "home":
+            self.offset = 0
+            return "handled"
+        if action == "end":
+            self.offset = max(self._last_line_count - max(self._last_visible_lines, 1), 0)
+            return "handled"
+        return "handled" if action == "text" else "ignored"
+
+    def scroll(self, delta: int) -> None:
+        max_offset = max(self._last_line_count - max(self._last_visible_lines, 1), 0)
+        self.offset = min(max(self.offset + delta, 0), max_offset)
+
+    def on_open(self) -> None:
+        pass
+
+    def on_close(self) -> None:
+        pass
+
+
+def render_activity_overlay(
+    view: ActivityOverlayView, width: int, height: int, *, ansi: bool = False
+) -> str:
+    width = max(int(width), 40)
+    height = max(int(height), 1)
+    header = _style_bar(" Activity ".ljust(width, "─")[:width], ansi=ansi)
+    footer = _style_bar(
+        " ↑/↓ scroll  PgUp/PgDn page  Home/End  Enter/Esc/q close ".ljust(width, "─")[:width],
+        ansi=ansi,
+    )
+    body_height = max(height - 2, 0)
+    body: list[str] = []
+    for i, output in enumerate(view.outputs):
+        if i:
+            body.append("")
+        body.extend(_output_lines(output, width, ansi=ansi))
+    if not body:
+        body = ["No activity."]
+    view._last_line_count = len(body)
+    view._last_visible_lines = body_height
+    view.scroll(0)
+    visible = body[view.offset : view.offset + body_height]
+    visible = [line if ansi and "\x1b[" in line else line.ljust(width)[:width] for line in visible]
+    while len(visible) < body_height:
+        visible.append("".ljust(width))
+    return "\n".join([header, *visible, footer])

--- a/packages/nooa-cli/src/nooa_cli/tui/agent.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/agent.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""TUI compatibility names for the shared coding agent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from nooa_cli.coding.agent import CodingAgent
+
+
+class TUIAgent(CodingAgent):
+    """The default coding agent hosted by the native terminal UI."""
+
+    def __init__(self, *, config: Any | None = None, **kwargs: Any) -> None:
+        cwd = Path(getattr(config, "working_dir", "."))
+        summarization = getattr(config, "summarization", None)
+        super().__init__(cwd=cwd, summarization=summarization, **kwargs)
+
+
+BaseTUIAgent = CodingAgent
+
+__all__ = ["BaseTUIAgent", "TUIAgent"]

--- a/packages/nooa-cli/src/nooa_cli/tui/agent_event_renderer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/agent_event_renderer.py
@@ -1,0 +1,334 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-turn rendering for agent events into the TUI's block queue.
+
+``AgentEventRenderer`` subscribes to the agent's ``Reasoning``,
+``ToolCallEvent`` and ``PythonOutput`` events and forwards them to
+``emit_text`` as Rich renderables. It also owns the monkey-patched
+``agent._render_message`` hook so ``self.message()`` output lands in
+the transcript.
+
+State (per-turn):
+
+- ``_agent_has_messaged`` — True after the first ``self.message()`` in
+  the current turn. Drives the one-time ``"OO ─"`` rule that separates
+  agent output from user input.
+
+``self.message()`` emits inline. There was a previous attempt to buffer
+messages and only flush them after the next ``PythonOutput`` / tool
+call, so they'd visually land *below* the preceding code cell; that
+created a silent-loss bug where any message emitted after the last
+``PythonOutput`` of a turn sat in the buffer until the user typed
+something else (``reset_turn`` was the only reliable flush path). The
+ordering constraint isn't worth the correctness cost: ``self.message()``
+is called mid-cell, the ``∴`` preview fires on the enclosing
+``ToolCallEvent`` *before* the cell body runs, and cell output arrives
+*after* the cell body — so inline emit naturally lands between preview
+and output.
+
+The class has no reference to ``Session``. Callers pass ``emit_text``
+(the ANSI-enqueue function), a ``show_python`` getter, and a shared
+``pending_code`` dict (keyed by ``tool_call_id``) that pairs a code
+preview with its eventual output.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol
+
+from rich.markdown import Markdown
+from rich.rule import Rule
+from rich.syntax import Syntax
+from rich.text import Text
+
+from .code_preview import _code_preview
+
+
+class _ReasoningEvent(Protocol):
+    """Fields the renderer reads from a ``Reasoning`` event."""
+
+    content: str
+
+
+class _ToolCallEvent(Protocol):
+    """Fields the renderer reads from a ``ToolCallEvent``."""
+
+    name: str
+    tool_call_id: str
+    arguments: dict[str, Any]
+
+
+class _PythonOutputEvent(Protocol):
+    """Fields the renderer reads from a ``PythonOutput`` event."""
+
+    tool_call_id: str
+    stdout: str
+    stderr: str
+
+
+class _SummaryEvent(Protocol):
+    """Fields the renderer reads from a ``Summary`` event."""
+
+    summary_tag: str
+    replaced_range: tuple[int, int]
+    children_tags: list[str]
+    summary_text: str | None
+
+
+class AgentEventRenderer:
+    """Render agent events into the TUI block queue, in turn order."""
+
+    def __init__(
+        self,
+        *,
+        agent: Any,
+        emit_text: Callable[..., None],
+        show_python: Callable[[], bool],
+        pending_code: dict[str, str],
+        colors: dict[str, str],
+    ) -> None:
+        self._agent = agent
+        self._emit_text = emit_text
+        self._show_python = show_python
+        self._pending_code = pending_code
+        self._colors = colors
+        self._unsubscribes: list[Callable[[], None]] = []
+        self._agent_has_messaged = False
+        # Assigned by attach() with whatever was on agent._render_message
+        # before; detach() restores to this value. Declaring it here
+        # means detach() can read it without a defensive getattr and
+        # pyright sees the field.
+        self._prior_render_message: Callable[[str], None] | None = None
+
+    # ── lifecycle ──────────────────────────────────────────────────────
+
+    def attach(self) -> None:
+        """Subscribe to the agent's event manager and wire _render_message.
+
+        Idempotent: a second call is a no-op (handlers already subscribed).
+        Chains onto any existing ``agent._render_message`` so an observer
+        hook installed by another component (e.g. a web mirror) still
+        fires when ``self.message()`` is called.
+        """
+        if self._unsubscribes:
+            return
+        em = self._agent.event_manager
+        self._unsubscribes.extend(
+            [
+                em.on("Reasoning", self._on_reasoning),
+                em.on("ToolCallEvent", self._on_tool_call),
+                em.on("PythonOutput", self._on_python_output),
+                em.on("Summary", self._on_summary),
+                em.on("TextOnlyReply", self._on_text_only_reply),
+            ]
+        )
+        # Chain onto any prior hook so we don't silently stomp observers.
+        prior = getattr(self._agent, "_render_message", None)
+        self._prior_render_message = prior
+        if hasattr(self._agent, "_render_message"):
+
+            def _hook(text: str, **emit_kwargs: Any) -> None:
+                if prior is not None:
+                    try:
+                        prior(text)
+                    except TypeError:
+                        try:
+                            prior(text, **emit_kwargs)
+                        except Exception:
+                            pass
+                    except Exception:
+                        pass
+                self._render_message(text, **emit_kwargs)
+
+            self._agent._render_message = _hook
+
+    def detach(self) -> None:
+        """Unsubscribe all handlers and clear the agent hook.
+
+        Safe to call multiple times. Restores ``agent._render_message``
+        to whatever was there before ``attach()`` (usually ``None``) so
+        a post-shutdown ``agent.message()`` doesn't invoke a dead renderer.
+        """
+        for fn in self._unsubscribes:
+            try:
+                fn()
+            except Exception:
+                pass
+        self._unsubscribes.clear()
+        # Restore the prior hook if the agent still has our chain installed.
+        if hasattr(self._agent, "_render_message"):
+            self._agent._render_message = self._prior_render_message
+
+    def reset_turn(self) -> None:
+        """Called on new user submission — reset the per-turn ``OO ─`` guard.
+
+        Nothing else to clean up now that ``self.message()`` emits
+        inline; the OO rule wants to re-fire once per turn so each
+        turn gets its own separator between agent output and user
+        input.
+        """
+        self._agent_has_messaged = False
+
+    # ── message rendering (agent self.message()) ───────────────────────
+
+    def _render_message(self, text: str, **emit_kwargs: Any) -> None:
+        """Hook plugged into ``agent._render_message``.
+
+        Emits the message inline as a Markdown block. Ordering vs
+        surrounding events is naturally correct because ``self.message()``
+        is called mid-cell, after the ``∴`` preview fires on the
+        enclosing ``ToolCallEvent`` and before the cell's
+        ``PythonOutput`` arrives.
+        """
+        self._emit_markdown(str(text), **emit_kwargs)
+
+    def _emit_markdown(self, text: str, **emit_kwargs: Any) -> None:
+        if not self._agent_has_messaged:
+            self._agent_has_messaged = True
+            self._emit_text(
+                Rule(Text("OO ", style=self._colors["mauve"]), style="dim", align="left"),
+                **emit_kwargs,
+            )
+        self._emit_text(Markdown(str(text)), **emit_kwargs)
+
+    # ── agent event handlers ───────────────────────────────────────────
+
+    def _event_emit_kwargs(self, event: Any) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {}
+        event_id = getattr(event, "id", None)
+        if event_id is not None:
+            kwargs["event_id"] = str(event_id)
+        tag = getattr(event, "tag", None)
+        if tag is not None:
+            kwargs["tags"] = {str(tag)}
+        return kwargs
+
+    def _on_reasoning(self, event: _ReasoningEvent) -> None:
+        content = getattr(event, "content", "") or ""
+        if not content.strip():
+            return
+        first_line = content.strip().split("\n", 1)[0][:80]
+        if "inspecting inputs" in first_line.lower():
+            return
+        self._emit_text(
+            Text(f"∴ Reasoning: {first_line}", style="dim italic"), **self._event_emit_kwargs(event)
+        )
+
+    def _on_tool_call(self, event: _ToolCallEvent) -> None:
+        name = getattr(event, "name", "")
+        if name != "execute_python":
+            # ``return_result`` and other tool calls have no visible
+            # rendering of their own — self.message() output (if any)
+            # was already emitted inline when the agent called it.
+            return
+        tool_call_id = getattr(event, "tool_call_id", "")
+        arguments = getattr(event, "arguments", {})
+        code = arguments.get("code", "") if isinstance(arguments, dict) else ""
+        if not code:
+            return
+        self._pending_code[tool_call_id] = code
+
+        # show_python=True mode renders the full cell from _on_python_output;
+        # no teaser preview line needed.
+        if self._show_python():
+            return
+
+        if tool_call_id.startswith("prefill_"):
+            return
+        preview = _code_preview(code)
+        if not preview:
+            return
+        first_line = preview.split("\n", 1)[0]
+        styled = Text(f"∴ {first_line}", style="dim")
+        if first_line.lstrip().startswith("#"):
+            styled.stylize("not dim", 0, len(first_line) + 2)
+        if "\n" in preview:
+            styled.append("\n  " + preview.split("\n", 1)[1], style="dim")
+        self._emit_text(styled, **self._event_emit_kwargs(event))
+
+    def _on_python_output(self, event: _PythonOutputEvent) -> None:
+        tool_call_id = getattr(event, "tool_call_id", "")
+        code = self._pending_code.pop(tool_call_id, None)
+        if tool_call_id.startswith("prefill_"):
+            return
+
+        stdout = str(getattr(event, "stdout", "") or "")
+        stderr = str(getattr(event, "stderr", "") or "")
+        error = str(getattr(event, "error", "") or "")
+        if error and not stderr:
+            stderr = error
+
+        # show_python=True: render a notebook-style cell — 'oo python'
+        # rule, syntax-highlighted code, 'oo stdout' rule + stdout,
+        # 'oo stderr' rule + stderr.
+        if self._show_python() and code:
+            mauve = self._colors["mauve"]
+            red = self._colors["red"]
+            text_color = self._colors["text"]
+            self._emit_text(Rule(Text("oo python", style=mauve), style="dim", align="left"))
+            self._emit_text(
+                Syntax(code.strip(), "python", theme="monokai", background_color="default")
+            )
+            if stdout.strip():
+                self._emit_text(Rule(Text("oo stdout", style=mauve), style="dim", align="left"))
+                self._emit_text(Text(stdout.rstrip("\n"), style=text_color))
+            if stderr.strip():
+                self._emit_text(Rule(Text("oo stderr", style=red), style="dim", align="left"))
+                self._emit_text(Text(stderr.rstrip("\n"), style=red))
+            return
+
+        # Preview mode: show a one-line error summary (muted red).
+        if stderr.strip():
+            first_err = stderr.strip().split("\n")[-1][:120]
+            self._emit_text(
+                Text(f"  ⚠ {first_err}", style="dim red"), **self._event_emit_kwargs(event)
+            )
+
+    def _on_summary(self, event: _SummaryEvent) -> None:
+        """Render a dim one-line notice when a summary/truncation is applied.
+
+        Makes the summarizer visible: seeing back-to-back lines here is the
+        signal that lets the user catch cascade bugs (same diagnosis we just
+        did via the DB, but live). Format:
+
+            ∴ summarized 1..600 · 600 events → 2.5KB summary
+            ∴ truncated 1..600 · 600 events (no summary)
+        """
+        tag = getattr(event, "summary_tag", "") or ""
+        rng = getattr(event, "replaced_range", None) or (0, 0)
+        children = getattr(event, "children_tags", None) or []
+        text = getattr(event, "summary_text", None)
+
+        # Event count: prefer children_tags len (exact, survives nested
+        # summaries) over replaced_range width (always an upper bound).
+        n_events = len(children) if children else max(0, rng[1] - rng[0] + 1)
+
+        if text is None:
+            detail = f"{n_events} events (no summary)"
+            verb = "truncated"
+        else:
+            chars = len(text)
+            if chars >= 1024:
+                size = f"{chars / 1024:.1f}KB"
+            else:
+                size = f"{chars}B"
+            detail = f"{n_events} events → {size} summary"
+            verb = "summarized"
+
+        self._emit_text(
+            Text(f"∴ {verb} {tag} · {detail}", style="dim italic"), **self._event_emit_kwargs(event)
+        )
+
+    def _on_text_only_reply(self, event: Any) -> None:
+        """Render a notice when a code-act turn replies without a tool call."""
+        recovered = getattr(event, "recovered", False)
+        n = getattr(event, "consecutive_text_only", 0)
+        state = "recovered" if recovered else f"#{n}"
+        self._emit_text(
+            Text(
+                f"⚠ agent replied without a tool call ({state}).",
+                style="yellow",
+            ),
+            **self._event_emit_kwargs(event),
+        )

--- a/packages/nooa-cli/src/nooa_cli/tui/agent_location.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/agent_location.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""On-demand "where is the agent stopped?" probe for the TUI.
+
+Answers the question the ``/activity`` command poses — not just *what phase*
+the agent is in (python / llm / idle), but *where in the code* it is currently
+suspended.
+
+Why this lives here and not in the core framework:
+
+- The agent runs as a coroutine on a dedicated asyncio loop on its own thread
+  (``TUIApplication._ensure_agent_loop``). A point-in-time "where is it"
+  snapshot is answered by asyncio task introspection (``Task.get_stack()``),
+  which must run *on the agent loop* — ``asyncio.Task`` is not safe to walk
+  from another thread. The ``ActivityCommand`` already has ``agent_run()``,
+  which executes a callable on the agent loop, so the probe runs there and
+  returns plain data back across the thread boundary.
+- ``sys.monitoring`` is the wrong tool for an on-demand probe: its callbacks
+  fire on the *executing* thread (not the asker's), there is no per-thread
+  instrumentation, and always-on ``LINE`` events cost ~3x runtime. It is built
+  for continuous collection (debuggers, coverage), not snapshots.
+
+No core (``src/``) changes are required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import linecache
+import re
+from dataclasses import dataclass, field
+
+# The agent's turn entrypoint task is named ``<AgentClass>.handle`` by
+# ActorRuntime._call_plan (see runtime/actor.py). We match on the method name
+# so any agent class works.
+_TURN_METHOD = "handle"
+
+
+@dataclass
+class SourceLine:
+    lineno: int
+    text: str
+    is_current: bool
+
+
+@dataclass
+class FrameInfo:
+    qualname: str
+    lineno: int
+    filename: str
+    # ±N lines of source around ``lineno``, when resolvable (real files and
+    # registered REPL/CodeAct cells both work via linecache). Empty otherwise.
+    context: list[SourceLine] = field(default_factory=list)
+
+    def short(self) -> str:
+        return f"{self.qualname} (line {self.lineno})"
+
+
+def _source_context(filename: str, lineno: int, ctx: int = 3) -> list[SourceLine]:
+    """±``ctx`` source lines around ``lineno``.
+
+    ``linecache.getlines`` resolves both real files and code cells registered
+    by the CodeAct/REPL runtime (their ``co_filename`` is a ``"Cell In[N]"``
+    key in ``linecache.cache``). Returns ``[]`` when no source is available
+    (e.g. C frames, generated code).
+    """
+    lines = linecache.getlines(filename)
+    if not lines:
+        return []
+    lo = max(1, lineno - ctx)
+    hi = min(len(lines), lineno + ctx)
+    return [SourceLine(n, lines[n - 1].rstrip("\n"), n == lineno) for n in range(lo, hi + 1)]
+
+
+# A REPL/CodeAct cell's ``co_filename`` is a Jupyter-style ``Cell In[N]`` key
+# (see ActorRuntime._execute_code). The agent's own ``execute_python`` code runs
+# under such a frame, so this is how we tell *the agent's code* apart from the
+# framework/stdlib plumbing it is currently awaiting.
+_CELL_FILENAME = re.compile(r"^Cell In\[\d+\]$")
+
+
+def _is_cell_frame(frame: FrameInfo) -> bool:
+    return bool(_CELL_FILENAME.match(frame.filename))
+
+
+@dataclass
+class AgentLocation:
+    """Where the agent coroutine is currently suspended."""
+
+    task_name: str | None
+    stack: list[FrameInfo]
+
+    @property
+    def innermost(self) -> FrameInfo | None:
+        # Outermost-first; the await/suspend point is the last frame.
+        return self.stack[-1] if self.stack else None
+
+    @property
+    def innermost_cell(self) -> FrameInfo | None:
+        """The deepest frame that is the agent's own ``execute_python`` cell.
+
+        The true ``innermost`` is usually framework/stdlib plumbing the cell is
+        blocked in (e.g. ``asyncio.to_thread`` → ``run_in_executor``, an HTTP
+        client, ``asyncio.sleep``). That is a faithful suspend point but unhelpful
+        to a user asking "which line of *my* cell is running?". This returns the
+        last ``Cell In[N]`` frame in the await chain — the line of the agent's
+        code that kicked off the pending await — or ``None`` if no cell frame is
+        on the stack (e.g. suspended in ``handle`` plumbing before any cell ran).
+        """
+        for frame in reversed(self.stack):
+            if _is_cell_frame(frame):
+                return frame
+        return None
+
+    @property
+    def highlight(self) -> FrameInfo | None:
+        """Frame to render as the highlighted suspend-point source.
+
+        Prefer the agent's own cell line (``innermost_cell``); fall back to the
+        true suspend point when no cell frame is present.
+        """
+        return self.innermost_cell or self.innermost
+
+
+def _frame_info(frame) -> FrameInfo:
+    code = frame.f_code
+    return FrameInfo(code.co_qualname, frame.f_lineno, code.co_filename)
+
+
+def _coro_qualname(coro) -> str:
+    code = getattr(coro, "cr_code", getattr(coro, "gi_code", None))
+    return code.co_qualname if code is not None else repr(coro)
+
+
+def _coro_frames(coro) -> list[FrameInfo]:
+    """Frames of one coroutine and everything it directly awaits (cr_await).
+
+    Stops at the first thing that is not a coroutine/generator — typically a
+    ``FutureIter`` (the await of a Task/Future), which has no inspectable frame.
+    Task boundaries are crossed by the caller via ``Task._fut_waiter``.
+    """
+    frames: list[FrameInfo] = []
+    obj = coro
+    seen = 0
+    while obj is not None and seen < 200:
+        seen += 1
+        frame = getattr(obj, "cr_frame", getattr(obj, "gi_frame", None))
+        if frame is None or frame.f_code is None:
+            break
+        frames.append(_frame_info(frame))
+        nxt = getattr(obj, "cr_await", None)
+        if nxt is None:
+            nxt = getattr(obj, "gi_yieldfrom", None)
+        if nxt is obj:
+            break
+        obj = nxt
+    return frames
+
+
+def _await_chain(task) -> list[FrameInfo]:
+    """Walk from *task* down to the actual suspend point, across Task boundaries.
+
+    ``Task.get_stack()`` only returns the task's own frame; the interesting part
+    — which tool / LLM call / sleep the agent is blocked in — lives in the
+    coroutines it is awaiting. Within a single task we follow ``cr_await``; when
+    a task is blocked on a child Task/Future (``asyncio.gather``, a Doer
+    subagent), we hop to it via ``Task._fut_waiter`` and keep walking.
+
+    Returns outermost-first, so the last entry is where the agent is suspended.
+    """
+    frames: list[FrameInfo] = []
+    current: asyncio.Task | None = task
+    seen_tasks: set[int] = set()
+    while current is not None and id(current) not in seen_tasks:
+        seen_tasks.add(id(current))
+        frames.extend(_coro_frames(current.get_coro()))
+        current = _next_task(getattr(current, "_fut_waiter", None), seen_tasks)
+    return frames
+
+
+def _next_task(waiter, seen_tasks: set[int]) -> asyncio.Task | None:
+    """Resolve the child Task a waiter blocks on, or ``None``.
+
+    A task awaiting a single child Task has that Task as its ``_fut_waiter``.
+    A task awaiting ``asyncio.gather`` blocks on a ``_GatheringFuture`` whose
+    pending children live in its ``_children`` list — we follow the first
+    not-yet-seen pending child so the stack descends into (one of) the
+    concurrent sub-tasks (e.g. a Doer subagent) rather than stopping at gather.
+
+    NOTE: depends on the private CPython attr ``Task._fut_waiter`` and the
+    ``_GatheringFuture._children`` layout (the latter reached via
+    ``gc.get_referents`` since it is closure-held, not a public attribute). If a
+    future CPython changes either, the walk degrades silently to a shallower
+    stack — ``test_locate_descends_through_gather`` pins the behaviour so an
+    interpreter upgrade surfaces the break.
+    """
+    if isinstance(waiter, asyncio.Task):
+        return waiter
+    if isinstance(waiter, asyncio.Future):
+        for ref in gc.get_referents(waiter):
+            children = ref.get("_children") if isinstance(ref, dict) else None
+            if not children:
+                continue
+            for child in children:
+                if (
+                    isinstance(child, asyncio.Task)
+                    and not child.done()
+                    and id(child) not in seen_tasks
+                ):
+                    return child
+    return None
+
+
+def locate_agent_on_loop(turn_method: str = _TURN_METHOD) -> AgentLocation | None:
+    """Build an :class:`AgentLocation` for the agent's current turn.
+
+    MUST be called on the agent loop (e.g. via ``Command.agent_run``). Returns
+    ``None`` if no turn task is currently running (the agent is idle between
+    turns).
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+
+    def _is_turn(task: asyncio.Task) -> bool:
+        # Match the method as a whole name segment, not a bare substring, so an
+        # unrelated coroutine like ``SomeHandler.handle_event`` isn't picked up.
+        segment = f".{turn_method}"
+        qual = _coro_qualname(task.get_coro())
+        name = task.get_name()
+        return (
+            qual == turn_method or segment in qual or name == turn_method or name.endswith(segment)
+        )
+
+    turn_task = next(
+        (t for t in asyncio.all_tasks(loop) if not t.done() and _is_turn(t)),
+        None,
+    )
+    if turn_task is None:
+        return None
+
+    stack = _await_chain(turn_task)
+    if not stack:
+        stack = [_frame_info(f) for f in turn_task.get_stack()]
+    location = AgentLocation(task_name=turn_task.get_name(), stack=stack)
+    # Attach source context to the frame the UI will highlight. That is the
+    # agent's own cell frame when present (``highlight`` prefers ``innermost_cell``),
+    # falling back to the true suspend point — so the rendered code block matches
+    # what /activity points its arrow at. Without this the cell frame carries no
+    # source and the highlighted-code block silently disappears.
+    if location.highlight is not None:
+        frame = location.highlight
+        frame.context = _source_context(frame.filename, frame.lineno)
+    return location

--- a/packages/nooa-cli/src/nooa_cli/tui/bootstrap.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/bootstrap.py
@@ -1,0 +1,536 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared bootstrap for the native terminal UI."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from nooa.sessions import SessionResumed
+
+from .output import Output, TextOutput
+
+if TYPE_CHECKING:
+    from nooa import Agent
+
+    from .commands import CommandRegistry
+    from .config import Config
+    from .frontend import Frontend
+    from .session import Session
+    from .session_manager import SessionManager
+
+logger = logging.getLogger(__name__)
+
+
+def _instantiate_custom_agent(
+    agent_cls,
+    *,
+    llm,
+    storage,
+    working_directory: str | Path,
+    skills_dirs: list[Path],
+):
+    """Instantiate an extension agent with the host arguments it declares."""
+    parameters = inspect.signature(agent_cls).parameters
+    kwargs = {"llm": llm, "storage": storage}
+    if "cwd" in parameters:
+        kwargs["cwd"] = working_directory
+    if "skills_dirs" in parameters:
+        kwargs["skills_dirs"] = skills_dirs
+    return agent_cls(**kwargs)
+
+
+@dataclass
+class BootstrapResult:
+    """Everything produced by bootstrap, ready to wire to a frontend."""
+
+    config: Config
+    agent: Agent
+    session_manager: SessionManager | None
+    tracing_enabled: bool
+    resumed: bool
+    restored: bool
+    session_id: str | None
+    messages: list[Output] = field(default_factory=list)
+
+
+def _scaffold_settings(config: Config) -> None:
+    from nooa.paths import get_user_dir
+
+    from .settings import SETTINGS_FILENAME, render_settings_template, settings_present
+
+    if settings_present():
+        return
+    target = get_user_dir(SETTINGS_FILENAME)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(render_settings_template(config))
+
+
+def tui_agent_memory_key(agent: Agent, config: Config) -> str:
+    """Return the stable settings key for an agent's memory preferences."""
+    if config.tui.agent_spec:
+        return config.tui.agent_spec
+    return f"{type(agent).__module__}:{type(agent).__qualname__}"
+
+
+def resolve_tui_memory_owner(agent: Agent, config: Config) -> str:
+    """Return the role portion of this agent's hierarchical memory owner."""
+    key = tui_agent_memory_key(agent, config)
+    per_agent = config.tui.memory_owner_agents.get(key)
+    if per_agent:
+        return per_agent
+    if config.tui.memory_owner:
+        return config.tui.memory_owner
+    return type(agent).__name__
+
+
+def resolve_tui_memory_scope(agent: Agent, config: Config) -> str:
+    """Return the effective memory scope for *agent*."""
+    key = tui_agent_memory_key(agent, config)
+    return config.tui.memory_agents.get(key, config.tui.memory)
+
+
+def resolve_tui_reflection_enabled(agent: Agent, config: Config) -> bool:
+    """Return whether idle reflection is enabled for *agent*."""
+    key = tui_agent_memory_key(agent, config)
+    return bool(config.tui.reflection_agents.get(key, config.tui.reflection))
+
+
+def _teardown_tui_reflection(agent: Agent) -> None:
+    """Tear down the reflection runner before detaching or replacing memory."""
+    runner = getattr(agent, "_tui_reflection_runner", None)
+    if runner is not None:
+        runner.teardown()
+        del agent._tui_reflection_runner
+
+
+def configure_tui_memory(
+    agent: Agent,
+    config: Config,
+    *,
+    agent_db: Path | None,
+    session_id: str | None,
+) -> None:
+    """Install or remove the memory skill according to the TUI configuration."""
+    key = tui_agent_memory_key(agent, config)
+    agent._tui_memory_key = key  # type: ignore[attr-defined]
+    scope = resolve_tui_memory_scope(agent, config)
+
+    _teardown_tui_reflection(agent)
+    existing = getattr(agent, "memory", None)
+    if existing is not None and hasattr(existing, "detach"):
+        try:
+            existing.detach()
+        except Exception:
+            logger.debug("Could not detach the previous memory skill", exc_info=True)
+
+    if scope == "off":
+        skills = getattr(agent, "skills", None)
+        if skills is not None:
+            try:
+                skills.deactivate(["nemo.memory"])
+            except Exception:
+                logger.debug("Could not deactivate memory", exc_info=True)
+        if hasattr(agent, "memory"):
+            try:
+                delattr(agent, "memory")
+            except Exception:
+                logger.debug("Could not remove memory from agent", exc_info=True)
+        return
+
+    if scope not in {"session", "project"}:
+        raise ValueError(
+            f"Unsupported TUI memory scope {scope!r}; use 'off', 'session', or 'project'."
+        )
+
+    from nooa_memory import MemoryConfig
+    from nooa_memory.memory_skill import MemorySkill
+
+    from nooa.paths import get_project_dir
+
+    project_dir = get_project_dir().resolve()
+    if config.tui.memory_path is not None:
+        if config.tui.memory_path.is_absolute():
+            raise ValueError("tui.memory_path must be relative to the project directory")
+        memory_path = (project_dir / config.tui.memory_path).resolve()
+        if project_dir not in memory_path.parents and memory_path != project_dir:
+            raise ValueError("tui.memory_path must stay under the project directory")
+    elif scope == "project":
+        memory_path = (
+            Path(config.agent.working_dir) / ".nooa" / "memory" / "memory.sqlite"
+        ).resolve()
+    else:
+        if session_id is None or agent_db is None:
+            raise RuntimeError("session-scoped memory requires a durable session")
+        memory_path = Path(agent_db).with_name(f"{session_id}-memory.db")
+
+    reflection_enabled = resolve_tui_reflection_enabled(agent, config)
+    memory_kwargs: dict[str, object] = {}
+    if reflection_enabled:
+        from nooa_memory.config import ReflectionPolicy
+
+        # ReflectionRunner owns consolidation while idle; do not also run it
+        # inline in the memory middleware after every response.
+        memory_kwargs["reflection"] = ReflectionPolicy(trigger="manual")
+
+    owner_role = resolve_tui_memory_owner(agent, config)
+    owner = f"{owner_role}@{session_id[:8]}" if session_id else owner_role
+    memory_config = MemoryConfig(
+        enabled=True,
+        path=str(memory_path),
+        owner=owner,
+        **memory_kwargs,
+    )
+
+    skill_kwargs: dict[str, object] = {}
+    episode_writer = None
+    if reflection_enabled and config.tui.reflection_generative:
+        from nooa_memory.generative import llm_episode_writer, llm_reasoner, llm_reconciler
+
+        def _session_llm() -> object:
+            return agent._llm  # type: ignore[attr-defined]
+
+        skill_kwargs = {
+            "reasoner": llm_reasoner(_session_llm),
+            "reconciler": llm_reconciler(_session_llm),
+        }
+        episode_writer = llm_episode_writer(_session_llm)
+
+    skills = getattr(agent, "skills", None)
+    if skills is None:
+        raise RuntimeError("memory requires an agent with a SkillRegistry")
+    skills.register("nemo.memory", MemorySkill(memory_config, **skill_kwargs))
+    skills.activate(["nemo.memory"])
+
+    manager = agent.memory._mgr  # type: ignore[attr-defined]
+    if key != owner_role:
+        renamed = manager.store.rename_owner(key, owner_role)
+        if renamed:
+            manager.store.log_maintenance(
+                "rename_owner",
+                {"from": key, "to": owner_role, "rows": renamed},
+            )
+    manager.session_ref = session_id
+
+    from .reflection_runner import ReflectionRunner
+
+    agent._tui_reflection_runner = ReflectionRunner(  # type: ignore[attr-defined]
+        agent,
+        manager,
+        config.tui,
+        enabled=reflection_enabled,
+        episode_writer=episode_writer,
+    )
+
+
+def _load_llm_registry(messages: list[Output]) -> None:
+    try:
+        from nooa.llm_config import llm_config_chain
+        from nooa.secrets import load_secrets_into_env
+        from nooa.unifiedllm import reload_registry
+
+        load_secrets_into_env()
+        reload_registry(*llm_config_chain())
+    except Exception as exc:
+        messages.append(TextOutput(f"Failed to load LLM registry config: {exc}", "warning"))
+
+
+def _enable_tracing(config: Config, messages: list[Output]):
+    if config.no_trace:
+        return False, None
+    try:
+        from nooa.paths import find_project_root, get_project_dir
+        from nooa.tracing import enable_tracing, exporters, set_session
+
+        trace_dir = config.tui.trace_dir
+        if trace_dir is not None:
+            if str(trace_dir) == ":project:":
+                trace_dir = get_project_dir("traces")
+            elif not trace_dir.is_absolute():
+                trace_dir = find_project_root() / trace_dir
+            trace_dir.mkdir(parents=True, exist_ok=True)
+            enable_tracing(exporters=[exporters.jsonl(trace_dir), exporters.journal()])
+        else:
+            enable_tracing()
+        return True, set_session
+    except ImportError:
+        messages.append(
+            TextOutput(
+                "Tracing package not installed (openinference-instrumentation-nooa)",
+                "warning",
+            )
+        )
+    except Exception as exc:
+        messages.append(TextOutput(f"Failed to enable tracing: {exc}", "warning"))
+    return False, None
+
+
+async def bootstrap(
+    config: Config,
+    *,
+    continue_last: bool = False,
+    resume_session_id: str | None = None,
+    agent: Agent | None = None,
+) -> BootstrapResult:
+    """Create the coding agent and its shared durable session."""
+    if agent is not None:
+        return BootstrapResult(
+            config=config,
+            agent=agent,
+            session_manager=None,
+            tracing_enabled=False,
+            resumed=False,
+            restored=False,
+            session_id=None,
+        )
+
+    messages: list[Output] = []
+    _scaffold_settings(config)
+    _load_llm_registry(messages)
+    tracing_enabled, set_trace_session = _enable_tracing(config, messages)
+
+    from .config import get_llm
+
+    try:
+        llm = get_llm(config)
+    except Exception as exc:
+        from nooa.unifiedllm import FakeLLMClient
+
+        messages.extend(
+            (
+                TextOutput(f"Failed to initialize LLM: {exc}", "error"),
+                TextOutput("Using fake LLM client for testing", "info"),
+            )
+        )
+        llm = FakeLLMClient()
+
+    from nooa.unifiedllm import FakeLLMClient
+
+    if not isinstance(llm, FakeLLMClient):
+        from .health_check import probe_llm
+
+        health = await probe_llm(llm)
+        if not health.ok:
+            messages.append(TextOutput(f"⚠️  {health.error_message}", "error"))
+            if health.fix_hint:
+                messages.append(TextOutput(health.fix_hint, "info"))
+
+    from nooa.storage.sqlite import SessionAlreadyActiveError
+
+    from .session_manager import SessionManager, _make_trace_session_name
+
+    resume_id: str | None = None
+    if resume_session_id:
+        matches = SessionManager.find_by_prefix(resume_session_id)
+        if len(matches) == 1:
+            resume_id = matches[0]
+        elif len(matches) > 1:
+            messages.append(
+                TextOutput(
+                    f"Session prefix '{resume_session_id}' is ambiguous; starting new.", "warning"
+                )
+            )
+        else:
+            messages.append(
+                TextOutput(f"Session '{resume_session_id}' not found; starting new.", "warning")
+            )
+    elif continue_last:
+        resume_id = next(
+            (item.id for item in SessionManager.list_sessions(limit=20) if item.turn_count > 0),
+            None,
+        )
+
+    resumed = resume_id is not None
+    try:
+        session_manager = (
+            SessionManager.open(resume_id)
+            if resume_id is not None
+            else SessionManager.create(
+                model=config.tui.default_model,
+                agent_cls="TUIAgent",
+                working_dir=str(config.agent.working_dir),
+            )
+        )
+    except SessionAlreadyActiveError as exc:
+        detail = f" (pid {exc.owner_pid})" if exc.owner_pid is not None else ""
+        messages.append(
+            TextOutput(
+                f"Session {str(resume_id)[:8]!r} is active in another process{detail}; starting new.",
+                "warning",
+            )
+        )
+        session_manager = SessionManager.create(
+            model=config.tui.default_model,
+            agent_cls="TUIAgent",
+            working_dir=str(config.agent.working_dir),
+        )
+        resumed = False
+
+    session_id = session_manager.session_id
+    if set_trace_session is not None:
+        set_trace_session(_make_trace_session_name(session_id))
+
+    from .agent import TUIAgent
+
+    storage_kwargs = {"storage": session_manager._storage}
+    if config.tui.agent_spec:
+        from .config import load_agent_class
+        from .theme import COLORS
+
+        try:
+            agent_cls = load_agent_class(config.tui.agent_spec)
+            agent = _instantiate_custom_agent(
+                agent_cls,
+                llm=llm,
+                storage=session_manager._storage,
+                working_directory=config.agent.working_dir,
+                skills_dirs=config.tui.skills_dirs,
+            )
+            session_manager.update_agent_cls(type(agent).__name__)
+            messages.append(
+                TextOutput(
+                    f"Loaded custom agent: [{COLORS['green']}]{agent_cls.__name__}[/] "
+                    f"from {config.tui.agent_spec}",
+                    "info",
+                )
+            )
+        except Exception as exc:
+            messages.extend(
+                (
+                    TextOutput(f"Failed to load agent '{config.tui.agent_spec}': {exc}", "error"),
+                    TextOutput("Falling back to default coding agent", "info"),
+                )
+            )
+            agent = TUIAgent(
+                llm=llm,
+                config=config.agent,
+                skills_dirs=config.tui.skills_dirs,
+                **storage_kwargs,
+            )
+    else:
+        agent = TUIAgent(
+            llm=llm,
+            config=config.agent,
+            skills_dirs=config.tui.skills_dirs,
+            **storage_kwargs,
+        )
+
+    restored = False
+    if resumed:
+        try:
+            restored = session_manager._storage.restore_latest_snapshot(agent)
+            if not restored:
+                messages.append(TextOutput("No agent snapshot found in session.", "warning"))
+        except Exception as exc:
+            messages.append(TextOutput(f"Could not restore agent state: {exc}", "warning"))
+
+    try:
+        configure_tui_memory(
+            agent,
+            config,
+            agent_db=session_manager.agent_db_path,
+            session_id=session_id,
+        )
+    except Exception as exc:
+        messages.append(TextOutput(f"Could not enable memory: {exc}", "warning"))
+
+    agent._session_manager = session_manager  # type: ignore[attr-defined]
+    return BootstrapResult(
+        config=config,
+        agent=agent,
+        session_manager=session_manager,
+        tracing_enabled=tracing_enabled,
+        resumed=resumed,
+        restored=restored,
+        session_id=session_id,
+        messages=messages,
+    )
+
+
+def build_startup_info(result: BootstrapResult) -> Output:
+    from .agent import TUIAgent
+    from .output import StartupInfo
+    from .session import _short_model_name
+
+    config = result.config
+    agent = result.agent
+    trace_dir: str | None = None
+    if result.tracing_enabled and config.tui.trace_dir:
+        from nooa.paths import get_project_dir
+
+        configured = config.tui.trace_dir
+        trace_dir = str(get_project_dir("traces") if str(configured) == ":project:" else configured)
+    return StartupInfo(
+        model=config.tui.default_model,
+        short_model=_short_model_name(config.tui.default_model),
+        working_dir=str(config.agent.working_dir),
+        vi_mode=config.tui.vi_mode,
+        history_policy=(config.agent.summarization.policy if isinstance(agent, TUIAgent) else None),
+        history_limit=(
+            config.agent.summarization.max_tokens if isinstance(agent, TUIAgent) else None
+        ),
+        tracing_enabled=result.tracing_enabled,
+        trace_dir=trace_dir,
+        custom_agent=(
+            type(agent).__name__
+            if config.tui.agent_spec and not isinstance(agent, TUIAgent)
+            else None
+        ),
+    )
+
+
+def build_registry(result: BootstrapResult, frontend: Frontend) -> CommandRegistry:
+    from .commands import CommandRegistry
+    from .mcp_registry import MCPRegistry
+
+    if hasattr(result.agent, "skills"):
+        result.agent.skills.register(  # type: ignore[union-attr]
+            "nemo.mcp",
+            MCPRegistry(
+                mcp_file=result.config.tui.mcp_file,
+                servers=result.config.tui.mcp_servers,
+            ),
+        )
+        result.agent.skills.activate(["nemo.mcp"])  # type: ignore[union-attr]
+
+    if result.session_id is not None:
+        try:
+            result.agent.event_manager.add(
+                SessionResumed(session_id=result.session_id, restored=result.restored)
+            )
+        except Exception:
+            logger.debug("Failed to emit SessionResumed", exc_info=True)
+
+    registry = CommandRegistry(
+        config=result.config.tui,
+        agent=result.agent,
+        frontend=frontend,
+        skills_dirs=result.config.tui.skills_dirs,
+        mcp_file=result.config.tui.mcp_file,
+        session_manager=result.session_manager,
+        root_config=result.config,
+    )
+    result.agent._command_registry = registry  # type: ignore[attr-defined]
+    return registry
+
+
+def build_session(
+    result: BootstrapResult,
+    frontend: Frontend,
+    registry: CommandRegistry,
+    initial_outputs: list[Output] | None = None,
+) -> Session:
+    from .session import Session
+
+    return Session(
+        frontend=frontend,
+        agent=result.agent,
+        config=result.config,
+        registry=registry,
+        session_manager=result.session_manager,
+        initial_outputs=initial_outputs,
+    )

--- a/packages/nooa-cli/src/nooa_cli/tui/bootstrap.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/bootstrap.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from nooa.sessions import SessionResumed
+from nooa_cli.sessions import SessionResumed
 
 from .output import Output, TextOutput
 

--- a/packages/nooa-cli/src/nooa_cli/tui/code_preview.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/code_preview.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compact code-preview formatter used by the TUI activity line."""
+
+from __future__ import annotations
+
+
+def _code_preview(code: str, max_cols: int = 100) -> str:
+    """Return a compact preview of *code* for the activity line.
+
+    Shape:
+      * First line is comment (``#…``): keep the comment (white-styled
+        downstream) AND the next non-blank code line (grey). Max 2.
+      * First line is code: show just that line (grey). Max 1.
+
+    Filters out lines matching ``return_result(...)`` — CodeAct
+    boilerplate the user doesn't care about in a preview. Long lines
+    truncate to ``max_cols`` with an ellipsis.
+    """
+    raw = [ln for ln in code.splitlines() if ln.strip()]
+    # Drop the CodeAct-internal return_result(...) scaffolding.
+    lines = [ln for ln in raw if not ln.lstrip().startswith("return_result(")]
+    if not lines:
+        return ""
+
+    def _clip(ln: str) -> str:
+        return ln if len(ln) <= max_cols else ln[: max_cols - 1] + "…"
+
+    first = lines[0]
+    if first.lstrip().startswith("#"):
+        result = [_clip(first)]
+        if len(lines) > 1:
+            result.append(_clip(lines[1]))
+        if len(lines) > 2:
+            result[-1] += "…"
+        return "\n".join(result)
+
+    # No comment — one line only, suffix with … if there was more.
+    clipped = _clip(first)
+    if len(lines) > 1:
+        clipped += "…"
+    return clipped

--- a/packages/nooa-cli/src/nooa_cli/tui/command_runner.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/command_runner.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""TUI-local command execution queue.
+
+This is intentionally separate from ``agent.queue_manager.spawn()``. Agent jobs
+are background agent work; command records are user-submitted TUI commands
+(``/...`` and ``!...``) with UI lifecycle/status.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal
+
+from .output import CommandStatus, Output
+
+CommandKind = Literal["slash", "bang"]
+CommandState = Literal["queued", "running", "done", "failed", "cancelled"]
+
+
+@dataclass
+class CommandRecord:
+    """One user-submitted TUI command invocation."""
+
+    id: int
+    kind: CommandKind
+    text: str
+    state: CommandState = "queued"
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    error: str = ""
+
+
+class CommandRunner:
+    """Serialize TUI command execution and render lifecycle status."""
+
+    def __init__(
+        self,
+        render: Callable[[Output], Awaitable[None]],
+        *,
+        set_dynamic_status: Callable[[str], None] | None = None,
+        set_dynamic_queue: Callable[[list[str]], None] | None = None,
+        history_size: int = 50,
+    ):
+        self._render = render
+        self._set_dynamic_status = set_dynamic_status or (lambda _text: None)
+        self._set_dynamic_queue = set_dynamic_queue or (lambda _commands: None)
+        self._status_generation = 0
+        self._spinner_frames = "·•"
+        self._spinner_frame = self._spinner_frames[0]
+        self._spinner_task: asyncio.Task[None] | None = None
+        self._history_size = history_size
+        self._ids = itertools.count(1)
+        self._records: list[CommandRecord] = []
+        self._queue: asyncio.Queue[
+            tuple[CommandRecord, Callable[[], Awaitable[Any]], asyncio.Future[None]]
+        ] = asyncio.Queue()
+        self._worker: asyncio.Task[None] | None = None
+
+    @property
+    def records(self) -> list[CommandRecord]:
+        return list(self._records)
+
+    async def run(
+        self,
+        *,
+        kind: CommandKind,
+        text: str,
+        work: Callable[[], Awaitable[Any]],
+    ) -> None:
+        """Enqueue one command and wait for it to finish.
+
+        Waiting here does not block prompt_toolkit's loop; callers await a Future
+        while the runner worker performs the command. Multiple command callback
+        tasks can therefore submit concurrently while execution stays ordered.
+        """
+        record = CommandRecord(id=next(self._ids), kind=kind, text=text)
+        self._records.append(record)
+        if len(self._records) > self._history_size:
+            del self._records[: len(self._records) - self._history_size]
+        self._update_dynamic_status()
+
+        loop = asyncio.get_running_loop()
+        done: asyncio.Future[None] = loop.create_future()
+        await self._queue.put((record, work, done))
+        self._ensure_worker()
+        await done
+
+    def _ensure_worker(self) -> None:
+        if self._worker is None or self._worker.done():
+            self._worker = asyncio.create_task(self._run_loop(), name="tui-command-runner")
+
+    async def _run_loop(self) -> None:
+        while True:
+            try:
+                record, work, done = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+            try:
+                record.state = "running"
+                record.started_at = datetime.now()
+                self._update_dynamic_status()
+                post_done = await work()
+            except asyncio.CancelledError as exc:
+                record.state = "cancelled"
+                record.finished_at = datetime.now()
+                if not done.done():
+                    done.set_exception(exc)
+                self._update_dynamic_status()
+                await self._render_status(record)
+                raise
+            except Exception as exc:  # noqa: BLE001 - surface command failures to scrollback
+                record.state = "failed"
+                record.finished_at = datetime.now()
+                record.error = f"{type(exc).__name__}: {exc}"
+                if not done.done():
+                    done.set_result(None)
+                self._update_dynamic_status()
+                await self._render_status(record)
+            else:
+                record.state = "done"
+                record.finished_at = datetime.now()
+                self._update_dynamic_status()
+                await self._render_status(record)
+                try:
+                    if callable(post_done):
+                        await post_done()
+                except Exception as exc:  # noqa: BLE001 - surface deferred render failures
+                    record.state = "failed"
+                    record.error = f"post-completion render failed: {type(exc).__name__}: {exc}"
+                    await self._render_status(record)
+                finally:
+                    if not done.done():
+                        done.set_result(None)
+            finally:
+                self._queue.task_done()
+
+    def _set_status(self, text: str) -> None:
+        self._status_generation += 1
+        self._set_dynamic_status(text)
+
+    def _running_status_text(self) -> str:
+        running = [r for r in self._records if r.state == "running"]
+        if not running:
+            return ""
+        current = running[0]
+        return f"{self._spinner_frame} {current.text}"
+
+    def _ensure_spinner_task(self) -> None:
+        if self._spinner_task is not None and not self._spinner_task.done():
+            return
+
+        async def _animate() -> None:
+            i = 0
+            while any(r.state == "running" for r in self._records):
+                self._spinner_frame = self._spinner_frames[i % len(self._spinner_frames)]
+                self._set_status(self._running_status_text())
+                i += 1
+                await asyncio.sleep(0.5)
+
+        self._spinner_task = asyncio.create_task(_animate(), name="tui-command-spinner")
+
+    def _update_dynamic_status(self) -> None:
+        running = [r for r in self._records if r.state == "running"]
+        queued = [r for r in self._records if r.state == "queued"]
+        self._set_dynamic_queue([r.text for r in queued])
+        if running:
+            self._set_status(self._running_status_text())
+            self._ensure_spinner_task()
+        elif queued:
+            self._set_status(f"○ {len(queued)} queued")
+        else:
+            self._set_status("")
+
+    async def _render_status(self, record: CommandRecord) -> None:
+        await self._render(
+            CommandStatus(
+                id=record.id,
+                kind=record.kind,
+                state=record.state,
+                text=record.text,
+                error=record.error,
+            )
+        )

--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -1,0 +1,2481 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Slash command parser and handlers for NeMo OO Agents TUI/Web.
+
+Commands return structured ``CommandResult`` objects whose ``outputs`` list
+is rendered by the active ``Frontend``.  No command calls the console or
+frontend directly for its results — it only uses ``self.frontend`` for
+interactive I/O that must happen *during* execution (spinners, prompts).
+"""
+
+import abc
+import asyncio
+import datetime
+import logging
+import os
+import re
+import shlex
+import urllib.parse
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar
+
+logger = logging.getLogger(__name__)
+
+from .output import (  # noqa: E402
+    ClearScreen,
+    CodeExecution,
+    DiffOutput,
+    HelpOutput,
+    Output,
+    TableOutput,
+    TextOutput,
+    _RichReplayPayload,
+)
+from .session_manager import SessionManager, build_resume_outputs  # noqa: E402
+
+if TYPE_CHECKING:
+    from nooa import Agent
+
+    from .config import TUIConfig
+    from .frontend import Frontend
+
+
+def _mcp_auto_connect_names(value: object) -> list[str]:
+    """Return validated MCP auto-connect names from config/test doubles."""
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
+def _batch_render_ctx(frontend: "Frontend"):
+    """Return a context manager that batches a command's outputs into one block.
+
+    Tolerant of frontends without ``batch_render`` and of test doubles whose
+    ``batch_render()`` returns a Mock/coroutine instead of a real context
+    manager — in either case we fall back to a no-op context. The real
+    ``TerminalFrontend.batch_render()`` holds the ``_EmitStream`` flush so a
+    multi-output command renders as a single ``run_in_terminal`` hop.
+    """
+    from contextlib import nullcontext
+
+    factory = getattr(frontend, "batch_render", None)
+    if not callable(factory):
+        return nullcontext()
+    ctx = factory()
+    if hasattr(ctx, "__enter__") and hasattr(ctx, "__exit__"):
+        return ctx
+    # Mock / coroutine / anything non-context — don't try to enter it.
+    if asyncio.iscoroutine(ctx):
+        ctx.close()
+    return nullcontext()
+
+
+async def render_command_outputs(frontend: "Frontend", outputs: list[Output]) -> None:
+    """Render command outputs, preserving Rich replay sentinel handling.
+
+    ``_RichReplayPayload`` is an internal sentinel, not a public frontend output.
+    CommandHandler normally intercepts it before rendering; Session uses this
+    helper when output rendering is deferred until after the durable done line.
+    """
+    import os as _os
+
+    _rich_url = (
+        _os.environ.get("NEMO_OO_RICH_URL")
+        if any(isinstance(o, _RichReplayPayload) for o in outputs)
+        else None
+    )
+    with _batch_render_ctx(frontend):
+        for output in outputs:
+            if isinstance(output, _RichReplayPayload):
+                if _rich_url:
+                    try:
+                        import httpx as _httpx
+
+                        await asyncio.to_thread(
+                            _httpx.post,
+                            _rich_url,
+                            json={**output.payload, "_replay": True},
+                            timeout=5.0,
+                        )
+                    except Exception as exc:
+                        logger.debug("replay POST to %s failed: %s", _rich_url, exc)
+            else:
+                await frontend.render(output)
+
+
+def _detect_language(suffix: str) -> str:
+    """Map a file extension to a language name for editor/diff rendering."""
+    return {
+        ".py": "python",
+        ".js": "javascript",
+        ".ts": "typescript",
+        ".jsx": "javascript",
+        ".tsx": "typescript",
+        ".json": "json",
+        ".yaml": "yaml",
+        ".yml": "yaml",
+        ".md": "markdown",
+        ".sh": "bash",
+        ".bash": "bash",
+        ".toml": "toml",
+        ".html": "html",
+        ".css": "css",
+        ".rs": "rust",
+        ".go": "go",
+        ".c": "c",
+        ".cpp": "cpp",
+        ".java": "java",
+        ".rb": "ruby",
+        ".sql": "sql",
+    }.get(suffix.lower(), "plaintext")
+
+
+# ---------------------------------------------------------------------------
+# CommandResult
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CommandResult:
+    """Result from a command execution."""
+
+    success: bool
+    outputs: list[Output] = field(default_factory=list)
+    exit: bool = False
+    # When set, Session.run() replaces the active SessionManager with this one.
+    new_session_manager: "SessionManager | None" = None
+    # Set by CompactCommand to signal that auto-renaming should be retried.
+    compact_done: bool = False
+    # When set, Session.run() passes this as the user message for an agent turn.
+    agent_message: str | None = None
+    # Structured slash command result — passed to the agent on a queue.
+    slash_result: "Any | None" = None
+    # Optional callback Session runs after acknowledged cancellation and session
+    # swap, on the agent loop when available. Used by /clear, /session new, and
+    # /session resume for agent-state mutations that must not run on the UI loop
+    # while a turn is active.
+    post_session_swap: "Any | None" = None
+
+    # Convenience constructors -------------------------------------------
+
+    @classmethod
+    def ok(cls, *outputs: "Output") -> "CommandResult":
+        return cls(success=True, outputs=list(outputs))
+
+    @classmethod
+    def err(cls, message: str) -> "CommandResult":
+        return cls(success=False, outputs=[TextOutput(message, "error")])
+
+    @classmethod
+    def bye(cls) -> "CommandResult":
+        return cls(
+            success=True,
+            outputs=[TextOutput("Goodbye! Stay vibing.", "status")],
+            exit=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Command base class
+# ---------------------------------------------------------------------------
+
+
+class Command(abc.ABC):
+    """Abstract base class for all slash commands."""
+
+    # Agent attributes that must be present for this command to be registered.
+    required_capabilities: ClassVar[frozenset[str]] = frozenset()
+
+    def __init__(
+        self,
+        frontend: "Frontend",
+        config: "TUIConfig",
+        agent: "Agent",
+        session_manager: "SessionManager | None" = None,
+        **kwargs,
+    ):
+        if agent is None:
+            raise ValueError("agent cannot be None.")
+        self.frontend = frontend
+        self.config = config
+        self.agent: Any = agent
+        self.session_manager = session_manager
+        self._registry: Any = kwargs.get("registry")
+        # Dispatch operations to the agent thread. Set by CommandRegistry
+        # after construction. Falls back to inline execution if not wired.
+        self._agent_run = kwargs.get("agent_run")
+        # Awaitable variant — set alongside _agent_run. Commands that run on
+        # the UI loop must use this so they never block it (see
+        # TUIApplication.agent_run_async).
+        self._agent_run_async = kwargs.get("agent_run_async")
+
+    def agent_run(self, fn):
+        """Run *fn* on the agent thread. Falls back to inline if not wired."""
+        if self._agent_run is not None:
+            return self._agent_run(fn)
+        return fn()
+
+    async def agent_run_async(self, fn):
+        """Awaitable ``agent_run`` — never blocks the calling loop.
+
+        Falls back to inline execution when no async dispatcher is wired
+        (tests / pre-startup), where there is no UI loop to protect.
+        """
+        if self._agent_run_async is not None:
+            return await self._agent_run_async(fn)
+        result = fn()
+        if asyncio.iscoroutine(result):
+            return await result
+        return result
+
+    @abc.abstractmethod
+    async def execute(self, args: list[str]) -> "CommandResult":
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        raise NotImplementedError
+
+    @classmethod
+    @abc.abstractmethod
+    def help_text(cls) -> dict[str, str]:
+        raise NotImplementedError
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if len(args) > 0:
+            return False, f"Usage: /{self.name}"
+        return True, None
+
+    def _persist_tui_setting(self, key: str, value: object) -> None:
+        from .settings import write_settings_updates
+
+        write_settings_updates({("tui", key): value})
+
+
+# ---------------------------------------------------------------------------
+# Concrete commands
+# ---------------------------------------------------------------------------
+
+
+class HelpCommand(Command):
+    def __init__(self, frontend, config, agent, **kwargs):
+        super().__init__(frontend, config, agent, **kwargs)
+        self._registry = kwargs.get("registry")
+
+    @property
+    def name(self) -> str:
+        return "help"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {"/help": "Show this help message"}
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        commands_dict = (
+            self._registry.get_active_help() if self._registry else CommandRegistry.get_help()
+        )
+        return CommandResult.ok(HelpOutput(commands_dict))
+
+
+class ExitCommand(Command):
+    @property
+    def name(self) -> str:
+        return "exit"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {
+            "/exit": "Exit the TUI",
+            "/quit": "Exit the TUI (alias for /exit)",
+        }
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        return CommandResult.bye()
+
+
+async def _reset_agent_working_state(agent: "Agent") -> None:
+    """Reset the agent's in-memory working state for a fresh ``/clear``.
+
+    The event manager is already pointed at the new (empty) storage via
+    ``_swap_session_manager`` — that handles conversation history. Here
+    we clear the *snapshotable* fields that live on the agent instance
+    itself and don't get reset by storage swap alone.
+
+    Guarded by ``hasattr`` / duck-typed checks so agents without a
+    particular skill keep working.
+    """
+    # 1. TodoManager
+    todo = getattr(agent, "todo", None)
+    if todo is not None and hasattr(todo, "clear") and callable(todo.clear):
+        try:
+            todo.clear()
+        except Exception:
+            pass
+
+    # 2. Persistent vars (self.v / agent.vars)
+    if hasattr(agent, "vars") and isinstance(agent.vars, dict):
+        agent.vars.clear()
+
+    # 3. User-set context blocks (preserve framework-protected ones)
+    cm = getattr(agent, "context_manager", None)
+    if cm is not None:
+        user_keys = [k for k in cm.keys() if k not in cm.protected_keys]
+        for k in user_keys:
+            try:
+                del cm[k]
+            except Exception:
+                pass
+
+    # 4. Shell session — kill and restart so env vars / cwd / aliases
+    #    from the old session don't leak.
+    shell = getattr(agent, "shell", None)
+    if shell is not None and hasattr(shell, "reset") and callable(shell.reset):
+        try:
+            await shell.reset()
+        except Exception:
+            pass
+
+    # 5. Notify skills the working state was just reset so they can
+    #    re-initialize session-scoped state (symmetric with SessionResumed).
+    em = getattr(agent, "event_manager", None)
+    if em is not None:
+        try:
+            from nooa.sessions import SessionCleared
+
+            em.register_event_type(SessionCleared)
+            sid = None
+            sm = getattr(agent, "_session_manager", None)
+            if sm is not None:
+                sid = getattr(sm, "session_id", None)
+            em.add(SessionCleared(session_id=sid))
+        except Exception:
+            logger.debug("Failed to emit SessionCleared", exc_info=True)
+
+
+class ClearCommand(Command):
+    @property
+    def name(self) -> str:
+        return "clear"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {"/clear": "Start a new session (preserves old session history)"}
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        # Create a fresh SessionManager so subsequent turns go to a new file.
+        # NOTE: do NOT call agent.event_manager.clear() here — that would
+        # destroy the old session's SQLite data before _swap_session_manager()
+        # can close and preserve it.  The new storage starts empty; the agent's
+        # event_manager property will return the new backend after the swap.
+        new_sm: SessionManager | None = None
+        if self.session_manager is not None:
+            try:
+                new_sm = SessionManager.create(
+                    model=self.session_manager.model,
+                    agent_cls=self.session_manager.agent_cls,
+                    working_dir=self.session_manager.working_dir,
+                )
+            except Exception:
+                pass
+
+        # Session._run_command performs acknowledged turn cancellation and
+        # loop-affine QueueManager shutdown/flush during the actual session
+        # swap. Do not call queue_manager.shutdown() here: spawned jobs live on
+        # the agent loop, while commands run on the UI loop.
+
+        # Session._run_command applies the agent working-state reset after
+        # acknowledged turn cancellation and after the storage/session swap, on
+        # the agent loop when available. Doing it here would run on the UI loop
+        # and can race or deadlock with the active turn.
+
+        outputs: list[Output] = [
+            ClearScreen(),
+            _RichReplayPayload(payload={"kind": "clear"}),  # type: ignore[list-item]
+        ]
+        if self._registry and self._registry.startup_info:
+            outputs.append(self._registry.startup_info)
+        outputs.append(TextOutput("Started new session. Previous session saved.", "success"))
+        result = CommandResult(success=True, outputs=outputs)
+        result.new_session_manager = new_sm
+        result.post_session_swap = lambda: _reset_agent_working_state(self.agent)
+        return result
+
+
+class ModelCommand(Command):
+    @property
+    def name(self) -> str:
+        return "model"
+
+    def help_text(self) -> dict[str, str]:  # type: ignore[override]
+        short = self.config.default_model.split("/")[-1] if hasattr(self, "config") else "?"
+        return {
+            "/model [name]": f"Switch model (currently {short})",
+        }
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if len(args) > 1:
+            return False, "Usage: /model [name]"
+        return True, None
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        if not args:
+            return CommandResult.ok(
+                TextOutput(f"Current model: {self.config.default_model}", "info")
+            )
+
+        from nooa.unifiedllm import get_llm_client
+
+        selected = args[0]
+        self.config.default_model = selected
+        try:
+            from nooa.interactive import apply_model_limits
+
+            def _switch():
+                self.agent.set_llm(get_llm_client(selected))
+                apply_model_limits(self.agent)
+
+            await self.agent_run_async(_switch)
+        except Exception as e:
+            return CommandResult.err(f"Failed to switch model: {e}")
+        try:
+            self._persist_tui_setting("default_model", selected)
+        except Exception as e:
+            logger.warning("Failed to persist selected TUI model %r: %s", selected, e)
+        return CommandResult.ok(TextOutput(f"Switched to model: {selected}", "success"))
+
+
+class ModelsCommand(Command):
+    @property
+    def name(self) -> str:
+        return "models"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {"/models": "List available models from registry"}
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        from nooa.unifiedllm import MODELS
+
+        rows: list[list[str]] = []
+        for model_name in sorted(MODELS.keys()):
+            marker = "\u25c0" if model_name == self.config.default_model else ""
+            rows.append([model_name, marker])
+
+        return CommandResult.ok(
+            TableOutput(
+                title="Available Models",
+                columns=["Model", ""],
+                rows=rows,
+                footer="Use /model <name> to switch. Any model supported by litellm works, not just these aliases.",
+            )
+        )
+
+
+class ReasoningCommand(Command):
+    """Toggle reasoning mode for the current model."""
+
+    @property
+    def name(self) -> str:
+        return "reasoning"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {"/reasoning [off|low|medium|high]": "Toggle reasoning mode for the current model"}
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if len(args) > 1:
+            return False, "Usage: /reasoning [off|low|medium|high]"
+        if args and args[0].lower() not in ("off", "low", "medium", "high"):
+            return False, "Usage: /reasoning [off|low|medium|high]"
+        return True, None
+
+    def _get_reasoning_state(self) -> tuple[str, str]:
+        """Return (effort_level, client_type) for the current model.
+
+        effort_level is 'off', 'low', 'medium', or 'high'.
+        client_type is 'responses' or 'completion'.
+        """
+        from nooa.unifiedllm.unifiedllm import ResponsesClient
+
+        llm = self.agent.llm
+        is_responses = isinstance(llm, ResponsesClient)
+        client_type = "responses" if is_responses else "completion"
+
+        if is_responses:
+            reasoning = llm.config.get("reasoning")
+            if reasoning and isinstance(reasoning, dict):
+                return reasoning.get("effort", "off"), client_type
+            return "off", client_type
+        else:
+            effort = llm.config.get("reasoning_effort")
+            if effort:
+                return str(effort), client_type
+            return "off", client_type
+
+    def _set_reasoning(self, level: str) -> None:
+        """Set reasoning level on the live LLM client config."""
+        from nooa.unifiedllm.unifiedllm import ResponsesClient
+
+        llm = self.agent.llm
+        is_responses = isinstance(llm, ResponsesClient)
+
+        if level == "off":
+            if is_responses:
+                llm.config.pop("reasoning", None)
+            else:
+                llm.config.pop("reasoning_effort", None)
+        else:
+            if is_responses:
+                llm.config["reasoning"] = {"effort": level}
+            else:
+                llm.config["reasoning_effort"] = level
+                # Ensure the gateway knows this param is allowed
+                allowed = llm.config.get("allowed_openai_params")
+                if isinstance(allowed, list):
+                    if "reasoning_effort" not in allowed:
+                        allowed.append("reasoning_effort")
+                else:
+                    llm.config["allowed_openai_params"] = ["reasoning_effort"]
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        if not args:
+            effort, client_type = self._get_reasoning_state()
+            model = self.config.default_model
+            status = f"**{effort}**" if effort != "off" else "off"
+            return CommandResult.ok(
+                TextOutput(
+                    f"Reasoning for {model} ({client_type}): {status}",
+                    "info",
+                )
+            )
+
+        level = args[0].lower()
+
+        def _apply():
+            self._set_reasoning(level)
+
+        try:
+            await self.agent_run_async(_apply)
+        except Exception as e:
+            return CommandResult.err(f"Failed to set reasoning: {e}")
+        model = self.config.default_model
+        if level == "off":
+            return CommandResult.ok(TextOutput(f"Reasoning disabled for {model}", "success"))
+        return CommandResult.ok(TextOutput(f"Reasoning set to {level} for {model}", "success"))
+
+
+class ThemeCommand(Command):
+    """Switch the color theme."""
+
+    THEMES = ("mocha", "latte", "vsdark", "vslight")
+
+    @property
+    def name(self) -> str:
+        return "theme"
+
+    def help_text(self) -> dict[str, str]:  # type: ignore[override]
+        from . import theme as theme_module
+
+        current = theme_module.get_theme() if hasattr(self, "config") else "?"
+        return {
+            "/theme [name]": f"Switch theme (currently {current})",
+        }
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if len(args) > 1:
+            return False, f"Usage: /theme [{'|'.join(self.THEMES)}]"
+        if len(args) == 1 and args[0].lower() not in self.THEMES:
+            return False, f"Theme must be one of: {', '.join(self.THEMES)}"
+        return True, None
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        from . import theme as theme_module
+
+        if not args:
+            current = theme_module.get_theme()
+            others = ", ".join(t for t in self.THEMES if t != current)
+            return CommandResult.ok(
+                TextOutput(f"Current theme: {current}  (available: {others})", "info")
+            )
+
+        name = args[0].lower()
+        theme_module.set_theme(name)
+
+        # Replace the base theme in Rich Console's ThemeStack
+        # We can't just push - we need to replace the base entry
+        if hasattr(self.frontend, "_console") and hasattr(self.frontend._console, "console"):  # type: ignore[attr-defined]
+            console = self.frontend._console.console  # type: ignore[attr-defined]
+            new_theme = theme_module.create_theme()
+
+            # Directly replace the base theme in the stack
+            # This is the only way to actually change colors since Theme snapshots
+            # the COLORS dict at creation time
+            console._theme_stack._entries[0] = new_theme.styles
+            console._theme_stack.get = console._theme_stack._entries[-1].get
+
+        # Rebuild prompt_toolkit style for the new theme
+        if hasattr(self.frontend, "_input_handler") and self.frontend._input_handler is not None:  # type: ignore[attr-defined]
+            self.frontend._input_handler.refresh_style()  # type: ignore[attr-defined]
+
+        return CommandResult.ok(TextOutput(f"Switched to {name} theme", "success"))
+
+
+# ---------------------------------------------------------------------------
+# History commands
+# ---------------------------------------------------------------------------
+
+
+class HistoryCommand(Command):
+    required_capabilities: ClassVar[frozenset[str]] = frozenset({"get_summarization_status"})
+
+    @property
+    def name(self) -> str:
+        return "history"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {
+            "/history status": "Show history and summarization status",
+            "/history tags": "Show active history tags",
+        }
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if not args:
+            return False, "Usage: /history <status|tags>"
+        if args[0].lower() not in ("status", "tags"):
+            return False, f"Unknown subcommand `{args[0]}`. Usage: /history <status|tags>"
+        return True, None
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        subcmd = args[0].lower()
+        if subcmd == "status":
+            return self._history_status()
+        return self._history_tags()
+
+    def _history_status(self) -> "CommandResult":
+        s = self.agent.get_summarization_status()
+
+        rows: list[list[str]] = [
+            ["Active events", str(s["active_events"])],
+            ["Policy", s["policy"]],
+        ]
+
+        if s.get("has_summarizer") and s.get("max_tokens", 0) > 0:
+            cur = s["current_tokens"]
+            mx = s["max_tokens"]
+            pct = cur / mx * 100 if mx else 0
+            rows.append([f"Token usage ({pct:.1f}%)", f"{cur:,} / {mx:,}"])
+            rows.append(["Preserve recent", str(s.get("preserve_recent", 0))])
+
+        rows.append(["Summary count", str(s.get("summary_count", 0))])
+
+        outputs: list[Output] = [
+            TableOutput(title="History Status", columns=["Field", "Value"], rows=rows)
+        ]
+        if s.get("summary_tags"):
+            outputs.append(TextOutput("Tags: " + ", ".join(s["summary_tags"]), "status"))
+
+        return CommandResult.ok(*outputs)
+
+    def _history_tags(self) -> "CommandResult":
+        if not hasattr(self.agent, "event_manager"):
+            return CommandResult.err("Agent does not support event history.")
+        tags = self.agent.event_manager.keys()
+        rows: list[list[str]] = []
+        for tag in tags[:50]:
+            event = self.agent.event_manager[tag]
+            etype = getattr(event, "event_type", type(event).__name__)
+            rows.append([tag, etype])
+
+        footer = f"\u2026 and {len(tags) - 50} more" if len(tags) > 50 else ""
+        return CommandResult.ok(
+            TableOutput(
+                title=f"Active History Tags ({len(tags)} total)",
+                columns=["Tag", "Type"],
+                rows=rows,
+                footer=footer,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Skills commands
+# ---------------------------------------------------------------------------
+
+
+class SkillsCommand(Command):
+    required_capabilities: ClassVar[frozenset[str]] = frozenset()
+
+    def __init__(self, frontend, config, agent, **kwargs):
+        super().__init__(frontend, config, agent, **kwargs)
+        self.skills_dirs = kwargs.get("skills_dirs")
+        self._registry: CommandRegistry | None = kwargs.get("registry")
+
+    @property
+    def name(self) -> str:
+        return "skills"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {
+            "/skills list": "List available skills",
+            "/skills activate <id>": "Activate a skill",
+            "/skills deactivate <id>": "Deactivate a skill",
+            "/skills commands": "Show auto-registered slash commands from skills",
+        }
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if not args:
+            return False, "Usage: /skills <list|activate|deactivate|commands>"
+        if args[0].lower() not in ("list", "activate", "deactivate", "commands"):
+            return False, f"Unknown subcommand `{args[0]}`"
+        if args[0].lower() in ("activate", "deactivate") and len(args) < 2:
+            return False, f"Usage: /skills {args[0]} <skill_id>"
+        return True, None
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        from nooa.skill_registry import SkillRegistry
+
+        registry = getattr(self.agent, "skills", None)
+        if not isinstance(registry, SkillRegistry):
+            return CommandResult.err(
+                "Agent has no SkillRegistry. Skills require self.skills = SkillRegistry(self)."
+            )
+
+        subcmd = args[0].lower()
+        subargs = args[1:]
+
+        if subcmd == "commands":
+            user_skills = self._registry._user_skills if self._registry else {}
+            rows_cmd = [
+                [f"/{name}", skill.argument_hint or "", skill.description]
+                for name, skill in sorted(user_skills.items())
+            ]
+            if rows_cmd:
+                return CommandResult.ok(
+                    TableOutput(
+                        columns=["Command", "Args", "Description"],
+                        rows=rows_cmd,
+                        title="Skill slash commands",
+                    ),
+                    TextOutput(f"Searched: {self.skills_dirs}", "status"),
+                )
+            return CommandResult.ok(
+                TextOutput("No user-invocable skill commands found.", "info"),
+                TextOutput(f"Searched: {self.skills_dirs}", "status"),
+            )
+
+        if subcmd == "list":
+            all_names = registry.discovered()
+            activated = set(registry.activated())
+            if not all_names:
+                return CommandResult.ok(TextOutput("No skills found", "info"))
+            rows = [[name, "\u2713" if name in activated else "", ""] for name in all_names]
+            return CommandResult.ok(
+                TableOutput(columns=["ID", "Active", "Description"], rows=rows, title="Skills"),
+            )
+
+        if subcmd == "activate":
+            skill_id = subargs[0]
+            if skill_id in registry.activated():
+                return CommandResult.err(f"Skill `{skill_id}` already active")
+            if skill_id not in registry.discovered():
+                return CommandResult.err(f"Skill `{skill_id}` not found. Use /skills list.")
+            try:
+                registry.activate([skill_id])
+                return CommandResult.ok(TextOutput(f"Skill `{skill_id}` activated", "success"))
+            except Exception as e:
+                return CommandResult.err(f"Failed to activate `{skill_id}`: {e}")
+
+        # deactivate
+        skill_id = subargs[0]
+        if skill_id not in registry.activated():
+            return CommandResult.err(f"`{skill_id}` not active. Use /skills list.")
+        try:
+            registry.deactivate([skill_id])
+            return CommandResult.ok(TextOutput(f"Skill `{skill_id}` deactivated", "success"))
+        except Exception as e:
+            return CommandResult.err(f"Failed to deactivate `{skill_id}`: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Todo commands
+# ---------------------------------------------------------------------------
+
+
+class ContextCommand(Command):
+    """Show context window utilization stats."""
+
+    @property
+    def name(self) -> str:
+        return "context"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {"/context": "Show context window utilization"}
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        stats = getattr(self.agent, "context_stats", None)
+        if stats is None:
+            return CommandResult.ok(
+                TextOutput("No context stats yet — run a generation first.", "info")
+            )
+        return CommandResult.ok(TextOutput(stats.format(), "info"))
+
+
+# ---------------------------------------------------------------------------
+# Compact command
+# ---------------------------------------------------------------------------
+
+
+class CompactCommand(Command):
+    """Summarize and compact conversation history."""
+
+    @property
+    def name(self) -> str:
+        return "compact"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {"/compact": "Summarize conversation history into a compact block (frees tokens)"}
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        if not hasattr(self.agent, "event_manager"):
+            return CommandResult.err("Agent does not support history management.")
+
+        tags = self.agent.event_manager.keys()
+        events_before = len(tags)
+        if events_before == 0:
+            return CommandResult.ok(
+                TextOutput("Nothing to compact \u2014 history is already empty.", "info")
+            )
+
+        tokens_before = 0
+        stats = self.agent.context_stats
+        if stats:
+            tokens_before = stats.total_tokens or 0
+        summarizers = getattr(self.agent, "_summarizers", [])
+
+        if summarizers:
+            summarizer = summarizers[0]
+            start_tag = tags[0]
+            end_tag = tags[-1]
+            # A static status line — not start_thinking(). The latter spins a
+            # rich.live.Live (~10 fps) layered on top of prompt_toolkit's
+            # full-screen app; each repaint hops through emit_block /
+            # run_in_terminal and fights pt's own status spinner, which the
+            # user sees as flicker. Compaction runs on the UI loop (a command,
+            # not an agent turn) so the native "thinking…" status never shows
+            # anyway — one status block plus the result block is enough.
+            await self.frontend.render(TextOutput("Summarizing history\u2026", "info"))
+            try:
+                history_md = summarizer._render_range_to_markdown(start_tag, end_tag)
+                target_chars = getattr(getattr(summarizer, "config", None), "target_chars", 2000)
+                summary_text = await summarizer.summarize(history_md, target_chars)
+                await self.agent_run_async(
+                    lambda: self.agent.event_manager.collapse(start_tag, end_tag, summary_text)
+                )
+                events_after = len(self.agent.event_manager.keys())
+                tok_sfx = f" (~{tokens_before:,} tokens freed)" if tokens_before else ""
+                result = CommandResult.ok(
+                    TextOutput(
+                        f"Compacted {events_before} events \u2192 {events_after} (summary block){tok_sfx}.",
+                        "success",
+                    )
+                )
+                result.compact_done = True
+                return result
+            except Exception as e:
+                return CommandResult.ok(
+                    TextOutput(
+                        f"Summarization failed ({e}); kept {events_before} events intact.",
+                        "warning",
+                    )
+                )
+
+        await self.agent_run_async(lambda: self.agent.event_manager.clear())
+        tok_sfx = f" (~{tokens_before:,} tokens freed)" if tokens_before else ""
+        result = CommandResult.ok(
+            TextOutput(f"Cleared {events_before} history events{tok_sfx}.", "success")
+        )
+        result.compact_done = True
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Python display toggle
+# ---------------------------------------------------------------------------
+
+
+class PythonCommand(Command):
+    """Toggle display of the Python execution panel."""
+
+    @property
+    def name(self) -> str:
+        return "python"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {
+            "/python status": "Show whether Python execution display is on or off",
+            "/python on": "Enable Python execution display",
+            "/python off": "Suppress Python execution display",
+        }
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if not args:
+            return False, "Usage: /python <status|on|off>"
+        if args[0].lower() not in ("status", "on", "off"):
+            return False, f"Unknown subcommand `{args[0]}`"
+        return True, None
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        subcmd = args[0].lower()
+
+        if subcmd == "status":
+            state = "on" if self.config.show_python else "off"
+            return CommandResult.ok(TextOutput(f"Python execution display: {state}", "info"))
+
+        if subcmd == "on":
+            self.config.show_python = True
+            return CommandResult.ok(TextOutput("Python execution display enabled.", "success"))
+
+        # off
+        self.config.show_python = False
+        return CommandResult.ok(TextOutput("Python execution display suppressed.", "success"))
+
+
+def _set_agent_settings_preference(agent: "Agent | None", field: str, value: object) -> Path:
+    """Persist one per-agent TUI preference in layered ``settings.yaml``."""
+    from .settings import write_settings_updates
+
+    key = getattr(agent, "_tui_memory_key", None)
+    if key is None and agent is not None:
+        key = f"{type(agent).__module__}:{type(agent).__qualname__}"
+    path, _data = write_settings_updates({("tui", field, key or "default"): value})
+    return path
+
+
+_MEMORY_MODES = {"on": "project", "local": "session", "off": "off"}
+_SCOPE_LABELS = {
+    "project": "on (shared across sessions, project-wide)",
+    "session": "local (this session only)",
+    "off": "off",
+}
+
+
+class MemoryCommand(Command):
+    """Configure long-term memory for this agent."""
+
+    @property
+    def name(self) -> str:
+        return "memory"
+
+    def help_text(self) -> dict[str, str]:  # type: ignore[override]
+        return {
+            "/memory [on|local|off]": (
+                "Configure long-term memory: on shares a project store; "
+                f"local uses this session (currently {self._scope_label()})"
+            )
+        }
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if len(args) > 1 or (args and args[0].lower() not in {*_MEMORY_MODES, "status"}):
+            return False, "Usage: /memory [on|local|off]"
+        return True, None
+
+    def _agent_key(self) -> str:
+        return getattr(
+            self.agent,
+            "_tui_memory_key",
+            f"{type(self.agent).__module__}:{type(self.agent).__qualname__}",
+        )
+
+    def _scope(self) -> str:
+        return self.config.memory_agents.get(self._agent_key(), self.config.memory)
+
+    def _scope_label(self) -> str:
+        scope = self._scope()
+        return _SCOPE_LABELS.get(scope, scope)
+
+    def _configure(self) -> None:
+        from .bootstrap import configure_tui_memory
+
+        root_config = getattr(self._registry, "_root_config", None)
+        if root_config is None:
+            raise RuntimeError("the TUI root configuration is unavailable")
+        session_manager = self.session_manager or getattr(self._registry, "session_manager", None)
+        configure_tui_memory(
+            self.agent,
+            root_config,
+            agent_db=session_manager.agent_db_path if session_manager is not None else None,
+            session_id=session_manager.session_id if session_manager is not None else None,
+        )
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        if not args or args[0].lower() == "status":
+            line = f"Memory: {self._scope_label()}"
+            skill = getattr(self.agent, "memory", None)
+            manager = getattr(skill, "_mgr", None) if skill is not None else None
+            if manager is not None:
+                line += f" — you are {manager.owner} · store: {manager.store.path}"
+            return CommandResult.ok(TextOutput(line, "info"))
+
+        scope = _MEMORY_MODES[args[0].lower()]
+        self.config.memory = scope
+        self.config.memory_agents[self._agent_key()] = scope
+        _set_agent_settings_preference(self.agent, "memory_agents", scope)
+        try:
+            await self.agent_run_async(self._configure)
+        except Exception as exc:
+            return CommandResult.err(f"Failed to configure memory: {exc}")
+
+        if scope == "off":
+            return CommandResult.ok(TextOutput("Memory disabled for this agent.", "success"))
+        return CommandResult.ok(
+            TextOutput(f"Memory {_SCOPE_LABELS[scope]} enabled for this agent.", "success")
+        )
+
+
+class ReflectionCommand(MemoryCommand):
+    """Configure idle consolidation for the current agent's memory."""
+
+    @property
+    def name(self) -> str:
+        return "reflection"
+
+    def help_text(self) -> dict[str, str]:  # type: ignore[override]
+        state = "on" if self._enabled() else "off"
+        return {
+            "/reflection [on|off|now]": (
+                f"Configure idle memory reflection (currently {state}); now runs immediately"
+            )
+        }
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if len(args) > 1 or (args and args[0].lower() not in {"on", "off", "status", "now"}):
+            return False, "Usage: /reflection [on|off|now]"
+        return True, None
+
+    def _enabled(self) -> bool:
+        return bool(self.config.reflection_agents.get(self._agent_key(), self.config.reflection))
+
+    def _runner(self):
+        return getattr(self.agent, "_tui_reflection_runner", None)
+
+    def _status_output(self) -> TextOutput:
+        state = "on" if self._enabled() else "off"
+        runner = self._runner()
+        if runner is None:
+            return TextOutput(f"Idle reflection: {state} (memory is not attached)", "info")
+        line = f"Idle reflection: {state} | dirty: {runner.dirty}"
+        report = runner.last_report
+        if report is not None:
+            stopped = f"interrupted @ {report.stopped_in}, " if report.interrupted else ""
+            line += (
+                f" | last: merged {report.merged}, +{report.edges_added} edges, "
+                f"rescored {report.rescored}, pruned {report.pruned}, "
+                f"created {report.created} ({stopped}{report.duration_ms / 1000:.1f}s)"
+            )
+        return TextOutput(line, "info")
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        if not args or args[0].lower() == "status":
+            return CommandResult.ok(self._status_output())
+
+        if args[0].lower() == "now":
+            runner = self._runner()
+            if runner is None:
+                return CommandResult.err("Memory is not attached. Enable it with /memory first.")
+            started = await self.agent_run_async(runner.run_now)
+            if not started:
+                return CommandResult.ok(TextOutput("A reflection run is already pending.", "info"))
+            return CommandResult.ok(
+                TextOutput("Reflection started; /reflection shows the report.", "success")
+            )
+
+        enabled = args[0].lower() == "on"
+        if enabled and getattr(self.agent, "memory", None) is None:
+            return CommandResult.err("Memory is not attached. Enable it with /memory first.")
+
+        self.config.reflection = enabled
+        self.config.reflection_agents[self._agent_key()] = enabled
+        _set_agent_settings_preference(self.agent, "reflection_agents", enabled)
+        runner = self._runner()
+        if runner is not None and not enabled:
+            await self.agent_run_async(runner.interrupt)
+        try:
+            await self.agent_run_async(self._configure)
+        except Exception as exc:
+            return CommandResult.err(f"Failed to configure reflection: {exc}")
+        state = "enabled" if enabled else "disabled"
+        return CommandResult.ok(TextOutput(f"Idle reflection {state} for this agent.", "success"))
+
+
+class KeepGoingCommand(Command):
+    """Toggle stop auditing and autonomous continuation for unfinished work."""
+
+    _VAR_KEY = "tui_keep_going"
+    _MODEL_VAR_KEY = "tui_keep_going_model"
+
+    @property
+    def name(self) -> str:
+        return "keep-going"
+
+    def help_text(self) -> dict[str, str]:  # type: ignore[override]
+        state = "on" if self._enabled() else "off"
+        model = self._model() or "not configured"
+        return {
+            "/keep-going [on|off]": (
+                f"Audit completed turns and continue unfinished work (currently {state}; "
+                f"model: {model})"
+            ),
+            "/keep-going model <name>": f"Set the keep-going judge model (currently {model})",
+        }
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if not args:
+            return True, None
+        subcommand = args[0].lower()
+        if subcommand in {"on", "off"} and len(args) == 1:
+            return True, None
+        if subcommand == "model" and len(args) == 2 and args[1].strip():
+            return True, None
+        return False, "Usage: /keep-going [on|off] or /keep-going model <name>"
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        if not args:
+            state = "on" if self._enabled() else "off"
+            model = self._model() or "not configured"
+            return CommandResult.ok(TextOutput(f"Keep-going mode: {state}; model: {model}", "info"))
+
+        if args[0].lower() == "model":
+            model = args[1].strip()
+            self.config.keep_going_model = model
+            vars_obj = getattr(self.agent, "vars", None)
+            if vars_obj is not None:
+                vars_obj[self._MODEL_VAR_KEY] = model
+            self._persist_tui_setting("keep_going_model", model)
+            return CommandResult.ok(TextOutput(f"Keep-going model set to {model}.", "success"))
+
+        enabled = args[0].lower() == "on"
+        if enabled and not self._model():
+            return CommandResult.err(
+                "Keep-going model is not configured. Run /keep-going model <model-id> first."
+            )
+        self.config.keep_going = enabled
+        vars_obj = getattr(self.agent, "vars", None)
+        if vars_obj is not None:
+            vars_obj[self._VAR_KEY] = enabled
+        self._persist_tui_setting("keep_going", enabled)
+        state = "enabled" if enabled else "disabled"
+        return CommandResult.ok(TextOutput(f"Keep-going mode {state}.", "success"))
+
+    def _enabled(self) -> bool:
+        vars_obj = getattr(self.agent, "vars", None)
+        if vars_obj is not None and self._VAR_KEY in vars_obj:
+            return bool(vars_obj.get(self._VAR_KEY))
+        return bool(getattr(self.config, "keep_going", False))
+
+    def _model(self) -> str | None:
+        vars_obj = getattr(self.agent, "vars", None)
+        if vars_obj is not None and self._MODEL_VAR_KEY in vars_obj:
+            value = vars_obj.get(self._MODEL_VAR_KEY)
+        else:
+            value = getattr(self.config, "keep_going_model", None)
+        if value is None:
+            return None
+        model = str(value).strip()
+        return model or None
+
+
+class ToolbarCommand(Command):
+    """Configure ordered, named toolbar items."""
+
+    @property
+    def name(self) -> str:
+        return "toolbar"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {"/toolbar [reset|set <items...>]": "Show or configure toolbar items"}
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        return True, None
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        from .toolbar import ToolbarRegistry
+
+        available = ToolbarRegistry().names()
+        if not args:
+            active = " · ".join(self.config.toolbar_items)
+            return CommandResult.ok(
+                TextOutput(
+                    f"Toolbar: {active}\nAvailable items: {', '.join(available)}",
+                    "info",
+                )
+            )
+
+        if args[0].lower() == "reset":
+            self.config.toolbar_items = ["time", "model", "context", "session"]
+            return CommandResult.ok(
+                TextOutput("Toolbar reset to time · model · context · session.", "success")
+            )
+
+        requested = args[1:] if args[0].lower() == "set" else args
+        requested = list(dict.fromkeys(item.lower() for item in requested))
+        if not requested:
+            return CommandResult.err("Usage: /toolbar set <item> [item ...]")
+        unknown = [item for item in requested if item not in available]
+        if unknown:
+            return CommandResult.err(
+                f"Unknown toolbar item(s): {', '.join(unknown)}. Available: {', '.join(available)}"
+            )
+        self.config.toolbar_items = requested
+        return CommandResult.ok(TextOutput(f"Toolbar set to: {' · '.join(requested)}", "success"))
+
+
+# ---------------------------------------------------------------------------
+# Edit command
+# ---------------------------------------------------------------------------
+
+
+class EditCommand(Command):
+    """Open a file in $EDITOR and show the diff on save."""
+
+    @property
+    def name(self) -> str:
+        return "edit"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {
+            "/edit <file>": "Open file in $EDITOR \u2014 shows diff on save",
+        }
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if not args:
+            return False, "Usage: /edit <file>"
+        return True, None
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        import difflib
+        from pathlib import Path
+
+        path = Path(args[0]).expanduser().resolve()
+        original = path.read_text(errors="replace") if path.exists() else ""
+        language = _detect_language(path.suffix)
+
+        new_content = await self.frontend.open_editor(str(path), original, language)
+        if new_content is None:
+            return CommandResult.ok(TextOutput("Edit cancelled.", "info"))
+        if new_content == original:
+            return CommandResult.ok(TextOutput("No changes.", "info"))
+
+        # Write the file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(new_content)
+
+        # Compute unified diff
+        diff_lines = list(
+            difflib.unified_diff(
+                original.splitlines(keepends=True),
+                new_content.splitlines(keepends=True),
+                fromfile=f"a/{path.name}",
+                tofile=f"b/{path.name}",
+                lineterm="\n",
+            )
+        )
+        diff_text = "".join(diff_lines)
+
+        outputs: list[Output] = [TextOutput(f"Saved {path}.", "success")]
+        if diff_text:
+            outputs.append(DiffOutput(diff=diff_text, filename=str(path)))
+        return CommandResult.ok(*outputs)
+
+
+class SessionCommand(Command):
+    """List, resume, and manage conversation sessions."""
+
+    @property
+    def name(self) -> str:
+        return "session"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {
+            "/session list": "Open the session explorer",
+            "/session new": "Start a new session (current history cleared)",
+            "/session resume <id>": "Resume a past session (injects history as context)",
+            "/session delete <id>": "Delete a session",
+            "/session export": "Export current session as Markdown",
+            "/session rename <name>": "Rename the current session",
+        }
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if not args:
+            return False, "Usage: /session <list|new|resume|delete|export|rename>"
+        if args[0].lower() not in ("list", "new", "resume", "delete", "export", "rename"):
+            return False, f"Unknown subcommand `{args[0]}`"
+        if args[0].lower() in ("resume", "delete") and len(args) < 2:
+            return False, f"Usage: /session {args[0]} <session_id>"
+        # /session rename with no name regenerates the automatic Predict title.
+        return True, None
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        subcmd = args[0].lower()
+
+        if subcmd == "list":
+            open_explorer = getattr(self.frontend, "open_session_explorer", None)
+            has_real_explorer = getattr(
+                type(self.frontend), "open_session_explorer", None
+            ) is not None or "open_session_explorer" in getattr(self.frontend, "__dict__", {})
+            if has_real_explorer and callable(open_explorer):
+                try:
+                    await open_explorer()
+                except Exception as exc:
+                    return CommandResult.err(f"Session explorer failed: {exc}")
+                return CommandResult.ok(TextOutput("Session explorer closed.", "status"))
+
+            sessions = [s for s in SessionManager.list_sessions() if s.turn_count > 0]
+            if not sessions:
+                return CommandResult.ok(TextOutput("No sessions found.", "info"))
+            rows = []
+            for s in sessions:
+                dt = datetime.datetime.fromtimestamp(s.last_active).strftime("%m/%d %H:%M")
+                name_display = s.name[:28] if s.name else ""
+                rows.append(
+                    [s.id[:8], dt, s.model.split("/")[-1][:20], str(s.turn_count), name_display]
+                )
+            return CommandResult.ok(
+                TableOutput(
+                    title="Recent Sessions",
+                    columns=["ID", "Last Active", "Model", "Turns", "Name"],
+                    rows=rows,
+                )
+            )
+
+        if subcmd == "export":
+            if self.session_manager is None:
+                return CommandResult.err("No active session manager.")
+            md = self.session_manager.as_markdown()
+            fname = f"session-{self.session_manager.session_id[:8]}-{datetime.date.today()}.md"
+            try:
+                Path(fname).write_text(md)
+                return CommandResult.ok(TextOutput(f"Session exported to {fname}", "success"))
+            except Exception as e:
+                return CommandResult.ok(TextOutput(f"Export failed: {e}\n\n{md[:500]}", "warning"))
+
+        if subcmd == "resume":
+            session_id = args[1]
+            matches = SessionManager.find_by_prefix(session_id)
+            if not matches:
+                return CommandResult.err(f"Session '{session_id}' not found. Use /session list.")
+            if len(matches) > 1:
+                ids = ", ".join(m[:8] for m in matches)
+                return CommandResult.err(f"Ambiguous session prefix '{session_id}' matches: {ids}")
+            full_id = matches[0]
+
+            import os as _os
+
+            from .session_manager import SESSIONS_DIR as _SESSIONS_DIR
+
+            _session_db_path = _SESSIONS_DIR / f"{full_id}.db"
+            _in_nemo_term = bool(_os.environ.get("NEMO_OO_RICH_URL"))
+
+            from nooa.storage.sqlite import SessionAlreadyActiveError
+
+            try:
+                new_sm = SessionManager.open(full_id)
+            except SessionAlreadyActiveError as e:
+                return CommandResult.err(str(e))
+
+            try:
+                outputs = build_resume_outputs(
+                    _session_db_path, full_id, in_nemo_term=_in_nemo_term
+                )
+                if not outputs:
+                    new_sm.close()
+                    return CommandResult.err(f"Session '{session_id}' is empty.")
+
+                # Session._run_command executes this after acknowledged turn
+                # cancellation and after the storage/session swap, on the agent
+                # loop when available. restore_latest_snapshot mutates agent
+                # vars/todos/context/tool state and must not race an active turn.
+                async def _restore_and_emit() -> list[Output]:
+                    restored = new_sm._storage.restore_latest_snapshot(self.agent)
+                    try:
+                        from nooa.sessions import SessionResumed
+
+                        self.agent.event_manager.register_event_type(SessionResumed)
+                        self.agent.event_manager.add(
+                            SessionResumed(session_id=full_id, restored=restored)
+                        )
+                    except Exception:
+                        logger.debug("Failed to emit SessionResumed", exc_info=True)
+                    if restored:
+                        return [
+                            TextOutput(
+                                f"Agent state restored from session {full_id[:8]}.", "status"
+                            )
+                        ]
+                    return []
+
+                result = CommandResult.ok(*outputs)
+                result.new_session_manager = new_sm
+                result.post_session_swap = _restore_and_emit
+                return result
+            except Exception as e:
+                new_sm.close()
+                return CommandResult.err(f"Could not restore session: {e}")
+
+        if subcmd == "delete":
+            session_id = args[1]
+            matches = SessionManager.find_by_prefix(session_id)
+            if not matches:
+                return CommandResult.err(f"Session '{session_id}' not found.")
+            if len(matches) > 1:
+                ids = ", ".join(m[:8] for m in matches)
+                return CommandResult.err(f"Ambiguous session prefix '{session_id}' matches: {ids}")
+            SessionManager.delete_session(matches[0])
+            return CommandResult.ok(TextOutput(f"Session {matches[0][:8]} deleted.", "success"))
+
+        if subcmd == "rename":
+            if self.session_manager is None:
+                return CommandResult.err("No active session.")
+
+            if len(args) > 1:
+                name = " ".join(args[1:]).strip()
+                self.session_manager.rename(name, user_named=True)
+                return CommandResult.ok(TextOutput(f"Session renamed to: {name}", "success"))
+
+            turns = self.session_manager.turns
+            first_user = next((t.content for t in turns if t.role == "user" and t.content), "")
+            if not first_user:
+                return CommandResult.err("No user message available to generate a session name.")
+
+            async def _generate_name() -> str:
+                name = await self.agent.name_session(first_user[:400])
+                return str(name).strip().strip('"').strip("'")[:60]
+
+            try:
+                name = await self.agent_run_async(_generate_name)
+            except Exception as e:
+                return CommandResult.err(f"Could not generate session name: {e}")
+
+            if not name:
+                return CommandResult.err("Generated session name was empty.")
+            self.session_manager.rename(name, user_named=False)
+            return CommandResult.ok(TextOutput(f"Session renamed to: {name}", "success"))
+
+        if subcmd == "new":
+            # NOTE: do NOT call agent.event_manager.clear() here — same
+            # reasoning as ClearCommand: it would wipe the old session's
+            # SQLite data before _swap_session_manager() preserves it.
+
+            # Create a fresh SessionManager so subsequent turns go to a new file.
+            new_sm: SessionManager | None = None
+            if self.session_manager is not None:
+                try:
+                    new_sm = SessionManager.create(
+                        model=self.session_manager.model,
+                        agent_cls=self.session_manager.agent_cls,
+                        working_dir=self.session_manager.working_dir,
+                    )
+                except Exception:
+                    pass
+
+            # Session._run_command performs acknowledged turn cancellation and
+            # loop-affine QueueManager shutdown/flush during the actual session
+            # swap. Do not call queue_manager.shutdown() here: spawned jobs live on
+            # the agent loop, while commands run on the UI loop.
+
+            # Session._run_command applies the agent working-state reset after
+            # acknowledged turn cancellation and after the storage/session swap,
+            # on the agent loop when available.
+
+            outputs: list[Output] = [
+                ClearScreen(),
+                _RichReplayPayload(payload={"kind": "clear"}),  # type: ignore[list-item]
+            ]
+            if self._registry and self._registry.startup_info:
+                outputs.append(self._registry.startup_info)
+            outputs.append(TextOutput("Started new session. History cleared.", "success"))
+            result = CommandResult(success=True, outputs=outputs)
+            result.new_session_manager = new_sm
+            result.post_session_swap = lambda: _reset_agent_working_state(self.agent)
+            return result
+
+        return CommandResult.err(f"Unknown subcommand `{subcmd}`")
+
+
+# ---------------------------------------------------------------------------
+# Registry and handler
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _UserSkill:
+    """Metadata for a user-invocable skill slash command."""
+
+    name: str
+    body: str
+    description: str
+    argument_hint: str | None = None
+    completions: tuple[str, ...] = ()
+    output_to_agent: bool = True
+    _method: Any = field(default=None, repr=False)
+
+    def help_entry(self) -> tuple[str, str]:
+        hint = self.argument_hint or ""
+        key = f"/{self.name} {hint}".strip()
+        return key, self.description
+
+    def make_agent_message(self, args: list[str]) -> str:
+        body = self.body
+        if args:
+            joined = " ".join(args)
+            if "$ARGUMENTS" in body:
+                return body.replace("$ARGUMENTS", joined)
+            return f"{body}\n\nArguments: {joined}"
+        return body
+
+
+# ---------------------------------------------------------------------------
+# Jobs command
+# ---------------------------------------------------------------------------
+
+
+class JobsCommand(Command):
+    """Open the job explorer."""
+
+    @property
+    def name(self) -> str:
+        return "jobs"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {"/jobs": "Open the job explorer"}
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if args:
+            return False, "Usage: /jobs"
+        return True, None
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        open_explorer = getattr(self.frontend, "open_job_explorer", None)
+        if callable(open_explorer):
+            try:
+                await open_explorer()
+            except Exception as exc:
+                return CommandResult.err(f"Job explorer failed: {exc}")
+            return CommandResult.ok(TextOutput("Job explorer closed.", "status"))
+        return CommandResult.err("The job explorer requires the terminal TUI.")
+
+
+# ---------------------------------------------------------------------------
+# Memories command
+# ---------------------------------------------------------------------------
+
+
+class MemoriesCommand(Command):
+    """Open the in-app long-term memory explorer."""
+
+    @property
+    def name(self) -> str:
+        return "memories"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {"/memories": "Open the long-term memory explorer"}
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if args:
+            return False, "Usage: /memories"
+        return True, None
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        if getattr(self.agent, "memory", None) is None:
+            return CommandResult.err("Memory is not attached. Enable it with /memory first.")
+        open_explorer = getattr(self.frontend, "open_memory_explorer", None)
+        if not callable(open_explorer):
+            return CommandResult.err("The memory explorer requires the terminal TUI.")
+        try:
+            await open_explorer()
+        except Exception as exc:
+            return CommandResult.err(f"Memory explorer failed: {exc}")
+        return CommandResult.ok(TextOutput("Memory explorer closed.", "status"))
+
+
+class TraceUrlCommand(Command):
+    """Print the full viewer URL for the current session's trace."""
+
+    @property
+    def name(self) -> str:
+        return "trace-url"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {
+            "/trace-url": "Print the full URL to the trace of the current session",
+        }
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        try:
+            from nooa.tracing import get_session
+        except ImportError:
+            return CommandResult.err("Tracing package not installed.")
+
+        session_name = get_session()
+        if not session_name:
+            return CommandResult.err("No active trace session.")
+
+        # Determine the viewer base URL from the OTLP endpoint
+        endpoint = os.environ.get("OTLP_ENDPOINT", "http://localhost:5001/v1/traces")
+        # Strip /v1/traces or /v1 suffix to get the viewer base
+        base = endpoint.rstrip("/")
+        for suffix in ("/v1/traces", "/v1"):
+            if base.endswith(suffix):
+                base = base[: -len(suffix)]
+                break
+
+        url = f"{base}/traces/view?session_id={urllib.parse.quote(session_name)}"
+        return CommandResult.ok(TextOutput(url, "info"))
+
+
+# ---------------------------------------------------------------------------
+# Show last Python command
+# ---------------------------------------------------------------------------
+
+
+class EventsCommand(Command):
+    """Open the in-app event explorer."""
+
+    @property
+    def name(self) -> str:
+        return "events"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {"/events": "Open the event explorer"}
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if args:
+            return False, "Usage: /events"
+        return True, None
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        if args:
+            return CommandResult.err("Usage: /events")
+        em = getattr(self.agent, "event_manager", None)
+        if em is None:
+            return CommandResult.err("No event manager available.")
+
+        return await self._open_explorer(em)
+
+    async def _open_explorer(self, em) -> "CommandResult":
+        """Open the event explorer as an in-app TUI view."""
+        open_explorer = getattr(self.frontend, "open_event_explorer", None)
+        if not callable(open_explorer):
+            return CommandResult.err("The event explorer requires the terminal TUI.")
+        try:
+            await open_explorer(em)
+        except Exception as exc:
+            return CommandResult.err(f"Event explorer failed: {exc}")
+        return CommandResult.ok(TextOutput("Event explorer closed.", "status"))
+
+
+class ActivityCommand(Command):
+    """Report what the agent is doing right now: executing Python, waiting on
+    an LLM call, or idle."""
+
+    @property
+    def name(self) -> str:
+        return "activity"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {"/activity": "Show what the agent is doing right now (python / LLM / idle)"}
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        result = await self._activity_result()
+        if not result.success:
+            return result
+        open_overlay = getattr(self.frontend, "open_activity_overlay", None)
+        has_real_overlay = getattr(
+            type(self.frontend), "open_activity_overlay", None
+        ) is not None or "open_activity_overlay" in getattr(self.frontend, "__dict__", {})
+        if has_real_overlay and callable(open_overlay):
+            try:
+                await open_overlay(result.outputs)
+            except Exception as exc:
+                return CommandResult.err(f"Activity overlay failed: {exc}")
+            return CommandResult.ok(TextOutput("Activity overlay closed.", "status"))
+        return result
+
+    async def _activity_result(self) -> "CommandResult":
+        try:
+            from nooa.runtime.debug_handler import get_activity
+        except ImportError:
+            return CommandResult.err("Activity tracking not available in this build.")
+
+        activity = get_activity()
+        phase = activity["phase"]
+        code_execs = activity["code_execs"]
+        llm_calls = activity["llm_calls"]
+
+        labels = {
+            "executing_python": "Executing Python",
+            "waiting_llm": "Waiting on LLM call",
+            # "idle" only reaches the table in the rare idle-with-live-turn case;
+            # idle-with-nothing-in-flight early-returns a one-liner below.
+            "idle": "Idle",
+        }
+        headline = labels.get(phase, phase)
+
+        # Where in the code is the agent suspended? Walk the agent turn task's
+        # await stack. This runs on the agent loop (asyncio.Task is not safe to
+        # introspect cross-thread), so dispatch via agent_run_async().
+        location = await self._locate_agent()
+        cell = location.innermost_cell if location is not None else None
+        highlight = location.highlight if location is not None else None
+
+        # Idle with nothing in flight: a one-liner, not a table.
+        if phase == "idle" and (location is None or not location.stack):
+            return CommandResult.ok(TextOutput("Agent idle — nothing in flight.", "status"))
+
+        rows: list[list[str]] = [["Phase", headline]]
+        for ex in code_execs:
+            detail = ex.get("preview") or "(code cell)"
+            rows.append([f"  python ({ex['elapsed']:.1f}s)", detail])
+        for call in llm_calls:
+            model = call.get("model", "unknown")
+            rows.append([f"  llm ({call['elapsed']:.1f}s)", model])
+
+        if location is not None and location.stack:
+            rows.append(["", ""])
+            rows.append(["Suspended at", location.task_name or "agent turn"])
+            for frame in location.stack:
+                if frame is highlight:
+                    marker = "→ "  # the frame /activity points its source block at
+                elif frame is location.innermost:
+                    marker = "↳ "  # deepest plumbing the highlighted frame is blocked in
+                else:
+                    marker = "  "
+                rows.append(["", f"{marker}{frame.short()}"])
+
+        if phase == "executing_python" and llm_calls:
+            footer = "Running a code cell that is itself blocked on an LLM call."
+        elif phase == "executing_python" and cell is not None:
+            footer = f"In a code cell — parked at {cell.short()}."
+        elif phase == "executing_python":
+            footer = "In a code cell — not waiting on the model."
+        elif phase == "waiting_llm":
+            footer = "Blocked waiting for the model to respond."
+        elif location is not None and location.innermost is not None:
+            footer = f"Awaiting at {location.innermost.short()}."
+        else:
+            footer = "Nothing in flight."
+
+        outputs: list[Output] = [
+            # Unlabelled key/value table: no title, no header row (Rich would
+            # otherwise draw an empty header band above the first row).
+            TableOutput(
+                columns=["", ""],
+                rows=rows,
+                footer=footer,
+                show_header=False,
+            )
+        ]
+
+        # Render the suspend-point source as a syntax-highlighted code block
+        # (the frontend lexes/colours CodeExecution.code). For a CodeAct/REPL
+        # cell this is the cell text; the suspend line is the last context line.
+        code_output = self._suspend_code_output(location)
+        if code_output is not None:
+            outputs.append(code_output)
+
+        return CommandResult.ok(*outputs)
+
+    @staticmethod
+    def _suspend_code_output(location) -> "CodeExecution | None":
+        """Build a highlighted code block for the suspend-point source, or None.
+
+        The snippet is numbered from its real file offset (``start_line``) and
+        the suspend line is tinted via ``highlight_line``, so the parked line
+        stands out and the line numbers match the await stack.
+        """
+        if location is None:
+            return None
+        frame = location.highlight
+        if frame is None or not frame.context:
+            return None
+        code = "\n".join(src.text for src in frame.context)
+        return CodeExecution(
+            tool_call_id=f"activity:{frame.filename}:{frame.lineno}",
+            code=code,
+            start_line=frame.context[0].lineno,
+            highlight_line=frame.lineno,
+        )
+
+    async def _locate_agent(self):
+        """Snapshot where the agent coroutine is suspended (or None if idle).
+
+        Runs the probe on the agent loop via ``agent_run_async`` —
+        ``asyncio.Task`` is not safe to walk from the command (UI) thread, and
+        the blocking ``agent_run`` would freeze the UI loop while the agent is
+        busy (causing status-bar flicker and stalling ``self.message()``
+        output). Awaiting yields control so the UI keeps painting.
+        """
+        from .agent_location import locate_agent_on_loop
+
+        try:
+            return await self.agent_run_async(locate_agent_on_loop)
+        except Exception:
+            return None
+
+
+class TodosCommand(Command):
+    """Open the todo explorer."""
+
+    @property
+    def name(self) -> str:
+        return "todos"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {"/todos": "Open the todo explorer"}
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if args:
+            return False, "Usage: /todos"
+        return True, None
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        open_explorer = getattr(self.frontend, "open_todo_explorer", None)
+        if callable(open_explorer):
+            try:
+                await open_explorer()
+            except Exception as exc:
+                return CommandResult.err(f"Todo explorer failed: {exc}")
+            return CommandResult.ok(TextOutput("Todo explorer closed.", "status"))
+        return CommandResult.err("The todo explorer requires the terminal TUI.")
+
+
+class MCPCommand(Command):
+    """User-owned MCP configuration, approval, and connection lifecycle."""
+
+    required_capabilities: ClassVar[frozenset[str]] = frozenset({"mcp"})
+
+    @property
+    def name(self) -> str:
+        return "mcp"
+
+    @classmethod
+    def help_text(cls) -> dict[str, str]:
+        return {
+            "/mcp list": "Show configured, approved, and connected MCP servers",
+            "/mcp add <server> <url-or-command>": "Add an MCP server to project settings",
+            "/mcp remove <server>": "Remove an inline project MCP server",
+            "/mcp connect <server>": "Connect an approved MCP server",
+            "/mcp approve <server> [code]": "Review or approve one exact MCP configuration",
+            "/mcp revoke <server>": "Disconnect a server and revoke its approvals",
+            "/mcp disconnect <server>": "Disconnect an MCP server",
+        }
+
+    def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        if not args:
+            return True, None
+        action = args[0].lower()
+        allowed = {"list", "add", "remove", "connect", "approve", "revoke", "disconnect"}
+        if action not in allowed:
+            return False, f"Unknown MCP action {action!r}"
+        if action == "list":
+            return (len(args) == 1, "Usage: /mcp list")
+        if action == "add":
+            return (len(args) == 3, "Usage: /mcp add <server> <url-or-command>")
+        if len(args) < 2:
+            return False, f"Usage: /mcp {action} <server>"
+        if action == "approve" and len(args) > 3:
+            return False, "Usage: /mcp approve <server> [confirmation-code]"
+        if action != "approve" and len(args) > 2:
+            return False, f"Usage: /mcp {action} <server>"
+        return True, None
+
+    async def execute(self, args: list[str]) -> "CommandResult":
+        from .mcp_approval import MCPApprovalRequired
+
+        mcp = self.agent.mcp
+        action = args[0].lower() if args else "list"
+        if action == "list":
+            return CommandResult.ok(TextOutput(mcp.status(), "info"))
+
+        server = args[1]
+        configured = set(mcp.discovered())
+
+        if action == "add":
+            if server in configured:
+                return CommandResult.err(
+                    f"Server {server!r} is already configured; edit its source configuration."
+                )
+            value = args[2]
+            entry = (
+                {"url": value, "transport": "streamable-http"}
+                if value.startswith(("http://", "https://"))
+                else {"command": value}
+            )
+            path = None
+            try:
+                mcp._validate_attach_name(server)
+                from .settings import write_settings_updates
+
+                path, _data = write_settings_updates({("tui", "mcp_servers", server): entry})
+                mcp.register(server, **entry)
+            except Exception as exc:
+                if path is not None:
+                    from .settings import delete_settings_value
+
+                    delete_settings_value(("tui", "mcp_servers", server))
+                return CommandResult.err(f"Failed to add {server!r}: {exc}")
+            kind = "HTTP" if "url" in entry else "stdio"
+            return CommandResult.ok(
+                TextOutput(
+                    f"Added {kind} MCP server {server!r} to {path}. "
+                    f"Review it with /mcp approve {server}.",
+                    "success",
+                )
+            )
+
+        if action == "remove":
+            if server not in mcp._servers:
+                if server in configured:
+                    return CommandResult.err(
+                        f"Server {server!r} comes from {mcp._mcp_file}; remove it from that file."
+                    )
+                return CommandResult.err(f"Server {server!r} is not configured. Try /mcp list.")
+            if server in mcp.connected():
+                await mcp.disconnect([server])
+            from .settings import delete_settings_value
+
+            path, _data, deleted = delete_settings_value(("tui", "mcp_servers", server))
+            if not deleted:
+                return CommandResult.err(
+                    f"Server {server!r} is not present in project settings at {path}."
+                )
+            mcp._servers.pop(server, None)
+            mcp._activated.discard(server)
+            mcp._revoke_approvals(server)
+            return CommandResult.ok(
+                TextOutput(f"Removed MCP server {server!r} from {path}.", "success")
+            )
+
+        if action != "revoke" and server not in configured:
+            return CommandResult.err(f"Server {server!r} not found. Try /mcp list.")
+
+        if action == "connect":
+            try:
+                connected = await mcp.connect([server])
+            except MCPApprovalRequired as exc:
+                return CommandResult.ok(TextOutput(str(exc), "warning"))
+            except Exception as exc:
+                return CommandResult.err(f"Failed to connect {server!r}: {exc}")
+            if not connected:
+                return CommandResult.ok(
+                    TextOutput(f"{server!r} is already connected.\n\n{mcp.status()}", "info")
+                )
+            return CommandResult.ok(
+                TextOutput(f"Connected {server!r}.\n\n{mcp.status()}", "success")
+            )
+
+        if action == "approve":
+            if len(args) == 2:
+                try:
+                    review = mcp._approval_request(server).review_text()
+                except Exception as exc:
+                    return CommandResult.err(f"Cannot review {server!r}: {exc}")
+                return CommandResult.ok(TextOutput(review, "warning"))
+            try:
+                mcp._approve(server, args[2])
+            except Exception as exc:
+                return CommandResult.err(f"Failed to approve {server!r}: {exc}")
+            try:
+                connected = await mcp.connect([server])
+            except Exception as exc:
+                return CommandResult.err(f"Approved {server!r}, but connection failed: {exc}")
+            state = "Approved and connected" if connected else "Approved"
+            return CommandResult.ok(TextOutput(f"{state} {server!r}.\n\n{mcp.status()}", "success"))
+
+        if action == "revoke":
+            if server in mcp.connected():
+                await mcp.disconnect([server])
+            revoked = mcp._revoke_approvals(server)
+            if revoked:
+                return CommandResult.ok(
+                    TextOutput(f"Disconnected {server!r} and revoked its approvals.", "success")
+                )
+            return CommandResult.ok(TextOutput(f"{server!r} had no stored approvals.", "info"))
+
+        if server not in mcp.connected():
+            return CommandResult.ok(
+                TextOutput(f"{server!r} is not connected. Try /mcp list.", "info")
+            )
+        try:
+            await mcp.disconnect([server])
+        except Exception as exc:
+            return CommandResult.err(f"Failed to disconnect {server!r}: {exc}")
+        return CommandResult.ok(
+            TextOutput(f"Disconnected {server!r}.\n\n{mcp.status()}", "success")
+        )
+
+
+class CommandRegistry:
+    """Registry of command instances."""
+
+    _command_classes: dict[str, type[Command]] = {
+        "help": HelpCommand,
+        "exit": ExitCommand,
+        "quit": ExitCommand,
+        "clear": ClearCommand,
+        "compact": CompactCommand,
+        "context": ContextCommand,
+        "edit": EditCommand,
+        "model": ModelCommand,
+        "models": ModelsCommand,
+        "theme": ThemeCommand,
+        "history": HistoryCommand,
+        "skills": SkillsCommand,
+        "python": PythonCommand,
+        "keep-going": KeepGoingCommand,
+        "memory": MemoryCommand,
+        "memories": MemoriesCommand,
+        "reflection": ReflectionCommand,
+        "session": SessionCommand,
+        "jobs": JobsCommand,
+        "events": EventsCommand,
+        "todos": TodosCommand,
+        "mcp": MCPCommand,
+        "trace-url": TraceUrlCommand,
+        "toolbar": ToolbarCommand,
+        "activity": ActivityCommand,
+        "reasoning": ReasoningCommand,
+    }
+
+    def __init__(
+        self,
+        config: "TUIConfig",
+        agent: "Agent",
+        frontend: "Frontend",
+        skills_dirs: list[Path] | None = None,
+        mcp_file: Path | None = None,
+        session_manager: "SessionManager | None" = None,
+        root_config: "Any | None" = None,
+    ):
+        self.config = config
+        self.agent = agent
+        self.frontend = frontend
+        self.skills_dirs = skills_dirs
+        self.mcp_file = mcp_file
+        self.session_manager = session_manager
+        self._root_config = root_config
+        self.startup_info: Output | None = None  # set by main after bootstrap
+        self._bind_mcp_oauth_prompt()
+        self._commands: dict[str, Command] = self._register()
+        self._discover_directory_skills()
+        self._user_skills: dict[str, _UserSkill] = self._discover_user_skills()
+
+    def _register(self) -> dict[str, Command]:
+        commands: dict[str, Command] = {}
+        kwargs: dict[str, Any] = {
+            "skills_dirs": self.skills_dirs,
+            "registry": self,
+            "session_manager": self.session_manager,
+        }
+        for name, cls in self.get_all_command_classes().items():
+            if not all(hasattr(self.agent, cap) for cap in cls.required_capabilities):
+                continue
+            commands[name] = cls(self.frontend, self.config, self.agent, **kwargs)
+        return commands
+
+    def _bind_mcp_oauth_prompt(self) -> None:
+        """Bridge worker-thread OAuth input onto the host UI event loop."""
+        mcp = getattr(self.agent, "mcp", None)
+        bind = getattr(mcp, "_bind_oauth_code_prompt", None)
+        if not callable(bind):
+            return
+        try:
+            ui_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            bind(None)
+            return
+
+        async def _ask_on_ui(auth_url: str) -> str:
+            prompt_sensitive = getattr(self.frontend, "prompt_sensitive", None)
+            if not callable(prompt_sensitive):
+                raise RuntimeError("This frontend cannot collect MCP OAuth codes securely")
+            return await prompt_sensitive(
+                "MCP OAuth authorization",
+                "Open this URL in a browser, authorize the server, then paste the "
+                f"authorization code or callback URL:\n\n{auth_url}",
+            )
+
+        async def _prompt(auth_url: str) -> str:
+            try:
+                current_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                current_loop = None
+            if current_loop is ui_loop:
+                return await _ask_on_ui(auth_url)
+            future = asyncio.run_coroutine_threadsafe(_ask_on_ui(auth_url), ui_loop)
+            return await asyncio.wrap_future(future)
+
+        bind(_prompt)
+
+    async def auto_connect_mcp(self) -> None:
+        """Connect approved startup servers after the live TUI is ready."""
+        await asyncio.sleep(0)
+        names = _mcp_auto_connect_names(getattr(self.config, "mcp_auto_connect", None))
+        if not names:
+            return
+        registry = getattr(self.agent, "mcp", None)
+        if registry is None:
+            logger.warning("MCP auto-connect requested but self.mcp is not available")
+            return
+
+        try:
+            configured = set(registry.discovered())
+        except Exception as exc:
+            logger.warning("MCP auto-connect skipped: failed to read config: %s", exc)
+            return
+
+        unknown = [n for n in names if n not in configured]
+        for name in unknown:
+            logger.warning("MCP auto-connect skipped unknown server %r", name)
+        wanted = [n for n in names if n in configured]
+        if not wanted:
+            return
+
+        from .mcp_approval import MCPApprovalRequired
+
+        for server_name in wanted:
+            try:
+                await registry.connect([server_name])
+                logger.info("MCP server %r auto-connected", server_name)
+            except MCPApprovalRequired as exc:
+                logger.warning("MCP auto-connect needs approval for %r", server_name)
+                await self.frontend.render(TextOutput(str(exc), "warning"))
+            except Exception as exc:
+                logger.warning("Failed to auto-connect MCP server %r: %s", server_name, exc)
+
+    def _discover_user_skills(self) -> "dict[str, _UserSkill]":
+        """Scan skills dirs for install-as:command skills and register them as slash commands.
+
+        Uses rglob to match SkillRegistry.discover_skills_dirs() — finds skills at any depth.
+        Parses SKILL.md frontmatter inline to avoid depending on private nooa
+        internals that may not be present in older installed versions.
+        """
+        skills: dict[str, _UserSkill] = {}
+        if not self.skills_dirs:
+            return skills
+        try:
+            import yaml
+        except ImportError:
+            return skills
+        for skills_dir in self.skills_dirs:
+            skills_dir = Path(skills_dir)
+            if not skills_dir.is_dir():
+                continue
+            for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+                entry = skill_md.parent
+                try:
+                    content = skill_md.read_text(encoding="utf-8")
+                    if not content.startswith("---"):
+                        continue
+                    parts = content.split("---", 2)
+                    if len(parts) < 3:
+                        continue
+                    try:
+                        meta = yaml.safe_load(parts[1]) or {}
+                        if not isinstance(meta, dict):
+                            raise ValueError("not a mapping")
+                    except Exception:
+                        # Fallback: line-by-line regex for invalid-YAML values like
+                        # argument-hint: "<action>" [issue-id]  (Claude Code style).
+                        # Parse each scalar individually so "false" → False (not "false").
+                        import re
+
+                        meta = {}
+                        for line in parts[1].splitlines():
+                            m = re.match(r"^([a-zA-Z][a-zA-Z0-9_-]*):\s*(.+)$", line)
+                            if not m:
+                                continue
+                            raw = m.group(2).strip()
+                            try:
+                                parsed = yaml.safe_load(raw)
+                                meta[m.group(1)] = (
+                                    str(parsed) if isinstance(parsed, list) else parsed
+                                )
+                            except Exception:
+                                meta[m.group(1)] = raw
+                    if not isinstance(meta, dict):
+                        continue
+                    # CC convention: user-invocable defaults to true.
+                    # Opt out with user-invocable: false.
+                    # install-as: command is honored for backward compat.
+                    if meta.get("user-invocable") is False:
+                        continue
+                    raw_name = str(meta.get("name") or "").strip()
+                    cmd_name = raw_name.lower()
+                    if not cmd_name or cmd_name in self._commands or cmd_name in skills:
+                        continue
+                    description = str(meta.get("description", "")).strip()
+                    body = parts[2].strip()
+                    hint = meta.get("argument-hint")
+                    if isinstance(hint, list):
+                        # YAML parses [label] as a list; reconstruct bracket notation
+                        hint = "[" + ", ".join(str(x) for x in hint) + "]"
+                    elif hint is not None:
+                        hint = str(hint)
+                    skills[cmd_name] = _UserSkill(
+                        name=cmd_name,
+                        body=body,
+                        description=description,
+                        argument_hint=hint,
+                    )
+                except Exception as e:
+                    logger.warning("Failed to load skill from %s: %s", entry, e)
+        # Also discover @slash_command methods from loaded Skills
+        skills.update(self._discover_skill_commands())
+        return skills
+
+    def _discover_skill_commands(self) -> "dict[str, _UserSkill]":
+        """Discover @slash_command methods from loaded Skill instances on the agent."""
+        skills: dict[str, _UserSkill] = {}
+        try:
+            from nooa.skill import get_slash_commands
+        except ImportError:
+            return skills
+
+        from nooa.skill import Skill
+
+        for attr_name in dir(self.agent):
+            if attr_name.startswith("_"):
+                continue
+            try:
+                obj = getattr(self.agent, attr_name)
+            except Exception:
+                continue
+            if not isinstance(obj, Skill):
+                continue
+            for meta, method in get_slash_commands(obj):
+                cmd_name = meta.name.lower()
+                if cmd_name in self._commands or cmd_name in skills:
+                    continue
+                description = (method.__doc__ or "").strip().split("\n")[0]
+                skills[cmd_name] = _UserSkill(
+                    name=cmd_name,
+                    body="",
+                    description=description,
+                    argument_hint=meta.argument_hint,
+                    completions=getattr(meta, "completions", ()),
+                    output_to_agent=getattr(meta, "output_to_agent", True),
+                    _method=method,
+                )
+        return skills
+
+    def _discover_directory_skills(self) -> None:
+        """Load directory skills without making them model-visible by default."""
+        if not self.skills_dirs:
+            return
+        try:
+            from nooa.skill_registry import SkillRegistry
+
+            registry = getattr(self.agent, "skills", None)
+            if isinstance(registry, SkillRegistry):
+                registry.discover_skills_dirs(self.skills_dirs)
+        except ImportError:
+            pass
+        except Exception as e:
+            logger.warning("Failed to auto-install skills: %s", e)
+
+    def get_command(self, name: str) -> "Command | None":
+        return self._commands.get(name.lower())
+
+    def commands(self) -> "list[Command]":
+        """Return the list of registered ``Command`` instances.
+
+        Public surface so callers (e.g. ``Session._swap_session_manager``)
+        don't have to reach into ``_commands`` directly.
+        """
+        return list(self._commands.values())
+
+    def get_user_skill(self, name: str) -> "_UserSkill | None":
+        return self._user_skills.get(name.lower())
+
+    def refresh_skill_commands(self) -> None:
+        """Re-discover @slash_command methods from agent skills (hot-reload support).
+
+        Called by LibraryManager after reloading a library so newly-added
+        slash commands become available and removed ones are deregistered
+        without TUI restart.
+        """
+        fresh = self._discover_skill_commands()
+        # Remove stale @slash_command entries (those with _method set);
+        # preserve text-skill entries (SKILL.md, _method is None).
+        self._user_skills = {k: v for k, v in self._user_skills.items() if v._method is None}
+        self._user_skills.update(fresh)
+
+    @classmethod
+    def get_all_command_classes(cls) -> dict[str, type[Command]]:
+        return cls._command_classes.copy()
+
+    @classmethod
+    def get_help(cls) -> dict[str, str]:
+        commands: dict[str, str] = {}
+        seen: set[type[Command]] = set()
+        for cmd_cls in cls._command_classes.values():
+            if cmd_cls not in seen:
+                seen.add(cmd_cls)
+                try:
+                    commands.update(cmd_cls.help_text())
+                except TypeError:
+                    # Instance-method help_text() overrides can't be called on the class
+                    pass
+        return commands
+
+    def get_active_help(self) -> dict[str, str]:
+        commands: dict[str, str] = {}
+        seen: set[type[Command]] = set()
+        for cmd in self._commands.values():
+            cls = type(cmd)
+            if cls not in seen:
+                seen.add(cls)
+                commands.update(cmd.help_text())
+        for skill in self._user_skills.values():
+            key, desc = skill.help_entry()
+            commands[key] = desc
+        return commands
+
+    def get_completions(self) -> dict[str, str]:
+        help_text = self.get_active_help()
+        completions: dict[str, str] = {}
+        for cmd, desc in help_text.items():
+            # Strip both <action> and [label] style argument hints
+            clean = re.split(r"\s+(?=[<\[])", cmd, maxsplit=1)[0].strip()
+            if clean and clean not in completions:
+                completions[clean] = desc
+        return dict(sorted(completions.items()))
+
+
+class CommandHandler:
+    """Parses slash-command input and dispatches to registered commands."""
+
+    def __init__(
+        self,
+        registry: "CommandRegistry",
+        frontend: "Frontend",
+        agent_run_async: Any | None = None,
+    ) -> None:
+        self.registry = registry
+        self.frontend = frontend
+        self._agent_run_async = agent_run_async
+
+    async def handle(self, input_text: str, *, render_outputs: bool = True) -> "CommandResult":
+        if not input_text.startswith("/"):
+            return CommandResult(False)
+
+        try:
+            parts = shlex.split(input_text[1:])
+        except ValueError:
+            parts = input_text[1:].split()
+
+        if not parts:
+            result = CommandResult.err("Empty command. Type /help for available commands.")
+            if render_outputs:
+                for output in result.outputs:
+                    await self.frontend.render(output)
+            return result
+
+        cmd_name = parts[0].lower()
+        args = parts[1:]
+
+        # Check user-invocable skills before falling through to unknown-command error
+        skill = self.registry.get_user_skill(cmd_name)
+        if skill is not None:
+            if skill._method is not None:
+                import inspect
+
+                from nooa.slash_dispatch import (
+                    CoercionError,
+                    SlashCommandResult,
+                    parse_typed_args,
+                )
+
+                raw_args = " ".join(args)
+                try:
+                    kwargs = parse_typed_args(skill._method, raw_args)
+                except CoercionError as e:
+                    msg = f"/{cmd_name}: {e.message}"
+                    if e.hint:
+                        msg += f"\nUsage: /{cmd_name} {e.hint}"
+                    result = CommandResult.err(msg)
+                    if render_outputs:
+                        for output in result.outputs:
+                            await self.frontend.render(output)
+                    return result
+
+                def _call_skill_method():
+                    return skill._method(**kwargs)
+
+                if self._agent_run_async is not None:
+                    result_val = await self._agent_run_async(_call_skill_method)
+                else:
+                    result_val = _call_skill_method()
+                    if inspect.isawaitable(result_val):
+                        result_val = await result_val
+
+                slash_result = SlashCommandResult(
+                    command=cmd_name,
+                    args=raw_args,
+                    value=result_val,
+                    text=str(result_val) if result_val is not None else None,
+                    output_to_agent=skill.output_to_agent,
+                )
+                return CommandResult(success=True, slash_result=slash_result)
+            return CommandResult(success=True, agent_message=skill.make_agent_message(args))
+
+        command = self.registry.get_command(cmd_name)
+        if not command:
+            all_classes = self.registry.get_all_command_classes()
+            if cmd_name in all_classes:
+                msg = f"/{cmd_name} is not available with this agent."
+            else:
+                suggestions = [c for c in all_classes if c.startswith(cmd_name[:2])][:3]
+                suffix = (
+                    f" Did you mean: {', '.join(f'/{s}' for s in suggestions)}?"
+                    if suggestions
+                    else ""
+                )
+                msg = f"Unknown command: /{cmd_name}.{suffix} Type /help."
+            result = CommandResult.err(msg)
+            if render_outputs:
+                for output in result.outputs:
+                    await self.frontend.render(output)
+            return result
+
+        is_valid, error_msg = command.validate_args(args)
+        if not is_valid:
+            result = CommandResult.err(error_msg or "Invalid arguments")
+            if render_outputs:
+                for output in result.outputs:
+                    await self.frontend.render(output)
+            return result
+
+        try:
+            result = await command.execute(args)
+        except Exception as exc:
+            result = CommandResult.err(f"Command failed: {exc}")
+        if render_outputs:
+            await render_command_outputs(self.frontend, result.outputs)
+        return result

--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -342,7 +342,7 @@ async def _reset_agent_working_state(agent: "Agent") -> None:
     em = getattr(agent, "event_manager", None)
     if em is not None:
         try:
-            from nooa.sessions import SessionCleared
+            from nooa_cli.sessions import SessionCleared
 
             em.register_event_type(SessionCleared)
             sid = None
@@ -1407,7 +1407,7 @@ class SessionCommand(Command):
                 async def _restore_and_emit() -> list[Output]:
                     restored = new_sm._storage.restore_latest_snapshot(self.agent)
                     try:
-                        from nooa.sessions import SessionResumed
+                        from nooa_cli.sessions import SessionResumed
 
                         self.agent.event_manager.register_event_type(SessionResumed)
                         self.agent.event_manager.add(

--- a/packages/nooa-cli/src/nooa_cli/tui/completer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/completer.py
@@ -1,0 +1,647 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared completion engine for NeMo OO Agents frontends.
+
+``Completer`` is frontend-agnostic: it takes a text buffer and returns a list
+of ``CompletionItem`` objects.  The terminal (prompt_toolkit adapter) uses
+this engine, so completion behavior is identical whether run natively or
+through the PTY web terminal (``nooa-term``).
+"""
+
+import keyword
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .commands import CommandRegistry
+
+logger = logging.getLogger(__name__)
+
+
+# An inline @ file/dir mention: an "@" at start-of-string or after whitespace,
+# followed by a no-whitespace path fragment. Anchored with \Z by _active_mention
+# (token being typed at the cursor) and used unanchored by expand_mentions (all
+# mentions in a submitted line). input_handler imports _MENTION_PATTERN to gate
+# its keybindings on the same definition.
+_MENTION_PATTERN = r"(?:^|(?<=\s))@(\S+?)"
+
+
+@dataclass(frozen=True)
+class CompletionItem:
+    """A single completion candidate."""
+
+    text: str  # what gets inserted (the full replacement text)
+    display: str  # what shows in the menu
+    description: str = ""  # help text / description
+
+
+class Completer:
+    """Frontend-agnostic completion engine.
+
+    Args:
+        registry: CommandRegistry to pull slash-command completions from.
+    """
+
+    def __init__(
+        self,
+        registry: "CommandRegistry",
+    ) -> None:
+        self._registry = registry
+
+    def complete(self, text: str) -> list[CompletionItem]:
+        """Return completion candidates for *text*."""
+        if text.startswith("/"):
+            return self._slash_completions(text)
+        if text.startswith("!"):
+            return self._bang_completions(text)
+        # Inline @ file/dir mention — may appear anywhere in the buffer,
+        # so this is checked for non-slash/bang input too.
+        mention = self._active_mention(text)
+        if mention is not None:
+            return self._mention_completions(text, mention)
+        return []
+
+    # ------------------------------------------------------------------
+    # Inline @ file/dir mentions
+    # ------------------------------------------------------------------
+
+    # The token being *typed* at the cursor: anchor the shared pattern at the
+    # end of the buffer and allow an empty fragment ("@" alone opens the menu).
+    _ACTIVE_MENTION_RE = re.compile(r"(?:^|(?<=\s))@(\S*)\Z")
+
+    @classmethod
+    def _active_mention(cls, text: str) -> "re.Match | None":
+        """Return the @-mention token being typed at the end of *text*, or None."""
+        return cls._ACTIVE_MENTION_RE.search(text)
+
+    def _mention_completions(self, text: str, match: "re.Match") -> list[CompletionItem]:
+        """Path completions for an inline ``@path`` token (prefix = buffer up to the @)."""
+        partial = match.group(1)
+        prefix = text[: match.start()] + "@"
+        return self._path_completions(partial, prefix=prefix)
+
+    # ------------------------------------------------------------------
+    # Slash commands
+    # ------------------------------------------------------------------
+
+    def _slash_completions(self, text: str) -> list[CompletionItem]:
+        # Path completion after "/edit "
+        lower = text.lower()
+        if lower.startswith("/edit "):
+            return self._path_completions(text[6:], prefix="/edit ")
+
+        # Job name completion after "/jobs "
+        if lower.startswith("/jobs "):
+            return self._job_name_completions(text)
+
+        # Theme name completion
+        if lower.startswith("/theme "):
+            return self._theme_completions(text)
+
+        # Model completion
+        if lower.startswith("/model ") or lower.startswith("/keep-going model "):
+            return self._model_completions(text)
+
+        if lower.startswith("/keep-going "):
+            prefix = "/keep-going "
+            partial = text[len(prefix) :].lower()
+            actions = {
+                "on": "Enable stop auditing",
+                "off": "Disable stop auditing",
+                "model": "Configure the judge model",
+            }
+            return [
+                CompletionItem(
+                    text=prefix + action,
+                    display=prefix + action,
+                    description=description,
+                )
+                for action, description in actions.items()
+                if action.startswith(partial)
+            ]
+
+        action_sets = {
+            "/memory ": {
+                "on": "Use project-wide memory",
+                "local": "Use memory only for this session",
+                "off": "Disable memory",
+            },
+            "/reflection ": {
+                "on": "Enable idle memory reflection",
+                "off": "Disable idle memory reflection",
+                "now": "Run memory reflection immediately",
+            },
+        }
+        for prefix, actions in action_sets.items():
+            if lower.startswith(prefix):
+                partial = text[len(prefix) :].lower()
+                return [
+                    CompletionItem(
+                        text=prefix + action,
+                        display=prefix + action,
+                        description=description,
+                    )
+                    for action, description in actions.items()
+                    if action.startswith(partial)
+                ]
+
+        # Skill ID completion for /skills activate and /skills deactivate
+        for prefix in ("/skills activate ", "/skills deactivate "):
+            if lower.startswith(prefix.lower()):
+                return self._skill_id_completions(text, prefix)
+
+        # Session ID completion
+        for prefix in ("/session resume ", "/session delete "):
+            if lower.startswith(prefix.lower()):
+                return self._session_id_completions(text, prefix)
+
+        # MCP server-name completion for actions that target existing servers.
+        for prefix in (
+            "/mcp connect ",
+            "/mcp approve ",
+            "/mcp revoke ",
+            "/mcp disconnect ",
+            "/mcp remove ",
+        ):
+            if lower.startswith(prefix.lower()):
+                return self._mcp_server_completions(text, prefix)
+
+        # Event tag completion — always return a non-empty list to
+        # prevent prompt_toolkit's CompletionsMenu from crashing on
+        # max() of an empty iterable.
+        if lower.startswith("/events "):
+            return self._event_tag_completions(text) or [
+                CompletionItem(text=text, display=text, description="(no matching tags)")
+            ]
+
+        # Subcommand completion for @slash_command(completions=[...])
+        items = self._skill_subcommand_completions(text)
+        if items:
+            return items
+
+        # Top-level slash commands + subcommands.
+        # get_active_help() keys may include argument hints ("/wtf-status [label]").
+        # We strip the hint for text (insertion) but keep it for display.
+        commands = self._registry.get_active_help()
+        seen: set[str] = set()
+        items: list[CompletionItem] = []
+        for display_cmd, desc in commands.items():
+            clean = re.split(r"\s+(?=[<\[])", display_cmd, maxsplit=1)[0].strip()
+            if clean in seen:
+                continue
+            if clean.lower().startswith(text.lower()):
+                seen.add(clean)
+                items.append(CompletionItem(text=clean, display=display_cmd, description=desc))
+        return items
+
+    # ------------------------------------------------------------------
+    # Skill subcommand completion
+    # ------------------------------------------------------------------
+
+    def _skill_subcommand_completions(self, text: str) -> list[CompletionItem]:
+        """Complete subcommands for @slash_command methods that declare completions."""
+        lower = text.lower()
+        # Check each user skill for a matching prefix with completions
+        for name, skill in self._registry._user_skills.items():
+            cmd_prefix = f"/{name} "
+            if not lower.startswith(cmd_prefix):
+                continue
+            if not skill.completions:
+                return []
+            partial = text[len(cmd_prefix) :]
+            items = []
+            for sub in skill.completions:
+                if sub.lower().startswith(partial.lower()):
+                    items.append(
+                        CompletionItem(
+                            text=cmd_prefix + sub,
+                            display=cmd_prefix + sub,
+                            description="",
+                        )
+                    )
+            return items
+        return []
+
+    # ------------------------------------------------------------------
+    # Theme completion
+    # ------------------------------------------------------------------
+
+    def _theme_completions(self, text: str) -> list[CompletionItem]:
+        from .theme import THEMES
+
+        prefix = "/theme "
+        partial = text[len(prefix) :]
+        items = []
+        for name in THEMES:
+            if name.startswith(partial.lower()):
+                items.append(
+                    CompletionItem(
+                        text=prefix + name,
+                        display=prefix + name,
+                        description=f"Switch to {name} theme",
+                    )
+                )
+        return items
+
+    # ------------------------------------------------------------------
+    # Model completion
+    # ------------------------------------------------------------------
+
+    def _model_completions(self, text: str) -> list[CompletionItem]:
+        try:
+            from nooa.unifiedllm import MODELS
+        except Exception:
+            return []
+
+        prefix = (
+            "/keep-going model " if text.lower().startswith("/keep-going model ") else "/model "
+        )
+        partial = text[len(prefix) :]
+        description = (
+            "Use {name} as keep-going judge"
+            if prefix == "/keep-going model "
+            else "Switch to {name}"
+        )
+        items = []
+        for name in sorted(MODELS.keys()):
+            if name.lower().startswith(partial.lower()):
+                items.append(
+                    CompletionItem(
+                        text=prefix + name,
+                        display=prefix + name,
+                        description=description.format(name=name),
+                    )
+                )
+        return items
+
+    # ------------------------------------------------------------------
+    # Skill ID completion
+    # ------------------------------------------------------------------
+
+    def _skill_id_completions(self, text: str, prefix: str) -> list[CompletionItem]:
+        agent = getattr(self._registry, "agent", None)
+        if agent is None:
+            return []
+        skills_reg = getattr(agent, "skills", None)
+        if skills_reg is None:
+            return []
+
+        partial = text[len(prefix) :]
+        items = []
+        try:
+            for sid in sorted(skills_reg.discovered()):
+                if partial and not sid.startswith(partial):
+                    continue
+                entry = skills_reg.entry(sid)
+                desc = getattr(entry, "category", "") if entry else ""
+                items.append(
+                    CompletionItem(
+                        text=prefix + sid,
+                        display=prefix + sid,
+                        description=desc,
+                    )
+                )
+        except Exception:
+            return []
+        return items
+
+    # ------------------------------------------------------------------
+    # Session ID completion
+    # ------------------------------------------------------------------
+
+    def _session_id_completions(self, text: str, prefix: str) -> list[CompletionItem]:
+        from .session_manager import SessionManager
+
+        partial = text[len(prefix) :]
+        try:
+            sessions = SessionManager.list_sessions(limit=50)
+        except Exception:
+            return []
+
+        items: list[CompletionItem] = []
+        for meta in sessions:
+            sid = meta.id
+            short = sid[:8]
+            if partial and not short.startswith(partial) and not sid.startswith(partial):
+                continue
+            items.append(
+                CompletionItem(
+                    text=prefix + short,
+                    display=prefix + short,
+                    description=meta.name or sid,
+                )
+            )
+        return items
+
+    def _mcp_server_completions(self, text: str, prefix: str) -> list[CompletionItem]:
+        """Complete safe configured names for MCP lifecycle operations.
+
+        Reads the live ``self.mcp`` ``MCPRegistry`` so the candidates reflect both
+        ``.mcp.json`` and inline ``settings.yaml`` servers,
+        and annotates which are currently connected. ``disconnect`` only offers
+        connected servers; ``connect`` and ``remove`` offer all configured servers.
+        """
+        partial = text[len(prefix) :]
+        registry = self._registry
+        mcp = getattr(getattr(registry, "agent", None), "mcp", None)
+        if mcp is None:
+            return []
+
+        try:
+            servers = mcp.discovered()
+            connected = set(mcp.connected())
+        except Exception:
+            logger.debug("MCP server completion failed", exc_info=True)
+            return []
+
+        is_disconnect = prefix.strip().endswith("disconnect")
+        names = sorted(connected) if is_disconnect else sorted(servers)
+
+        items: list[CompletionItem] = []
+        for name in names:
+            attr_name = name.replace("-", "_")
+            if (
+                not attr_name.isidentifier()
+                or keyword.iskeyword(attr_name)
+                or attr_name.startswith("_")
+                or any(ord(char) < 32 or 127 <= ord(char) <= 159 for char in name)
+            ):
+                continue
+            if partial and not name.lower().startswith(partial.lower()):
+                continue
+            if name in connected:
+                status = "connected"
+            else:
+                try:
+                    status = "approved" if mcp._is_approved(name) else "approval required"
+                except Exception:
+                    status = "configured"
+            items.append(
+                CompletionItem(
+                    text=prefix + name,
+                    display=prefix + name,
+                    description=status,
+                )
+            )
+        return items
+
+    def _job_name_completions(self, text: str) -> list[CompletionItem]:
+        prefix = "/jobs "
+        partial = text[len(prefix) :].lower()
+        agent = getattr(self._registry, "agent", None)
+        qm = getattr(agent, "queue_manager", None) if agent else None
+        if qm is None:
+            return []
+
+        items: list[CompletionItem] = []
+        icons = {"running": "⏳", "done": "✅", "failed": "❌", "cancelled": "⏹"}
+        for name, state in sorted(qm.jobs().items()):
+            if partial and not name.lower().startswith(partial):
+                continue
+            handle = qm.job(name)
+            buf = f" ({len(handle.values)} delivered)" if handle and handle.values else ""
+            items.append(
+                CompletionItem(
+                    text=prefix + name,
+                    display=prefix + name,
+                    description=f"{icons.get(state, '?')} {state}{buf}",
+                )
+            )
+        return items
+
+    # ------------------------------------------------------------------
+    # Event tag completion
+    # ------------------------------------------------------------------
+
+    def _event_tag_completions(self, text: str) -> list[CompletionItem]:
+        prefix = "/events "
+        partial = text[len(prefix) :]
+        agent = getattr(self._registry, "agent", None)
+        em = getattr(agent, "event_manager", None) if agent else None
+        if em is None:
+            return []
+
+        icons = {
+            "ToolCallEvent": "\U0001f527",
+            "PythonOutput": "\U0001f4e4",
+            "Task": "\U0001f4cb",
+            "SessionUserMessage": "\U0001f4ac",
+            "TUIUserInput": "\U0001f4ac",
+            "SessionStarted": "\U0001f680",
+            "TUISessionStart": "\U0001f680",
+            "Summary": "\U0001f4dd",
+            "Error": "\u274c",
+        }
+
+        items: list[CompletionItem] = []
+        for tag in em.keys():
+            if partial and not tag.startswith(partial):
+                continue
+            if tag == partial:
+                continue  # skip exact match — already typed
+            event = em.get(tag)
+            if event is None:
+                continue
+            etype = getattr(event, "event_type", type(event).__name__)
+            icon = icons.get(etype, "\U0001f4cc")
+
+            # One-line summary
+            summary = self._event_summary(event, etype)
+            items.append(
+                CompletionItem(
+                    text=prefix + tag,
+                    display=prefix + tag,
+                    description=f"{icon} {summary}",
+                )
+            )
+        return items
+
+    @staticmethod
+    def _event_summary(event, etype: str) -> str:
+        """One-line summary for event tag completion."""
+        if etype == "ToolCallEvent":
+            name = getattr(event, "name", "?")
+            args = getattr(event, "arguments", {})
+            if name == "execute_python" and isinstance(args, dict) and "code" in args:
+                for line in args["code"].split("\n"):
+                    s = line.strip()
+                    if s and not s.startswith("#"):
+                        return f"{name} \u2014 {s[:50]}"
+            return name
+        elif etype == "PythonOutput":
+            status = str(getattr(event, "execution_status", "?"))
+            label = status.rsplit(".", 1)[-1]
+            icon = "\u2705" if label == "complete" else "\u274c"
+            stdout = getattr(event, "stdout", "") or ""
+            error = getattr(event, "error", "") or ""
+            if label != "complete" and error:
+                return f"{icon} {error.strip().splitlines()[-1][:50]}"
+            elif stdout:
+                return f"{icon} {stdout.strip().splitlines()[0][:50]}"
+            return f"{icon} {label}"
+        elif etype in {"SessionUserMessage", "TUIUserInput"}:
+            field = "content" if etype == "SessionUserMessage" else "text"
+            text = getattr(event, field, "") or ""
+            return text[:50] + ("..." if len(text) > 50 else "")
+        elif etype in {"SessionStarted", "TUISessionStart"}:
+            return f"model={getattr(event, 'model', '?')}"
+        elif etype == "Task":
+            prompt = getattr(event, "prompt", "") or ""
+            first = prompt.strip().splitlines()[0] if prompt.strip() else ""
+            return first[:50]
+        return str(event)[:50]
+
+    # ------------------------------------------------------------------
+    # Bang commands
+    # ------------------------------------------------------------------
+
+    def _bang_completions(self, text: str) -> list[CompletionItem]:
+        items: list[CompletionItem] = []
+
+        rest = text[1:]  # strip leading !
+        if " " not in rest:
+            # Still typing the command name (single unterminated token, no
+            # space yet). Bare "!" offers nothing; "!gi" completes $PATH
+            # executables (git, gibo, …) rather than files named gi*.
+            # A space ends the command token and switches to path completion.
+            return items + self._command_completions(rest)
+
+        # An argument is being typed (command token is followed by a space) →
+        # complete filesystem paths on the last token, keeping the command +
+        # earlier args as the prefix.
+        head, _, last = rest.rpartition(" ")
+        prefix = "!" + head + " "
+        items.extend(self._path_completions(last, prefix=prefix))
+        return items
+
+    @staticmethod
+    def _command_completions(partial: str) -> list[CompletionItem]:
+        """Complete executable names from $PATH for the command token of !cmd."""
+        if not partial:
+            return []
+        seen: set[str] = set()
+        items: list[CompletionItem] = []
+        for d in os.environ.get("PATH", "").split(os.pathsep):
+            if not d:
+                continue
+            try:
+                entries = sorted(os.listdir(d))
+            except OSError:
+                continue
+            for name in entries:
+                if name in seen or not name.startswith(partial):
+                    continue
+                full = os.path.join(d, name)
+                if not (os.path.isfile(full) and os.access(full, os.X_OK)):
+                    continue
+                seen.add(name)
+                items.append(CompletionItem(text="!" + name + " ", display=name, description=""))
+        return items
+
+    # ------------------------------------------------------------------
+    # File path completion
+    # ------------------------------------------------------------------
+
+    def _path_completions(self, partial: str, prefix: str = "") -> list[CompletionItem]:
+        """Complete filesystem paths from *partial*.
+
+        Args:
+            partial: The path fragment the user has typed so far.
+            prefix: Command prefix to prepend to each item's ``text`` so that
+                    the result is a full input replacement (e.g. ``"/edit "``).
+        """
+        if not partial:
+            partial = "."
+
+        # Expand ~ to home dir
+        expanded = os.path.expanduser(partial)
+        p = Path(expanded)
+
+        # Determine directory to list and filter prefix
+        if p.is_dir():
+            parent = p
+            name_filter = ""
+        else:
+            parent = p.parent
+            name_filter = p.name
+
+        if not parent.exists():
+            return []
+
+        items: list[CompletionItem] = []
+        try:
+            for entry in sorted(parent.iterdir()):
+                name = entry.name
+                if name_filter and not name.lower().startswith(name_filter.lower()):
+                    continue
+                # Skip hidden files unless the user typed a dot
+                if name.startswith(".") and not name_filter.startswith("."):
+                    continue
+
+                display = name + ("/" if entry.is_dir() else "")
+                # Build the path portion
+                if p.is_dir():
+                    path_text = str(Path(partial) / name)
+                else:
+                    path_text = str(Path(partial).parent / name)
+
+                if entry.is_dir():
+                    path_text += "/"
+
+                # Full input replacement = command prefix + path
+                items.append(
+                    CompletionItem(
+                        text=prefix + path_text,
+                        display=display,
+                        description="",
+                    )
+                )
+        except PermissionError:
+            pass
+
+        return items
+
+
+# ---------------------------------------------------------------------------
+# Mention expansion (used at submit time, shared by all frontends)
+# ---------------------------------------------------------------------------
+
+# Submit-time form of the mention: greedy so it grabs the whole path token.
+# Trailing sentence punctuation is peeled back off the captured token below so
+# "see @docs/file.md." still resolves to docs/file.md.
+_MENTION_TOKEN = re.compile(r"(?:^|(?<=\s))@(\S+)")
+
+# Punctuation that is almost always sentence-trailing rather than part of a
+# real filename, stripped from the right of a captured mention before resolving.
+_TRAILING_PUNCT = ".,;:!?)]}\"'"
+
+
+def expand_mentions(text: str) -> str:
+    """Expand inline ``@path`` mentions into Markdown links before sending.
+
+    ``@docs/blah.md`` becomes ``[docs/blah.md](</abs/docs/blah.md>)`` so the
+    agent receives an unambiguous absolute path while the user keeps the short
+    form they typed. Only mentions resolving to an existing file/dir expand;
+    emails (``a@b``), nonexistent paths, etc. are left untouched. Trailing
+    sentence punctuation is peeled off before resolving. The link target is
+    angle-bracketed so a path containing ``)`` can't break out of the link.
+    """
+
+    def _sub(m: "re.Match") -> str:
+        raw = m.group(1)
+        # Peel trailing punctuation, but try the full token first so a real
+        # filename that legitimately ends in such a char still resolves.
+        stripped = raw.rstrip(_TRAILING_PUNCT)
+        for candidate in (raw, stripped):
+            p = Path(os.path.expanduser(candidate))
+            if p.exists():
+                trailer = raw[len(candidate) :]
+                label = candidate.rstrip("/")
+                return f"[{label}](<{p.resolve()}>){trailer}"
+        return m.group(0)
+
+    return _MENTION_TOKEN.sub(_sub, text)

--- a/packages/nooa-cli/src/nooa_cli/tui/config.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/config.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration loading for NeMo OO Agents TUI.
+
+Hydra-like config: structured Pydantic models with Config.load(**overrides).
+
+Resolution order (last wins):
+    1. Model defaults
+    2. Layered ``settings.yaml`` (user → project → ``NEMO_OO_SETTINGS``),
+       loaded via :mod:`nooa_cli.tui.settings`
+    3. Keyword overrides from CLI args (_OVERRIDES map)
+
+Usage:
+    # From the Click command
+    config = Config.load(model="gpt-4o", working_dir="/tmp")
+
+    # Programmatic
+    config = Config.load()
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+if TYPE_CHECKING:
+    from nooa.unifiedllm import CompletionClient
+
+# Default model — direct litellm-supported name. Override via config or --model.
+DEFAULT_MODEL = "claude-opus-4-8"
+
+
+# SummarizationConfig moved to core with the interactive-agent base;
+# re-exported here so existing ``nooa_cli.tui.config`` imports keep working.
+from nooa.interactive import SummarizationConfig as SummarizationConfig  # noqa: E402
+
+
+class AgentConfig(BaseModel):
+    """Configuration for the TUI agent's behavior."""
+
+    # History summarization settings
+    summarization: SummarizationConfig = Field(default_factory=SummarizationConfig)
+
+    # Working directory for bash commands. Stored as a string (downstream
+    # always str()s it); a Path is accepted and coerced for ergonomics.
+    working_dir: str = "."
+
+    @field_validator("working_dir", mode="before")
+    @classmethod
+    def _coerce_working_dir(cls, v: object) -> object:
+        return str(v) if isinstance(v, Path) else v
+
+
+class TUIConfig(BaseModel):
+    """Configuration for the TUI presentation layer."""
+
+    # MCP servers.  Inline ``mcp_servers`` in settings.yaml is the preferred single-file
+    # configuration; ``mcp_file`` remains as a compatibility bridge for VS Code / Claude
+    # style .mcp.json files.
+    mcp_file: Path = Path(".mcp.json")
+    mcp_servers: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    mcp_auto_connect: list[str] = Field(default_factory=list)
+
+    # Directories to search for skills and user-invocable commands.
+    # Includes both project-local and user-global Claude/Cursor conventions.
+    skills_dirs: list[Path] = Field(
+        default_factory=lambda: [
+            Path(".agents/skills"),
+            Path(".cursor/skills"),
+            Path(".claude/skills"),
+            Path(".claude/commands"),
+            Path.home() / ".agents" / "skills",
+            Path.home() / ".claude" / "skills",
+            Path.home() / ".claude" / "commands",
+        ]
+    )
+
+    # Default LLM model (from unifiedllm registry)
+    default_model: str = DEFAULT_MODEL
+
+    # Trace output directory (None = OTLP auto-probe only; --trace writes files)
+    trace_dir: Path | None = None
+
+    # Vi keybindings in prompt_toolkit input
+    vi_mode: bool = False
+
+    # Custom agent spec: "module.path:ClassName" or "./file.py:ClassName"
+    agent_spec: str | None = None
+
+    # Show agent Python code execution panels (off by default)
+    show_python: bool = False
+
+    # Audit DONE turns and continue autonomously when the configured judge
+    # finds unfinished work. Disabled until explicitly enabled by the user.
+    keep_going: bool = False
+    keep_going_model: str | None = None
+
+    # Long-term memory is opt-in and can be scoped to this session or shared
+    # by every session rooted in the current project. Per-agent maps let custom
+    # agents keep independent choices in the same settings file.
+    memory: Literal["off", "session", "project"] = "off"
+    memory_agents: dict[str, Literal["off", "session", "project"]] = Field(default_factory=dict)
+    memory_path: Path | None = None
+    memory_owner: str | None = None
+    memory_owner_agents: dict[str, str] = Field(default_factory=dict)
+
+    # Idle reflection consolidates memory between completed turns. It stays
+    # off until explicitly enabled for an agent.
+    reflection: bool = False
+    reflection_agents: dict[str, bool] = Field(default_factory=dict)
+    reflection_generative: bool = True
+    reflection_debounce_s: float = 10.0
+    reflection_grace_s: float = 0.5
+
+    # Native scrollback with clear+rewrite transcript replay on resize.
+    full_screen: bool = True
+
+    # Ordered, structured toolbar providers. Third-party packages can register
+    # additional providers through the ``nooa_cli.tui.toolbar_items`` group.
+    toolbar_items: list[str] = Field(
+        default_factory=lambda: ["time", "model", "context", "session"]
+    )
+
+
+class Config(BaseModel):
+    """Top-level configuration. Single source of truth.
+
+    Usage:
+        config = Config.load(model="gpt-4o") # programmatic
+        config = Config.load()               # pure defaults + env
+    """
+
+    tui: TUIConfig = Field(default_factory=TUIConfig)
+    agent: AgentConfig = Field(default_factory=AgentConfig)
+
+    # Runtime flags (not persisted)
+    no_splash: bool = False
+    no_trace: bool = False
+
+    # ── Declarative mapping: kwarg name → dotted config path ──────────
+    # Tuple form: (path, transform_fn) for type coercion.
+    # String form: path only, value passed through as-is.
+    _OVERRIDES: ClassVar[dict] = {
+        "model": "tui.default_model",
+        "mcp_file": ("tui.mcp_file", Path),
+        "mcp_servers": "tui.mcp_servers",
+        "mcp_auto_connect": (
+            "tui.mcp_auto_connect",
+            lambda v: [str(item) for item in v] if isinstance(v, (list, tuple, set)) else [str(v)],
+        ),
+        "trace": ("tui.trace_dir", Path),
+        "context_limit": "agent.summarization.max_tokens",
+        "working_dir": "agent.working_dir",
+        "no_splash": "no_splash",
+        "no_trace": "no_trace",
+        "vi": "tui.vi_mode",
+        "agent": "tui.agent_spec",
+        "python": "tui.show_python",
+        "full_screen": "tui.full_screen",
+        "memory": "tui.memory",
+        "memory_agents": "tui.memory_agents",
+        "memory_path": ("tui.memory_path", Path),
+        "memory_owner": "tui.memory_owner",
+        "memory_owner_agents": "tui.memory_owner_agents",
+        "reflection": "tui.reflection",
+        "reflection_agents": "tui.reflection_agents",
+        "reflection_generative": "tui.reflection_generative",
+        "reflection_debounce_s": "tui.reflection_debounce_s",
+        "reflection_grace_s": "tui.reflection_grace_s",
+    }
+
+    # Boolean CLI flags: False means absent and must not overwrite settings.
+    _FLAG_OVERRIDES: ClassVar[set[str]] = {
+        "no_splash",
+        "no_trace",
+        "vi",
+        "python",
+        "full_screen",
+    }
+
+    @classmethod
+    def load(cls, **overrides) -> "Config":
+        """Build config: defaults → config file → overrides.
+
+        Config file: layered ``settings.yaml`` (user → project →
+        ``NEMO_OO_SETTINGS``), discovered through the shared layered-config
+        helper. Accepts any keyword argument matching _OVERRIDES keys.
+        Unknown keys are silently ignored so CLI adapters can pass their
+        complete option mappings directly.
+        """
+        from .settings import load_settings
+
+        # Layers 1-2: dataclass defaults, then layered settings.yaml.
+        cfg = load_settings(cls())
+
+        # Layer 3: explicit overrides (highest priority)
+        for key, target in cls._OVERRIDES.items():
+            val = overrides.get(key)
+            if val is None:
+                continue
+            # False flag defaults mean "not provided" and must not overwrite
+            # layered settings.
+            if isinstance(val, bool) and not val and key in cls._FLAG_OVERRIDES:
+                continue
+            _set_nested(cfg, *_unpack_target(target, val))
+
+        # ── Special-case overrides ────────────────────────────────────
+        # --no-trace clears trace_dir
+        if overrides.get("no_trace"):
+            cfg.tui.trace_dir = None
+
+        # Explicit skill directories take precedence over conventional paths.
+        explicit: list[Path] = []
+
+        extra_skills = overrides.get("skills_dir")
+        if extra_skills:
+            # Accept a single str/Path OR a list/tuple of them. The bare
+            # fallback ``list(x)`` would iterate *characters* when given a
+            # lone string, producing nonsense paths.
+            if isinstance(extra_skills, (str, Path)):
+                dirs: list = [extra_skills]
+            elif isinstance(extra_skills, (list, tuple)):
+                dirs = list(extra_skills)
+            else:
+                dirs = list(extra_skills)  # last-resort: any other iterable
+            for d in dirs:
+                p = Path(d)
+                if p not in explicit:
+                    explicit.append(p)
+
+        defaults = [d for d in cfg.tui.skills_dirs if d not in explicit]
+        cfg.tui.skills_dirs = explicit + defaults
+
+        # Ignore absent conventional locations.
+        cfg.tui.skills_dirs = [d for d in cfg.tui.skills_dirs if d.exists()]
+
+        return cfg
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _unpack_target(target, value):
+    """Unpack a target spec into (path, transformed_value)."""
+    if isinstance(target, tuple):
+        path, transform = target
+        return path, transform(value)
+    return target, value
+
+
+def _set_nested(obj, path: str, value):
+    """Set a dotted attribute path on a nested config model."""
+    parts = path.split(".")
+    for part in parts[:-1]:
+        obj = getattr(obj, part)
+    setattr(obj, parts[-1], value)
+
+
+# ── LLM helpers ───────────────────────────────────────────────────────────
+
+
+def get_llm(config: TUIConfig | Config) -> "CompletionClient":
+    """Get the LLM client based on configuration.
+
+    Accepts either a TUIConfig or the top-level Config.
+    """
+    from nooa.unifiedllm import MODELS, CompletionClient, get_llm_client
+
+    tui = config.tui if isinstance(config, Config) else config
+    model_name = tui.default_model
+
+    if model_name in MODELS:
+        return get_llm_client(model_name)
+
+    return CompletionClient(model=model_name)
+
+
+def list_models() -> list[str]:
+    """List available models from the unifiedllm registry."""
+    from nooa.unifiedllm import MODELS
+
+    return sorted(MODELS.keys())
+
+
+def load_agent_class(spec: str) -> type:
+    """Load an agent class from a 'module:ClassName' or './file.py:ClassName' spec.
+
+    Args:
+        spec: Agent spec in the form ``module.path:ClassName`` or
+              ``./path/to/file.py:ClassName`` (absolute paths also work).
+
+    Returns:
+        The agent class (uninstantiated).
+
+    Raises:
+        ValueError: If the spec format is invalid or the class is not an Agent subclass.
+        FileNotFoundError: If a file-path spec points to a missing file.
+        ImportError: If the module cannot be imported.
+        AttributeError: If the class name is not found in the module.
+    """
+    import importlib
+    import importlib.util
+    import sys
+
+    if ":" not in spec:
+        raise ValueError(
+            f"Invalid agent spec '{spec}'. "
+            "Expected 'module.path:ClassName' or './path/to/file.py:ClassName'."
+        )
+
+    module_part, class_name = spec.rsplit(":", 1)
+    class_name = class_name.strip()
+
+    # File path: ends in .py OR contains a path separator OR starts with . / ~
+    is_file = module_part.endswith(".py") or "/" in module_part or module_part.startswith(".")
+    if is_file:
+        file_path = Path(module_part).expanduser().resolve()
+        if not file_path.exists():
+            raise FileNotFoundError(f"Agent module file not found: {file_path}")
+
+        parent_str = str(file_path.parent)
+        inserted = False
+        if parent_str not in sys.path:
+            sys.path.insert(0, parent_str)
+            inserted = True
+
+        try:
+            mod_spec = importlib.util.spec_from_file_location("_tui_custom_agent", file_path)
+            if mod_spec is None or mod_spec.loader is None:
+                raise ImportError(f"Cannot load module from {file_path}")
+            module = importlib.util.module_from_spec(mod_spec)
+            mod_spec.loader.exec_module(module)  # type: ignore[union-attr]
+        finally:
+            if inserted:
+                sys.path.remove(parent_str)
+    else:
+        module = importlib.import_module(module_part)
+
+    cls = getattr(module, class_name, None)
+    if cls is None:
+        raise AttributeError(f"Class '{class_name}' not found in '{module_part}'.")
+
+    # Validate it's an Agent subclass
+    try:
+        from nooa import Agent
+
+        if not (isinstance(cls, type) and issubclass(cls, Agent)):
+            raise ValueError(
+                f"'{class_name}' is not a subclass of NeMo OO Agents Agent. "
+                "Make sure your class inherits from Agent."
+            )
+    except ImportError:
+        pass  # Can't validate without nooa; proceed anyway
+
+    return cls

--- a/packages/nooa-cli/src/nooa_cli/tui/console.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/console.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Rich console wrapper with spinners and styled output.
+
+Uses Catppuccin Mocha theme from https://catppuccin.com/palette/
+"""
+
+from rich.console import Console
+from rich.live import Live
+from rich.markdown import Markdown
+from rich.rule import Rule
+from rich.spinner import Spinner
+from rich.table import Table
+from rich.text import Text
+
+from .theme import CATPPUCCIN_THEME, COLORS
+
+
+class TUIConsole:
+    """Rich console wrapper with Catppuccin styling for NeMo OO Agents TUI."""
+
+    def __init__(self) -> None:
+        self.console = Console(theme=CATPPUCCIN_THEME)
+        self._live_spinner: Live | None = None
+        self._spinner: Spinner | None = None
+
+    def replace_console(self, console: Console) -> None:
+        """Swap the underlying Rich Console (e.g. to redirect output).
+
+        ``Session`` uses this to route slash-command rendering through
+        the ``TUIApplication`` block queue instead of the real stdout —
+        without this seam, callers would have to patch ``self.console``
+        directly, a private on a foreign object.
+        """
+        self.console = console
+
+    def start_spinner(self, message: str = "thinking...") -> None:
+        """Start the thinking spinner with an empty input prompt.
+
+        The Live display renders as a Group:
+          <spinner>
+          ❯ █
+        """
+        if self._live_spinner is not None:
+            return
+
+        from rich.console import Group
+
+        self._spinner = Spinner(
+            "dots",
+            text=Text(message, style=f"{COLORS['subtext1']}"),
+            style=COLORS["mauve"],
+        )
+        prompt = Text("\u276f ", style=COLORS["subtext0"])
+        prompt.append(" ", style=f"reverse {COLORS['subtext0']}")
+        self._live_spinner = Live(
+            Group(self._spinner, prompt),
+            console=self.console,
+            refresh_per_second=10,
+            transient=True,
+        )
+        self._live_spinner.start()
+
+    def stop_spinner(self) -> None:
+        """Stop the thinking spinner if running."""
+        if self._live_spinner is not None:
+            self._live_spinner.stop()
+            self._live_spinner = None
+            self._spinner = None
+
+    def print_agent(self, message: str, *, show_rule: bool = True) -> None:
+        """Print an agent response, optionally with the OO ── rule header."""
+        import textwrap
+
+        # Aggressive cleanup for markdown rendering:
+        # 1. Replace any non-breaking spaces with regular spaces
+        cleaned = message.replace("\u00a0", " ").replace("\xa0", " ")
+        # 2. Dedent and strip
+        cleaned = textwrap.dedent(cleaned).strip()
+        # 3. Remove common leading whitespace from all lines
+        lines = cleaned.split("\n")
+        non_empty_lines = [line for line in lines if line.strip()]
+        if non_empty_lines:
+            min_indent = min(len(line) - len(line.lstrip()) for line in non_empty_lines)
+            if min_indent > 0:
+                lines = [line[min_indent:] if len(line) >= min_indent else line for line in lines]
+        # 4. Normalize line endings and rejoin
+        cleaned = "\n".join(line.rstrip() for line in lines)
+
+        if show_rule:
+            self.console.print(
+                Rule(title="[agent]OO[/agent]", style=COLORS["surface2"], align="left")
+            )
+        self.console.print(Markdown(cleaned))
+
+    def print_error(self, message: str) -> None:
+        """Print an error message."""
+        self.console.print(f"[error]Error:[/error] {message}")
+
+    def print_warning(self, message: str) -> None:
+        """Print a warning message."""
+        self.console.print(f"[warning]Warning:[/warning] {message}")
+
+    def print_status(self, message: str) -> None:
+        """Print a dim status message."""
+        self.console.print(f"[status]{message}[/status]")
+
+    def print_success(self, message: str) -> None:
+        """Print a success message."""
+        self.console.print(f"[success]\u2713[/success] {message}")
+
+    def print_info(self, message: str) -> None:
+        """Print an info message."""
+        self.console.print(f"[info]\u2139[/info] {message}")
+
+    def print_table(
+        self,
+        title: str,
+        columns: list[str],
+        rows: list[list[str]],
+        *,
+        show_header: bool = True,
+    ) -> None:
+        """Print a formatted table with Catppuccin styling.
+
+        ``show_header=False`` drops the column-header row — use it for
+        key/value tables whose columns are unlabelled (otherwise Rich draws
+        an empty header band above the first row).
+        """
+        table = Table(
+            title=title or None,
+            title_style=f"bold {COLORS['lavender']}",
+            border_style=COLORS["surface2"],
+            header_style=f"bold {COLORS['lavender']}",
+            show_header=show_header,
+        )
+        for col in columns:
+            table.add_column(col, style=COLORS["text"])
+        for row in rows:
+            table.add_row(*row)
+        self.console.print(table)
+
+    def print_help(self, commands: dict[str, str]) -> None:
+        """Print help for available commands."""
+        self.console.print(f"\n[bold {COLORS['mauve']}]Available Commands:[/]\n")
+        for cmd, desc in commands.items():
+            self.console.print(
+                f"  [bold {COLORS['sapphire']}]{cmd}[/] - [{COLORS['subtext1']}]{desc}[/]"
+            )
+        self.console.print()

--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -1,0 +1,1026 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Event explorer model, renderer, and in-app subview."""
+
+from __future__ import annotations
+
+import datetime
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from .explorer_base import (
+    BAR_STYLE,
+    highlight_terms,
+    search_terms,
+    style_bar,
+    style_fts_prompt,
+    style_mode_label,
+    wrap_plain_line,
+)
+from .subapp import SubviewKeyResult
+
+
+def highlight_terms_with_current(
+    text: str, terms: list[str], current_occurrence: int | None = None
+) -> str:
+    """ANSI-highlight query terms, using a distinct color for the selected occurrence."""
+    if not terms:
+        return text
+    import re
+
+    pattern = re.compile(
+        "|".join(re.escape(t) for t in sorted(terms, key=len, reverse=True)), re.IGNORECASE
+    )
+    seen = -1
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal seen
+        seen += 1
+        color = (
+            "30;106" if current_occurrence is not None and seen == current_occurrence else "30;43"
+        )
+        return f"\x1b[{color}m{match.group(0)}\x1b[0m"
+
+    return pattern.sub(replace, text)
+
+
+@dataclass
+class EventExplorerRow:
+    tag: str
+    event_type: str
+    summary: str
+    search_text: str
+    detail: str
+    code: str | None = None
+    code_language: str = "python"
+    markdown: str | None = None
+
+
+class EventExplorerModel:
+    """Searchable, keyboard-navigable event list."""
+
+    def __init__(self, rows: list[EventExplorerRow]) -> None:
+        self.rows = rows
+        self.query = ""
+        self.matches = list(range(len(rows)))
+        self.cursor = max(len(self.matches) - 1, 0)
+        self.detail_offset = 0
+        self.focus = "list"
+        self.search_active = False
+        self.search_line_cursor = 0
+        self._last_detail_line_count = 0
+        self._last_detail_match_lines: list[int] = []
+        self._last_detail_match_occurrences: list[tuple[int, int]] = []
+        self._last_detail_visible_lines = 0
+
+    @property
+    def empty(self) -> bool:
+        return not self.rows
+
+    @property
+    def current_index(self) -> int | None:
+        if not self.matches:
+            return None
+        self.cursor = min(max(self.cursor, 0), len(self.matches) - 1)
+        return self.matches[self.cursor]
+
+    @property
+    def current(self) -> EventExplorerRow | None:
+        idx = self.current_index
+        return None if idx is None else self.rows[idx]
+
+    def set_query(self, query: str) -> None:
+        self.query = query
+        words = [w.lower() for w in query.split() if w.strip()]
+        if not words:
+            self.matches = list(range(len(self.rows)))
+        else:
+            self.matches = [
+                i
+                for i, row in enumerate(self.rows)
+                if all(word in row.search_text.lower() for word in words)
+            ]
+        self.cursor = 0
+        self.detail_offset = 0
+        self.search_line_cursor = 0
+
+    def edit_query(self, text: str) -> None:
+        self.set_query(text)
+        self.search_active = True
+
+    def move(self, delta: int) -> None:
+        if not self.matches:
+            return
+        self.cursor = min(max(self.cursor + delta, 0), len(self.matches) - 1)
+        self.detail_offset = 0
+        self.search_line_cursor = 0
+
+    def current_search_line(self) -> int | None:
+        if self._last_detail_match_occurrences:
+            match_count = len(self._last_detail_match_occurrences)
+            self.search_line_cursor = min(max(self.search_line_cursor, 0), match_count - 1)
+            return self._last_detail_match_occurrences[self.search_line_cursor][0]
+        if self._last_detail_match_lines:
+            match_count = len(self._last_detail_match_lines)
+            self.search_line_cursor = min(max(self.search_line_cursor, 0), match_count - 1)
+            return self._last_detail_match_lines[self.search_line_cursor]
+        return None
+
+    def center_detail_on_line(self, line: int, visible_lines: int | None = None) -> None:
+        visible = max(
+            visible_lines if visible_lines is not None else self._last_detail_visible_lines, 1
+        )
+        self.detail_offset = max(line - visible // 2, 0)
+        self.clamp_detail_offset(visible)
+
+    def move_search_occurrence(self, delta: int) -> None:
+        if not self.matches:
+            return
+        match_count = len(self._last_detail_match_occurrences) or len(self._last_detail_match_lines)
+        if not match_count:
+            self.move(delta)
+            return
+        next_cursor = self.search_line_cursor + delta
+        if 0 <= next_cursor < match_count:
+            self.search_line_cursor = next_cursor
+            target = self.current_search_line()
+            if target is not None:
+                self.center_detail_on_line(target)
+            return
+        old_cursor = self.cursor
+        self.move(delta)
+        if self.cursor != old_cursor:
+            self.search_line_cursor = 0 if delta > 0 else 10**9
+
+    def move_or_scroll(self, delta: int) -> None:
+        if self.search_active and self.focus == "list":
+            self.move_search_occurrence(delta)
+        elif self.focus == "list":
+            self.move(delta)
+        else:
+            self.scroll_detail(delta)
+
+    def jump_home(self) -> None:
+        self.cursor = 0
+        self.detail_offset = 0
+        self.search_line_cursor = 0
+
+    def jump_end(self) -> None:
+        if self.matches:
+            self.cursor = len(self.matches) - 1
+            self.detail_offset = 0
+            self.search_line_cursor = 0
+
+    def toggle_focus(self) -> None:
+        self.focus = "detail" if self.focus == "list" else "list"
+
+    def scroll_detail(self, delta: int) -> None:
+        max_offset = max(self._last_detail_line_count - 1, 0)
+        self.detail_offset = min(max(self.detail_offset + delta, 0), max_offset)
+
+    def page_detail(self, delta: int) -> None:
+        self.scroll_detail(delta)
+
+    def clamp_detail_offset(self, visible_lines: int) -> None:
+        max_offset = max(self._last_detail_line_count - max(visible_lines, 1), 0)
+        self.detail_offset = min(max(self.detail_offset, 0), max_offset)
+
+
+class EventExplorerView:
+    """In-app subview wrapper for browsing recorded events."""
+
+    title = "events"
+
+    def __init__(self, event_manager: Any) -> None:
+        self.model = EventExplorerModel(build_event_rows(event_manager))
+
+    def render(self, width: int, height: int) -> str:
+        return render_event_explorer(self.model, width, height, ansi=True)
+
+    def handle_key(self, action: str, value: str = "") -> SubviewKeyResult:
+        model = self.model
+        if action == "quit":
+            if model.search_active:
+                model.edit_query(model.query + "q")
+                return "handled"
+            return "close"
+        if action == "resume":
+            if model.search_active:
+                model.edit_query(model.query + "r")
+                return "handled"
+            return "ignored"
+        if action == "escape":
+            if model.search_active:
+                model.search_active = False
+            elif model.query:
+                model.set_query("")
+            else:
+                return "ignored"
+        elif action == "enter":
+            model.search_active = False
+        elif action == "slash":
+            model.search_active = True
+        elif action == "backspace":
+            if model.search_active:
+                model.edit_query(model.query[:-1])
+        elif action == "tab":
+            model.toggle_focus()
+        elif action == "down":
+            model.move_or_scroll(+1)
+        elif action == "j":
+            if model.search_active:
+                model.edit_query(model.query + "j")
+            else:
+                model.move_or_scroll(+1)
+        elif action == "up":
+            model.move_or_scroll(-1)
+        elif action == "k":
+            if model.search_active:
+                model.edit_query(model.query + "k")
+            else:
+                model.move_or_scroll(-1)
+        elif action == "page_down":
+            if not model.search_active:
+                model.page_detail(+10)
+        elif action == "page_up":
+            if not model.search_active:
+                model.page_detail(-10)
+        elif action == "home":
+            if not model.search_active:
+                model.jump_home()
+        elif action == "end":
+            if not model.search_active:
+                model.jump_end()
+        elif action == "scroll_down":
+            model.focus = "detail"
+            model.scroll_detail(+3)
+        elif action == "scroll_up":
+            model.focus = "detail"
+            model.scroll_detail(-3)
+        elif action == "text":
+            if model.search_active and value and value.isprintable():
+                model.edit_query(model.query + value)
+            else:
+                return "ignored"
+        else:
+            return "ignored"
+        return "handled"
+
+    def on_open(self) -> None:
+        pass
+
+    def on_close(self) -> None:
+        pass
+
+
+def _event_to_mapping(event: Any) -> dict[str, Any]:
+    if hasattr(event, "model_dump"):
+        try:
+            return event.model_dump()
+        except Exception:
+            pass
+    if hasattr(event, "dict"):
+        try:
+            return event.dict()
+        except Exception:
+            pass
+    return {"repr": repr(event)}
+
+
+def _event_summary(event: Any, event_type: str) -> str:
+    if event_type == "ToolCallEvent":
+        name = str(getattr(event, "name", "?"))
+        args = getattr(event, "arguments", {})
+        if name == "execute_python" and isinstance(args, dict):
+            code = str(args.get("code", ""))
+            for line in code.splitlines():
+                stripped = line.strip()
+                if stripped and not stripped.startswith("#"):
+                    return f"{name} — {stripped[:90]}"
+        return name
+    if event_type == "PythonOutput":
+        status = str(getattr(event, "execution_status", "?")).rsplit(".", 1)[-1]
+        stdout = str(getattr(event, "stdout", "") or "").strip()
+        error = str(getattr(event, "error", "") or "").strip()
+        if error:
+            return f"{status} — {error.splitlines()[-1][:90]}"
+        if stdout:
+            return f"{status} — {stdout.splitlines()[0][:90]}"
+        return status
+    if event_type in {"SessionUserMessage", "TUIUserInput"}:
+        field = "content" if event_type == "SessionUserMessage" else "text"
+        return str(getattr(event, field, "") or "")[:100]
+    if event_type == "Task":
+        prompt = str(getattr(event, "prompt", "") or "").strip()
+        return prompt.splitlines()[0][:100] if prompt else ""
+    data = _event_to_mapping(event)
+    for key in ("content", "text", "message", "name", "summary"):
+        value = data.get(key)
+        if value:
+            return str(value).strip().splitlines()[0][:100]
+    return repr(event)[:100]
+
+
+def _extract_fenced_code(text: str) -> tuple[str, str] | None:
+    import re
+
+    match = re.search(r"```([a-zA-Z0-9_+-]*)\n(.*?)```", text, re.DOTALL)
+    if not match:
+        return None
+    language = match.group(1).strip() or "python"
+    return match.group(2).rstrip("\n"), language
+
+
+def _event_code(event: Any, event_type: str) -> tuple[str | None, str]:
+    if event_type == "ToolCallEvent" and getattr(event, "name", None) == "execute_python":
+        args = getattr(event, "arguments", {})
+        if isinstance(args, dict) and args.get("code"):
+            return str(args["code"]), "python"
+    for value in _event_to_mapping(event).values():
+        if isinstance(value, str):
+            extracted = _extract_fenced_code(value)
+            if extracted is not None:
+                return extracted
+    return None, "python"
+
+
+def _format_detail(tag: str, event: Any) -> str:
+    event_type = str(getattr(event, "event_type", type(event).__name__))
+    data = _event_to_mapping(event)
+    fields = [(k, v) for k, v in data.items() if k != "event_type"]
+    if fields:
+        body = f"{event_type}(" + ", ".join(f"{k}={v!r}" for k, v in fields) + ")"
+    else:
+        body = repr(event)
+    return f"tag = {tag!r}\ntype = {event_type!r}\n\nevent = {body}"
+
+
+_NOISE_FIELDS = {
+    "event_type",
+    "id",
+    "event_id",
+    "uuid",
+    "timestamp",
+    "created_at",
+    "updated_at",
+    "metadata",
+    "children_tags",
+    "images",
+    "execution_count",
+    "explicit_return",
+    "parent_call_id",
+    "call_id",
+    "generation_id",
+    "parent_generation_id",
+    "trace_id",
+    "span_id",
+    "tool_call_id",
+}
+
+_RENDERED_FIELD_ORDER = {
+    "AgentMessage": ("content",),
+    "TUIAgentMessage": ("content",),
+    "Message": ("content",),
+    "SessionUserMessage": ("content",),
+    "TUIUserInput": ("text",),
+    "Task": ("prompt",),
+    "Reasoning": ("content",),
+    "Error": ("content",),
+    "Feedback": ("content",),
+    "DebugTrace": ("content",),
+    "TextOnlyReply": ("content", "finish_reason", "route"),
+    "LLMOutput": ("content",),
+    "PythonOutput": ("stdout", "stderr", "error", "value"),
+    "ToolCallEvent": ("name", "arguments", "result"),
+    "Summary": ("summary_text", "summary_tag", "replaced_range"),
+    "SessionResumed": ("session_id", "restored"),
+    "TuiSessionResumed": ("session_id", "restored"),
+    "SessionCleared": ("session_id",),
+    "TuiSessionCleared": ("session_id",),
+    "LLMComplete": ("model", "finish_reason", "usage", "content"),
+    "SessionStarted": ("host", "model", "agent", "working_directory"),
+    "TUISessionStart": ("model", "agent_cls", "working_dir"),
+    "SessionTitleUpdated": ("title", "user_set"),
+    "TUISessionRename": ("name", "user_named"),
+}
+
+_MARKDOWN_FIELDS = {"content", "text", "prompt", "summary_text"}
+_CODE_EVENT_FIELDS = {
+    "PythonOutput": {"stdout": "text", "stderr": "text", "error": "pytb"},
+}
+
+
+def _escape_terminal_controls(text: str) -> str:
+    safe: list[str] = []
+    for char in text:
+        codepoint = ord(char)
+        if char in {"\n", "\t"}:
+            safe.append(char)
+        elif char == "\r":
+            safe.append("\\r")
+        elif codepoint < 32 or codepoint == 127 or 0x80 <= codepoint <= 0x9F:
+            safe.append(f"\\x{codepoint:02x}")
+        else:
+            safe.append(char)
+    return "".join(safe)
+
+
+def _safe_inline(value: Any, max_len: int = 160) -> str:
+    if isinstance(value, str):
+        text = value
+    else:
+        try:
+            text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        except TypeError:
+            text = repr(value)
+    text = _escape_terminal_controls(" ".join(str(text).split()))
+    if len(text) > max_len:
+        return text[: max_len - 1] + "…"
+    return text
+
+
+def _short_id(value: Any, max_len: int = 8) -> str:
+    text = _safe_inline(value, 80)
+    if len(text) <= max_len:
+        return text
+    return text[:max_len]
+
+
+def _pretty_timestamp(value: Any) -> str:
+    if isinstance(value, datetime.datetime):
+        return value.strftime("%Y-%m-%d %H:%M:%S")
+    if isinstance(value, datetime.date):
+        return value.isoformat()
+    text = _safe_inline(value, 80)
+    if not text:
+        return ""
+    if "T" in text and len(text) >= 19:
+        return text[:19].replace("T", " ")
+    if text.startswith("datetime.datetime("):
+        parts = text.removeprefix("datetime.datetime(").split(")", 1)[0].split(",")
+        try:
+            nums = [int(part.strip()) for part in parts[:6]]
+        except ValueError:
+            return text
+        while len(nums) < 6:
+            nums.append(0)
+        return (
+            f"{nums[0]:04d}-{nums[1]:02d}-{nums[2]:02d} {nums[3]:02d}:{nums[4]:02d}:{nums[5]:02d}"
+        )
+    return text
+
+
+def _event_header_line(tag: str, event_type: str, data: dict[str, Any]) -> str:
+    parts = [f"**[{tag}]** *{event_type}*"]
+    timestamp = data.get("timestamp") or data.get("created_at") or data.get("updated_at")
+    if not _is_empty_event_field(timestamp):
+        parts.append(_pretty_timestamp(timestamp))
+    event_id = data.get("id") or data.get("event_id") or data.get("uuid")
+    if not _is_empty_event_field(event_id):
+        parts.append(f"id={_short_id(event_id)}")
+    tool_call_id = data.get("tool_call_id")
+    if not _is_empty_event_field(tool_call_id):
+        parts.append(f"tool={_short_id(tool_call_id, 12)}")
+    call_id = data.get("call_id") or (
+        data.get("metadata", {}).get("call_id") if isinstance(data.get("metadata"), dict) else None
+    )
+    if not _is_empty_event_field(call_id):
+        parts.append(f"call={_short_id(call_id)}")
+    return " · ".join(parts)
+
+
+def _metadata_footer_line(data: dict[str, Any]) -> str:
+    parts = []
+    for field, value in data.items():
+        if field == "event_type":
+            continue
+        if field in _NOISE_FIELDS and not _is_empty_event_field(value):
+            parts.append(f"{field}={_safe_inline(value, 96)}")
+    if not parts:
+        return ""
+    return "_metadata: " + " · ".join(parts) + "_"
+
+
+def _append_metadata_footer(lines: list[str], data: dict[str, Any]) -> None:
+    footer = _metadata_footer_line(data)
+    if footer:
+        lines.extend(["", "---", "", footer])
+
+
+def _json_block(value: Any, language: str = "json") -> str:
+    try:
+        text = json.dumps(value, indent=2, ensure_ascii=False, sort_keys=True)
+    except TypeError:
+        text = repr(value)
+        language = "python"
+    return _markdown_code_block(text, language)
+
+
+def _markdown_code_block(value: Any, language: str = "") -> str:
+    text = value if isinstance(value, str) else repr(value)
+    text = _escape_terminal_controls(text)
+    fence = "```"
+    while fence in text:
+        fence += "`"
+    lang = language.strip()
+    opener = f"{fence}{lang}" if lang else fence
+    return f"{opener}\n{text.rstrip()}\n{fence}"
+
+
+def _is_empty_event_field(value: Any) -> bool:
+    return value is None or value == "" or value == [] or value == {}
+
+
+def _field_title(field: str) -> str:
+    return field.replace("_", " ").title()
+
+
+def _event_field_markdown(value: Any, *, language: str | None = None) -> str:
+    if isinstance(value, str):
+        extracted = _extract_fenced_code(value)
+        if extracted is not None:
+            return _escape_terminal_controls(value.rstrip())
+        if language is not None:
+            return _markdown_code_block(value, language)
+        return _escape_terminal_controls(value.rstrip())
+    if isinstance(value, dict | list | tuple):
+        return _json_block(value)
+    return _markdown_code_block(value, "python")
+
+
+def _ordered_content_fields(data: dict[str, Any], event_type: str) -> list[str]:
+    preferred = [field for field in _RENDERED_FIELD_ORDER.get(event_type, ()) if field in data]
+    remaining = [
+        field
+        for field in data
+        if field not in preferred
+        and field not in _NOISE_FIELDS
+        and not _is_empty_event_field(data[field])
+    ]
+    return preferred + remaining
+
+
+def _append_section(lines: list[str], title: str, body: str) -> None:
+    body = body.rstrip()
+    if not body:
+        return
+    lines.extend(["", f"## {title}", "", body])
+
+
+def _event_markdown(tag: str, event: Any, event_type: str) -> str | None:
+    data = _event_to_mapping(event)
+    lines = [_event_header_line(tag, event_type, data)]
+
+    if event_type in {"AgentMessage", "TUIAgentMessage", "Message"}:
+        content = data.get("content")
+        if not _is_empty_event_field(content):
+            lines.extend(["", _escape_terminal_controls(str(content).rstrip())])
+        _append_metadata_footer(lines, data)
+        return "\n".join(lines)
+
+    if event_type in {
+        "SessionUserMessage",
+        "TUIUserInput",
+        "Task",
+        "Reasoning",
+        "Error",
+        "Feedback",
+        "DebugTrace",
+    }:
+        field = (
+            "prompt"
+            if event_type == "Task"
+            else "content"
+            if event_type == "SessionUserMessage"
+            else "text"
+            if event_type == "TUIUserInput"
+            else "content"
+        )
+        value = data.get(field)
+        if not _is_empty_event_field(value):
+            title = (
+                "User input"
+                if event_type in {"SessionUserMessage", "TUIUserInput"}
+                else _field_title(field)
+            )
+            _append_section(lines, title, _event_field_markdown(value))
+
+    elif event_type == "ToolCallEvent":
+        name = str(data.get("name", "tool"))
+        args = data.get("arguments", {})
+        _append_section(lines, "Tool", f"`{_safe_inline(name)}`")
+        if name == "execute_python" and isinstance(args, dict) and args.get("code"):
+            _append_section(lines, "Python", _markdown_code_block(str(args["code"]), "python"))
+            extras = {k: v for k, v in args.items() if k != "code" and not _is_empty_event_field(v)}
+            if extras:
+                _append_section(lines, "Arguments", _json_block(extras))
+        elif not _is_empty_event_field(args):
+            _append_section(lines, "Arguments", _json_block(args))
+        result = data.get("result")
+        if not _is_empty_event_field(result):
+            _append_section(lines, "Result", _event_field_markdown(result))
+
+    elif event_type == "PythonOutput":
+        status = _safe_inline(data.get("execution_status", ""))
+        if status:
+            _append_section(lines, "Status", f"`{status}`")
+        for field, language in _CODE_EVENT_FIELDS["PythonOutput"].items():
+            value = data.get(field)
+            if not _is_empty_event_field(value):
+                _append_section(
+                    lines, _field_title(field), _event_field_markdown(value, language=language)
+                )
+        value = data.get("value")
+        if not _is_empty_event_field(value):
+            _append_section(lines, "Value", _event_field_markdown(value))
+
+    elif event_type == "LLMOutput":
+        content = data.get("content")
+        if not _is_empty_event_field(content):
+            language = "json" if str(content).lstrip().startswith(("{", "[")) else "python"
+            _append_section(lines, "LLM output", _markdown_code_block(str(content), language))
+
+    elif event_type == "Summary":
+        summary = data.get("summary_text")
+        if not _is_empty_event_field(summary):
+            lines.extend(["", _escape_terminal_controls(str(summary).rstrip())])
+        summary_bits = []
+        for field in ("summary_tag", "replaced_range", "children_tags"):
+            value = data.get(field)
+            if not _is_empty_event_field(value):
+                summary_bits.append(f"**{_field_title(field)}:** `{_safe_inline(value)}`")
+        if summary_bits:
+            lines.extend(["", " ".join(summary_bits)])
+
+    else:
+        for field in _ordered_content_fields(data, event_type):
+            value = data[field]
+            if _is_empty_event_field(value):
+                continue
+            language = _CODE_EVENT_FIELDS.get(event_type, {}).get(field)
+            if field in _MARKDOWN_FIELDS and language is None and isinstance(value, str):
+                body = _escape_terminal_controls(value.rstrip())
+            else:
+                body = _event_field_markdown(value, language=language)
+            _append_section(lines, _field_title(field), body)
+
+    rendered_fields = "\n".join(lines)
+    # Fallback: if no content sections were added (only the header line exists),
+    # render all non-noise fields so unknown event types still show something useful.
+    if rendered_fields.strip() == _event_header_line(tag, event_type, data).strip():
+        for field, value in data.items():
+            if field == "event_type" or field in _NOISE_FIELDS or _is_empty_event_field(value):
+                continue
+            _append_section(lines, _field_title(field), _event_field_markdown(value))
+    _append_metadata_footer(lines, data)
+    return "\n".join(lines)
+
+
+def build_event_rows(event_manager: Any) -> list[EventExplorerRow]:
+    """Build explorer rows from an EventManager-like object."""
+    rows: list[EventExplorerRow] = []
+    if hasattr(event_manager, "items"):
+        items = list(event_manager.items())
+    else:
+        items = [(tag, event_manager.get(tag)) for tag in event_manager.keys()]
+    for tag, event in items:
+        if event is None:
+            continue
+        event_type = str(getattr(event, "event_type", type(event).__name__))
+        summary = _event_summary(event, event_type)
+        detail = _format_detail(str(tag), event)
+        code, code_language = _event_code(event, event_type)
+        markdown = _event_markdown(str(tag), event, event_type)
+        search_text = f"{tag} {event_type} {summary} {detail} {code or ''} {markdown or ''}"
+        rows.append(
+            EventExplorerRow(
+                tag=str(tag),
+                event_type=event_type,
+                summary=summary,
+                search_text=search_text,
+                detail=detail,
+                code=code,
+                code_language=code_language,
+                markdown=markdown,
+            )
+        )
+    return rows
+
+
+def detail_match_lines(row: EventExplorerRow, width: int, query: str) -> list[int]:
+    terms = search_terms(query)
+    if not terms:
+        return []
+    lower_terms = [term.lower() for term in terms]
+    lines = wrapped_detail_lines(row, width)
+    matches: list[int] = []
+    for i, line in enumerate(lines):
+        lower = line.lower()
+        if any(term in lower for term in lower_terms):
+            matches.append(i)
+    return matches
+
+
+def detail_match_occurrences(
+    row: EventExplorerRow, width: int, query: str
+) -> list[tuple[int, int]]:
+    terms = search_terms(query)
+    if not terms:
+        return []
+    import re
+
+    pattern = re.compile(
+        "|".join(re.escape(t) for t in sorted(terms, key=len, reverse=True)), re.IGNORECASE
+    )
+    matches: list[tuple[int, int]] = []
+    for line_no, line in enumerate(wrapped_detail_lines(row, width)):
+        for occurrence_no, _match in enumerate(pattern.finditer(line)):
+            matches.append((line_no, occurrence_no))
+    return matches
+
+
+def wrapped_detail_lines(row: EventExplorerRow, width: int) -> list[str]:
+    """Return width-wrapped detail lines, with extracted code at the top."""
+    width = max(int(width), 20)
+    lines: list[str] = []
+    if row.markdown is not None:
+        for line in row.markdown.splitlines() or [""]:
+            lines.extend(wrap_plain_line(line, width))
+        return lines
+    if row.code:
+        lines.append(f"code ({row.code_language}):")
+        for line in row.code.rstrip("\n").splitlines() or [""]:
+            lines.extend(wrap_plain_line(line, width))
+        lines.append("")
+    lines.append("event:")
+    for line in row.detail.splitlines():
+        lines.extend(wrap_plain_line(line, width))
+    return lines
+
+
+def _highlight_syntax(text: str, width: int, language: str = "python") -> str:
+    try:
+        import io
+
+        from rich.console import Console as RichConsole
+        from rich.syntax import Syntax
+
+        render_width = max(int(width), 20)
+        buf = io.StringIO()
+        console = RichConsole(
+            file=buf,
+            force_terminal=True,
+            color_system="256",
+            width=render_width,
+            _environ={"COLUMNS": str(render_width), "LINES": "25"},
+        )
+        console.print(
+            Syntax(
+                text,
+                language or "python",
+                theme="monokai",
+                word_wrap=True,
+                line_numbers=False,
+                background_color="default",
+            )
+        )
+        return buf.getvalue()
+    except Exception:
+        wrapped: list[str] = []
+        for line in text.splitlines():
+            wrapped.extend(wrap_plain_line(line, width))
+        return "\n".join(wrapped)
+
+
+def _render_markdown(markdown: str, width: int) -> str:
+    try:
+        import io
+
+        from rich.console import Console as RichConsole
+        from rich.markdown import Markdown
+
+        render_width = max(int(width), 20)
+        buf = io.StringIO()
+        console = RichConsole(
+            file=buf,
+            force_terminal=True,
+            color_system="256",
+            width=render_width,
+            _environ={"COLUMNS": str(render_width), "LINES": "25"},
+        )
+        console.print(Markdown(markdown))
+        return buf.getvalue()
+    except Exception:
+        wrapped: list[str] = []
+        for line in markdown.splitlines():
+            wrapped.extend(wrap_plain_line(line, width))
+        return "\n".join(wrapped)
+
+
+_EVENT_HEADER_STYLE = "\x1b[1;38;5;230;48;5;238m"
+
+
+def _strip_ansi(text: str) -> str:
+    import re
+
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _style_event_header_line(lines: list[str], width: int) -> list[str]:
+    if not lines:
+        return lines
+    styled = list(lines)
+    for i, line in enumerate(styled):
+        if not line.strip():
+            continue
+        plain = _strip_ansi(line).strip()
+        # Header lines render as "[tag] EventType ..." after Rich strips markdown emphasis.
+        if not plain.startswith("["):
+            return styled
+        banner = f" {plain} "[: max(width, 1)]
+        styled[i] = f"{_EVENT_HEADER_STYLE}{banner.ljust(width)}\x1b[0m"
+        return styled
+    return styled
+
+
+def highlighted_detail_lines(
+    row: EventExplorerRow,
+    width: int,
+    query: str = "",
+    current_match_line: int | None = None,
+    current_match_occurrence: int | None = None,
+) -> list[str]:
+    """Return detail lines with code and Python-repr event syntax highlighted."""
+    width = max(int(width), 20)
+    lines: list[str] = []
+    terms = search_terms(query)
+
+    def mark(line: str) -> str:
+        line_no = len(lines)
+        if current_match_line is not None and line_no == current_match_line:
+            return highlight_terms_with_current(line, terms, current_match_occurrence)
+        return highlight_terms(line, terms)
+
+    if terms:
+        # Search navigation is computed from wrapped plain text. Use the same
+        # representation for search rendering so the selected occurrence index
+        # stays correct even when many matches share one line.
+        for line in wrapped_detail_lines(row, width):
+            lines.append(mark(line))
+        return lines
+
+    if row.markdown is not None:
+        rendered_lines = _render_markdown(row.markdown, width).splitlines() or [""]
+        return _style_event_header_line(rendered_lines, width)
+    if row.code:
+        lines.append(f"code ({row.code_language}):")
+        code_lines = _highlight_syntax(
+            row.code.rstrip("\n"), width, row.code_language
+        ).splitlines() or [""]
+        lines.extend(code_lines)
+        lines.append("")
+    lines.append("event:")
+    rendered = _highlight_syntax(row.detail, width, "python")
+    lines.extend(rendered.splitlines() or [""])
+    return lines
+
+
+def render_event_explorer(
+    model: EventExplorerModel, width: int, height: int, *, ansi: bool = False
+) -> str:
+    """Render the current explorer state as text/ANSI."""
+    width = max(int(width), 40)
+    height = max(int(height), 1)
+    row = model.current
+    match_count = len(model.matches)
+    total = len(model.rows)
+    title = "Event Explorer"
+    query = f" search={model.query!r}" if model.query else ""
+    pos = f" {model.cursor + 1}/{match_count}" if match_count else " 0/0"
+    match_label = f" match {model.cursor + 1}/{match_count}" if model.query and match_count else ""
+    header = style_bar(
+        f" {title}{pos} of {total}{match_label}{query} ".ljust(width, "─")[:width], ansi=ansi
+    )
+    pane_label = "events" if model.focus == "list" else "event text"
+    if model.search_active:
+        mode_text = "FTS MODE"
+        search_prompt = f"FTS: {model.query}"
+        nav_hint = "↑/↓ next match" if model.focus == "list" else "↑/↓ scroll text"
+        enter_hint = "enter exit FTS"
+    else:
+        mode_text = "BROWSE MODE"
+        search_prompt = "/ FTS"
+        nav_hint = "↑/↓ matches/scroll"
+        enter_hint = ""
+    focus_label = f"{mode_text} · pane={pane_label}"
+    footer_parts = [
+        focus_label,
+        "tab switch pane",
+        nav_hint,
+        search_prompt,
+        enter_hint,
+        "esc clear",
+        "q close",
+    ]
+    footer_plain = (" " + "  ".join(part for part in footer_parts if part) + " ").ljust(width, "─")[
+        :width
+    ]
+    if ansi:
+        before_mode, after_mode = footer_plain.split(mode_text, 1)
+        styled_mode = style_mode_label(mode_text, active=model.search_active, ansi=True)
+        footer = f"{BAR_STYLE}{before_mode}{styled_mode}{BAR_STYLE}{after_mode}\x1b[0m"
+    else:
+        footer = footer_plain
+    body_height = max(height - 2, 0)
+    if not total:
+        body = ["No events recorded."]
+    elif row is None:
+        body = [f"No matches for {model.query!r}."]
+    else:
+        list_count = min(8, max(3, body_height // 3))
+        half = list_count // 2
+        start = max(0, model.cursor - half)
+        end = min(match_count, start + list_count)
+        start = max(0, end - list_count)
+        body = []
+        for visible_i in range(start, end):
+            row_i = model.matches[visible_i]
+            item = model.rows[row_i]
+            marker = (
+                "❯"
+                if visible_i == model.cursor and model.focus == "list"
+                else "•"
+                if visible_i == model.cursor
+                else " "
+            )
+            line = f"{marker} {item.tag:<8} {item.event_type:<22} {item.summary}"
+            line = line[:width]
+            body.append(highlight_terms(line, search_terms(model.query)) if ansi else line)
+        divider_label = (
+            f"[FTS: {model.query}] " if model.search_active or model.query else "[/: FTS] "
+        )
+        divider_plain = divider_label.ljust(width, "─")[:width]
+        if ansi and (model.search_active or model.query):
+            divider = style_fts_prompt(divider_label, active=model.search_active, ansi=True)
+            divider += "─" * max(width - len(divider_label), 0)
+            body.append(divider)
+        else:
+            body.append(divider_plain)
+        available = max(body_height - len(body), 0)
+        model._last_detail_match_lines = detail_match_lines(row, width, model.query)
+        model._last_detail_match_occurrences = detail_match_occurrences(row, width, model.query)
+        current_match_line = None
+        current_match_occurrence = None
+        match_count_in_detail = len(model._last_detail_match_occurrences) or len(
+            model._last_detail_match_lines
+        )
+        if match_count_in_detail:
+            if model.search_line_cursor >= match_count_in_detail:
+                model.search_line_cursor = match_count_in_detail - 1
+            if model._last_detail_match_occurrences:
+                current_match_line, current_match_occurrence = model._last_detail_match_occurrences[
+                    model.search_line_cursor
+                ]
+            else:
+                current_match_line = model._last_detail_match_lines[model.search_line_cursor]
+
+        else:
+            model.search_line_cursor = 0
+        detail_lines = (
+            highlighted_detail_lines(
+                row,
+                width,
+                model.query,
+                current_match_line=current_match_line,
+                current_match_occurrence=current_match_occurrence,
+            )
+            if ansi
+            else wrapped_detail_lines(row, width)
+        )
+        model._last_detail_line_count = len(detail_lines)
+        detail_visible = (
+            max(available - 1, 0) if model._last_detail_line_count > available else available
+        )
+        model._last_detail_visible_lines = detail_visible
+        if (
+            model.search_active
+            and model.focus == "list"
+            and current_match_line is not None
+            and detail_visible > 0
+        ):
+            model.center_detail_on_line(current_match_line, detail_visible)
+        else:
+            model.clamp_detail_offset(detail_visible)
+        if model._last_detail_line_count > available:
+            scroll_label = (
+                f"{'❯ ' if model.focus == 'detail' else ''}event lines {model.detail_offset + 1}-"
+                f"{min(model.detail_offset + detail_visible, model._last_detail_line_count)}"
+                f"/{model._last_detail_line_count}"
+            )
+            body.append(scroll_label[:width])
+        for line in detail_lines[model.detail_offset : model.detail_offset + detail_visible]:
+            body.append(line if ansi else line[:width])
+    body = body[:body_height]
+    body.extend("" for _ in range(body_height - len(body)))
+    return "\n".join([header, *body, footer])

--- a/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
@@ -1,0 +1,547 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared explorer framework for in-app subviews.
+
+Provides the common layout, navigation, search, and rendering primitives
+shared across session, event, job, and todo explorers. Each concrete explorer
+supplies:
+
+- A row dataclass (what shows in the list)
+- A detail renderer (what shows in the detail pane)
+- Optional custom actions (e.g. resume session, cancel job, add comment)
+
+Layout (all explorers):
+    ┌─ header bar ─────────────────────────────────┐
+    │ list pane (scrollable, searchable rows)       │
+    ├─ divider (FTS prompt) ───────────────────────┤
+    │ detail pane (scrollable detail for selection) │
+    └─ footer bar (mode, keybindings) ─────────────┘
+"""
+
+from __future__ import annotations
+
+import re
+import textwrap
+from dataclasses import dataclass, field
+from typing import Any
+
+from .subapp import SubviewKeyResult
+
+# ─── ANSI styling primitives ─────────────────────────────────────────────────
+
+BAR_STYLE = "\x1b[48;5;236;38;5;252m"
+
+
+def style_bar(text: str, *, ansi: bool) -> str:
+    """Style a header/footer bar line."""
+    if not ansi:
+        return text
+    return f"{BAR_STYLE}{text}\x1b[0m"
+
+
+def style_mode_label(text: str, *, active: bool, ansi: bool) -> str:
+    """Style the mode indicator (FTS/BROWSE)."""
+    if not ansi:
+        return text
+    color = "30;45" if active else "30;46"
+    return f"\x1b[1;{color}m{text}\x1b[0m"
+
+
+def style_fts_prompt(text: str, *, active: bool, ansi: bool) -> str:
+    """Style the search prompt in the divider."""
+    if not ansi or not active:
+        return text
+    return f"\x1b[1;30;45m{text}\x1b[0m"
+
+
+# ─── Text utilities ──────────────────────────────────────────────────────────
+
+
+def wrap_plain_line(line: str, width: int) -> list[str]:
+    """Wrap a single line to *width*, preserving leading indent."""
+    if line == "":
+        return [""]
+    indent_len = len(line) - len(line.lstrip(" "))
+    subsequent = " " * min(indent_len, max(width - 1, 0))
+    return textwrap.wrap(
+        line,
+        width=max(width, 1),
+        replace_whitespace=False,
+        drop_whitespace=False,
+        break_long_words=True,
+        break_on_hyphens=False,
+        subsequent_indent=subsequent,
+    ) or [""]
+
+
+def search_terms(query: str) -> list[str]:
+    """Split a search query into non-empty terms."""
+    return [term for term in query.split() if term.strip()]
+
+
+def highlight_terms(text: str, terms: list[str], *, current: bool = False) -> str:
+    """Highlight search terms in text using ANSI colors."""
+    if not terms:
+        return text
+    pattern = re.compile(
+        "|".join(re.escape(t) for t in sorted(terms, key=len, reverse=True)), re.IGNORECASE
+    )
+    color = "30;106" if current else "30;43"
+    return pattern.sub(lambda m: f"\x1b[{color}m{m.group(0)}\x1b[0m", text)
+
+
+def display_line(
+    text: str, width: int, terms: list[str], *, ansi: bool, current_match: bool = False
+) -> str:
+    """Fit a plain line to width, then optionally highlight search terms."""
+    plain = text.ljust(width)[:width]
+    if ansi and terms:
+        return highlight_terms(plain, terms, current=current_match)
+    return plain
+
+
+def detail_match_lines(lines: list[str], terms: list[str]) -> list[int]:
+    """Return line indices that contain any search term."""
+    if not terms:
+        return []
+    lowered = [t.lower() for t in terms]
+    return [i for i, line in enumerate(lines) if any(t in line.lower() for t in lowered)]
+
+
+def render_markdown_lines(markdown: str, width: int) -> list[str]:
+    """Render markdown to ANSI lines via Rich, falling back to plain wrap."""
+    try:
+        import io
+
+        from rich.console import Console as RichConsole
+        from rich.markdown import Markdown
+
+        render_width = max(int(width), 20)
+        buf = io.StringIO()
+        console = RichConsole(
+            file=buf,
+            force_terminal=True,
+            color_system="256",
+            width=render_width,
+            _environ={"COLUMNS": str(render_width), "LINES": "25"},
+        )
+        console.print(Markdown(markdown))
+        return buf.getvalue().splitlines() or [""]
+    except Exception:
+        lines: list[str] = []
+        for line in markdown.splitlines() or [""]:
+            lines.extend(wrap_plain_line(line, width))
+        return lines or [""]
+
+
+# ─── Generic Explorer Model ──────────────────────────────────────────────────
+
+
+class ExplorerModel:
+    """Searchable, keyboard-navigable list with detail pane.
+
+    Subclass or use directly — the model is generic over any row type.
+    Rows must have a ``search_text: str`` attribute for FTS filtering.
+    """
+
+    def __init__(self, rows: list[Any]) -> None:
+        self.rows = rows
+        self.query = ""
+        self.matches = list(range(len(rows)))
+        self.cursor = 0
+        self.detail_offset = 0
+        self.focus = "list"
+        self.search_active = False
+        self.search_line_cursor = 0
+        self._last_detail_line_count = 0
+        self._last_detail_visible_lines = 0
+        self._last_detail_match_lines: list[int] = []
+
+    @property
+    def current_index(self) -> int | None:
+        if not self.matches:
+            return None
+        self.cursor = min(max(self.cursor, 0), len(self.matches) - 1)
+        return self.matches[self.cursor]
+
+    @property
+    def current(self) -> Any | None:
+        idx = self.current_index
+        return None if idx is None else self.rows[idx]
+
+    def set_query(self, query: str) -> None:
+        """Update search query and refilter matches."""
+        self.query = query
+        words = [w.lower() for w in query.split() if w.strip()]
+        if not words:
+            self.matches = list(range(len(self.rows)))
+        else:
+            self.matches = [
+                i
+                for i, row in enumerate(self.rows)
+                if all(word in row.search_text.lower() for word in words)
+            ]
+        self.cursor = 0
+        self.detail_offset = 0
+        self.search_line_cursor = 0
+
+    def edit_query(self, text: str) -> None:
+        self.set_query(text)
+        self.search_active = True
+
+    def clear_query(self) -> None:
+        self.set_query("")
+
+    def move(self, delta: int) -> None:
+        """Move cursor in the list."""
+        if not self.matches:
+            return
+        self.cursor = min(max(self.cursor + delta, 0), len(self.matches) - 1)
+        self.detail_offset = 0
+        self.search_line_cursor = 0
+
+    def move_or_scroll(self, delta: int) -> None:
+        if self.search_active and self.focus != "list":
+            self._move_detail_match(delta)
+        elif self.focus == "list":
+            self.move(delta)
+        else:
+            self.scroll_detail(delta)
+
+    def _move_detail_match(self, delta: int) -> None:
+        if not self._last_detail_match_lines:
+            return
+        count = len(self._last_detail_match_lines)
+        self.search_line_cursor = min(max(self.search_line_cursor + delta, 0), count - 1)
+        line = self._last_detail_match_lines[self.search_line_cursor]
+        visible = max(self._last_detail_visible_lines, 1)
+        self.detail_offset = max(line - visible // 2, 0)
+        self.clamp_detail_offset(visible)
+
+    def jump_home(self) -> None:
+        self.cursor = 0
+        self.detail_offset = 0
+        self.search_line_cursor = 0
+
+    def jump_end(self) -> None:
+        if self.matches:
+            self.cursor = len(self.matches) - 1
+            self.detail_offset = 0
+            self.search_line_cursor = 0
+
+    def toggle_focus(self) -> None:
+        self.focus = "detail" if self.focus == "list" else "list"
+
+    def scroll_detail(self, delta: int) -> None:
+        max_offset = max(self._last_detail_line_count - max(self._last_detail_visible_lines, 1), 0)
+        self.detail_offset = min(max(self.detail_offset + delta, 0), max_offset)
+
+    def page_detail(self, delta: int) -> None:
+        self.scroll_detail(delta)
+
+    def clamp_detail_offset(self, visible_lines: int) -> None:
+        max_offset = max(self._last_detail_line_count - max(visible_lines, 1), 0)
+        self.detail_offset = min(max(self.detail_offset, 0), max_offset)
+
+
+# ─── Generic Explorer View ───────────────────────────────────────────────────
+
+
+@dataclass
+class ExplorerConfig:
+    """Configuration for a concrete explorer instance.
+
+    Attributes:
+        title: Explorer title shown in header bar.
+        detail_pane_name: Label for the detail focus (e.g. "dialog", "event text").
+        empty_message: Shown when no rows exist.
+        no_match_message: Template for no search results (gets .format(query=...)).
+        list_ratio: Fraction of body height for the list pane (0.0-1.0).
+        actions: Custom action names mapped to descriptions (for footer hints).
+    """
+
+    title: str = "Explorer"
+    detail_pane_name: str = "detail"
+    empty_message: str = "No items."
+    no_match_message: str = "No matches for {query!r}."
+    list_ratio: float = 0.33
+    actions: dict[str, str] = field(default_factory=dict)
+
+
+class ExplorerView:
+    """Generic in-app explorer subview.
+
+    Concrete explorers subclass this and provide:
+    - ``config``: an ExplorerConfig
+    - ``format_row(row, width)``: format a row for the list pane
+    - ``detail_lines(row, width)``: render detail content as plain-text lines
+    - Optionally override ``handle_action(action, row)`` for custom actions
+    """
+
+    title: str = "explorer"
+
+    def __init__(self, model: ExplorerModel, config: ExplorerConfig) -> None:
+        self.model = model
+        self.config = config
+        self.title = config.title
+        self.pending_input: str | None = None
+
+    def format_row(self, row: Any, width: int) -> str:
+        """Format a single row for the list. Override in subclasses."""
+        return str(row)[:width]
+
+    def detail_lines(self, row: Any, width: int) -> list[str]:
+        """Return detail lines for the selected row. Override in subclasses."""
+        return [str(row)]
+
+    def handle_action(self, action: str, row: Any) -> SubviewKeyResult:
+        """Handle a custom action on the current row. Override for custom behavior."""
+        return "ignored"
+
+    def render(self, width: int, height: int) -> str:
+        return render_explorer(self, width, height, ansi=True)
+
+    def handle_key(self, action: str, value: str = "") -> SubviewKeyResult:
+        model = self.model
+        if action == "quit":
+            if model.search_active:
+                model.edit_query(model.query + "q")
+                return "handled"
+            return "close"
+        if action == "resume":
+            if model.search_active:
+                model.edit_query(model.query + "r")
+                return "handled"
+            return self.handle_action("resume", model.current)
+        if action == "escape":
+            if model.search_active:
+                model.search_active = False
+            elif model.query:
+                model.clear_query()
+            else:
+                return "ignored"
+        elif action == "enter":
+            if model.search_active:
+                model.search_active = False
+            else:
+                result = self.handle_action("enter", model.current)
+                if result != "ignored":
+                    return result
+        elif action == "slash":
+            if model.search_active:
+                model.edit_query(model.query + "/")
+            else:
+                model.search_active = True
+        elif action == "backspace":
+            if model.search_active:
+                model.edit_query(model.query[:-1])
+        elif action == "tab":
+            model.toggle_focus()
+        elif action in ("down", "j"):
+            if action == "j" and model.search_active:
+                model.edit_query(model.query + "j")
+            else:
+                model.move_or_scroll(+1)
+        elif action in ("up", "k"):
+            if action == "k" and model.search_active:
+                model.edit_query(model.query + "k")
+            else:
+                model.move_or_scroll(-1)
+        elif action == "page_down":
+            if not model.search_active:
+                model.page_detail(+10)
+        elif action == "page_up":
+            if not model.search_active:
+                model.page_detail(-10)
+        elif action == "home":
+            if not model.search_active:
+                model.jump_home()
+        elif action == "end":
+            if not model.search_active:
+                model.jump_end()
+        elif action == "scroll_down":
+            model.focus = "detail"
+            model.scroll_detail(+3)
+        elif action == "scroll_up":
+            model.focus = "detail"
+            model.scroll_detail(-3)
+        elif action == "text":
+            if model.search_active and value and value.isprintable():
+                model.edit_query(model.query + value)
+            else:
+                return self.handle_action(f"text:{value}", model.current)
+        else:
+            return self.handle_action(action, model.current)
+        return "handled"
+
+    def on_open(self) -> None:
+        pass
+
+    def on_close(self) -> None:
+        pass
+
+
+# ─── Generic Explorer Renderer ───────────────────────────────────────────────
+
+
+def render_explorer(view: ExplorerView, width: int, height: int, *, ansi: bool = True) -> str:
+    """Render an explorer view to a string frame.
+
+    This is the shared layout engine. Concrete explorers customize via
+    their ExplorerConfig, format_row(), and detail_lines() methods.
+    """
+    width = max(int(width), 40)
+    height = max(int(height), 1)
+    model = view.model
+    config = view.config
+
+    row = model.current
+    match_count = len(model.matches)
+    total = len(model.rows)
+
+    # ── Header ──
+    pos = f" {model.cursor + 1}/{match_count}" if match_count else " 0/0"
+    match_label = f" match {model.cursor + 1}/{match_count}" if model.query and match_count else ""
+    query_display = f" search={model.query!r}" if model.query else ""
+    header = style_bar(
+        f" {config.title}{pos} of {total}{match_label}{query_display} ".ljust(width, "\u2500")[
+            :width
+        ],
+        ansi=ansi,
+    )
+
+    # ── Footer ──
+    pane_label = "list" if model.focus == "list" else config.detail_pane_name
+    if model.search_active:
+        mode_text = "FTS MODE"
+        search_prompt = f"FTS: {model.query}"
+        enter_hint = "enter exit FTS"
+    else:
+        mode_text = "BROWSE MODE"
+        search_prompt = "/ FTS"
+        enter_hint = ""
+    focus_label = f"{mode_text} \u00b7 pane={pane_label}"
+    footer_parts = [
+        focus_label,
+        "tab switch pane",
+        "\u2191/\u2193 nav/scroll",
+        search_prompt,
+        enter_hint,
+        "esc clear",
+        "q close",
+    ]
+    # Add custom action hints
+    for _action_name, hint in config.actions.items():
+        footer_parts.append(hint)
+
+    footer_plain = (" " + "  ".join(part for part in footer_parts if part) + " ").ljust(
+        width, "\u2500"
+    )[:width]
+    if ansi:
+        before_mode, after_mode = footer_plain.split(mode_text, 1)
+        styled_mode = style_mode_label(mode_text, active=model.search_active, ansi=True)
+        footer = f"{BAR_STYLE}{before_mode}{styled_mode}{BAR_STYLE}{after_mode}\x1b[0m"
+    else:
+        footer = footer_plain
+
+    # ── Body ──
+    body_height = max(height - 2, 0)
+
+    if not total:
+        body = [config.empty_message]
+    elif row is None:
+        body = [config.no_match_message.format(query=model.query)]
+    else:
+        # List pane
+        list_count = max(3, min(int(body_height * config.list_ratio), body_height - 4))
+        half = list_count // 2
+        start = max(0, model.cursor - half)
+        end = min(match_count, start + list_count)
+        start = max(0, end - list_count)
+        terms = search_terms(model.query)
+
+        body = []
+        for visible_i in range(start, end):
+            row_i = model.matches[visible_i]
+            item = model.rows[row_i]
+            marker = (
+                "\u276f"
+                if visible_i == model.cursor and model.focus == "list"
+                else "\u2022"
+                if visible_i == model.cursor
+                else " "
+            )
+            row_text = view.format_row(item, width - 2)
+            line = f"{marker} {row_text}"
+            body.append(display_line(line, width, terms, ansi=ansi))
+
+        # Divider
+        divider_label = (
+            f"[FTS: {model.query}] " if model.search_active or model.query else "[/: FTS] "
+        )
+        divider_plain = divider_label.ljust(width, "\u2500")[:width]
+        if ansi and (model.search_active or model.query):
+            divider = style_fts_prompt(divider_label, active=model.search_active, ansi=True)
+            divider += "\u2500" * max(width - len(divider_label), 0)
+            body.append(divider)
+        else:
+            body.append(divider_plain)
+
+        # Detail pane
+        available = max(body_height - len(body), 0)
+        # Reserve 1 line for scroll indicator when detail overflows
+        detail_lines_list = view.detail_lines(row, width)
+        model._last_detail_line_count = len(detail_lines_list)
+        needs_indicator = len(detail_lines_list) > available
+        detail_visible = max(available - (1 if needs_indicator else 0), 0)
+        model._last_detail_visible_lines = detail_visible
+
+        # Update match lines for search navigation
+        terms_for_detail = search_terms(model.query)
+        model._last_detail_match_lines = detail_match_lines(detail_lines_list, terms_for_detail)
+
+        # Auto-center on match when searching
+        if model.search_active and model._last_detail_match_lines:
+            count = len(model._last_detail_match_lines)
+            model.search_line_cursor = min(max(model.search_line_cursor, 0), count - 1)
+            line = model._last_detail_match_lines[model.search_line_cursor]
+            visible = max(detail_visible, 1)
+            if not (model.detail_offset <= line < model.detail_offset + visible):
+                model.detail_offset = max(line - visible // 2, 0)
+
+        model.clamp_detail_offset(detail_visible)
+        visible_slice = detail_lines_list[
+            model.detail_offset : model.detail_offset + detail_visible
+        ]
+
+        # Highlight search terms in detail
+        if ansi and terms_for_detail:
+            current_match_line = (
+                model._last_detail_match_lines[model.search_line_cursor]
+                if model._last_detail_match_lines
+                else None
+            )
+            highlighted = []
+            for i, dl in enumerate(visible_slice):
+                abs_line = model.detail_offset + i
+                is_current = abs_line == current_match_line
+                highlighted.append(
+                    display_line(dl, width, terms_for_detail, ansi=True, current_match=is_current)
+                )
+            visible_slice = highlighted
+
+        # Scroll indicator
+        if model._last_detail_line_count > detail_visible and detail_visible > 0:
+            remaining = model._last_detail_line_count - model.detail_offset - detail_visible
+            if remaining > 0:
+                indicator = f"  \u2193 {remaining} more lines"
+                visible_slice.append(indicator[:width])
+
+        body.extend(visible_slice)
+
+    # Pad to fill height
+    while len(body) < body_height:
+        body.append("")
+
+    lines = [header] + body[:body_height] + [footer]
+    return "\n".join(lines)

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -1,0 +1,640 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Frontend protocol and TerminalFrontend implementation.
+
+A ``Frontend`` is a **pure rendering surface** — it renders Output objects,
+reads user input, and shows/hides a thinking indicator.  It has NO behavior:
+no event subscription, no show_python decisions, no streaming state.
+
+All behavior lives in ``Session``.
+"""
+
+import asyncio
+import io
+import sys
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from .output import (
+    AgentMessage,
+    BashOutput,
+    ClearScreen,
+    CodeExecution,
+    CommandStatus,
+    DiffOutput,
+    HelpOutput,
+    HistoryReplay,
+    Output,
+    RichOutput,
+    StartupInfo,
+    StopReasonOutput,
+    TableOutput,
+    TextOutput,
+    Thinking,
+)
+from .theme import COLORS
+
+if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
+    from .config import Config
+
+
+def render_history_replay_to_ansi(output: HistoryReplay, width: int) -> str:
+    """Render resumed conversation history to one ANSI block at *width*."""
+    from rich.console import Console as RichConsole
+    from rich.markdown import Markdown
+    from rich.rule import Rule
+    from rich.text import Text
+
+    dim = COLORS["overlay1"]
+    user_color = COLORS["subtext1"]
+
+    render_width = max(int(width), 20)
+    buf = io.StringIO()
+    # Rich ignores ``width=`` for force_terminal consoles when it can read the
+    # real terminal size.  Supplying COLUMNS pins the semantic replay width.
+    bc = RichConsole(
+        file=buf,
+        width=render_width,
+        highlight=False,
+        force_terminal=True,
+        _environ={"COLUMNS": str(render_width), "LINES": "25"},
+    )
+
+    if output.show_header:
+        omit_note = ""
+        if output.omitted_count:
+            omit_note = f" ({output.omitted_count} earlier turns omitted)"
+        bc.print(
+            Rule(
+                title=f"[{dim}]session {output.session_id} — history{omit_note}[/]",
+                style=COLORS["surface1"],
+            )
+        )
+    for turn in output.turns:
+        if turn.role == "user":
+            bc.print(Text(f" You: {turn.content}", style=f"{user_color} on {COLORS['surface0']}"))
+        else:
+            bc.print(Text("OO:", style=f"bold {dim}"))
+            bc.print(Markdown(turn.content), style=dim)
+        bc.print()
+    if output.show_footer:
+        bc.print(Rule(style=COLORS["surface1"]))
+
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class Frontend(Protocol):
+    """Everything a Session needs from its rendering layer.
+
+    ``TerminalFrontend`` is the concrete implementation of this protocol.
+    Commands and Session code should ONLY interact with frontends through
+    this protocol — never reach into frontend-specific attributes.
+
+    Frontends are PURE RENDERING — no event subscription, no streaming state,
+    no behavioral decisions.
+    """
+
+    async def render(self, output: Output) -> None:
+        """Render one structured output object."""
+        ...
+
+    def batch_render(self) -> "AbstractContextManager[None]":
+        """Context manager grouping multiple ``render()`` calls into one block.
+
+        Terminal frontends coalesce the enclosed output into a single
+        scrollback write (one ``run_in_terminal`` hop) so the live prompt /
+        spinner doesn't repaint between a command's outputs. Non-batching
+        frontends may return a no-op context (e.g. ``contextlib.nullcontext``).
+        """
+        ...
+
+    async def get_input(
+        self,
+        prompt: str,
+        completions: list[str] | None = None,
+        default: str = "",
+        bottom_toolbar: object = None,
+    ) -> str:
+        """Read one line of user input.
+
+        Args:
+            prompt: The text to display before the cursor.
+            completions: Optional list of completion candidates (e.g. model names).
+                         When provided the frontend may offer autocomplete.
+            default: Pre-fill the input buffer with this text.
+            bottom_toolbar: Optional callable for a status bar (e.g. spinner).
+        """
+        ...
+
+    async def prompt_sensitive(self, title: str, message: str) -> str:
+        """Collect a masked one-line value without adding it to input history."""
+        ...
+
+    async def start_thinking(self, message: str = "thinking...") -> None:
+        """Show a loading/thinking indicator."""
+        ...
+
+    async def stop_thinking(self) -> None:
+        """Hide the loading/thinking indicator."""
+        ...
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the frontend is still connected (always True for terminal)."""
+        ...
+
+    async def open_editor(
+        self, filename: str, content: str, language: str = "plaintext"
+    ) -> str | None:
+        """Open an editor for the given file content. Returns edited content or None."""
+        ...
+
+    def close(self) -> None:
+        """Clean up frontend resources."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# TerminalFrontend
+# ---------------------------------------------------------------------------
+
+
+class TerminalFrontend:
+    """Frontend backed by Rich (output) + prompt_toolkit (input).
+
+    Pure rendering — no event subscription or behavioral state.
+    """
+
+    def __init__(self, config: "Config") -> None:
+        from .console import TUIConsole
+
+        self._config = config
+        self._console = TUIConsole()
+        self._input_handler = None  # initialised after registry is ready
+        self._app = None
+        self._renderers = self._build_renderer_map()
+
+    # ------------------------------------------------------------------
+    # Input handler initialisation (needs the command registry)
+    # ------------------------------------------------------------------
+
+    def bind_app(self, app: Any) -> None:
+        """Bind the live TUIApplication for in-app modal views."""
+        self._app = app
+
+    async def open_event_explorer(self, event_manager: Any) -> None:
+        if self._app is None:
+            raise RuntimeError("TUI application is not ready.")
+        await self._app.open_event_explorer(event_manager)
+
+    async def open_session_explorer(self) -> None:
+        if self._app is None:
+            raise RuntimeError("TUI application is not ready.")
+        await self._app.open_session_explorer()
+
+    async def open_job_explorer(self) -> None:
+        if self._app is None:
+            raise RuntimeError("TUI application is not ready.")
+        await self._app.open_job_explorer()
+
+    async def open_todo_explorer(self) -> None:
+        if self._app is None:
+            raise RuntimeError("TUI application is not ready.")
+        await self._app.open_todo_explorer()
+
+    async def open_memory_explorer(self) -> None:
+        if self._app is None:
+            raise RuntimeError("TUI application is not ready.")
+        await self._app.open_memory_explorer()
+
+    async def open_activity_overlay(self, outputs: list[Output]) -> None:
+        if self._app is None:
+            raise RuntimeError("TUI application is not ready.")
+        await self._app.open_activity_overlay(outputs)
+
+    def init_input(self, registry) -> None:
+        """Wire up the prompt_toolkit input handler with slash completions."""
+        from .input_handler import TUIInputHandler
+
+        self._input_handler = TUIInputHandler(
+            registry=registry,
+            vi_mode=self._config.tui.vi_mode,
+        )
+
+    @property
+    def is_connected(self) -> bool:
+        """Terminal is always connected."""
+        return True
+
+    def close(self) -> None:
+        """Clean up terminal state."""
+        pass
+
+    # ------------------------------------------------------------------
+    # Frontend protocol implementation
+    # ------------------------------------------------------------------
+
+    async def render(self, output: Output) -> None:  # type: ignore[override]
+        """Dispatch *output* to the appropriate Rich rendering call."""
+        handler = self._renderers.get(type(output))
+        if handler is not None:
+            handler(output)
+
+    def batch_render(self):
+        """Coalesce the enclosed ``render()`` calls into one scrollback block.
+
+        When the Rich console writes through a ``_EmitStream`` (the live TUI),
+        this holds its flush so a multi-output command renders as a single
+        ``emit_block`` / ``run_in_terminal`` hop — no prompt repaint between
+        outputs. Falls back to a no-op context for plain consoles (tests).
+        """
+        from contextlib import nullcontext
+
+        stream = getattr(self._console.console, "file", None)
+        hold = getattr(stream, "hold", None)
+        return hold() if callable(hold) else nullcontext()
+
+    def _build_renderer_map(self) -> "dict[type, Callable[[Any], None]]":
+        """Build the {Output subclass → handler} dispatch table once at
+        construction time. Cheaper and clearer than an isinstance ladder;
+        also surfaces unregistered Output kinds as silent no-ops (same
+        behaviour as the old default-fallthrough)."""
+        return {
+            TextOutput: self._render_text,
+            TableOutput: self._render_table,
+            HelpOutput: self._render_help,
+            AgentMessage: self._render_agent_message,
+            CodeExecution: self._render_code_execution,
+            StartupInfo: self._render_startup,
+            ClearScreen: self._render_clear,
+            Thinking: self._render_thinking,
+            StopReasonOutput: self._render_stop_reason,
+            BashOutput: self._render_bash,
+            CommandStatus: self._render_command_status,
+            RichOutput: self._render_rich,
+            DiffOutput: self._render_diff,
+            HistoryReplay: self._render_history_replay,
+        }
+
+    def _render_help(self, output: HelpOutput) -> None:
+        self._console.print_help(output.commands)
+
+    def _render_agent_message(self, output: AgentMessage) -> None:
+        self._console.print_agent(output.content, show_rule=output.show_rule)
+
+    def _render_clear(self, _output: ClearScreen) -> None:
+        stream = getattr(self._console.console, "file", None)
+        clear_transcript = getattr(stream, "clear_transcript", None)
+        if callable(clear_transcript):
+            clear_transcript()
+        else:
+            self._console.console.clear()
+
+    def _render_thinking(self, output: Thinking) -> None:
+        if output.active:
+            self._console.start_spinner(output.message)
+        else:
+            self._console.stop_spinner()
+
+    def _render_stop_reason(self, output: StopReasonOutput) -> None:
+        from rich.markup import escape
+
+        self._console.console.print(f"[{COLORS['overlay2']}]{escape(output.display_text())}[/]")
+
+    async def get_input(
+        self,
+        prompt: str,
+        completions: list[str] | None = None,
+        default: str = "",
+        bottom_toolbar: object = None,
+    ) -> str:
+        """Read user input from the terminal.
+
+        When *completions* are provided, a temporary PromptSession with
+        WordCompleter is used when a prompt supplies a fixed choice list.
+        Otherwise the main session (with slash-command completion) is used.
+        """
+        if completions:
+            from prompt_toolkit import PromptSession
+            from prompt_toolkit.completion import WordCompleter
+
+            session = PromptSession(
+                completer=WordCompleter(completions, ignore_case=True),
+                complete_while_typing=True,
+            )
+            return (await session.prompt_async(prompt)).strip()
+
+        if self._input_handler:
+            return await self._input_handler.get_input(
+                prompt, default=default, bottom_toolbar=bottom_toolbar
+            )
+
+        # Fallback: plain input via executor
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._console.console.input(f"[user]{prompt}[/user]").strip()
+        )
+
+    async def prompt_sensitive(self, title: str, message: str) -> str:
+        """Collect OAuth material in the live application's masked modal view."""
+        if self._app is not None:
+            return await self._app.prompt_sensitive(title, message)
+
+        from prompt_toolkit import PromptSession
+
+        self._console.console.print(message)
+        session = PromptSession(is_password=True)
+        return (await session.prompt_async(f"{title}: ")).strip()
+
+    async def start_thinking(self, message: str = "thinking...") -> None:
+        self._console.start_spinner(message)
+
+    async def stop_thinking(self) -> None:
+        self._console.stop_spinner()
+
+    # ------------------------------------------------------------------
+    # Internal rendering helpers
+    # ------------------------------------------------------------------
+
+    def _render_text(self, output: TextOutput) -> None:
+        lvl = output.level
+        if lvl == "error":
+            self._console.print_error(output.content)
+        elif lvl == "warning":
+            self._console.print_warning(output.content)
+        elif lvl == "success":
+            self._console.print_success(output.content)
+        elif lvl == "status":
+            self._console.print_status(output.content)
+        else:
+            self._console.print_info(output.content)
+
+    def _render_table(self, output: TableOutput) -> None:
+        self._console.print_table(
+            output.title, output.columns, output.rows, show_header=output.show_header
+        )
+        if output.footer:
+            self._console.print_status(output.footer)
+
+    def _render_bash(self, output: BashOutput) -> None:
+        if output.stdout:
+            # Ensure text ends with newline so _EmitStream produces exactly
+            # ONE flush (one emit_block call). Two separate flushes (text
+            # sans \n, then bare \n) create two run_in_terminal hops with
+            # a prompt repaint between them that overwrites single-line
+            # output. See issue #156.
+            text = output.stdout if output.stdout.endswith("\n") else output.stdout + "\n"
+            self._console.console.print(text, end="")
+        if output.stderr:
+            self._console.print_error(output.stderr)
+
+    def _render_command_status(self, output: CommandStatus) -> None:
+        prefix = "/" if output.kind == "slash" else "!"
+        text = output.text if output.text.startswith(("/", "!")) else f"{prefix}{output.text}"
+        label = f"[{output.id}] {text}"
+        if output.state == "queued":
+            self._console.print_status(f"○ queued {label}")
+        elif output.state == "running":
+            self._console.print_status(f"▶ running {label}")
+        elif output.state == "done":
+            from rich.markup import escape
+
+            self._console.print_success(f"[command]{escape(text)}[/command]")
+        elif output.state == "cancelled":
+            self._console.print_warning(f"■ cancelled {label}")
+        else:
+            suffix = f": {output.error}" if output.error else ""
+            self._console.print_error(f"✗ failed {label}{suffix}")
+
+    def _render_rich(self, output: RichOutput) -> None:
+        """Terminal fallback for rich visual output — show summary text."""
+        label = f"[bold]{output.kind}[/bold]"
+        if output.title:
+            label = f"[bold]{output.kind}: {output.title}[/bold]"
+        if output.fallback_text:
+            self._console.print_info(f"{label} — {output.fallback_text}")
+        else:
+            self._console.print_info(
+                f"{label} (rich rendering available in the web terminal — run `nooa-term`)"
+            )
+
+    def _render_diff(self, output: DiffOutput) -> None:
+        """Render a unified diff with syntax highlighting."""
+        from rich.rule import Rule
+        from rich.syntax import Syntax
+
+        if not output.diff.strip():
+            return
+        label = f"diff — {output.filename}" if output.filename else "diff"
+        self._console.console.print(
+            Rule(title=f"[bold]{label}[/bold]", style=COLORS["surface2"], align="left")
+        )
+        self._console.console.print(Syntax(output.diff, "diff", theme="monokai", word_wrap=True))
+
+    async def open_editor(
+        self, filename: str, content: str, language: str = "plaintext"
+    ) -> str | None:
+        """Open *content* in $EDITOR via a temp file and return the edited text."""
+        import os
+        import subprocess
+        import tempfile
+        from pathlib import Path
+
+        from prompt_toolkit.application import run_in_terminal
+
+        suffix = Path(filename).suffix or ".txt"
+        editor = os.environ.get("EDITOR", os.environ.get("VISUAL", "vi"))
+
+        tmp_fd, tmp_path = tempfile.mkstemp(suffix=suffix)
+        try:
+            os.close(tmp_fd)
+            Path(tmp_path).write_text(content)
+            self._console.stop_spinner()
+            await run_in_terminal(lambda: subprocess.run([editor, tmp_path]), in_executor=True)
+            return Path(tmp_path).read_text(errors="replace")
+        except Exception:
+            return None
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass
+
+    def _render_history_replay(self, output: HistoryReplay) -> None:
+        """Render past conversation turns in a dimmed style.
+
+        Uses a buffered console to pre-render all output, then writes one block.
+        When the live TUI has redirected the console through ``_EmitStream``,
+        attach a semantic replay callback so fullscreen resize replay re-renders
+        resumed history at the new width instead of reusing stale ANSI.
+        """
+        stream = self._console.console.file
+        replay_width = getattr(stream, "replay_width", None)
+        if callable(replay_width):
+            width = replay_width(self._console.console.width or 80)
+        else:
+            width = self._console.console.width or 80
+
+        rendered = render_history_replay_to_ansi(output, width)
+        emit_with_replay = getattr(stream, "emit_with_replay", None)
+        if getattr(stream, "supports_semantic_replay", False) is True and callable(
+            emit_with_replay
+        ):
+            emit_with_replay(
+                rendered,
+                lambda o=output, s=stream, w=width: render_history_replay_to_ansi(
+                    o, s.replay_width(w) if callable(getattr(s, "replay_width", None)) else w
+                ),
+            )
+            return
+
+        # Single write to the real terminal
+        stream.write(rendered)
+        stream.flush()
+
+    def _render_startup(self, info: StartupInfo) -> None:
+        from rich.rule import Rule
+        from rich.table import Table
+
+        green = COLORS["green"]
+        subtext = COLORS["subtext1"]
+        overlay = COLORS["overlay1"]
+        sapphire = COLORS["sapphire"]
+        peach = COLORS["peach"]
+
+        self._console.console.print(
+            Rule(
+                title=f"[bold {COLORS['mauve']}]NeMo OO Agents ready[/]",
+                style=COLORS["surface2"],
+            )
+        )
+
+        table = Table.grid(padding=(0, 2))
+        table.add_column(style=f"bold {sapphire}", no_wrap=True)
+        table.add_column(style=subtext)
+
+        table.add_row(
+            "model",
+            f"[bold {green}]{info.short_model}[/] [{overlay}]({info.model})[/]",
+        )
+        table.add_row("working dir", info.working_dir)
+
+        if info.history_policy and info.history_limit:
+            table.add_row(
+                "history",
+                f"{info.history_policy}  limit {info.history_limit:,} tokens",
+            )
+
+        if info.tracing_enabled:
+            trace_val = (
+                f"[{peach}]{info.trace_dir}[/]"
+                if info.trace_dir
+                else f"[{peach}]OTLP auto-probe[/]"
+            )
+            table.add_row("tracing", trace_val)
+
+        if info.custom_agent:
+            table.add_row("agent", f"[{green}]{info.custom_agent}[/]")
+
+        keybinds = ("vi mode  " if info.vi_mode else "") + (
+            "Tab: complete  |  ↑↓: history  |  Shift+Enter: newline  |  Esc: interrupt  |  Ctrl+C ×2: exit"
+        )
+        table.add_row("keys", f"[{overlay}]{keybinds}[/]")
+        table.add_row(
+            "commands",
+            f"[{sapphire}]/help[/][{overlay}] for all  ·  [/][{sapphire}]/exit[/][{overlay}] to quit[/]",
+        )
+        table.add_row("!cmd", f"[{overlay}]run a bash command (e.g. !ls -la)[/]")
+
+        self._console.console.print(table)
+        self._console.console.print()
+
+    def _render_code_execution(self, execution: CodeExecution) -> None:
+        """Render a code execution panel (reasoning + code + output)."""
+
+        from rich.rule import Rule
+        from rich.syntax import Syntax
+        from rich.text import Text
+
+        try:
+            from nooa.context_blocks import ResultStatus as _RS
+
+            _NO_RETURN = None
+            try:
+                from nooa.events import (
+                    _NO_RETURN as _NO_RETURN,  # type: ignore[assignment]
+                )
+            except ImportError:
+                pass
+        except ImportError:
+            _RS = None
+            _NO_RETURN = None
+
+        self._console.stop_spinner()
+
+        elements: list = []
+
+        if execution.code:
+            highlight = {execution.highlight_line} if execution.highlight_line is not None else None
+            # A snippet (start_line > 1) is numbered from its real file offset, so
+            # leading whitespace lines must be preserved or the gutter numbers and
+            # highlighted line drift. Only full-cell blocks get the cosmetic strip.
+            code = execution.code.rstrip() if execution.start_line > 1 else execution.code.strip()
+            elements.append(
+                Syntax(
+                    code,
+                    "python",
+                    theme="monokai",
+                    line_numbers=True,
+                    word_wrap=True,
+                    start_line=execution.start_line,
+                    highlight_lines=highlight,
+                )
+            )
+
+        output_parts: list = []
+        if execution.stdout:
+            output_parts.append(Text(execution.stdout, style=COLORS["text"]))
+        if execution.stderr:
+            output_parts.append(Text(execution.stderr, style=COLORS["peach"]))
+        if execution.error:
+            output_parts.append(Text(execution.error, style=f"bold {COLORS['red']}"))
+        if execution.value is not None:
+            if _NO_RETURN is None or execution.value is not _NO_RETURN:
+                val = execution.value if isinstance(execution.value, str) else repr(execution.value)
+                output_parts.append(Text(f"=> {val}", style=f"bold {COLORS['green']}"))
+
+        if output_parts:
+            elements.append(Text(""))
+            elements.append(Rule(style=COLORS["surface1"]))
+            for part in output_parts:
+                elements.append(part)
+
+        if elements:
+            self._console.console.print(
+                Rule(title="[python]Python[/python]", style=COLORS["surface2"], align="left")
+            )
+            for el in elements:
+                self._console.console.print(el)
+            sys.stdout.flush()
+            sys.stderr.flush()
+
+    # ------------------------------------------------------------------
+    # Pass-through accessors (used by Session)
+    # ------------------------------------------------------------------
+
+    @property
+    def console(self):
+        return self._console
+
+    @property
+    def raw_console(self):
+        return self._console.console

--- a/packages/nooa-cli/src/nooa_cli/tui/health_check.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/health_check.py
@@ -1,0 +1,363 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Startup health check for the LLM endpoint.
+
+Sends a minimal completion request at TUI launch to surface misconfiguration
+early — before the user types their first message and gets a cryptic traceback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nooa.unifiedllm import UnifiedLLM
+
+logger = logging.getLogger(__name__)
+
+# Timeout for the probe call — fast enough to not annoy, slow enough
+# for cold-start endpoints (serverless, NIM behind an autoscaler).
+_PROBE_TIMEOUT_SECONDS = 30
+
+# Some providers/models reject a one-token output cap as too small to finish
+# even a tiny health-check response. Keep this cheap without being pathological.
+_PROBE_MAX_TOKENS = 32
+
+# Known provider → env var mapping (covers the common cases)
+_PROVIDER_API_KEY_ENV: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "vertex_ai": "GOOGLE_APPLICATION_CREDENTIALS",
+    "azure": "AZURE_API_KEY",
+    "cohere": "COHERE_API_KEY",
+    "mistral": "MISTRAL_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "together_ai": "TOGETHERAI_API_KEY",
+    "fireworks_ai": "FIREWORKS_AI_API_KEY",
+    "nvidia_nim": "NVIDIA_API_KEY",
+}
+
+
+@dataclass
+class HealthCheckResult:
+    """Outcome of the LLM health probe."""
+
+    ok: bool
+    error_message: str | None = None
+    fix_hint: str | None = None
+
+
+def _detect_provider(model: str) -> str | None:
+    """Best-effort provider detection from model string."""
+    try:
+        import litellm
+
+        _, provider, _, _ = litellm.get_llm_provider(model)
+        return provider
+    except Exception:
+        return None
+
+
+def _get_expected_env_var(llm: UnifiedLLM) -> str | None:
+    """Determine which API key env var the LLM expects."""
+    # Check registry config first (explicit api_key_env)
+    registry_cfg = getattr(llm, "_registry_config", None) or {}
+    if api_key_env := registry_cfg.get("api_key_env"):
+        return api_key_env
+
+    # Fall back to provider detection
+    model = getattr(llm, "model", "")
+    provider = _detect_provider(model)
+    if provider:
+        return _PROVIDER_API_KEY_ENV.get(provider)
+    return None
+
+
+def _has_llm_config_yaml() -> bool:
+    """Check if a **user-supplied** llm_config.yaml is discoverable.
+
+    Returns ``True`` only when the user has added a config file via
+    one of the user-controlled layers (user dir, ``NEMO_OO_LLM_CONFIG``,
+    project dir). The bundled defaults that ship in the wheel are
+    deliberately excluded — they're always present on every install,
+    so including them here would steer every connection / auth /
+    model-not-found failure toward "check your llm_config.yaml" hints
+    even for users who haven't created one.
+    """
+    try:
+        from nooa.llm_config import (
+            bundled_config_paths,
+            llm_config_chain,
+        )
+
+        bundled_set = {p.resolve() for p in bundled_config_paths()}
+        return any(p not in bundled_set for p in llm_config_chain())
+    except ImportError:
+        # Helper not installed (e.g. running against a stripped-down
+        # wheel). Treat as "no config" — caller will fall through to
+        # generic hints.
+        return False
+    except Exception:
+        # Unexpected failure inside discovery (broken paths.py
+        # dependency, OSError walking dirs, etc.). Don't crash the
+        # health-check; log it so the real error is recoverable.
+        logger.debug("llm_config_chain() raised unexpectedly", exc_info=True)
+        return False
+
+
+def _has_project_config() -> bool:
+    """Check if a settings.yaml exists in any layer (user / project / env)."""
+    try:
+        from .settings import settings_present
+
+        return settings_present()
+    except Exception:
+        return Path(".nooa/settings.yaml").exists()
+
+
+def _classify_error(exc: Exception, llm: UnifiedLLM) -> HealthCheckResult:
+    """Map a raw exception to a user-friendly diagnosis with fix instructions."""
+    model = getattr(llm, "model", "unknown")
+    msg = str(exc).lower()
+    exc_type = type(exc).__name__
+
+    expected_env = _get_expected_env_var(llm)
+    has_yaml = _has_llm_config_yaml()
+    has_config = _has_project_config()
+
+    # --- Authentication / API key issues ---
+    if any(
+        k in msg
+        for k in (
+            "401",
+            "unauthorized",
+            "invalid api key",
+            "invalid x-api-key",
+            "authentication",
+            "api key not valid",
+            "incorrect api key",
+            "invalid_api_key",
+        )
+    ):
+        hint_lines = [f"Authentication failed for model '{model}'."]
+        fix_lines = []
+
+        if expected_env:
+            env_val = os.environ.get(expected_env)
+            if env_val is None:
+                fix_lines.append(
+                    f"  • {expected_env} is NOT set — export it in your shell or .env file"
+                )
+            else:
+                fix_lines.append(
+                    f"  • {expected_env} is set but the key appears invalid — "
+                    "check it hasn't expired or been revoked"
+                )
+        else:
+            fix_lines.append(
+                "  • Check the API key env var for your provider "
+                "(e.g. ANTHROPIC_API_KEY, OPENAI_API_KEY)"
+            )
+
+        if has_yaml:
+            fix_lines.append(
+                "  • If using llm_config.yaml, verify 'api_key_env' points to the right variable"
+            )
+
+        return HealthCheckResult(
+            ok=False,
+            error_message=hint_lines[0],
+            fix_hint="\n".join(fix_lines),
+        )
+
+    # --- Model not found / doesn\'t exist ---
+    if any(
+        k in msg
+        for k in (
+            "404",
+            "not found",
+            "model not found",
+            "does not exist",
+            "no such model",
+            "model_not_found",
+            "invalid model",
+            "decommissioned",
+        )
+    ):
+        fix_lines = [
+            f"  • Verify the model name is correct (currently: '{model}')",
+            "  • Run with --model <name> to try a different model",
+        ]
+        if has_config:
+            fix_lines.append("  • Or edit 'default_model' in .nooa/settings.yaml")
+        else:
+            fix_lines.append(
+                "  • Or run `/config set model <valid-model-name>` to write settings.yaml"
+            )
+        if has_yaml:
+            fix_lines.append(
+                "  • If using a custom endpoint via llm_config.yaml, ensure the model is deployed"
+            )
+
+        return HealthCheckResult(
+            ok=False,
+            error_message=f"Model '{model}' was not found by the API provider.",
+            fix_hint="\n".join(fix_lines),
+        )
+
+    # --- Permission / access denied ---
+    if any(
+        k in msg
+        for k in (
+            "403",
+            "forbidden",
+            "permission",
+            "access denied",
+            "insufficient_quota",
+            "billing",
+        )
+    ):
+        return HealthCheckResult(
+            ok=False,
+            error_message=f"Access denied for model '{model}'.",
+            fix_hint=(
+                "Your account doesn't have access to this model. Check:\n"
+                "  • Your API plan includes access to this model\n"
+                "  • Billing is active and quota is not exhausted\n"
+                "  • Organization/project permissions are correct"
+            ),
+        )
+
+    # --- Connection refused / DNS / network ---
+    if any(
+        k in msg
+        for k in (
+            "connection",
+            "connect",
+            "refused",
+            "unreachable",
+            "dns",
+            "name or service not known",
+            "nodename nor servname",
+            "network",
+            "errno",
+            "gaierror",
+        )
+    ):
+        fix_lines = ["  • Check your internet connection"]
+        if has_yaml:
+            fix_lines.append("  • Verify 'api_base' in llm_config.yaml is correct and reachable")
+        else:
+            # If no llm_config.yaml, the endpoint is the provider default
+            fix_lines.append("  • The provider's API may be temporarily down — try again")
+        fix_lines.append("  • Check VPN or proxy settings if behind a firewall")
+
+        return HealthCheckResult(
+            ok=False,
+            error_message=f"Cannot connect to the LLM endpoint for model '{model}'.",
+            fix_hint="\n".join(fix_lines),
+        )
+
+    # --- Timeout ---
+    if any(k in msg for k in ("timeout", "timed out", "deadline")):
+        fix_lines = [
+            f"The endpoint did not respond within {_PROBE_TIMEOUT_SECONDS}s.",
+            "  • The service may be overloaded or cold-starting — try again",
+            "  • A firewall may be silently dropping packets",
+        ]
+        if has_yaml:
+            fix_lines.append("  • Check 'api_base' in llm_config.yaml is correct")
+
+        return HealthCheckResult(
+            ok=False,
+            error_message=f"LLM endpoint timed out for model '{model}'.",
+            fix_hint="\n".join(fix_lines),
+        )
+
+    # --- Output cap too small ---
+    if any(
+        k in msg
+        for k in (
+            "max_tokens or model output limit was reached",
+            "model output limit was reached",
+            "finish the message because max_tokens",
+            "output limit was reached",
+        )
+    ):
+        return HealthCheckResult(
+            ok=False,
+            error_message=f"LLM health check output limit was too small for model '{model}'.",
+            fix_hint=(
+                "The startup probe reached the model output cap before completing.\n"
+                "  • Try a different model temporarily with --model <name>\n"
+                "  • Upgrade nooa if a newer version is available\n"
+                "  • If this persists on the latest version, file a bug with the "
+                "model name and full startup error"
+            ),
+        )
+
+    # --- Rate limit ---
+    if any(k in msg for k in ("429", "rate limit", "too many requests", "rate_limit")):
+        return HealthCheckResult(
+            ok=False,
+            error_message=f"Rate limited by the API provider for model '{model}'.",
+            fix_hint=(
+                "You've hit the rate limit. This is usually temporary:\n"
+                "  • Wait a moment and try again\n"
+                "  • Check your plan's rate limits at the provider dashboard"
+            ),
+        )
+
+    # --- Generic / unknown ---
+    fix_lines = ["Troubleshooting steps:"]
+    if expected_env:
+        env_status = "set" if os.environ.get(expected_env) else "NOT set"
+        fix_lines.append(f"  • API key env var: {expected_env} ({env_status})")
+    else:
+        fix_lines.append(
+            "  • Check env vars for API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)"
+        )
+    fix_lines.append(f"  • Current model: '{model}' — try --model gpt-4o-mini")
+    if has_yaml:
+        fix_lines.append("  • Check llm_config.yaml for api_base / api_key_env")
+    if has_config:
+        fix_lines.append("  • Check .nooa/settings.yaml for model name")
+
+    return HealthCheckResult(
+        ok=False,
+        error_message=f"LLM health check failed for model '{model}': {exc_type}: {exc}",
+        fix_hint="\n".join(fix_lines),
+    )
+
+
+async def probe_llm(llm: UnifiedLLM) -> HealthCheckResult:
+    """Send a minimal request to verify the LLM endpoint is reachable and authenticated.
+
+    This sends a tiny completion request ("hi") with max_tokens=1 so it\'s fast
+    and cheap. The goal is to exercise the full auth + routing path without
+    burning meaningful tokens.
+
+    Returns HealthCheckResult with ok=True on success, or a user-friendly
+    error_message + fix_hint on failure.
+    """
+    try:
+        await asyncio.wait_for(
+            llm.acall(
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=_PROBE_MAX_TOKENS,
+            ),
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+        return HealthCheckResult(ok=True)
+
+    except TimeoutError:
+        return _classify_error(Exception("Request timed out"), llm)
+    except Exception as exc:
+        return _classify_error(exc, llm)

--- a/packages/nooa-cli/src/nooa_cli/tui/input_handler.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/input_handler.py
@@ -1,0 +1,318 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Input handling with history, completion, and multi-line support.
+
+Uses prompt_toolkit for readline-like input experience.
+The actual completion logic lives in ``completer.py`` (shared with the web
+frontend); this module is just the prompt_toolkit adapter.
+"""
+
+import re
+from typing import TYPE_CHECKING
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.completion import Completer as PtCompleter
+from prompt_toolkit.completion import Completion
+from prompt_toolkit.history import InMemoryHistory
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.styles import Style
+
+from .completer import _MENTION_PATTERN, Completer
+from .theme import COLORS
+
+if TYPE_CHECKING:
+    from .commands import CommandRegistry
+
+# The keybindings trigger completion when an @ mention is being typed at the
+# cursor — same pattern the engine uses (anchored at end-of-buffer here).
+_MENTION_RE = re.compile(_MENTION_PATTERN + r"?\Z")
+
+
+class SlashCommandCompleter(PtCompleter):
+    """prompt_toolkit adapter over the shared ``Completer`` engine."""
+
+    def __init__(self, registry: "CommandRegistry"):
+        self._completer = Completer(registry=registry)
+
+    def get_completions(self, document, complete_event):
+        text = document.text_before_cursor
+        if (
+            not text.startswith("/")
+            and not text.startswith("!")
+            and _MENTION_RE.search(text) is None
+        ):
+            return
+
+        for item in self._completer.complete(text):
+            # Calculate how much text to replace: the item.text is the full
+            # replacement, so we insert the suffix after what's already typed.
+            suffix = item.text[len(text) :] if item.text.startswith(text) else item.text
+            if not suffix and item.text == text:
+                # Exact match — still yield it so prompt_toolkit's
+                # completion menu never receives an empty list (which
+                # crashes _get_menu_width with max() on empty iterable).
+                yield Completion(
+                    "",
+                    start_position=0,
+                    display=item.display,
+                    display_meta=item.description,
+                )
+                continue
+            yield Completion(
+                suffix if item.text.startswith(text) else item.text,
+                start_position=0 if item.text.startswith(text) else -len(text),
+                display=item.display,
+                display_meta=item.description,
+            )
+
+
+def _set_completions_sync(buffer) -> None:
+    """Generate completions synchronously and set them on the buffer.
+
+    Avoids the prompt_toolkit race in ``Buffer.start_completion()`` which
+    creates an empty ``CompletionState`` before completions are loaded,
+    causing ``_get_menu_width`` to call ``max()`` on an empty sequence.
+
+    Uses ``Buffer._set_completions`` (private API) with a fallback to the
+    public ``start_completion`` for forward-compatibility.
+    """
+    from prompt_toolkit.completion import CompleteEvent
+
+    if not buffer.completer:
+        return
+
+    completions = list(
+        buffer.completer.get_completions(buffer.document, CompleteEvent(completion_requested=True))
+    )
+    if completions:
+        try:
+            buffer._set_completions(completions=completions)
+            # Ensure no completion is pre-selected (matches start_completion(select_first=False)).
+            if buffer.complete_state:
+                buffer.complete_state.go_to_index(None)
+        except (AttributeError, TypeError):
+            # Fallback if private API changes in a future prompt_toolkit release.
+            buffer.start_completion(select_first=False)
+    else:
+        # No matches — dismiss any visible menu.
+        if buffer.complete_state:
+            buffer.cancel_completion()
+
+
+def create_key_bindings(vi_mode: bool = False) -> KeyBindings:
+    """Create key bindings for multi-line input and slash command completion.
+
+    - Enter: Submit
+    - Alt+Enter or Option+Enter: Insert newline for multi-line input
+    - Shift+Enter: Insert newline (requires iTerm2/kitty/WezTerm with CSI u mode)
+    - Any character after /: Keep completion menu open (disabled in vi mode to
+      avoid clashing with vi normal-mode movement keys)
+
+    Note: Most terminals send Alt+Enter as Escape followed by Enter.
+    Shift+Enter works in terminals that send \\x1b[13;2u (Kitty keyboard protocol).
+
+    Args:
+        vi_mode: When True, skip letter-key completion bindings that would
+                 conflict with vi normal-mode commands.
+    """
+    bindings = KeyBindings()
+
+    @bindings.add("enter")
+    def _(event):
+        """Enter submits the current input."""
+        event.current_buffer.validate_and_handle()
+
+    @bindings.add("c-j")
+    def _(event):
+        """Shift+Enter on iTerm2 sends \\n (ControlJ) — insert a newline."""
+        event.current_buffer.insert_text("\n")
+
+    @bindings.add("escape", "enter")
+    def _(event):
+        """Alt+Enter (Option+Enter without CSI u mode) inserts a newline."""
+        event.current_buffer.insert_text("\n")
+
+    # Trigger and maintain completion for slash commands
+    def _handle_char_for_completion(event, char: str):
+        """Insert character and trigger completion if in a slash command."""
+        buffer = event.current_buffer
+        buffer.insert_text(char)
+
+        # Check if we're typing a slash or bang command, or an inline @ mention.
+        text = buffer.text[: buffer.cursor_position]
+        if (
+            text.startswith("/")
+            or text.startswith("!")
+            or (("\n/" in text) and text.rsplit("\n", 1)[-1].startswith("/"))
+            or _MENTION_RE.search(text) is not None
+        ):
+            # Generate completions synchronously and set them directly.
+            # buffer.start_completion() creates an empty CompletionState before
+            # completions load, which races with the renderer: prompt_toolkit's
+            # _get_menu_width calls max() on the empty list → ValueError.
+            try:
+                _set_completions_sync(buffer)
+            except (IndexError, ValueError):
+                # prompt_toolkit race: completion state accessed with empty list.
+                # Safe to ignore — the next keystroke will retry.
+                pass
+
+    if not vi_mode:
+        # Bind alphanumeric + path-relevant punctuation to maintain completion.
+        # Skipped in vi mode: letters are vi normal-mode movement/action keys.
+        _completion_chars = (
+            "abcdefghijklmnopqrstuvwxyz"
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            "0123456789"
+            "._-~"  # common in file paths: dotfiles, underscores, hyphens, home ~
+        )
+        for char in _completion_chars:
+
+            @bindings.add(char)
+            def _(event, c=char):
+                _handle_char_for_completion(event, c)
+
+        @bindings.add(" ")
+        def _(event):
+            _handle_char_for_completion(event, " ")
+
+        @bindings.add("c-h")  # Backspace
+        @bindings.add("backspace")
+        def _(event):
+            """Handle backspace and re-trigger completion if still in / or ! command."""
+            buffer = event.current_buffer
+            buffer.delete_before_cursor(1)
+
+            text = buffer.text[: buffer.cursor_position]
+            if text.startswith("/") or text.startswith("!") or _MENTION_RE.search(text) is not None:
+                try:
+                    _set_completions_sync(buffer)
+                except (IndexError, ValueError):
+                    pass
+
+    # Always bind "/" — in vi mode only trigger completion when the buffer
+    # already starts with "/" (i.e. we're already in a slash command), so that
+    # vi normal-mode "/" search still fires on an empty buffer.
+    @bindings.add("/")
+    def _(event):
+        buffer = event.current_buffer
+        text_before = buffer.text[: buffer.cursor_position]
+        if vi_mode and not text_before.startswith("/"):
+            # Let vi handle "/" search on an empty/non-slash buffer
+            buffer.insert_text("/")
+        else:
+            _handle_char_for_completion(event, "/")
+
+    # "!" on an empty buffer starts a bang command; trigger completion immediately.
+    @bindings.add("!")
+    def _(event):
+        buffer = event.current_buffer
+        buffer.insert_text("!")
+        text = buffer.text[: buffer.cursor_position]
+        if text == "!" or text.startswith("!"):
+            _set_completions_sync(buffer)
+
+    # "@" starts an inline file/dir mention; trigger completion immediately
+    # whenever it lands at start-of-line or after whitespace.
+    @bindings.add("@")
+    def _(event):
+        buffer = event.current_buffer
+        buffer.insert_text("@")
+        text = buffer.text[: buffer.cursor_position]
+        if _MENTION_RE.search(text) is not None:
+            try:
+                _set_completions_sync(buffer)
+            except (IndexError, ValueError):
+                pass
+
+    return bindings
+
+
+def create_prompt_style() -> Style:
+    """Create prompt_toolkit style using Catppuccin colors."""
+    return Style.from_dict(
+        {
+            # Prompt
+            "prompt": COLORS["green"],
+            "prompt.continuation": COLORS["overlay1"],
+            # Completion menu
+            "completion-menu": f"bg:{COLORS['surface0']} {COLORS['text']}",
+            "completion-menu.completion": f"bg:{COLORS['surface0']} {COLORS['text']}",
+            "completion-menu.completion.current": f"bg:{COLORS['surface2']} {COLORS['mauve']}",
+            "completion-menu.meta": COLORS["overlay1"],
+            "completion-menu.meta.current": COLORS["lavender"],
+            # Scrollbar
+            "scrollbar.background": COLORS["surface0"],
+            "scrollbar.button": COLORS["surface2"],
+        }
+    )
+
+
+class TUIInputHandler:
+    """Handle user input with history, completion, and multi-line support."""
+
+    def __init__(self, registry: "CommandRegistry", vi_mode: bool = False):
+        """Initialize the input handler.
+
+        Args:
+            registry: CommandRegistry instance to get completion options from
+            vi_mode: Enable vi keybindings (normal/insert mode). When True,
+                     letter-key completion bindings are skipped to avoid
+                     conflicts with vi movement commands.
+        """
+        from prompt_toolkit.shortcuts import CompleteStyle
+
+        self.vi_mode = vi_mode
+        self.history = InMemoryHistory()
+        self.completer = SlashCommandCompleter(registry)
+        self.key_bindings = create_key_bindings(vi_mode=vi_mode)
+        self.style = create_prompt_style()
+
+        self.session = PromptSession(
+            history=self.history,
+            completer=self.completer,
+            key_bindings=self.key_bindings,
+            style=self.style,
+            multiline=True,  # Allow Shift+Enter newlines; Enter binding submits
+            complete_while_typing=False,  # We handle it manually via key bindings
+            complete_style=CompleteStyle.COLUMN,  # Single column with descriptions
+            enable_history_search=True,  # Ctrl+R for reverse search
+            vi_mode=vi_mode,
+        )
+
+    def refresh_style(self) -> None:
+        """Rebuild prompt_toolkit style from current theme colors."""
+        self.style = create_prompt_style()
+        self.session.style = self.style
+
+    async def get_input(self, prompt: str = "You: ", default: str = "", bottom_toolbar=None) -> str:
+        """Get input from user with history and completion.
+
+        Args:
+            prompt: The prompt to display
+            default: Pre-fill the input buffer with this text
+            bottom_toolbar: Optional callable returning toolbar text (for spinner)
+
+        Returns:
+            User input string (may be multi-line)
+
+        Raises:
+            EOFError: If Ctrl+D is pressed
+            KeyboardInterrupt: If Ctrl+C is pressed
+        """
+        kwargs: dict = {
+            "prompt_continuation": "",
+            "default": default,
+        }
+        if bottom_toolbar is not None:
+            kwargs["bottom_toolbar"] = bottom_toolbar
+        result = await self.session.prompt_async(
+            [("class:prompt", prompt)],
+            **kwargs,
+        )
+        return result.strip()
+
+    def invalidate(self) -> None:
+        """Force a redraw of the prompt (used by spinner to update toolbar)."""
+        if self.session.app:
+            self.session.app.invalidate()

--- a/packages/nooa-cli/src/nooa_cli/tui/job_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/job_explorer.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Job explorer — browse and inspect background QueueManager jobs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .explorer_base import (
+    ExplorerConfig,
+    ExplorerModel,
+    ExplorerView,
+    wrap_plain_line,
+)
+from .subapp import SubviewKeyResult
+
+
+@dataclass
+class JobExplorerRow:
+    """One background job in the explorer list."""
+
+    channel: str
+    label: str
+    state: str
+    delivered: int
+    queued: int
+    values: list[Any]
+    search_text: str
+
+
+def build_job_rows(queue_manager: Any) -> list[JobExplorerRow]:
+    """Build explorer rows from active QueueManager jobs."""
+    rows: list[JobExplorerRow] = []
+    if queue_manager is None:
+        return rows
+    for channel_name, state in queue_manager.jobs().items():
+        handle = queue_manager.job(channel_name)
+        if handle is None:
+            continue
+        ch = queue_manager.channels().get(channel_name)
+        queued = ch.qsize() if ch and hasattr(ch, "qsize") else 0
+        values = handle.values
+        search_parts = [
+            handle.name,
+            handle.label,
+            state,
+            *[str(v) for v in values[-20:]],
+        ]
+        rows.append(
+            JobExplorerRow(
+                channel=handle.name,
+                label=handle.label,
+                state=state,
+                delivered=len(values),
+                queued=queued,
+                values=values,
+                search_text="\n".join(search_parts),
+            )
+        )
+    return rows
+
+
+class JobExplorerView(ExplorerView):
+    """In-app subview for browsing background jobs."""
+
+    def __init__(self, queue_manager: Any) -> None:
+        self._queue_manager = queue_manager
+        rows = build_job_rows(queue_manager)
+        model = ExplorerModel(rows)
+        config = ExplorerConfig(
+            title="Job Explorer",
+            detail_pane_name="job output",
+            empty_message="No background jobs.",
+            no_match_message="No jobs matching {query!r}.",
+            list_ratio=0.4,
+            actions={},
+        )
+        super().__init__(model, config)
+
+    def format_row(self, row: JobExplorerRow, width: int) -> str:
+        state_icon = {
+            "running": "⚡",
+            "done": "✓",
+            "failed": "✗",
+            "cancelled": "⊘",
+        }.get(row.state, "?")
+        line = (
+            f"{state_icon} {row.channel:<20} {row.state:<10} "
+            f"delivered={row.delivered:<6} queued={row.queued}"
+        )
+        if row.label != row.channel:
+            line += f"  ({row.label})"
+        return line[:width]
+
+    def detail_lines(self, row: JobExplorerRow, width: int) -> list[str]:
+        width = max(int(width), 20)
+        lines: list[str] = [
+            f"Channel: {row.channel}",
+            f"Label: {row.label}",
+            f"State: {row.state}",
+            f"Delivered: {row.delivered}  Queued: {row.queued}",
+            "",
+        ]
+        if not row.values:
+            lines.append("(no buffered output)")
+        else:
+            lines.append(f"Output (last {min(len(row.values), 50)} of {len(row.values)}):")
+            lines.append("")
+            for val in row.values[-50:]:
+                for raw in str(val).splitlines() or [""]:
+                    lines.extend(wrap_plain_line(raw, width))
+        return lines
+
+    def handle_action(self, action: str, row: Any) -> SubviewKeyResult:
+        return "ignored"

--- a/packages/nooa-cli/src/nooa_cli/tui/keep_going.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/keep_going.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Built-in keep-going stop audit for the TUI."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from nooa import PredictStrategy, strategy
+from nooa.config import PredictConfig
+from nooa.unifiedllm import get_llm_client
+
+DEFAULT_KEEP_GOING_MODEL = "nemotron3-nano-30b"
+KEEP_GOING_PREFIX = "[keep-going] "
+
+
+class KeepGoingDecision(BaseModel):
+    """Judgement of whether the agent should continue after returning DONE."""
+
+    should_reprompt: bool = Field(
+        description="True only when the agent stopped early and should continue autonomously."
+    )
+    reason: str = Field(
+        default="",
+        description="One short user-visible reason, under 100 characters.",
+    )
+    next_action: str = Field(
+        default="",
+        description="If should_reprompt is true, one concise imperative instruction for the agent.",
+    )
+
+
+class KeepGoingPrompt(BaseModel):
+    """System continuation prompt plus the one-line reason shown to the user."""
+
+    prompt: str
+    display_reason: str
+
+
+def _predict_config() -> PredictConfig:
+    return PredictConfig(
+        max_retries=2,
+        max_tokens=300,
+        temperature=0,
+        output_serialization="tool_call",
+    )
+
+
+@lru_cache(maxsize=16)
+def _judge_keep_going_for_model(model: str):
+    keep_going_llm = get_llm_client(model)
+
+    @strategy(PredictStrategy(config=_predict_config()), llm=keep_going_llm)
+    async def _judge_keep_going(
+        last_turns: str,
+        todo_state: str,
+        queue_state: str,
+        return_result: str,
+        user_visible_messages: str,
+    ) -> KeepGoingDecision:
+        """Decide whether an agent that just returned DONE should continue.
+
+        Use only the supplied evidence. Return should_reprompt=true only when
+        the agent stopped early and can continue without user input.
+
+        Continue for obvious unfinished autonomous work: open unblocked todos,
+        promised edits/tests/checks not done, actionable failures/findings not
+        handled, or asking the user to inspect output the agent can inspect.
+
+        Do not continue when the turn is complete, genuinely needs user input,
+        needs approval/credentials, or is waiting for a running background job.
+
+        Keep outputs short:
+        - reason: one user-visible fragment under 100 chars, e.g. "open todos remain".
+        - next_action: one imperative instruction, e.g. "Run the focused tests.".
+        If should_reprompt=false, set reason and next_action to empty strings.
+        """
+        ...
+
+    return _judge_keep_going
+
+
+async def judge_keep_going(
+    last_turns: str,
+    todo_state: str,
+    queue_state: str,
+    return_result: str,
+    user_visible_messages: str,
+    *,
+    model: str = DEFAULT_KEEP_GOING_MODEL,
+) -> KeepGoingDecision:
+    """Run the keep-going judge with the configured model."""
+    judge = _judge_keep_going_for_model(model)
+    return await judge(
+        last_turns=last_turns,
+        todo_state=todo_state,
+        queue_state=queue_state,
+        return_result=return_result,
+        user_visible_messages=user_visible_messages,
+    )
+
+
+async def build_keep_going_prompt(
+    agent: Any, result: Any, *, model: str = DEFAULT_KEEP_GOING_MODEL
+) -> KeepGoingPrompt | None:
+    """Return a synthetic continuation prompt when a DONE result stopped too early."""
+    if _result_kind(result) != "DONE":
+        return None
+    if KEEP_GOING_PREFIX in str(result):
+        return None
+    decision = await judge_keep_going(**_snapshot(agent, result), model=model)
+    if not decision.should_reprompt:
+        return None
+    reason = _one_line(decision.reason)
+    next_action = decision.next_action.strip() or reason
+    if not next_action:
+        return None
+    system_prompt = (
+        f"{KEEP_GOING_PREFIX}A stop-reason audit says you are not actually done.\n\n"
+        f"Reason: {reason}\n\n"
+        f"Next action: {next_action}\n\n"
+        "Continue now. Do not ask the user to read logs/output you can inspect yourself."
+    )
+    return KeepGoingPrompt(prompt=system_prompt, display_reason=reason)
+
+
+def _one_line(value: str, max_len: int = 100) -> str:
+    text = " ".join(str(value).split())
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1].rstrip() + "…"
+
+
+def _result_kind(result: Any) -> str:
+    if isinstance(result, dict):
+        return str(result.get("kind", ""))
+    kind = getattr(result, "kind", "")
+    return getattr(kind, "value", str(kind)) if kind else ""
+
+
+def _snapshot(agent: Any, result: Any) -> dict[str, str]:
+    return {
+        "last_turns": _last_turns(agent, 12),
+        "todo_state": _todo_state(agent),
+        "queue_state": _safe_call(getattr(getattr(agent, "queue_manager", None), "status", None)),
+        "return_result": str(result),
+        "user_visible_messages": _messages_from_recent_events(agent, 12),
+    }
+
+
+def _todo_state(agent: Any) -> str:
+    todo = getattr(agent, "todo", None)
+    if todo is None:
+        return ""
+    lines: list[str] = []
+    try:
+        open_todos = todo.list_todos(status="open")
+    except Exception:
+        open_todos = []
+    if open_todos:
+        lines.append(f"OPEN TODOS ({len(open_todos)}) — these are unresolved work:")
+        for item in open_todos[:10]:
+            title = getattr(item, "title", "")
+            notes = getattr(item, "notes", "")
+            item_id = getattr(item, "id", "")
+            line = f"- [{item_id}] {title}"
+            if notes:
+                line += f" — {notes[:500]}"
+            lines.append(line)
+    else:
+        lines.append("OPEN TODOS (0)")
+    full_status = _safe_call(getattr(todo, "status", None))
+    if len(full_status) > 3000:
+        full_status = full_status[:1500] + "\n…\n" + full_status[-1500:]
+    lines.append("\nFULL TODO STATUS (truncated if long):\n" + full_status)
+    return "\n".join(lines)
+
+
+def _last_turns(agent: Any, n: int) -> str:
+    event_manager = getattr(agent, "event_manager", None)
+    if event_manager is None:
+        return ""
+    try:
+        items = event_manager.items()[-n:]
+    except Exception:
+        return ""
+    lines: list[str] = []
+    for tag, event in items:
+        text = str(event)
+        if len(text) > 2000:
+            text = text[:2000] + "…"
+        lines.append(f"<{tag}> {type(event).__name__}: {text}")
+    return "\n".join(lines)
+
+
+def _messages_from_recent_events(agent: Any, n: int) -> str:
+    event_manager = getattr(agent, "event_manager", None)
+    if event_manager is None:
+        return ""
+    try:
+        events = event_manager.values()[-n:]
+    except Exception:
+        return ""
+    snippets: list[str] = []
+    for event in events:
+        if type(event).__name__ not in {
+            "AgentMessage",
+            "Message",
+            "MessageOutput",
+            "TextOutput",
+            "MarkdownOutput",
+            "TUIAgentMessage",
+        }:
+            continue
+        text = getattr(event, "text", None) or getattr(event, "content", None) or str(event)
+        snippets.append(str(text))
+    return "\n\n".join(snippets)
+
+
+def _safe_call(fn: Any) -> str:
+    if fn is None:
+        return ""
+    try:
+        return str(fn())
+    except Exception as exc:
+        return f"<unavailable: {type(exc).__name__}>"

--- a/packages/nooa-cli/src/nooa_cli/tui/main.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/main.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Main entry point for NeMo OO Agents TUI (terminal frontend).
+
+Thin wrapper around the shared bootstrap.  Creates a ``TerminalFrontend``,
+calls ``bootstrap()``, wires them together, and runs the session.
+
+The ``main()`` coroutine keeps its original signature so that callers like
+``examples/tools_agent_tui/example.py`` continue to work unchanged::
+
+    await main(config=config, agent=agent)
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nooa import Agent
+
+    from .config import Config
+
+
+async def main(
+    config: "Config | None" = None,
+    agent: "Agent | None" = None,
+    continue_last: bool = False,
+    resume_session_id: str | None = None,
+) -> None:
+    """Main entry point for the TUI.
+
+    Args:
+        config: Optional Config instance. If None, load layered defaults.
+        agent: Optional NeMo OO Agents agent.  If None, a TUIAgent (or custom class
+               from ``config.tui.agent_spec``) is created from ``config``.
+               Custom hosts must implement the InteractiveAgent queue contract.
+        resume_session_id: Explicit session ID (or prefix) to resume.
+    """
+    from .bootstrap import bootstrap, build_registry, build_session, build_startup_info
+    from .config import Config
+    from .frontend import TerminalFrontend
+    from .output import TextOutput, _RichReplayPayload
+    from .session_manager import SESSIONS_DIR, build_resume_outputs
+    from .splash import show_splash
+
+    if config is None:
+        config = Config.load()
+
+    # Terminal-specific: create frontend and splash screen
+    frontend = TerminalFrontend(config)
+    if not config.no_splash:
+        show_splash(frontend.raw_console)
+
+    # Shared bootstrap: tracing, LLM, storage, agent, session manager
+    result = await bootstrap(
+        config,
+        continue_last=continue_last,
+        resume_session_id=resume_session_id,
+        agent=agent,
+    )
+
+    _startup_info = build_startup_info(result)
+    _initial_outputs = [*result.messages, _startup_info]
+
+    # Show resumed session history (interleaved with any rich content). Terminal
+    # text/markdown outputs are deferred until Session.run(), after the frontend
+    # console is redirected through TUIApplication.emit_block; that makes them
+    # part of fullscreen resize replay instead of one-off pre-app writes.
+    if result.resumed and result.session_id is not None:
+        import os as _os
+
+        _in_nemo_term = bool(_os.environ.get("NEMO_OO_RICH_URL"))
+        _db_path = SESSIONS_DIR / f"{result.session_id}.db"
+        _resume_outputs = build_resume_outputs(
+            _db_path, result.session_id, in_nemo_term=_in_nemo_term
+        )
+        if _resume_outputs:
+            _rich_url = _os.environ.get("NEMO_OO_RICH_URL") if _in_nemo_term else None
+            for _item in _resume_outputs:
+                if isinstance(_item, _RichReplayPayload):
+                    if _rich_url:
+                        try:
+                            import httpx as _httpx
+
+                            _httpx.post(
+                                _rich_url,
+                                json={**_item.payload, "_replay": True},
+                                timeout=5.0,
+                            )
+                        except Exception:
+                            pass
+                else:
+                    _initial_outputs.append(_item)
+            _initial_outputs.append(
+                TextOutput(f"Session {result.session_id[:8]} resumed.", "status")
+            )
+        else:
+            _initial_outputs.append(TextOutput("No previous session with turns found.", "info"))
+    elif continue_last:
+        _initial_outputs.append(TextOutput("No previous session with turns found.", "info"))
+
+    # Wire frontend → registry → session
+    registry = build_registry(result, frontend)
+    registry.startup_info = _startup_info
+    frontend.init_input(registry)  # terminal-specific: prompt_toolkit completions
+    session = build_session(result, frontend, registry, initial_outputs=_initial_outputs)
+
+    await session.run()

--- a/packages/nooa-cli/src/nooa_cli/tui/mcp_approval.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/mcp_approval.py
@@ -1,0 +1,425 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""User-owned approvals for TUI MCP server configurations.
+
+Repository configuration is not a trust grant.  Before the TUI connects to an
+MCP server, this module fingerprints the complete effective server definition
+and requires that exact fingerprint to be present in a user-level approval
+store.  Environment placeholders are resolved only after that check succeeds.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import hmac
+import json
+import os
+import re
+import shlex
+import stat
+import tempfile
+import unicodedata
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, quote_plus, urlsplit, urlunsplit
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+_APPROVALS_FILENAME = "mcp_approvals.json"
+_STORE_VERSION = 1
+_CONFIRMATION_LENGTH = 16
+_TARGET_PREVIEW_LENGTH = 240
+_SUPPORTED_CONFIG_FIELDS = {
+    "args",
+    "command",
+    "env",
+    "headers",
+    "oauth_client_id",
+    "oauth_manual",
+    "oauth_open_browser",
+    "oauth_redirect_uri",
+    "oauth_scope",
+    "transport",
+    "url",
+}
+
+
+def _safe_display(value: Any) -> str:
+    """Escape terminal control characters in untrusted config-derived text."""
+    out: list[str] = []
+    for character in str(value):
+        codepoint = ord(character)
+        if codepoint < 32 or 127 <= codepoint <= 159:
+            out.append(f"\\x{codepoint:02x}")
+        elif unicodedata.category(character) == "Cf":
+            escape = f"\\u{codepoint:04x}" if codepoint <= 0xFFFF else f"\\U{codepoint:08x}"
+            out.append(escape)
+        else:
+            out.append(character)
+    return "".join(out)
+
+
+def _safe_preview(value: Any, limit: int = _TARGET_PREVIEW_LENGTH) -> str:
+    """Escape untrusted text and bound how much a config can render."""
+    rendered = _safe_display(value)
+    if len(rendered) <= limit:
+        return rendered
+    return rendered[:limit] + f"… ({len(rendered) - limit} more characters)"
+
+
+def _load_server_config(
+    server_name: str,
+    *,
+    mcp_file: Path | None,
+    servers: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Load one effective config using the same whole-entry precedence as core."""
+    configured: dict[str, Any] = {}
+    path = mcp_file or Path(".mcp.json")
+    if path.exists():
+        try:
+            root = json.loads(path.read_text())
+            file_servers = root.get("mcpServers", {}) if isinstance(root, dict) else {}
+            if isinstance(file_servers, dict):
+                configured.update(file_servers)
+        except (json.JSONDecodeError, OSError):
+            # Match MCPManager: a missing or malformed compatibility file is
+            # treated as empty, while inline TUI servers remain usable.
+            pass
+    configured.update(servers)
+    config = configured.get(server_name)
+    if not isinstance(config, dict):
+        raise ValueError(f"MCP server {server_name!r} has no valid configuration mapping")
+    return copy.deepcopy(config)
+
+
+def _placeholder_bindings(value: Any, path: str = "") -> list[tuple[str, str]]:
+    """Return ``(variable, config-path)`` pairs without reading the environment."""
+    found: list[tuple[str, str]] = []
+    if isinstance(value, str):
+        found.extend(
+            (match.group(1), path or "<value>") for match in _ENV_VAR_PATTERN.finditer(value)
+        )
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            child = f"{path}[{index}]" if path else f"[{index}]"
+            found.extend(_placeholder_bindings(item, child))
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            child = f"{path}.{key}" if path else str(key)
+            found.extend(_placeholder_bindings(item, child))
+    return sorted(set(found))
+
+
+def _fingerprint(server_name: str, config: dict[str, Any]) -> str:
+    """Hash the server name and complete literal config deterministically."""
+    try:
+        canonical = json.dumps(
+            {"server": server_name, "config": config},
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"MCP server {server_name!r} must contain only JSON-compatible values"
+        ) from exc
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def _safe_http_target(raw_url: Any) -> str:
+    """Show the destination without echoing userinfo, query values, or fragments."""
+    if not isinstance(raw_url, str) or not raw_url:
+        return "(missing URL)"
+    try:
+        parsed = urlsplit(raw_url)
+        hostname = parsed.hostname or ""
+        if ":" in hostname and not hostname.startswith("["):
+            hostname = f"[{hostname}]"
+        port = f":{parsed.port}" if parsed.port is not None else ""
+        netloc = hostname + port
+        query = "<redacted>" if parsed.query else ""
+        return _safe_display(urlunsplit((parsed.scheme, netloc, parsed.path, query, "")))
+    except (TypeError, ValueError):
+        return "(configured URL; inspect the config file)"
+
+
+@dataclass(frozen=True)
+class MCPApprovalRequest:
+    """Review material bound to one exact MCP server definition."""
+
+    server_name: str
+    fingerprint: str
+    transport: str
+    target: str
+    bindings: tuple[tuple[str, str], ...]
+    config: dict[str, Any] = field(repr=False, compare=False)
+
+    @property
+    def confirmation(self) -> str:
+        """Short fingerprint a user must echo to approve this definition."""
+        return self.fingerprint[:_CONFIRMATION_LENGTH]
+
+    @property
+    def variables(self) -> tuple[str, ...]:
+        return tuple(sorted({variable for variable, _path in self.bindings}))
+
+    def accepts_confirmation(self, value: str) -> bool:
+        return hmac.compare_digest(value, self.confirmation) or hmac.compare_digest(
+            value, self.fingerprint
+        )
+
+    def review_text(self) -> str:
+        """Render a secret-safe review and a second-step confirmation command."""
+        quoted_name = _safe_display(shlex.quote(self.server_name))
+        lines = [
+            f"Approval required for MCP server {_safe_display(self.server_name)!r}.",
+            "",
+            f"Transport: {_safe_display(self.transport)}",
+            f"Target: {self.target}",
+            f"Config fingerprint: sha256:{self.fingerprint}",
+        ]
+        if self.transport == "stdio":
+            lines.extend(
+                ("", "Warning: approval allows this configuration to execute a local process.")
+            )
+        headers = self.config.get("headers") or {}
+        if headers:
+            lines.append(f"Header names: {_safe_preview(', '.join(sorted(headers)))}")
+        child_environment = self.config.get("env") or {}
+        if child_environment:
+            lines.append(
+                "Child environment keys: " + _safe_preview(", ".join(sorted(child_environment)))
+            )
+        if self.config.get("oauth_redirect_uri"):
+            lines.append("OAuth redirect: " + _safe_http_target(self.config["oauth_redirect_uri"]))
+        if self.config.get("oauth_scope"):
+            lines.append("OAuth scope: " + _safe_preview(self.config["oauth_scope"]))
+        if self.config.get("oauth_client_id"):
+            lines.append("OAuth client ID: " + _safe_preview(self.config["oauth_client_id"]))
+        if self.bindings:
+            lines.extend(("", "Host environment values that will be copied after approval:"))
+            for variable, location in self.bindings:
+                lines.append(f"  {variable} -> {_safe_display(location)}")
+        else:
+            lines.extend(("", "No host environment placeholders were found."))
+        lines.extend(
+            (
+                "",
+                "Approval is user-level and applies only to this exact configuration. Any change",
+                "to its URL, command, arguments, headers, environment, or OAuth settings requires approval again.",
+                "",
+                "Review the source config, then approve and connect with:",
+                f"  /mcp approve {quoted_name} {self.confirmation}",
+            )
+        )
+        return "\n".join(lines)
+
+
+def build_approval_request(
+    server_name: str,
+    *,
+    mcp_file: Path | None,
+    servers: dict[str, dict[str, Any]],
+) -> MCPApprovalRequest:
+    """Build review material for the current effective server definition."""
+    config = _load_server_config(server_name, mcp_file=mcp_file, servers=servers)
+    if not all(isinstance(field_name, str) for field_name in config):
+        raise ValueError(f"MCP server {server_name!r} field names must be strings")
+    unsupported = sorted(set(config) - _SUPPORTED_CONFIG_FIELDS)
+    if unsupported:
+        names = ", ".join(unsupported)
+        raise ValueError(f"MCP server {server_name!r} has unsupported field(s): {names}")
+    if not config.get("transport") and config.get("url"):
+        # TUI configs have always documented URL entries as HTTP servers. Make
+        # that effective value explicit before fingerprinting and before core
+        # sees the definition, instead of falling through to core's stdio
+        # default and failing with a missing command.
+        config["transport"] = "streamable-http"
+    transport = str(config.get("transport") or "stdio")
+    if transport not in ("stdio", "sse", "streamable-http"):
+        raise ValueError(f"Unsupported MCP transport {transport!r}")
+    if transport == "stdio" and (
+        not isinstance(config.get("command"), str) or not config["command"].strip()
+    ):
+        raise ValueError(f"MCP stdio server {server_name!r} requires a string command")
+    if transport in ("sse", "streamable-http") and (
+        not isinstance(config.get("url"), str) or not config["url"].strip()
+    ):
+        raise ValueError(f"MCP HTTP server {server_name!r} requires a string URL")
+    args = config.get("args")
+    if args is not None and (
+        not isinstance(args, list) or not all(isinstance(item, str) for item in args)
+    ):
+        raise ValueError(f"MCP server {server_name!r} args must be a list of strings")
+    for field_name in ("env", "headers"):
+        values = config.get(field_name)
+        if values is not None and (
+            not isinstance(values, dict)
+            or not all(
+                isinstance(key, str) and isinstance(value, str) for key, value in values.items()
+            )
+        ):
+            raise ValueError(f"MCP server {server_name!r} {field_name} must map strings to strings")
+    for field_name in ("oauth_client_id", "oauth_redirect_uri", "oauth_scope"):
+        value = config.get(field_name)
+        if value is not None and not isinstance(value, str):
+            raise ValueError(f"MCP server {server_name!r} {field_name} must be a string")
+    for field_name in ("oauth_open_browser", "oauth_manual"):
+        value = config.get(field_name)
+        if value is not None and not isinstance(value, bool):
+            raise ValueError(f"MCP server {server_name!r} {field_name} must be a boolean")
+    if transport in ("sse", "streamable-http"):
+        target = _safe_http_target(config.get("url"))
+    else:
+        command = config.get("command")
+        args = config.get("args")
+        invocation = shlex.join([command, *(args or [])])
+        target = _safe_preview(invocation)
+    return MCPApprovalRequest(
+        server_name=server_name,
+        fingerprint=_fingerprint(server_name, config),
+        transport=transport,
+        target=target,
+        bindings=tuple(_placeholder_bindings(config)),
+        config=config,
+    )
+
+
+def resolve_approved_environment(
+    request: MCPApprovalRequest, environment: Mapping[str, str] | None = None
+) -> dict[str, Any]:
+    """Resolve placeholders in an already-approved request, failing atomically."""
+    source = os.environ if environment is None else environment
+    missing = sorted(variable for variable in request.variables if variable not in source)
+    if missing:
+        names = ", ".join(missing)
+        raise ValueError(
+            f"Approved MCP server {request.server_name!r} requires unset environment "
+            f"variable(s): {names}"
+        )
+
+    def _resolve(value: Any) -> Any:
+        if isinstance(value, str):
+            return _ENV_VAR_PATTERN.sub(lambda match: source[match.group(1)], value)
+        if isinstance(value, list):
+            return [_resolve(item) for item in value]
+        if isinstance(value, dict):
+            return {key: _resolve(item) for key, item in value.items()}
+        return value
+
+    return _resolve(request.config)
+
+
+def redact_approved_environment(
+    request: MCPApprovalRequest,
+    value: Any,
+    environment: Mapping[str, str] | None = None,
+) -> str:
+    """Remove approved environment values from an error before displaying it."""
+    rendered = str(value)
+    replacements: list[tuple[str, str]] = []
+    source = os.environ if environment is None else environment
+    for variable in request.variables:
+        secret = source.get(variable)
+        if not secret:
+            continue
+        marker = f"${{{variable}}}"
+        candidates = {secret, quote(secret, safe=""), quote_plus(secret, safe="")}
+        replacements.extend((candidate, marker) for candidate in candidates if candidate)
+    for candidate, marker in sorted(replacements, key=lambda item: len(item[0]), reverse=True):
+        rendered = rendered.replace(candidate, marker)
+    return _safe_display(rendered)
+
+
+class MCPApprovalRequired(RuntimeError):
+    """Raised before transport creation when a definition is not approved."""
+
+    def __init__(self, request: MCPApprovalRequest) -> None:
+        self.request = request
+        super().__init__(request.review_text())
+
+
+class MCPApprovalStore:
+    """A fail-closed, user-level store containing config fingerprints only."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        if path is None:
+            from nooa.paths import get_user_dir
+
+            path = get_user_dir(_APPROVALS_FILENAME)
+        self.path = path
+
+    def _load(self) -> dict[str, Any]:
+        try:
+            data = json.loads(self.path.read_text())
+        except (OSError, ValueError):
+            return {"version": _STORE_VERSION, "approvals": {}}
+        if not isinstance(data, dict) or data.get("version") != _STORE_VERSION:
+            return {"version": _STORE_VERSION, "approvals": {}}
+        approvals = data.get("approvals")
+        if not isinstance(approvals, dict):
+            return {"version": _STORE_VERSION, "approvals": {}}
+        return {"version": _STORE_VERSION, "approvals": approvals}
+
+    def is_approved(self, request: MCPApprovalRequest) -> bool:
+        return request.fingerprint in self._load()["approvals"]
+
+    def approve(self, request: MCPApprovalRequest) -> None:
+        data = self._load()
+        data["approvals"][request.fingerprint] = {
+            "server": request.server_name,
+            "variables": list(request.variables),
+            "approved_at": datetime.now(UTC).isoformat(),
+        }
+        self._write(data)
+
+    def revoke_server(self, server_name: str) -> bool:
+        data = self._load()
+        approvals = data["approvals"]
+        remove = [
+            fingerprint
+            for fingerprint, record in approvals.items()
+            if isinstance(record, dict) and record.get("server") == server_name
+        ]
+        for fingerprint in remove:
+            approvals.pop(fingerprint, None)
+        if remove:
+            self._write(data)
+        return bool(remove)
+
+    def _write(self, data: dict[str, Any]) -> None:
+        """Atomically replace the store and keep it readable only by the user."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, raw_temp = tempfile.mkstemp(prefix=f".{self.path.name}.", dir=self.path.parent)
+        temp = Path(raw_temp)
+        try:
+            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp, self.path)
+            self.path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        except BaseException:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            temp.unlink(missing_ok=True)
+            raise
+
+
+__all__ = [
+    "MCPApprovalRequest",
+    "MCPApprovalRequired",
+    "MCPApprovalStore",
+    "build_approval_request",
+    "redact_approved_environment",
+    "resolve_approved_environment",
+]

--- a/packages/nooa-cli/src/nooa_cli/tui/mcp_registry.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/mcp_registry.py
@@ -1,0 +1,705 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""MCPRegistry — agent-facing MCP server management mirroring SkillRegistry."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import fnmatch
+import inspect
+import keyword
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated, Any, Literal
+
+from nooa.agentdoc import hidden, spec
+from nooa.skill import Skill, slash_command
+
+from .mcp_approval import (
+    MCPApprovalRequest,
+    MCPApprovalRequired,
+    MCPApprovalStore,
+    _safe_display,
+    build_approval_request,
+    redact_approved_environment,
+    resolve_approved_environment,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+_MAX_TOOL_NAMES = 8
+_ALLOWED_CONNECT_KWARGS = {"tool_call_timeout"}
+_FACTORY_CONFIG_FIELDS = (
+    "command",
+    "args",
+    "env",
+    "url",
+    "headers",
+    "transport",
+    "oauth_client_id",
+    "oauth_redirect_uri",
+    "oauth_scope",
+    "oauth_open_browser",
+    "oauth_manual",
+)
+
+
+def _to_attr_name(name: str) -> str:
+    """Convert a hyphenated server name to a valid Python attribute name."""
+    return name.replace("-", "_")
+
+
+class MCPRegistry(Skill):
+    """Connect to MCP servers and surface their tools to the agent.
+
+    Mirrors :class:`SkillRegistry`. An MCP server is *configured* (in
+    ``.mcp.json`` or the TUI ``tui.mcp_servers`` settings.yaml block), *connected* (an
+    authenticated client that lists the server's tools), and *activated* (its
+    tools are listed as callable free functions in the ``<mcp>`` context
+    block). A connected-but-deactivated server keeps its generated tool/client
+    cached without flooding the agent's context; each tool invocation still
+    opens and closes its own transport session. This mirrors the visibility
+    rationale of ``SkillRegistry.activate/deactivate``.
+
+    **The ``<mcp>`` context block is the single source of truth for what is
+    callable.** Each *active* server contributes one free-function line per
+    tool (signature + first docstring line); the agent calls them as
+    ``self.<server>.<tool>(...)``. The ``self.<server>`` attribute is always
+    hidden from ``doc(self)`` so the top-level surface never bloats —
+    activation changes the block, not attribute visibility.
+
+    ## Lifecycle
+
+    ::
+
+        self.mcp.discovered()              # configured server names
+        await self.mcp.connect(["maas"])   # open session(s), attach as self.maas
+        self.mcp.connected()               # connected server names
+        self.mcp.activate(["maas"])        # list maas tools in <mcp> as free functions
+        self.mcp.deactivate(["maas"])      # drop from <mcp> (client stays cached)
+        self.mcp.status()                  # render the <mcp> block
+
+    ``connect``/``activate``/``deactivate`` take fnmatch globs
+    (``"maas"``, ``"*"``, ``"conf-*"``).
+
+    ## User approval and environment secrets
+
+    Configuration is discovery, not trust. Before any transport is created,
+    the TUI requires a user-level approval for the fingerprint of the complete
+    effective server definition. The human reviews and grants it through
+    ``/mcp approve <name> <code>``; the agent cannot grant approval through this
+    skill. Changes to the URL, command, args, headers, env, or OAuth settings
+    invalidate approval. Only after the exact fingerprint matches does the TUI resolve
+    ``${VAR}`` placeholders from the host environment. Core ``MCPManager`` keeps
+    config placeholders literal.
+
+    ## Adding a server
+
+    Register an in-memory server entry, then connect it::
+
+        self.mcp.register(
+            "myserver",
+            url="https://host/mcp",
+            transport="streamable-http",
+            headers={"Authorization": "Bearer ..."},
+        )
+        await self.mcp.connect(["myserver"])
+
+    To persist a server, add a ``tui.mcp_servers.<name>`` block to
+    ``.nooa/settings.yaml`` or a VS Code /
+    Claude-style ``.mcp.json``; ``register`` is in-memory only.
+
+    ## OAuth: what the AGENT can do vs. what the HUMAN must do
+
+    HTTP servers that return 401 trigger an OAuth flow (RFC 9728 / dynamic
+    client registration) on first connect. **OAuth consent is inherently a
+    human action** — the agent cannot click "Approve" in a browser. Know which
+    side of the line each step is on:
+
+    **The agent CAN, unattended:**
+
+    - ``register(...)`` a server and request ``connect``/``activate``/``deactivate``.
+      A new or changed definition still needs the human's ``/mcp approve`` action.
+    - Reconnect a server whose token is already **cached** (a prior successful
+      auth in this environment) — no human needed; the cached token is reused.
+    - Put auth settings such as ``oauth_client_id``/``oauth_scope`` or static
+      authorization headers in the approved server definition. After exact-config
+      approval, a static-key or pre-authorized server connects fully unattended.
+
+    **The HUMAN MUST do (agent cannot substitute):**
+
+    - **Grant first-time OAuth consent.** On a 401 with no cached token, a real
+      person has to open the consent URL, approve, and let the callback return.
+      The TUI surfaces the URL and collects the pasted code/callback in a masked
+      in-app prompt, but the agent cannot approve on the user's behalf. Prefer
+      letting the human drive ``/mcp connect <name>`` so a single flow runs
+      start-to-finish — OAuth codes are single-use, and a half-finished
+      agent-driven flow burns the code (causing a confusing 401 on retry).
+    - **Be present for the browser handoff.** ``oauth_open_browser`` (default
+      True) opens the system browser; it falls back to manual when none exists.
+      Either way a human completes consent.
+
+    **Timeout / no-hang guarantee.** ``connect`` bounds the OAuth wait with
+    ``oauth_timeout`` (default 180s) — a never-returning browser callback raises
+    a clear ``TimeoutError`` telling the user to retry, rather than wedging the
+    agent indefinitely. Pass ``on_connecting=cb`` to surface "launching browser
+    for <name>..." feedback *before* the wait begins (the UI must not look
+    frozen while the user is sent to a browser).
+
+    Tokens are cached with the dynamically registered client credentials, so
+    later connects in the same environment skip the prompt — the *second* connect
+    is something the agent can do unattended.
+
+    ## Developer API
+
+    ``MCPManager`` (``nooa.mcp``) stays a stateless, dependency-free
+    factory — library code calls ``MCPManager.create_from_server(...)``
+    directly. This registry wraps it to hold connection/activation state for an
+    agent.
+    """
+
+    __nosnapshot__ = True
+    context_block = ("mcp", "self.mcp.status()")
+
+    _agent: Annotated[Any, hidden] = None
+
+    @slash_command(
+        "mcp-add",
+        argument_hint="<server info: name, URL, transport, auth notes>",
+        output_to_agent=True,
+    )
+    async def mcp_add_command(self, args: str) -> str:
+        """Add a new MCP server: hand the details to the agent to wire it up.
+
+        The user pastes whatever they have about a server — a name and URL, a
+        ``claude mcp add ...`` line, a docs snippet, an OAuth client id, etc.
+        This does NOT edit anything itself; it returns a task for the agent,
+        which reads the details, writes the ``tui.mcp_servers.<name>`` block in
+        ``.nooa/settings.yaml``, and guides the user through connecting
+        (OAuth/host-browser handoff as needed).
+        """
+        details = args.strip()
+        if not details:
+            return (
+                "Usage: /mcp-add <server info>\n"
+                "Paste a name + URL (and transport/auth notes), or a "
+                "`claude mcp add ...` line, e.g.:\n"
+                "  /mcp-add maas-gdrive https://maas.prd.astra.nvidia.com/maas/gdrive/mcp "
+                "streamable-http"
+            )
+        config_path = self._config_path()
+        configured = ", ".join(self.discovered()) or "(none)"
+        return (
+            "The user wants to add a new MCP server. Here are the details they provided:\n\n"
+            f"{details}\n\n"
+            "Do the following:\n"
+            "1. Parse the server name, URL, transport (default `streamable-http` for HTTP "
+            "URLs), and any auth info (OAuth client_id, static API key/headers).\n"
+            f"2. Add a `tui.mcp_servers.<name>` YAML block to the TUI config at `{config_path}` "
+            "(create the file/section if missing; do NOT clobber existing servers). Use an "
+            "environment placeholder in `headers` for a static API key, or `oauth_client_id` "
+            "for a pre-provisioned OAuth client. Never write a secret value into project "
+            "config. Don't set `oauth_manual` unless the server requires OOB.\n"
+            "3. Tell the user to run `/mcp connect <name>` to review the exact config, then "
+            "personally run the displayed `/mcp approve <name> <code>` command. The agent "
+            "must not approve MCP config. Explain browser consent / masked code entry if the "
+            "server needs OAuth.\n"
+            "4. Confirm what you wrote and show the resulting config block without resolving "
+            "or printing secret values.\n\n"
+            f"Currently configured servers: {configured}.\n"
+            f"Config file: {config_path}."
+        )
+
+    def _config_path(self) -> Path:
+        """Return the project-local TUI settings.yaml path."""
+        from nooa.paths import get_project_dir
+
+        from .settings import SETTINGS_FILENAME
+
+        return get_project_dir(SETTINGS_FILENAME)
+
+    def __init__(
+        self,
+        mcp_file: Path | None = None,
+        servers: dict[str, dict[str, Any]] | None = None,
+        approval_path: Path | None = None,
+    ) -> None:
+        """Initialize with optional config sources.
+
+        Args:
+            mcp_file: Path to a VS Code / Claude-style ``.mcp.json``.
+            servers: Inline server config (from TUI ``tui.mcp_servers`` in settings.yaml).
+            approval_path: Override the user approval store path (primarily for tests).
+        """
+        self._mcp_file = mcp_file
+        self._servers: dict[str, dict[str, Any]] = copy.deepcopy(servers or {})
+        self._approval_store = MCPApprovalStore(approval_path)
+        self._connected: dict[str, Any] = {}
+        self._activated: set[str] = set()
+        self._oauth_code_prompt: Callable[[str], Awaitable[str]] | None = None
+        # Servers whose connect() is currently in-flight — guards against a
+        # retry spawning a second concurrent create_from_server (and second
+        # browser window / racing token-cache write) while the first to_thread
+        # is still running after a wait_for timeout (the thread keeps going).
+        self._pending: set[str] = set()
+        super().__init__()
+
+    def _bind_oauth_code_prompt(self, callback: Callable[[str], Awaitable[str]] | None) -> None:
+        """Bind the host TUI's thread-safe manual OAuth input bridge."""
+        self._oauth_code_prompt = callback
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+
+    def discovered(self) -> list[str]:
+        """All configured server names (``.mcp.json`` + inline + registered).
+
+        Returns an empty list if the ``mcp`` package is unavailable (the TUI
+        package depends on it, but ``MCPManager`` lives in core where it stays
+        optional), so the ``<mcp>`` context block renders cleanly instead of
+        leaking an ``ImportError`` every turn.
+        """
+        try:
+            from nooa.mcp import MCPManager
+        except ImportError:
+            return []
+        return sorted(MCPManager.list_servers(self._mcp_file, servers=self._servers))
+
+    def register(
+        self,
+        name: str,
+        *,
+        url: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        transport: Literal["stdio", "sse", "streamable-http"] | None = None,
+        headers: dict[str, str] | None = None,
+        oauth_client_id: str | None = None,
+        oauth_redirect_uri: str | None = None,
+        oauth_scope: str | None = None,
+        oauth_open_browser: bool | None = None,
+        oauth_manual: bool | None = None,
+    ) -> None:
+        """Add an in-memory server entry (not persisted to config).
+
+        Use ``url``/``headers``/``transport`` for HTTP servers, or
+        ``command``/``args``/``env`` for stdio servers. To persist, add a
+        ``tui.mcp_servers.<name>`` block to settings.yaml instead.
+        """
+        if name in self._connected or name in self._pending:
+            raise RuntimeError(f"Disconnect MCP server {name!r} before changing its configuration")
+        entry: dict[str, Any] = {}
+        for key, val in (
+            ("url", url),
+            ("command", command),
+            ("args", args),
+            ("env", env),
+            ("transport", transport),
+            ("headers", headers),
+            ("oauth_client_id", oauth_client_id),
+            ("oauth_redirect_uri", oauth_redirect_uri),
+            ("oauth_scope", oauth_scope),
+            ("oauth_open_browser", oauth_open_browser),
+            ("oauth_manual", oauth_manual),
+        ):
+            if val is not None:
+                entry[key] = val
+        self._servers[name] = copy.deepcopy(entry)
+
+    # ------------------------------------------------------------------
+    # User approval boundary
+    # ------------------------------------------------------------------
+
+    def _approval_request(self, name: str) -> MCPApprovalRequest:
+        return build_approval_request(
+            name,
+            mcp_file=self._mcp_file,
+            servers=self._servers,
+        )
+
+    def _is_approved(self, name: str) -> bool:
+        return self._approval_store.is_approved(self._approval_request(name))
+
+    def _approve(self, name: str, confirmation: str) -> MCPApprovalRequest:
+        request = self._approval_request(name)
+        if not request.accepts_confirmation(confirmation):
+            raise ValueError(
+                "Approval code does not match the current MCP configuration. "
+                "Run `/mcp approve " + name + "` to review it again."
+            )
+        self._approval_store.approve(request)
+        return request
+
+    def _revoke_approvals(self, name: str) -> bool:
+        return self._approval_store.revoke_server(name)
+
+    def _prepared_connection(
+        self, name: str
+    ) -> tuple[
+        MCPApprovalRequest,
+        dict[str, dict[str, Any]],
+        dict[str, Any],
+        dict[str, str],
+    ]:
+        """Return an approved config as explicit, non-reexpanded factory arguments.
+
+        The blank server override prevents either the selected ``.mcp.json`` or
+        the process-default one from contributing fields after approval. Passing
+        resolved values as explicit arguments also keeps older core releases from
+        applying their legacy environment expansion a second time.
+        """
+        request = self._approval_request(name)
+        if not self._approval_store.is_approved(request):
+            raise MCPApprovalRequired(request)
+        approved_environment = {
+            variable: value
+            for variable in request.variables
+            if (value := os.environ.get(variable)) is not None
+        }
+        resolved = resolve_approved_environment(request, approved_environment)
+        factory_config = {
+            field: copy.deepcopy(resolved[field])
+            for field in _FACTORY_CONFIG_FIELDS
+            if field in resolved
+        }
+        return request, {name: {}}, factory_config, approved_environment
+
+    # ------------------------------------------------------------------
+    # Connecting
+    # ------------------------------------------------------------------
+
+    def connected(self) -> list[str]:
+        """Currently connected server names."""
+        return sorted(self._connected)
+
+    async def connect(
+        self,
+        patterns: list[str],
+        *,
+        oauth_timeout: float = 180.0,
+        on_connecting: Callable[[str], None] | None = None,
+        activate: bool = True,
+        **kwargs: Any,
+    ) -> list[str]:
+        """Connect to configured servers matching *patterns*.
+
+        Each connected server is attached to the agent as ``self.<name>``
+        (hyphens become underscores), hidden from ``doc(self)``. By default
+        newly connected servers are also activated (listed in ``<mcp>``); pass
+        ``activate=False`` to keep them connected but unlisted.
+
+        Security-relevant connection settings, including OAuth options, must be
+        part of the approved server definition. ``tool_call_timeout`` is the only
+        operational factory override accepted through extra keyword arguments.
+
+        Every configured server must first be approved by the user through
+        ``/mcp approve``. The approval covers the complete effective config;
+        environment placeholders are resolved only after it matches.
+
+        Returns the list of server names connected by this call.
+        """
+        from nooa.mcp import MCPManager
+
+        unexpected = sorted(set(kwargs) - _ALLOWED_CONNECT_KWARGS)
+        if unexpected:
+            names = ", ".join(unexpected)
+            raise TypeError(
+                "Connection-time MCP endpoint/config overrides are not allowed by the TUI "
+                f"approval boundary: {names}. Register a new server definition instead."
+            )
+
+        matched = self._match(patterns, set(self.discovered()))
+        newly: list[str] = []
+        for name in sorted(matched):
+            if name in self._connected:
+                continue
+            # In-flight guard: prevent a retry from starting a SECOND concurrent
+            # connect for the same server while a prior attempt is still waiting
+            # on OAuth — that would race token-cache writes, duplicate client
+            # registrations, or open two browser windows.
+            if name in self._pending:
+                raise RuntimeError(
+                    f"Connect to {name!r} is already in progress (a prior attempt "
+                    f"may still be waiting on OAuth). Wait for it to finish or time "
+                    f"out before retrying."
+                )
+            self._validate_attach_name(name)
+            request, prepared_servers, approved_kwargs, approved_environment = (
+                self._prepared_connection(name)
+            )
+            # Feedback BEFORE the (possibly long, browser-launching) OAuth wait —
+            # otherwise the UI looks frozen while the user is sent to a browser.
+            if on_connecting is not None:
+                on_connecting(name)
+            self._pending.add(name)
+            worker: asyncio.Task[Any] | None = None
+            try:
+                # Outer to_thread keeps the prompt_toolkit UI loop painting during
+                # OAuth waits (see !373). The OAuth wait itself is bounded by a
+                # SINGLE authoritative timeout owned by the OAuth layer: the local
+                # callback server polls every 1s and exits on it, so there is no
+                # orphaned thread — we pass oauth_timeout straight down rather than
+                # stacking a second wait_for here.
+                create_kwargs = {**approved_kwargs, **kwargs}
+                if oauth_timeout is not None:
+                    create_kwargs["oauth_timeout"] = oauth_timeout
+                worker = asyncio.create_task(
+                    asyncio.to_thread(
+                        MCPManager.create_from_server,
+                        name,
+                        mcp_file=self._mcp_file,
+                        servers=prepared_servers,
+                        oauth_code_prompt=self._oauth_code_prompt,
+                        **create_kwargs,
+                    )
+                )
+                tool = await asyncio.shield(worker)
+            except asyncio.CancelledError:
+                assert worker is not None
+
+                def _finish_cancelled_connect(
+                    finished: asyncio.Task[Any], server_name: str = name
+                ) -> None:
+                    self._pending.discard(server_name)
+                    if not finished.cancelled():
+                        # Retrieve a late worker exception so asyncio does not
+                        # report it as an unhandled background task.
+                        finished.exception()
+
+                worker.add_done_callback(_finish_cancelled_connect)
+                raise
+            except Exception as exc:
+                message = redact_approved_environment(request, exc, approved_environment)
+                raise RuntimeError(f"MCP server {name!r} connection failed: {message}") from None
+            finally:
+                if worker is None or worker.done():
+                    self._pending.discard(name)
+            self._attach(name, tool)
+            newly.append(name)
+        if activate and newly:
+            self.activate(newly)
+        return newly
+
+    async def disconnect(self, patterns: list[str]) -> list[str]:
+        """Close connected servers matching *patterns* and detach them.
+
+        Returns the list of server names disconnected.
+        """
+        matched = self._match(patterns, set(self._connected))
+        for name in sorted(matched):
+            self.deactivate([name])
+            self._detach(name)
+        return sorted(matched)
+
+    # ------------------------------------------------------------------
+    # Activation
+    # ------------------------------------------------------------------
+
+    def activated(self) -> list[str]:
+        """Currently activated (listed in ``<mcp>``) server names."""
+        return sorted(self._activated)
+
+    def activate(self, patterns: list[str]) -> None:
+        """List connected servers' tools as free functions in ``<mcp>``."""
+        matched = self._match(patterns, set(self._connected))
+        self._activated.update(matched)
+
+    def deactivate(self, patterns: list[str]) -> None:
+        """Drop a connected server's tools from ``<mcp>`` (session stays open)."""
+        matched = self._match(patterns, set(self._activated))
+        self._activated.difference_update(matched)
+
+    # ------------------------------------------------------------------
+    # Status / context block
+    # ------------------------------------------------------------------
+
+    def status(self) -> str:
+        """Render the ``<mcp>`` block, mirroring ``SkillRegistry.status()``.
+
+        Three sections of uniform ``self.<attr>   <one-line summary>`` rows so a
+        server is never invisible while its client is still alive:
+
+        * **Active** — connected and listed for the agent (callable now).
+        * **Connected (inactive)** — session/client still open, hidden from the
+          agent until re-activated.
+        * **Configured** — known but not connected; how to connect.
+
+        Matches the ``<skills>`` block so the two read identically.
+        """
+        configured = self.discovered()
+        if not configured:
+            return "No MCP servers configured."
+
+        lines: list[str] = []
+
+        active = [n for n in configured if n in self._activated]
+        if active:
+            lines.append(
+                "Active MCP servers (use via self.<attr>, docs via doc(self.<attr>),"
+                " deactivate via self.mcp.deactivate(['name'])):"
+            )
+            for name in active:
+                attr = _to_attr_name(name)
+                lines.append(f"  self.{attr:22s} {self._server_summary(name)}")
+
+        inactive = [n for n in configured if n in self._connected and n not in self._activated]
+        if inactive:
+            if lines:
+                lines.append("")
+            lines.append(
+                "Connected but inactive (client/token still live;"
+                " activate with self.mcp.activate(['name'])):"
+            )
+            for name in inactive:
+                attr = _to_attr_name(name)
+                lines.append(f"  self.{attr:22s} {self._server_summary(name)}")
+
+        available = [n for n in configured if n not in self._connected]
+        if available:
+            if lines:
+                lines.append("")
+            lines.append("Configured MCP servers (connect with self.mcp.connect(['name'])):")
+            for name in available:
+                safe_name = _safe_display(name)
+                lines.append(f"  {safe_name:24s} {self._server_summary(name)}")
+
+        return "\n".join(lines)
+
+    def _server_summary(self, name: str) -> str:
+        """One-line summary for a server row (tool names if connected, else endpoint)."""
+        tool = self._connected.get(name)
+        if tool is not None:
+            method_names = sorted(getattr(type(tool), "_tool_method_names", ()) or [])
+            if not method_names:
+                method_names = sorted(
+                    m
+                    for m in dir(type(tool))
+                    if not m.startswith("_")
+                    and callable(getattr(tool, m, None))
+                    and getattr(getattr(type(tool), m, None), "__qualname__", "").startswith(
+                        type(tool).__name__
+                    )
+                )
+            n = len(method_names)
+            shown = ", ".join(method_names[:_MAX_TOOL_NAMES])
+            extra = n - min(n, _MAX_TOOL_NAMES)
+            tools = shown + (f", +{extra} more" if extra > 0 else "")
+            return f"{tools} ({n} tool{'s' if n != 1 else ''})" if n else "(no tools)"
+        try:
+            request = self._approval_request(name)
+        except Exception:
+            return "(invalid MCP configuration)"
+        suffix = "" if self._approval_store.is_approved(request) else " [approval required]"
+        return f"{request.target} ({request.transport}){suffix}"
+
+    # ------------------------------------------------------------------
+    # Access
+    # ------------------------------------------------------------------
+
+    def __getitem__(self, name: str) -> Any:
+        """Access a connected server's tool by name."""
+        if name not in self._connected:
+            raise KeyError(f"MCP server {name!r} is not connected")
+        return self._connected[name]
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _match(patterns: list[str], names: set[str]) -> set[str]:
+        """fnmatch *patterns* against *names* (same semantics as SkillRegistry)."""
+        matched: set[str] = set()
+        for pat in patterns:
+            matched.update(n for n in names if fnmatch.fnmatch(n, pat))
+        return matched
+
+    def _attach(self, name: str, tool: Any) -> None:
+        """Attach a connected tool to the agent, hidden from doc(self)."""
+        self._validate_attach_name(name)
+        self._connected[name] = tool
+        if self._agent is not None:
+            try:
+                self._bind_agent_attr(name, tool)
+            except BaseException:
+                self._connected.pop(name, None)
+                raise
+
+    def _validate_attach_name(self, name: str) -> None:
+        """Reject unusable names and collisions before any transport side effect."""
+        attr = _to_attr_name(name)
+        if not attr.isidentifier() or keyword.iskeyword(attr) or attr.startswith("_"):
+            raise ValueError(f"MCP server name {name!r} does not map to a safe agent attribute")
+        for connected_name in self._connected:
+            if connected_name != name and _to_attr_name(connected_name) == attr:
+                raise ValueError(
+                    f"MCP server {name!r} conflicts with connected server {connected_name!r}"
+                )
+        if self._agent is not None:
+            missing = object()
+            existing = inspect.getattr_static(self._agent, attr, missing)
+            if existing is not missing:
+                raise ValueError(
+                    f"MCP server {name!r} would overwrite existing agent attribute self.{attr}"
+                )
+
+    def _bind_agent_attr(self, name: str, tool: Any) -> None:
+        attr = _to_attr_name(name)
+        setattr(self._agent, attr, tool)
+        try:
+            spec(self._agent, attr, hidden=True)
+        except Exception:
+            logger.debug("Failed to hide MCP attr self.%s", attr, exc_info=True)
+
+    def _detach(self, name: str) -> None:
+        """Detach a connected tool from the agent."""
+        attr = _to_attr_name(name)
+        self._connected.pop(name, None)
+        if self._agent is not None and hasattr(self._agent, attr):
+            try:
+                delattr(self._agent, attr)
+            except AttributeError:
+                pass
+
+    def attach(self, agent: Any) -> None:
+        """Wire into the agent and self-register the ``<mcp>`` context block."""
+        previous_agent = self._agent
+        self._agent = agent
+        bound: list[str] = []
+        try:
+            for name, tool in self._connected.items():
+                self._validate_attach_name(name)
+                self._bind_agent_attr(name, tool)
+                bound.append(name)
+        except BaseException:
+            for name in bound:
+                attr = _to_attr_name(name)
+                if hasattr(agent, attr):
+                    delattr(agent, attr)
+            self._agent = previous_agent
+            raise
+        cm = getattr(agent, "context_manager", None)
+        if cm is not None and self.context_block:
+            key, expr = self.context_block
+            if key not in cm.protected_keys:
+                cm.set_dynamic(key, expr)
+
+    def detach(self) -> None:
+        """Disconnect all servers and remove the context block."""
+        for name in list(self._connected):
+            self.deactivate([name])
+            self._detach(name)
+        agent = self._agent
+        if agent is not None and self.context_block:
+            cm = getattr(agent, "context_manager", None)
+            key = self.context_block[0]
+            if cm is not None and key in cm and key not in cm.protected_keys:
+                cm.pop(key, None)
+        self._agent = None

--- a/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Memory explorer — browse and curate the agent's long-term memory store.
+
+Rows are prebuilt snapshots: ``build_memory_rows`` touches the SQLite store
+and resolves references against live agent state, so it must run on the
+agent thread (the host dispatches it via ``TUIApplication.agent_run_async``).
+The view itself only renders those snapshots; the ``f``/``d`` actions go
+through host-supplied callables that route back to the agent thread.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from .explorer_base import (
+    ExplorerConfig,
+    ExplorerModel,
+    ExplorerView,
+    render_markdown_lines,
+    wrap_plain_line,
+)
+from .subapp import SubviewKeyResult
+
+_TYPE_GLYPHS = {
+    "info": "ℹ",
+    "skill": "⚙",
+    "episode": "◈",
+    "intent": "⚡",
+    "reflection": "✦",
+    "scratch": "≈",
+}
+_TODO_GLYPHS = {"open": "○", "done": "✓", "dropped": "⊘"}
+
+
+def _span(seconds: float) -> str:
+    """Compact duration ("42s", "3m", "2h", "5d")."""
+    seconds = max(seconds, 0.0)
+    if seconds < 60:
+        return f"{int(seconds)}s"
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m"
+    if seconds < 86400:
+        return f"{int(seconds // 3600)}h"
+    return f"{int(seconds // 86400)}d"
+
+
+def relative_age(ts: float | None, now: float | None = None) -> str:
+    """Relative age of a past timestamp; "never" for None."""
+    if ts is None:
+        return "never"
+    now = time.time() if now is None else now
+    return _span(now - ts)
+
+
+@dataclass
+class MemoryExplorerRow:
+    """One memory record in the explorer list (a prebuilt snapshot)."""
+
+    id: str
+    type: str
+    status: str | None  # todo lifecycle (open/done/dropped); None otherwise
+    title: str | None
+    content: str
+    owner: str
+    importance: str  # verbal band (CRITICAL..TRIVIAL)
+    tags: list[str]
+    created_at: float
+    last_accessed_at: float
+    usage: dict  # per_memory_usage(...) output
+    reference_lines: list[str]  # pre-rendered via references.resolve/render
+    edges: list[tuple[str, str, float]]  # (target_id, edge_type, weight)
+    search_text: str
+
+    @property
+    def type_tag(self) -> str:
+        return f"{self.type}:{self.status}" if self.status is not None else self.type
+
+
+def build_memory_rows(agent: Any, manager: Any) -> list[MemoryExplorerRow]:
+    """Build explorer rows from a ``MemoryManager``'s store, newest first.
+
+    Touches the store and resolves references against the live agent, so it
+    MUST run on the agent thread.
+    """
+    from nooa_memory.observability import per_memory_usage
+    from nooa_memory.references import render, resolve
+
+    rows: list[MemoryExplorerRow] = []
+    for m in manager.store.all_memories():
+        tag = f"{m.type.value}:{m.status}" if m.status is not None else m.type.value
+        search_parts = [m.id, tag, m.title or "", m.content, *m.tags, m.owner]
+        rows.append(
+            MemoryExplorerRow(
+                id=m.id,
+                type=m.type.value,
+                status=m.status,
+                title=m.title,
+                content=m.content,
+                owner=m.owner,
+                importance=m.importance_label(),
+                tags=list(m.tags),
+                created_at=m.created_at,
+                last_accessed_at=m.last_accessed_at,
+                usage=per_memory_usage(m, forgetting=manager.forgetting),
+                reference_lines=[
+                    render(resolve(agent, manager.store, ref)) for ref in m.references
+                ],
+                edges=[
+                    (e.target_id, e.type.value, e.weight) for e in manager.store.neighbors(m.id)
+                ],
+                search_text="\n".join(search_parts),
+            )
+        )
+    rows.sort(key=lambda r: -r.created_at)
+    return rows
+
+
+def last_reflection_summary(manager: Any) -> str | None:
+    """One header line for the latest consolidation run (agent thread only).
+
+    ``last reflection: 2m ago — merged 3, +5 edges, pruned 1 (idle, 1.4s)``;
+    interrupted runs render ``(idle, interrupted @ form_edges, 0.3s)``.
+    """
+    history = manager.store.maintenance_history(1)
+    if not history or history[0]["kind"] != "reflect":
+        return None
+    row = history[0]
+    r = row["report"]
+    when = relative_age(row["ts"])
+    trigger = r.get("trigger", "manual")
+    duration = f"{r.get('duration_ms', 0.0) / 1000.0:.1f}s"
+    if r.get("interrupted"):
+        tail = f"({trigger}, interrupted @ {r.get('stopped_in') or '?'}, {duration})"
+    else:
+        tail = f"({trigger}, {duration})"
+    return (
+        f"last reflection: {when} — merged {r.get('merged', 0)}, "
+        f"+{r.get('edges_added', 0)} edges, pruned {r.get('pruned', 0)} {tail}"
+    )
+
+
+class MemoryExplorerView(ExplorerView):
+    """In-app subview for browsing and curating long-term memories."""
+
+    def __init__(
+        self,
+        rows: list[MemoryExplorerRow],
+        *,
+        forget: Callable[[str], None],
+        mark_done: Callable[[str], None],
+        last_reflection: str | None = None,
+    ) -> None:
+        self._forget = forget
+        self._mark_done = mark_done
+        model = ExplorerModel(rows)
+        title = "Memory Explorer"
+        if last_reflection:
+            title = f"{title} — {last_reflection}"
+        config = ExplorerConfig(
+            title=title,
+            detail_pane_name="memory detail",
+            empty_message="No memories.",
+            no_match_message="No memories matching {query!r}.",
+            list_ratio=0.4,
+            actions={
+                "forget": "f forget",
+                "done": "d todo done",
+            },
+        )
+        super().__init__(model, config)
+
+    def format_row(self, row: MemoryExplorerRow, width: int) -> str:
+        glyph = (
+            _TODO_GLYPHS.get(row.status or "", "?")
+            if row.type == "todo"
+            else _TYPE_GLYPHS.get(row.type, "?")
+        )
+        fetches = row.usage["fetches"]
+        fetched = relative_age(row.usage["last_ts"]) if fetches else "never"
+        head = (row.title or row.content).replace("\n", " ").strip()
+        line = f"{glyph} {row.type_tag:<12} {row.importance:<8} {fetches:>3}x {fetched:>6}  {head}"
+        return line[:width]
+
+    def detail_lines(self, row: MemoryExplorerRow, width: int) -> list[str]:
+        width = max(int(width), 20)
+        u = row.usage
+        lines: list[str] = [
+            f"Memory: [{row.id[:8]}] {row.title or '(untitled)'}",
+            f"Id: {row.id}",
+            f"Type: {row.type_tag}   Owner: {row.owner or '(unowned)'}   "
+            f"Importance: {row.importance}",
+            f"Tags: {', '.join(row.tags) if row.tags else '(none)'}",
+            f"Created: {relative_age(row.created_at)} ago   "
+            f"Last accessed: {relative_age(row.last_accessed_at)} ago",
+            "",
+        ]
+        lines.extend(render_markdown_lines(row.content, width))
+        lines.append("")
+        lines.append("Usage:")
+        lines.append(
+            f"  fetches={u['fetches']}  recalled={u['recalled']}  searched={u['searched']}  "
+            f"injected={u['injected']}  reinforced={u['reinforced']}  deref={u['deref']}"
+        )
+        if u["last_channel"] is not None:
+            last = f"  last: {u['last_channel']} {relative_age(u['last_ts'])} ago"
+            if u["last_session_ref"]:
+                last += f" (session {u['last_session_ref'][:8]})"
+            lines.append(last)
+        rank_bits = []
+        if u["mean_rank"] is not None:
+            rank_bits.append(f"mean rank {u['mean_rank']}")
+        if u["mean_score"] is not None:
+            rank_bits.append(f"mean score {u['mean_score']}")
+        if rank_bits:
+            lines.append("  " + "  ".join(rank_bits))
+        if u["injected_never_used"]:
+            lines.append("  injected but never used")
+        prune = "never" if u["prune_eta"] is None else f"in {_span(u['prune_eta'] - time.time())}"
+        lines.append(f"  retention={u['retention']}   strength={u['strength']}   prune: {prune}")
+        if row.reference_lines:
+            lines.append("")
+            lines.append("References:")
+            for ref_line in row.reference_lines:
+                lines.extend(wrap_plain_line(f"  {ref_line}", width))
+        if row.edges:
+            lines.append("")
+            lines.append("Edges:")
+            for target_id, edge_type, weight in row.edges:
+                lines.append(f"  → {target_id[:8]} {edge_type} ({weight:.2f})")
+        return lines
+
+    def handle_action(self, action: str, row: Any) -> SubviewKeyResult:
+        if row is None:
+            return "ignored"
+        if action == "text:f":
+            self._forget(row.id)
+            self.model.rows.remove(row)
+            self.model.set_query(self.model.query)  # rebuild matches without the row
+            return "handled"
+        if action == "text:d":
+            if row.type != "todo" or row.status == "done":
+                return "ignored"
+            self._mark_done(row.id)
+            # The search tag mirrors the CURRENT status (todo:open / todo:dropped
+            # — see build_memory_rows), so replace whatever tag the row was
+            # built with, not just todo:open.
+            old_tag = f"todo:{row.status}"
+            row.status = "done"
+            row.search_text = row.search_text.replace(old_tag, "todo:done", 1)
+            return "handled"
+        return "ignored"

--- a/packages/nooa-cli/src/nooa_cli/tui/output.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/output.py
@@ -1,0 +1,396 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Structured output types for NeMo OO Agents frontends.
+
+Commands and agent events produce ``Output`` instances; the
+``TerminalFrontend`` renders them as Rich panels in the terminal.
+
+Every concrete type is a plain dataclass with a ``to_json()`` method that
+returns a dict suitable for JSON serialisation.  This is the **single source
+of truth** for the JSON form of rich content pushed to the browser via the
+PTY web terminal's rich side-channel (``nooa-term``).  Adding a new Output
+type keeps working as long as ``to_json()`` is defined.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from nooa.agentdoc import hidden
+
+_STOP_REASON_ESCAPE_SEQUENCE_RE = re.compile(
+    "\x1b(?:[@-Z\\-_]|\\[[0-?]*[ -/]*[@-~]|\\][^\x07\x1b]*(?:\x07|\x1b\\\\)?)"
+)
+_STOP_REASON_CONTROL_RE = re.compile("[\x00-\x1f\x7f-\x9f]+")
+
+
+def _sanitize_stop_reason_text(value: str) -> str:
+    value = _STOP_REASON_ESCAPE_SEQUENCE_RE.sub(" ", str(value))
+    value = _STOP_REASON_CONTROL_RE.sub(" ", value)
+    return " ".join(value.split())
+
+
+# ---------------------------------------------------------------------------
+# Concrete output types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TextOutput:
+    """A plain text message with a severity level."""
+
+    content: str
+    level: Literal["info", "error", "warning", "success", "status"] = "info"
+
+    def to_json(self) -> dict:
+        return {"type": "text", "content": self.content, "level": self.level}
+
+
+@dataclass
+class TableOutput:
+    """Tabular data."""
+
+    columns: list[str]
+    rows: list[list[str]]
+    title: str = ""
+    footer: str = ""
+    show_header: bool = True
+
+    def to_json(self) -> dict:
+        return {
+            "type": "table",
+            "title": self.title,
+            "columns": self.columns,
+            "rows": self.rows,
+            "footer": self.footer,
+            "show_header": self.show_header,
+        }
+
+
+@dataclass
+class HelpOutput:
+    """Slash-command help listing."""
+
+    commands: dict[str, str]  # {"/cmd subcmd": "description"}
+
+    def to_json(self) -> dict:
+        return {"type": "help", "commands": self.commands}
+
+
+@dataclass
+class AgentMessage:
+    """A markdown-formatted message produced by the agent via ``message()``."""
+
+    content: str
+    # False for 2nd+ message() calls in the same turn — suppresses the OO ── rule
+    show_rule: bool = True
+
+    def to_json(self) -> dict:
+        return {"type": "agent_message", "content": self.content, "show_rule": self.show_rule}
+
+
+@dataclass
+class CodeExecution:
+    """One Python execution turn: code + outputs.
+
+    ``start_line`` / ``highlight_line`` let a *snippet* (e.g. the ±N lines
+    around an agent suspend point shown by ``/activity``) number from its real
+    file offset and tint the one line that matters. ``start_line`` defaults to
+    1 (whole-cell rendering); ``highlight_line`` is absolute (file line number),
+    not relative to the snippet.
+    """
+
+    tool_call_id: str
+    code: str | None = None
+    stdout: str | None = None
+    stderr: str | None = None
+    error: str | None = None
+    value: str | None = None
+    start_line: int = 1
+    highlight_line: int | None = None
+
+    def to_json(self) -> dict:
+        v = self.value
+        if v is not None and not isinstance(v, str):
+            v = repr(v)
+        return {
+            "type": "code_execution",
+            "tool_call_id": self.tool_call_id,
+            "code": self.code,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "error": self.error,
+            "value": v,
+            "start_line": self.start_line,
+            "highlight_line": self.highlight_line,
+        }
+
+
+@dataclass
+class StartupInfo:
+    """Structured startup banner data."""
+
+    model: str  # full model id
+    short_model: str  # display name
+    working_dir: str
+    vi_mode: bool
+    history_policy: str | None = None
+    history_limit: int | None = None
+    tracing_enabled: bool = False
+    trace_dir: str | None = None
+    custom_agent: str | None = None
+
+    def to_json(self) -> dict:
+        return {
+            "type": "startup",
+            "model": self.model,
+            "short_model": self.short_model,
+            "working_dir": self.working_dir,
+            "vi_mode": self.vi_mode,
+            "history_policy": self.history_policy,
+            "history_limit": self.history_limit,
+            "tracing_enabled": self.tracing_enabled,
+            "trace_dir": self.trace_dir,
+            "custom_agent": self.custom_agent,
+        }
+
+
+@dataclass
+class ClearScreen:
+    """Clear the visible output area."""
+
+    def to_json(self) -> dict:
+        return {"type": "clear"}
+
+
+@dataclass
+class Thinking:
+    """Show or hide the loading/thinking indicator."""
+
+    active: bool
+    message: str = "thinking..."
+
+    def to_json(self) -> dict:
+        return {
+            "type": "thinking_start" if self.active else "thinking_stop",
+            "message": self.message,
+        }
+
+
+@dataclass
+class StopReasonOutput:
+    """Why the agent ended the turn or what it is waiting for."""
+
+    kind: str
+    explanation: str = ""
+
+    @property
+    @hidden
+    def label(self) -> str:
+        if str(self.kind) == "WAIT":
+            return "waiting"
+        if str(self.kind) == "DONE":
+            return "done"
+        if str(self.kind) == "KEEP_GOING":
+            return "keep going"
+        if str(self.kind) in {"NEED_INPUT", "GET_USER_INPUT"}:
+            return "need input"
+        return "paused"
+
+    @hidden
+    def display_text(self) -> str:
+        explanation = _sanitize_stop_reason_text(self.explanation)
+        if explanation:
+            return f"∴ {self.label}: {explanation}"
+        return f"∴ {self.label}"
+
+    @hidden
+    def to_json(self) -> dict:
+        explanation = _sanitize_stop_reason_text(self.explanation)
+        return {
+            "type": "stop_reason",
+            "kind": str(self.kind),
+            "label": self.label,
+            "explanation": explanation,
+            "text": self.display_text(),
+        }
+
+
+@dataclass
+class BashOutput:
+    """Result from a ``!bash`` command."""
+
+    stdout: str
+    stderr: str
+    return_code: int
+
+    def to_json(self) -> dict:
+        return {
+            "type": "bash_output",
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "return_code": self.return_code,
+        }
+
+
+@dataclass
+class CommandStatus:
+    """Lifecycle status for one TUI command invocation.
+
+    This is UI-local command state, not an agent background job. Slash commands
+    and bang commands use it for consistent queued/running/finished feedback.
+    """
+
+    id: int
+    kind: Literal["slash", "bang"]
+    state: Literal["queued", "running", "done", "failed", "cancelled"]
+    text: str
+    error: str = ""
+
+    def to_json(self) -> dict:
+        return {
+            "type": "command_status",
+            "id": self.id,
+            "kind": self.kind,
+            "state": self.state,
+            "text": self.text,
+            "error": self.error,
+        }
+
+
+@dataclass
+class HistoryTurn:
+    """One turn in a replayed session history."""
+
+    role: Literal["user", "agent"]
+    content: str
+
+    def to_json(self) -> dict:
+        return {"type": "history_turn", "role": self.role, "content": self.content}
+
+
+@dataclass
+class HistoryReplay:
+    """A block of past conversation turns rendered above the live prompt.
+
+    Used when resuming or continuing a session so the user can see what was
+    said before.  Frontends should render this in a visually dimmed / muted
+    style to distinguish it from the live conversation.
+
+    When rich content is interleaved with history (session resume inside
+    ``nooa-term``), one session's history may be split into several
+    ``HistoryReplay`` chunks with ``_RichReplayPayload`` objects between them.
+    ``show_header`` / ``show_footer`` control which chunk renders the enclosing
+    rule bars so they appear exactly once around the whole block.
+    """
+
+    turns: list[HistoryTurn]
+    session_id: str  # short (8-char) id for the header label
+    show_header: bool = True
+    show_footer: bool = True
+    omitted_count: int = 0  # number of older turns that were truncated
+
+    def to_json(self) -> dict:
+        return {
+            "type": "history_replay",
+            "session_id": self.session_id,
+            "turns": [t.to_json() for t in self.turns],
+        }
+
+
+@dataclass
+class DiffOutput:
+    """A unified diff between two versions of a file, shown after /edit saves."""
+
+    diff: str
+    filename: str = ""
+
+    def to_json(self) -> dict:
+        return {"type": "diff", "diff": self.diff, "filename": self.filename}
+
+
+@dataclass
+class RichOutput:
+    """Generic rich visual output for frontends that support it.
+
+    The ``kind`` field identifies the rendering type; ``data`` is the
+    kind-specific payload.  The terminal falls back to ``fallback_text``;
+    the web terminal (``nooa-term``) renders the real thing.
+
+    Built-in kinds recognised by the web terminal:
+
+    ``"plotly"``
+        ``data["figure_json"]`` — result of ``plotly.Figure.to_json()``.
+        Rendered via Plotly.js.
+
+    ``"html"``
+        ``data["html"]`` — arbitrary safe HTML fragment.
+
+    ``"image"``
+        ``data["src"]`` — a ``data:`` URI or URL.
+        ``data["alt"]`` — optional alt-text.
+
+    ``"vega"``
+        ``data["spec"]`` — a Vega-Lite or Vega spec dict.
+        Rendered via the Vega CDN.
+
+    ``"dataframe"``
+        ``data["columns"]``, ``data["rows"]`` — rendered as a sortable table.
+
+    Any other ``kind`` value is forwarded as-is to the frontend; unknown
+    kinds are displayed as a JSON code block.
+    """
+
+    kind: str
+    data: dict
+    title: str = ""
+    fallback_text: str = ""  # shown in terminal / non-graphical frontends
+
+    def to_json(self) -> dict:
+        return {
+            "type": "rich",
+            "kind": self.kind,
+            "data": self.data,
+            "title": self.title,
+            "fallback_text": self.fallback_text,
+        }
+
+
+# ---------------------------------------------------------------------------
+# _RichReplayPayload — internal sentinel for interleaved rich-content replay
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _RichReplayPayload:
+    """Carry a raw WebPublisher payload through an output list.
+
+    Not part of the public ``Output`` union — intercepted by ``CommandHandler``
+    and the ``--continue`` startup path before reaching any frontend renderer.
+    Each instance is POSTed to ``NEMO_OO_RICH_URL`` in sequence so that plots
+    appear at their correct inline positions between history turns.
+    """
+
+    payload: dict
+
+
+# ---------------------------------------------------------------------------
+# Union alias used in type annotations
+# ---------------------------------------------------------------------------
+
+Output = (
+    TextOutput
+    | TableOutput
+    | HelpOutput
+    | AgentMessage
+    | CodeExecution
+    | StartupInfo
+    | ClearScreen
+    | Thinking
+    | StopReasonOutput
+    | BashOutput
+    | CommandStatus
+    | DiffOutput
+    | RichOutput
+    | HistoryReplay
+)

--- a/packages/nooa-cli/src/nooa_cli/tui/reflection_runner.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/reflection_runner.py
@@ -1,0 +1,313 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Idle-reflection runner: consolidate memory while the user isn't looking.
+
+Owns the lifecycle state machine from
+``docs/design/memory-system/design-idle-reflection.md`` §3::
+
+    IDLE --(response done)--> DEBOUNCE --> RUNNING --> IDLE
+                                  |            |
+                                  +--(input)---+--> interrupted --> IDLE
+
+The runner lives on the agent thread's event loop: ``on_response_done()`` is
+called by the dispatcher when a turn ends and the prompt returns to the user;
+``interrupt()`` is awaited wherever new input is about to reach the agent.
+The consolidation itself runs in an executor thread via
+``MemoryManager.reflect_interruptible``, whose per-item commits make an
+interrupted (or briefly overlapping) pass safe by construction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+try:  # optional-import pattern mirrored from nooa_memory.tracing_bridge
+    from opentelemetry import trace as _ot_trace
+except ImportError:  # pragma: no cover - exercised only without the tracing extra
+    _ot_trace = None
+
+if TYPE_CHECKING:
+    from nooa_memory.manager import MemoryManager
+    from nooa_memory.reflection import ReflectionReport
+
+    from .config import TUIConfig
+
+logger = logging.getLogger(__name__)
+
+# Indicator animation: a small wave gliding right, one step per repaint tick.
+_WAVE = "▁▂▃▅▃▂▁"
+_TICK_S = 0.15  # repaint cadence (and wave step) while a run is active
+_FLASH_S = 0.3  # lifetime of the single "reflection interrupted" flash frame
+
+
+class ReflectionRunner:
+    """Debounced, promptly-interruptible idle reflection for one agent."""
+
+    def __init__(
+        self,
+        agent: Any,
+        manager: MemoryManager,
+        config: TUIConfig,
+        *,
+        enabled: bool,
+        episode_writer: Callable[[str], str | None] | None = None,
+    ) -> None:
+        self._agent = agent
+        self._manager = manager
+        self._config = config
+        self.enabled = enabled
+        # Generative phase 1: LLM writes an episode about the recent session
+        # window before consolidation (which also feeds the reasoner).
+        self._episode_writer = episode_writer
+        self._self_writing = False  # our own episode write is not "dirt"
+        self._stop = threading.Event()
+        self._task: asyncio.Task | None = None
+        self._state: str = "idle"  # idle | debounce | running
+        self._flash_until = 0.0
+        self.last_report: ReflectionReport | None = None
+        # Dirty counter: memory mutations since the last consolidation pass.
+        # Fed by the MemoryWritten subscription below (add/update/forget/
+        # reinforce); ReflectionCompleted is deliberately NOT subscribed, so a
+        # run never re-triggers itself. Seeded from store state: the runner is
+        # REBUILT whenever memory is reconfigured (e.g. `/reflection on`), and
+        # a fresh counter must not forget writes that predate it — that would
+        # gate idle runs off exactly when the user just asked for them.
+        self.dirty = self._initial_dirt()
+        # Repaint hook, wired lazily by TUIApplication (thread-safe callable).
+        self.invalidate: Callable[[], None] | None = None
+        self._unsubscribe: Callable[[], None] | None = agent.event_manager.on(
+            "MemoryWritten", self._on_memory_written
+        )
+
+    # ------------------------------------------------------------------
+    # dirty signal
+    # ------------------------------------------------------------------
+    def _initial_dirt(self) -> int:
+        """Memories touched since the last consolidation (pre-existing dirt)."""
+        try:
+            history = self._manager.store.maintenance_history(50)
+            last = max((h["ts"] for h in history if h["kind"] == "reflect"), default=0.0)
+            return sum(
+                1
+                for m in self._manager.store.all_memories(owner=self._manager.role)
+                if max(m.created_at, m.last_accessed_at) > last
+            )
+        except Exception:  # a broken store must not take bootstrap down
+            logger.warning("reflection: could not seed the dirty counter", exc_info=True)
+            return 0
+
+    def _on_memory_written(self, _event: object) -> None:
+        if self._self_writing:
+            return  # the runner's own episode write must not re-trigger a run
+        self.dirty += 1
+
+    # ------------------------------------------------------------------
+    # start / stop
+    # ------------------------------------------------------------------
+    @property
+    def state(self) -> str:
+        return self._state
+
+    def _agent_idle(self) -> bool:
+        """No queued user input, no running jobs, no pending channel work."""
+        # Both lookups are host-optional surfaces: plain Agents (tests,
+        # embedders) have neither queue; a missing queue means nothing pending.
+        q = getattr(self._agent, "_user_messages_in", None)
+        if q is not None and not q.is_empty():
+            return False
+        qm = getattr(self._agent, "queue_manager", None)
+        if qm is None:
+            return True
+        if any(h.state == "running" for h in qm._handles):
+            return False
+        for name, ch in qm._channels.items():
+            if name == "user_messages":
+                continue
+            if ch.mode == "queue" and not ch.is_empty():
+                return False
+        return True
+
+    def on_response_done(self) -> None:
+        """Schedule a debounced run. Called on the agent loop when a turn ends.
+
+        Start gate (§3): enabled ∧ dirty ∧ agent-otherwise-idle, and no run
+        already pending — otherwise this is a no-op.
+        """
+        if not self.enabled or self.dirty <= 0 or not self._agent_idle():
+            return
+        if self._task is not None and not self._task.done():
+            return
+        self._stop.clear()
+        self._state = "debounce"
+        self._task = asyncio.ensure_future(self._debounce_then_run())
+
+    def run_now(self) -> bool:
+        """Start a run immediately (``/reflection now``): no debounce, no
+        dirty gate, no enabled check — an explicit user request runs whatever
+        is configured. Returns False when a run is already pending/active.
+        Must be called on the agent loop (like ``on_response_done``)."""
+        if self._task is not None and not self._task.done():
+            return False
+        self._stop.clear()
+        self._state = "running"  # indicator shows immediately
+        self._task = asyncio.ensure_future(self._run_to_idle())
+        return True
+
+    async def _debounce_then_run(self) -> None:
+        try:
+            await asyncio.sleep(self._config.reflection_debounce_s)
+            # Re-check the gate: the world may have changed during debounce.
+            if self._stop.is_set() or self.dirty <= 0 or not self._agent_idle():
+                return
+            await self._run()
+        finally:
+            self._state = "idle"
+            self._invalidate()
+
+    async def _run_to_idle(self) -> None:
+        try:
+            await self._run()
+        finally:
+            self._state = "idle"
+            self._invalidate()
+
+    async def _run(self) -> None:
+        self._state = "running"
+        # Snapshot semantics: writes landing while the run executes
+        # re-increment the counter for the next idle window.
+        self.dirty = 0
+        # Event access happens on the agent loop; the executor only gets text.
+        events_text = ""
+        if self._episode_writer is not None:
+            from nooa_memory.generative import render_recent_events
+
+            events_text = render_recent_events(self._agent)
+        ticker = asyncio.ensure_future(self._tick())
+        try:
+            self.last_report = await asyncio.get_running_loop().run_in_executor(
+                None, self._reflect_in_thread, events_text
+            )
+        except Exception:
+            # Surfaced loudly, but a failed consolidation must never take
+            # the session down — the store is consistent per item.
+            logger.exception("memory.reflection idle run failed")
+        finally:
+            ticker.cancel()
+
+    def _reflect_in_thread(self, events_text: str = "") -> ReflectionReport:
+        """The one sync function handed to the executor.
+
+        Phase 1 (generative only): the LLM writes an episode about the recent
+        session window — then consolidation runs, so the reasoner sees the
+        fresh episode in the same pass. The span is opened *inside* the
+        executor thread: OTel context does not flow into executors, so opening
+        it on the loop would orphan the ``memory.reflected`` event the tracing
+        bridge attaches to the current span. Degrades without opentelemetry.
+        """
+        if _ot_trace is None:
+            self._write_episode(events_text)
+            return self._manager.reflect_interruptible(self._stop.is_set, trigger="idle")
+        db_path = self._manager.store.path
+        attributes = {
+            "memory.trigger": "idle",
+            "memory.owner": self._manager.owner,
+            "memory.db_path": str(Path(db_path).resolve()) if db_path != ":memory:" else db_path,
+        }
+        tracer = _ot_trace.get_tracer("nooa_cli.tui.reflection")
+        with tracer.start_as_current_span("memory.reflection", attributes=attributes):
+            self._write_episode(events_text)
+            return self._manager.reflect_interruptible(self._stop.is_set, trigger="idle")
+
+    def _write_episode(self, events_text: str) -> None:
+        """Generative phase 1 — contained: a failed episode write never blocks
+        consolidation, and the stop flag is honored before the LLM call."""
+        if self._episode_writer is None or self._stop.is_set() or not events_text:
+            return
+        try:
+            episode = self._episode_writer(events_text)
+        except Exception:
+            logger.warning("memory.reflection episode write failed", exc_info=True)
+            return
+        if episode is None or self._stop.is_set():
+            return  # not noteworthy, or the stop arrived while the LLM ran
+        from nooa_memory import MemoryType
+
+        self._self_writing = True
+        try:
+            self._manager.remember(
+                episode,
+                type=MemoryType.EPISODE,
+                title="session episode",
+                salience=0.5,
+                source_task_ref="idle_reflection",
+            )
+        finally:
+            self._self_writing = False
+
+    async def interrupt(self, grace: float | None = None) -> None:
+        """Stop any pending or active run; return within *grace* regardless.
+
+        A pending debounce is cancelled silently (the indicator was never
+        shown). A running pass gets the stop flag — observed between items —
+        and up to *grace* seconds to wind down; after that the caller proceeds
+        anyway: per-item commits make a short overlap safe (design §5).
+        """
+        grace = self._config.reflection_grace_s if grace is None else grace
+        task = self._task
+        if task is None or task.done():
+            return
+        if self._state == "debounce":
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            # A task cancelled before its first step never runs its finally —
+            # reset here so the state can't stick in "debounce".
+            self._task = None
+            self._state = "idle"
+            return
+        self._stop.set()
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(task), grace)
+        if not task.done() or (self.last_report is not None and self.last_report.interrupted):
+            self._flash_until = time.monotonic() + _FLASH_S
+
+    def teardown(self) -> None:
+        """Unsubscribe and cancel without waiting (off / reconfigure / detach)."""
+        self._stop.set()
+        task = self._task
+        if task is not None and not task.done():
+            task.cancel()
+        self._task = None
+        self._state = "idle"
+        if self._unsubscribe is not None:
+            self._unsubscribe()
+            self._unsubscribe = None
+
+    # ------------------------------------------------------------------
+    # indicator
+    # ------------------------------------------------------------------
+    def indicator_frame(self) -> str:
+        """Status-bar segment: a gliding wave while RUNNING, one 'interrupted'
+        flash frame right after a cancel, empty (zero width) otherwise."""
+        if self._state == "running" and not self._stop.is_set():
+            shift = int(time.monotonic() / _TICK_S) % len(_WAVE)
+            return f"✦ reflecting {_WAVE[shift:]}{_WAVE[:shift]}"
+        if time.monotonic() < self._flash_until:
+            return "✦ reflection interrupted"
+        return ""
+
+    async def _tick(self) -> None:
+        while True:
+            self._invalidate()
+            await asyncio.sleep(_TICK_S)
+
+    def _invalidate(self) -> None:
+        if self.invalidate is not None:
+            self.invalidate()

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -1,0 +1,1355 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Session — the REPL loop that glues a Frontend to an Agent.
+
+``Session`` is frontend-agnostic: it reads input via ``frontend.get_input()``,
+routes commands through ``CommandHandler``, and renders every output through
+``frontend.render()``.  ``TerminalFrontend`` is the concrete frontend
+implementation.
+
+All *behavior* lives here — event subscription, streaming state, show_python
+decisions.  Frontends are pure rendering.
+"""
+
+import asyncio
+import inspect
+import io
+import logging
+import re
+import shlex
+import sys
+import traceback
+from collections.abc import Awaitable, Callable
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from rich.console import Console as RichConsole
+from rich.text import Text
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from nooa import Agent
+    from nooa.tools.shell_tools import ShellTools
+
+    from .agent_event_renderer import AgentEventRenderer
+    from .commands import CommandRegistry
+    from .config import Config
+    from .frontend import Frontend
+    from .session_manager import SessionManager
+    from .tui_application import TUIApplication
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _hex_to_ansi256(hex_color: str) -> int:
+    """Convert a ``#rrggbb`` hex string to the nearest xterm-256 index.
+
+    Used when we render ANSI directly (e.g. the user-message bar) and
+    can't rely on Rich's width/wrap logic to emit correctly-padded
+    terminal output.
+    """
+    h = hex_color.lstrip("#")
+    r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+
+    # 6x6x6 color cube starting at index 16.
+    def _q(v: int) -> int:
+        # 0,95,135,175,215,255 — standard xterm cube steps.
+        if v < 48:
+            return 0
+        if v < 115:
+            return 1
+        return (v - 35) // 40
+
+    return 16 + 36 * _q(r) + 6 * _q(g) + _q(b)
+
+
+def _effective_slash_output_to_agent(agent: Any, slash_result: Any) -> bool:
+    """Return fresh output routing for a slash result.
+
+    The command registry can be stale across hot reloads or long-lived TUI
+    processes. Prefer the currently attached Skill metadata when it can be
+    found; fall back to the SlashCommandResult flag for built-in/text commands.
+    """
+    command = str(getattr(slash_result, "command", "")).lower()
+    if command:
+        try:
+            from nooa.skill import Skill, get_slash_commands
+
+            for attr_name in dir(agent):
+                if attr_name.startswith("_"):
+                    continue
+                try:
+                    obj = getattr(agent, attr_name)
+                except Exception:
+                    continue
+                if not isinstance(obj, Skill):
+                    continue
+                for meta, _method in get_slash_commands(obj):
+                    if meta.name.lower() == command:
+                        return bool(getattr(meta, "output_to_agent", True))
+        except Exception:
+            logger.debug("Failed to resolve fresh slash command metadata", exc_info=True)
+    return bool(getattr(slash_result, "output_to_agent", True))
+
+
+def _build_user_bar(text: str, app: "TUIApplication", colors: dict) -> str:
+    """Build a full-width highlighted user-message bar as raw ANSI.
+
+    Bypasses Rich because reconciling Rich's wrap/crop/overflow logic
+    with manual ``ljust`` padding is brittle across Rich versions and
+    terminal emulators — direct CSI emission always renders the full
+    width-spanning highlighted row the spec asks for.
+
+    Each input line becomes one bar row:
+      ``ESC[fg;bg m{prefix}{line}{padding}{ ESC[0m}\\n``
+    where the first row carries the ``❯`` prompt glyph and
+    continuation rows start flush-left.
+    """
+    # Prefer prompt_toolkit's live width — ``run_in_terminal`` will use
+    # this number when writing above the prompt. Falls back to the
+    # terminal_cols helper if the app output can't report.
+    cols: int
+    try:
+        cols = app.output_columns(minimum=20)
+    except Exception:
+        try:
+            cols = app._app.output.get_size().columns  # type: ignore[attr-defined]
+        except Exception:
+            from .tui_application import terminal_cols
+
+            cols = terminal_cols(minimum=40)
+    cols = max(cols, 20)
+
+    fg = _hex_to_ansi256(colors["text"])
+    bg = _hex_to_ansi256(colors["surface2"])
+    on = f"\x1b[38;5;{fg};48;5;{bg}m"
+    off = "\x1b[0m"
+
+    rows: list[str] = []
+    for i, line in enumerate(text.split("\n")):
+        shown = f" ❯ {line} " if i == 0 else f" {line} "
+        # Clamp to cols so an overlong line becomes multiple bar rows
+        # rather than wrapping chaotically at the terminal's edge.
+        while len(shown) > cols:
+            rows.append(f"{on}{shown[:cols]}{off}")
+            shown = shown[cols:]
+        rows.append(f"{on}{shown.ljust(cols)}{off}")
+    return "\n".join(rows) + "\n"
+
+
+class _EmitStream:
+    """A ``Console.file`` target that batches writes into one ``emit_block``
+    per ``flush()`` — or one per ``hold()`` span.
+
+    Rich's ``Console.print`` flushes at the end; without buffering each
+    stylised chunk (many per print call) would enqueue a separate block
+    and pay the ``run_in_terminal`` hop. Batching collapses them into
+    one atomic scrollback block.
+
+    A multi-output command (e.g. ``/activity`` → table + code block) calls
+    ``frontend.render()`` once per output, each ending in a ``flush()``. That
+    is several ``emit_block``s → several ``run_in_terminal`` hops, and the
+    thinking-spinner's ``invalidate()`` (~12/s) repaints the prompt region
+    between them — visible flicker. ``hold()`` defers flushing so the whole
+    command renders as ONE block / ONE hop.
+    """
+
+    def __init__(
+        self,
+        emit: Callable[..., None],
+        replay_width: Callable[[], int] | None = None,
+        clear: Callable[[], None] | None = None,
+    ) -> None:
+        self.supports_semantic_replay = True
+        self._emit = emit
+        self._replay_width = replay_width
+        self._clear = clear
+        self._buf: list[str] = []
+        self._held = 0
+
+    def write(self, text: str) -> int:
+        if text:
+            self._buf.append(text)
+        return len(text)
+
+    def flush(self) -> None:
+        if self._held:
+            # Defer until the hold span releases — keep the buffer intact so
+            # subsequent renders append to the same block.
+            return
+        if not self._buf:
+            return
+        chunk = "".join(self._buf)
+        self._buf.clear()
+        if chunk:
+            self._emit(chunk)
+
+    def clear_transcript(self) -> None:
+        self._buf.clear()
+        if self._clear is not None:
+            self._clear()
+
+    def replay_width(self, default: int = 80) -> int:
+        if self._replay_width is None:
+            return default
+        try:
+            return int(self._replay_width())
+        except Exception:
+            return default
+
+    def emit_with_replay(self, text: str, replay: Callable[[], str]) -> None:
+        if self._buf:
+            chunk = "".join(self._buf)
+            self._buf.clear()
+            if chunk:
+                self._emit(chunk)
+        if text:
+            self._emit(text, replay=replay)
+
+    @contextmanager
+    def hold(self):
+        """Defer ``flush()`` for the duration of the span, emitting once on exit.
+
+        Re-entrant: nested holds only release on the outermost exit.
+        """
+        self._held += 1
+        try:
+            yield
+        finally:
+            self._held -= 1
+            if self._held == 0:
+                self.flush()
+
+    def isatty(self) -> bool:
+        return True
+
+
+def _short_model_name(full_name: str) -> str:
+    """Convert a full model registry key to a short display name.
+
+    Examples:
+        "claude-sonnet-4-5" → "sonnet-4-5"
+        "gpt-4o" → "gpt-4o"
+    """
+    part = full_name.split("/")[-1]
+    part = part.replace("bedrock-claude-", "").replace("bedrock-", "").replace("claude-", "")
+    part = re.sub(r"-v\d+$", "", part)
+    return part
+
+
+# ---------------------------------------------------------------------------
+# Session
+# ---------------------------------------------------------------------------
+
+
+class Session:
+    """Frontend-agnostic REPL loop.
+
+    Owns all behavior: agent event subscription, streaming state, show_python
+    decisions.  The frontend is a pure rendering surface.
+
+    Args:
+        frontend: Any object implementing the ``Frontend`` protocol.
+        agent: An NeMo OO Agents agent with a ``handle(notification)`` async method.
+        config: Loaded ``Config`` (holds tui / agent sub-configs).
+        registry: Pre-built ``CommandRegistry``.
+        session_manager: Optional ``SessionManager`` for persisting turns.
+    """
+
+    def __init__(
+        self,
+        frontend: "Frontend",
+        agent: "Agent",
+        config: "Config",
+        registry: "CommandRegistry",
+        session_manager: "SessionManager | None" = None,
+        initial_outputs: list[Any] | None = None,
+    ) -> None:
+        from .commands import CommandHandler
+
+        self.frontend = frontend
+        self.agent = agent
+        self.config = config
+        self.registry = registry
+        self._handler = CommandHandler(registry=registry, frontend=frontend)
+        self._session_manager = session_manager
+        from .toolbar import ToolbarRegistry
+
+        self._toolbar = ToolbarRegistry()
+        self._initial_outputs = list(initial_outputs or [])
+        self._first_message: str | None = None  # first user turn (for auto-naming)
+
+        # Streaming state shared with the AgentEventRenderer: the
+        # tool_call_id → code map that pairs a preview with its matching
+        # ``PythonOutput`` event.
+        self._pending_code: dict[str, str] = {}
+        self._background_tasks: set[asyncio.Task] = set()  # fire-and-forget tasks
+        self._naming_futures: set = set()  # concurrent.futures.Future from agent-loop dispatch
+        self._command_runner = None
+
+        # Populated at the start of ``run()``; referenced by the handler
+        # methods (``_on_command``, ``_on_user_message_ui``, ``_loud_handler``,
+        # etc.) so they can live as real methods instead of 240 lines of
+        # nested closures inside ``run()``.
+        self._app: TUIApplication | None = None
+        self._renderer: AgentEventRenderer | None = None
+        self._unsub_activity: Callable[[], None] | None = None
+        self._emit_console: RichConsole | None = None
+        self._loud_handler_reentrant: bool = False
+        # Own ShellTools for bang (!) commands — avoids cross-loop issues
+        # when the agent's shell was created on a different event loop.
+        self._bang_shell: ShellTools | None = None
+
+    @property
+    def show_python(self) -> bool:
+        """Whether to display full Python code execution panels."""
+        return self.config.tui.show_python
+
+    @show_python.setter
+    def show_python(self, value: bool) -> None:
+        self.config.tui.show_python = value
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_manager.session_id if self._session_manager else None
+
+    def _context_usage_label(self) -> str:
+        """Compact ``"ctx N%"`` label from the most recent ContextWindowStats.
+
+        The percentage is the provider-reported prompt-token count over the
+        USABLE context window (model window minus the output-token reserve) —
+        so 100% means "the next call at the current completion budget will be
+        rejected", not "the window is byte-full". Until the first response
+        returns usage (``prompt_tokens`` is None) we show the placeholder
+        ``"ctx —"`` rather than a local estimate.
+        """
+        stats = getattr(self.agent, "context_stats", None)
+        if stats is None:
+            return "ctx —"
+        util = stats.overall_utilization  # prompt / (window - output reserve)
+        if util is None:
+            return "ctx —"
+        return f"ctx {util * 100:.0f}%"
+
+    # ------------------------------------------------------------------
+    # Exit diagnostics
+    # ------------------------------------------------------------------
+
+    def _dump_exit_diagnostics(self) -> None:
+        """Print pending tasks, threads, and subprocesses on exit for debugging hangs."""
+        import sys
+        import threading
+
+        lines: list[str] = []
+
+        # Pending asyncio tasks
+        try:
+            pending = [t for t in asyncio.all_tasks() if not t.done()]
+            if pending:
+                lines.append(f"Pending asyncio tasks ({len(pending)}):")
+                for t in pending:
+                    coro = t.get_coro()
+                    name = getattr(coro, "__qualname__", str(coro))
+                    lines.append(f"  - {t.get_name()}: {name}")
+        except RuntimeError:
+            pass
+
+        # Non-daemon threads still alive
+        alive = [
+            t
+            for t in threading.enumerate()
+            if t.is_alive() and not t.daemon and t != threading.main_thread()
+        ]
+        if alive:
+            lines.append(f"Live non-daemon threads ({len(alive)}):")
+            for t in alive:
+                lines.append(f"  - {t.name} (ident={t.ident})")
+
+        # Background tasks tracked by this session
+        bg = [t for t in self._background_tasks if not t.done()]
+        if bg:
+            lines.append(f"Background session tasks ({len(bg)}):")
+            for t in bg:
+                lines.append(f"  - {t.get_name()}")
+
+        if lines:
+            sys.stderr.write("\n\033[2m[exit diagnostics]\n")
+            for line in lines:
+                sys.stderr.write(f"  {line}\n")
+            sys.stderr.write("\033[0m\n")
+            sys.stderr.flush()
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    async def run(self) -> None:
+        """Drive the single long-lived ``TUIApplication`` REPL.
+
+        One Application owns the whole terminal: output scrolls above
+        the live prompt region via a single-consumer block queue, so
+        producers (command dispatch, agent events, messages) render in
+        strict submission order and there's no handoff race that drops
+        the first keystroke between turns.
+
+        The handler logic lives in instance methods (``_on_command``,
+        ``_on_user_message_ui``, ``_emit_text``, ``_loud_handler``, …);
+        ``run`` is just the wiring.
+        """
+        from .agent_event_renderer import AgentEventRenderer
+        from .input_handler import SlashCommandCompleter
+        from .output import TextOutput
+        from .theme import CATPPUCCIN_THEME
+        from .tui_application import TUIApplication
+
+        # Save terminal attributes so we can restore them on exit, even
+        # if prompt_toolkit crashes without resetting the terminal.
+        self._saved_termios = None
+        try:
+            import termios
+
+            if sys.stdin.isatty():
+                self._saved_termios = termios.tcgetattr(sys.stdin.fileno())
+        except (ImportError, OSError):
+            pass
+
+        # The block-rendering Rich Console: re-used across ``_emit_text``
+        # calls with width reset per-call to track live terminal width.
+        self._emit_console = RichConsole(
+            file=io.StringIO(),
+            force_terminal=True,
+            color_system="256",
+            width=120,
+            theme=CATPPUCCIN_THEME,
+        )
+
+        self._app = TUIApplication(
+            agent=self.agent,
+            on_command=self._on_command,
+            on_bang=self._on_bang,
+            on_output=self._on_app_output,
+            completer=SlashCommandCompleter(self.registry),
+            session_label=self._session_label,
+            config=self.config,
+            full_screen=self.config.tui.full_screen,
+        )
+        bind_app = getattr(self.frontend, "bind_app", None)
+        if callable(bind_app):
+            bind_app(self._app)
+        # Wire agent_run into all commands so they can dispatch mutations
+        # to the agent thread via self.agent_run(fn). agent_run_async is the
+        # awaitable variant — commands running on the UI loop use it so they
+        # never block the loop (and stall message() output / spin the prompt).
+        self._handler._agent_run_async = self._app.agent_run_async
+        for cmd in self.registry.commands():
+            cmd._agent_run = self._app.agent_run
+            cmd._agent_run_async = self._app.agent_run_async
+        # Wire the user-bar render + SessionUserMessage log on the channel's
+        # on_get hook so the echo fires when the dispatcher (or agent
+        # code mid-turn) actually dequeues the message — symmetric across
+        # both consumer paths, which is why the hook lives on the queue
+        # and not on the dispatcher loop. self.agent is typed as Agent;
+        # the queue is on BaseTUIAgent. getattr matches the existing
+        # convention in tui_application.py for the same lookup.
+        queue = getattr(self.agent, "_user_messages_in", None)
+        if queue is not None:
+
+            def _on_user_message_hook(text: str) -> None:
+                # DB writes run here on the agent loop thread (the on_get
+                # caller), keeping all sqlite access on one thread.
+                user_event_id = None
+                user_tags = None
+                if self._session_manager is not None:
+                    recorded = self._session_manager.record_user(text)
+                    if isinstance(recorded, tuple) and len(recorded) == 2:
+                        tag, event = recorded
+                        user_tags = {str(tag)}
+                        event_id = getattr(event, "id", None)
+                        if event_id is not None:
+                            user_event_id = str(event_id)
+                # UI rendering must happen on the UI loop.
+                app = self._app
+                loop = getattr(app, "_loop", None) if app is not None else None
+                if loop is None:
+                    self._on_user_message_ui(text, event_id=user_event_id, tags=user_tags)
+                    return
+                try:
+                    on_ui_loop = asyncio.get_running_loop() is loop
+                except RuntimeError:
+                    on_ui_loop = False
+                if on_ui_loop:
+                    self._on_user_message_ui(text, event_id=user_event_id, tags=user_tags)
+                else:
+                    loop.call_soon_threadsafe(
+                        lambda: self._on_user_message_ui(
+                            text,
+                            event_id=user_event_id,
+                            tags=user_tags,
+                        )
+                    )
+
+            queue.set_on_get(_on_user_message_hook)
+
+        # Swap the frontend's Rich Console for one that writes through
+        # our block queue, so slash-command output (e.g. /help tables)
+        # lands in scrollback instead of clobbering the live prompt.
+        tui_console = getattr(self.frontend, "console", None)
+        if tui_console is not None and hasattr(tui_console, "replace_console"):
+            tui_console.replace_console(
+                RichConsole(
+                    file=_EmitStream(
+                        self._app.emit_block,
+                        replay_width=lambda app=self._app: app.output_columns(minimum=40),
+                        clear=self._app.clear_transcript,
+                    ),  # type: ignore[arg-type]
+                    force_terminal=True,
+                    color_system="256",
+                    width=120,
+                    theme=CATPPUCCIN_THEME,
+                )
+            )
+
+            for output in self._initial_outputs:
+                await self.frontend.render(output)
+            self._initial_outputs.clear()
+
+        self._renderer = AgentEventRenderer(
+            agent=self.agent,
+            emit_text=self._emit_text,
+            show_python=lambda: self.show_python,
+            pending_code=self._pending_code,
+            colors=self._colors,
+        )
+        # Replace Python's default asyncio exception handler with one
+        # that surfaces every swallowed task exception into the TUI.
+        # Without this, any coroutine we schedule (spinner, commands,
+        # background bookkeeping) that raises vanishes into logging and
+        # the user sees "nothing happened".
+        self._startup_loop = asyncio.get_running_loop()
+        self._prev_exception_handler = self._startup_loop.get_exception_handler()
+        self._startup_loop.set_exception_handler(self._loud_handler)
+
+        # Subscribe inside the try so any exception between attach and
+        # ``app.run_async`` completion still fires ``renderer.detach``
+        # in the finally.
+        try:
+            self._renderer.attach()
+            # Event-driven activity tracking: LLMCallStart/LLMCallEnd "on"
+            # hooks feed get_activity() (and /activity) without inferring
+            # model-wait state from cell boundaries.
+            try:
+                from nooa.runtime.debug_handler import attach_activity_tracking
+
+                em = getattr(self.agent, "event_manager", None)
+                if em is not None:
+                    self._unsub_activity = attach_activity_tracking(em)
+            except Exception:
+                logger.debug("attach_activity_tracking failed", exc_info=True)
+            auto_connect_mcp = getattr(self.registry, "auto_connect_mcp", None)
+            if callable(auto_connect_mcp):
+                auto_connect_result = auto_connect_mcp()
+                if asyncio.iscoroutine(auto_connect_result):
+                    self._fire_and_forget(auto_connect_result)
+            await self._app.run_async()
+        except (KeyboardInterrupt, EOFError):
+            await self.frontend.render(
+                TextOutput("Interrupted by the user. Exiting TUI...", "warning")
+            )
+        finally:
+            # Order matters:
+            # 1. Detach the renderer FIRST. Clears agent._render_message
+            #    so any post-shutdown self.message() call (e.g. from
+            #    save_snapshot) doesn't write through a dead emit_text.
+            # 2. Cancel AND AWAIT fire-and-forget tasks so they don't
+            #    trip "Task was destroyed but it is pending" warnings
+            #    when the loop closes.
+            # 3. Diagnostics, frontend close, snapshot, session close.
+            self._renderer.detach()
+            if self._unsub_activity is not None:
+                try:
+                    self._unsub_activity()
+                except Exception:
+                    logger.debug("detach activity tracking failed", exc_info=True)
+                self._unsub_activity = None
+            # Shut down spawned jobs before cancelling background tasks
+            # so generator finally blocks run cleanly.
+            qm = getattr(self.agent, "queue_manager", None)
+            if qm is not None:
+                app = getattr(self, "_app", None)
+                if app is not None:
+                    await app.shutdown_agent_queue_manager(agent=self.agent)
+                else:
+                    await qm.shutdown()
+            await self._cancel_background_tasks()
+            if self._bang_shell is not None:
+                await self._bang_shell.close()
+                self._bang_shell = None
+            self._dump_exit_diagnostics()
+            self.frontend.close()
+            if self._session_manager is not None:
+                storage = getattr(self.agent, "_storage", None)
+                if storage is not None and hasattr(storage, "save_snapshot"):
+                    try:
+                        app = getattr(self, "_app", None)
+                        if app is not None:
+                            await app.agent_run_async(lambda: storage.save_snapshot(self.agent))
+                        else:
+                            # No agent loop — safe to call inline (single-threaded).
+                            storage.save_snapshot(self.agent)
+                    except Exception:
+                        # A failed shutdown snapshot silently loses ALL durable
+                        # state (vars, todos, ...) on the next resume — surface
+                        # it at WARNING, not DEBUG, so it can't hide.
+                        logger.warning("save_snapshot on shutdown failed", exc_info=True)
+            # Coding agents own long-lived shell and LLM resources. Close them
+            # after the final snapshot but before releasing session storage.
+            close_agent = getattr(type(self.agent), "close", None)
+            if callable(close_agent):
+                try:
+                    close_result = close_agent(self.agent)
+                    if inspect.isawaitable(close_result):
+                        await close_result
+                except Exception:
+                    logger.warning("agent shutdown failed", exc_info=True)
+            if self._session_manager is not None:
+                self._session_manager.close()
+            # Restore the previous exception handler so we don't pin
+            # this Session or route unrelated failures through a torn-down TUI.
+            if self._startup_loop is not None:
+                self._startup_loop.set_exception_handler(self._prev_exception_handler)
+            self._restore_terminal()
+            self._print_exit_message()
+
+    async def _on_app_output(self, output: Any) -> None:
+        """Render structured output emitted by ``TUIApplication``.
+
+        The dispatcher can run on the dedicated agent loop thread, while
+        frontend rendering belongs on the UI/startup loop. This bridge keeps
+        the app frontend-agnostic and preserves one structured output path for
+        terminal and non-terminal frontends.
+        """
+        loop = self._startup_loop
+        if loop is None:
+            return
+
+        async def _render() -> None:
+            await self.frontend.render(output)
+
+        try:
+            on_ui_loop = asyncio.get_running_loop() is loop
+        except RuntimeError:
+            on_ui_loop = False
+        if on_ui_loop:
+            await _render()
+            return
+
+        future = asyncio.run_coroutine_threadsafe(_render(), loop)
+        await asyncio.wrap_future(future)
+
+    def _restore_terminal(self) -> None:
+        """Best-effort restoration of terminal state on exit.
+
+        prompt_toolkit normally restores the terminal, but on crashes,
+        signals, or unhandled exceptions the terminal can be left in raw
+        mode with echo disabled. We saved termios attrs at startup and
+        restore them here as a safety net.
+        """
+        try:
+            import termios
+
+            if self._saved_termios is not None and sys.stdin.isatty():
+                termios.tcsetattr(sys.stdin.fileno(), termios.TCSANOW, self._saved_termios)
+                return
+        except (ImportError, OSError):
+            pass
+        # Fallback: if termios isn't available or failed, shell out to stty
+        try:
+            import subprocess
+
+            if sys.stdin.isatty():
+                subprocess.run(["stty", "sane"], stdin=sys.stdin, check=False)
+        except Exception:
+            pass
+
+    def _print_exit_message(self) -> None:
+        """Print the parting line to stderr with session id + name.
+
+        Runs after session_manager.close() so the persisted session is
+        what the user sees referenced. Goes through ``sys.stderr``
+        (not the frontend) because the prompt_toolkit Application has
+        already cleaned up its terminal state and the frontend is
+        closed.
+        """
+        sm = self._session_manager
+        if sm is not None:
+            short = (sm.session_id or "")[:8]
+            name = sm.name
+            if name and short:
+                tag = f"{name} [{short}]"
+            elif short:
+                tag = f"[{short}]"
+            else:
+                tag = ""
+        else:
+            tag = ""
+        suffix = f" — {tag}" if tag else ""
+        sys.stderr.write(f"\n\x1b[2mGoodbye! Stay vibing.{suffix}\x1b[0m\n")
+        if sm is not None and short:
+            sys.stderr.write(
+                f"\x1b[2mResume this session with \x1b[0m\x1b[1mnooa tui -c {short}\x1b[0m\n"
+            )
+
+    # ------------------------------------------------------------------
+    # Handlers — driven by TUIApplication, called in run()'s event loop.
+    # Each closes over ``self._app`` / ``self._renderer`` / ``self._emit_console``
+    # set up in ``run()``. Don't call any of these before ``run()`` has
+    # started; calling an assertion-gated attribute access ("``self._app``
+    # is None") raises a descriptive error.
+    # ------------------------------------------------------------------
+
+    @property
+    def _colors(self) -> dict[str, str]:
+        """Theme colour table — reads the current theme so ``/theme`` has
+        effect without restarting the app."""
+        from .theme import COLORS
+
+        return COLORS
+
+    def _render_to_ansi(self, renderable: Any) -> str:
+        """Render a Rich renderable using the current terminal width."""
+        assert self._emit_console is not None
+        from .tui_application import terminal_cols
+
+        try:
+            width = self._app.output_columns(minimum=40)  # type: ignore[union-attr]
+        except Exception:
+            width = terminal_cols(minimum=40)
+        self._emit_console.width = max(int(width), 40)
+        buf = io.StringIO()
+        self._emit_console.file = buf
+        self._emit_console.print(renderable)
+        return buf.getvalue()
+
+    def _emit_text(
+        self,
+        renderable: Any,
+        *,
+        event_id: str | None = None,
+        tags: set[str] | frozenset[str] | None = None,
+        keep: bool = False,
+    ) -> None:
+        """Render a Rich renderable → ANSI → enqueue to the block queue.
+
+        In fullscreen mode, also retain a replay callback that re-renders the
+        same semantic Rich/Markdown object at the current width on resize.
+        """
+        assert self._app is not None
+
+        rendered = self._render_to_ansi(renderable)
+        full_screen = bool(
+            getattr(getattr(getattr(self, "config", None), "tui", None), "full_screen", False)
+            is True
+        )
+        replay = (lambda r=renderable: self._render_to_ansi(r)) if full_screen else None
+        if replay is None:
+            self._app.emit_block(rendered, event_id=event_id, tags=tags, keep=keep)
+        else:
+            self._app.emit_block(rendered, replay=replay, event_id=event_id, tags=tags, keep=keep)
+
+    def _get_command_runner(self):
+        """Return the TUI-local command runner, creating it lazily for tests."""
+        runner = getattr(self, "_command_runner", None)
+        if runner is None:
+            from .command_runner import CommandRunner
+
+            frontend = getattr(self, "frontend", None)
+            render = getattr(frontend, "render", None)
+            if not callable(render):
+
+                async def render(_output):
+                    return None
+
+            app = getattr(self, "_app", None)
+            set_dynamic_status = getattr(app, "set_command_status", None)
+            set_dynamic_queue = getattr(app, "set_command_queue", None)
+            runner = CommandRunner(
+                render,
+                set_dynamic_status=set_dynamic_status if callable(set_dynamic_status) else None,
+                set_dynamic_queue=set_dynamic_queue if callable(set_dynamic_queue) else None,
+            )
+            self._command_runner = runner
+        return runner
+
+    async def _on_command(self, text: str) -> None:
+        """Handle one slash command through the TUI-local command runner."""
+
+        async def _work():
+            return await self._run_command(text)
+
+        await self._get_command_runner().run(kind="slash", text=text, work=_work)
+
+    async def _run_command(self, text: str) -> Callable[[], Awaitable[None]] | None:
+        """Run one slash command body and return any post-done render callback."""
+        assert self._app is not None
+
+        result = await self._handler.handle(text, render_outputs=False)
+        if result.new_session_manager is not None:
+            # Suppress normal cancelled-turn UX/restart while the command runner
+            # moves storage/session state; the post-swap render is the user-visible
+            # result for /clear, /session new, and /session resume.
+            self._app._session_transitioning = True
+            try:
+                # Cancel the running agent turn so it doesn't keep working
+                # in the stale session after /clear or /session new.
+                await self._app.cancel_agent_turn(source="session")
+                await self._swap_session_manager(result.new_session_manager)
+                post_swap = getattr(result, "post_session_swap", None)
+                if post_swap is not None:
+                    extra_outputs = await self._app.agent_run_async(post_swap)
+                    if extra_outputs:
+                        result.outputs.extend(extra_outputs)
+                self._first_message = None
+            finally:
+                self._app._session_transitioning = False
+        if (
+            result.compact_done
+            and self._first_message
+            and self._session_manager
+            and not self._session_manager.user_named
+        ):
+            self._name_session_on_agent_loop(self._first_message)
+
+        async def _render_result_outputs() -> None:
+            frontend = getattr(self, "frontend", None)
+            render = getattr(frontend, "render", None)
+            if not callable(render):
+                return
+
+            from .commands import render_command_outputs
+
+            await render_command_outputs(frontend, result.outputs)
+
+        if result.exit:
+
+            async def _render_outputs_then_exit() -> None:
+                await _render_result_outputs()
+                self._app.exit()
+
+            return _render_outputs_then_exit
+
+        if result.slash_result is None and result.agent_message is None:
+            return _render_result_outputs
+        if result.slash_result is not None:
+            # slash-inception: a SwapAgentRequest asks us to hot-swap the agent
+            # the dispatcher drives. The skill (running on the UI loop, with no
+            # app handle) built the new agent and shared the old agent's live
+            # channels; we hold the app, so we do the actual swap here.
+            # Identify the request structurally (duck typing on its fields)
+            # rather than by class name — the inception skill lives in another
+            # package, and a string __name__ check breaks silently on a rename
+            # or a same-named class from elsewhere.
+            _swap_req = getattr(result.slash_result, "value", None)
+            if (
+                _swap_req is not None
+                and hasattr(_swap_req, "new_agent")
+                and hasattr(_swap_req, "seed_prompt")
+            ):
+                from .output import AgentMessage
+
+                async def _render_and_swap() -> None:
+                    _text = str(result.slash_result)
+                    if _text:
+                        await self.frontend.render(AgentMessage(_text, show_rule=False))
+                    assert self._app is not None
+                    _new = _swap_req.new_agent
+                    # Queue the seed prompt on the SHARED user-messages channel, then
+                    # swap+restart the dispatcher onto the new agent (on the agent loop).
+                    _q = getattr(_new, "_user_messages_in", None)
+                    if _q is not None:
+                        _q.put(_swap_req.seed_prompt)
+                    await self._app.agent_run_async(lambda: self._app.swap_agent(_new))
+
+                return _render_and_swap
+
+            # Show slash-command output after the durable done marker. Skill slash
+            # commands often return Markdown (tables, lists), so render via the
+            # frontend instead of dumping raw text through emit_block.
+            async def _render_slash_output() -> None:
+                await _render_result_outputs()
+                text = str(result.slash_result)
+                if text:
+                    from .output import AgentMessage
+
+                    await self.frontend.render(AgentMessage(text, show_rule=False))
+
+            if not _effective_slash_output_to_agent(self.agent, result.slash_result):
+                # User-only command (e.g. a read-only /mcp list): the human sees
+                # the output above, but it is NOT fed to the agent — no queue
+                # put, no submitted message, no agent turn spent.
+                return _render_slash_output
+            # Post the full SlashCommandResult to the slash_commands queue
+            # (agent can access .value for the raw Python object). This put
+            # also wakes the dispatcher (qm.race() includes the slash_commands
+            # queue), so the slash command must NOT also be submitted as a user
+            # message — doing both delivers the same command twice (once on
+            # each queue).
+            #
+            # Strict routing: a slash command result ONLY ever travels the
+            # slash_commands channel — never user_messages. Every real TUI
+            # agent (BaseTUIAgent) creates that channel in __init__, so this
+            # is always present in normal use. If self.agent is something else
+            # (a plain Agent, a partially-initialized object, a test double),
+            # there is no slash-capable destination: warn loudly to scrollback
+            # and drop the result rather than smuggling it through the
+            # user-message path (where it would masquerade as something the
+            # human typed).
+            slash_ch = getattr(self.agent, "_slash_commands_in", None)
+            if slash_ch is not None:
+                slash_ch.put(result.slash_result)
+            else:
+                self._emit_text(
+                    Text(
+                        f"⚠ agent has no slash_commands channel — dropping /{result.slash_result.command}",
+                        style="yellow",
+                    )
+                )
+            return _render_slash_output
+        elif result.agent_message is not None:
+            # Slash-command-generated agent turn — feed through the same
+            # path as a typed message so the user bar, session bookkeeping,
+            # and agent dispatch stay consistent.
+            self._app.submit_message(result.agent_message)
+            return _render_result_outputs
+
+    async def _on_bang(self, body: str) -> None:
+        """Dispatch a ``!shell-command`` body through the command runner."""
+        text = "!" + body
+
+        async def _work():
+            return await self._handle_bang(text, defer_render=True)
+
+        await self._get_command_runner().run(kind="bang", text=text, work=_work)
+
+    def _session_label(self) -> str:
+        """Render configured toolbar items on the rule above the input."""
+        from .toolbar import ToolbarContext
+
+        manager = self._session_manager
+        shell = getattr(self.agent, "shell", None)
+        cwd = Path(getattr(shell, "cwd", self.config.agent.working_dir)).resolve()
+        return self._toolbar.render(
+            self.config.tui.toolbar_items,
+            ToolbarContext(
+                model=self.config.tui.default_model,
+                working_directory=cwd,
+                context_usage=self._context_usage_label(),
+                session_id=manager.session_id if manager is not None else None,
+                session_title=manager.name if manager is not None else None,
+                agent=self.agent,
+            ),
+        )
+
+    def _on_user_message_ui(
+        self,
+        text: str,
+        *,
+        event_id: str | None = None,
+        tags: set[str] | frozenset[str] | None = None,
+    ) -> None:
+        """Render the user's submitted text as a full-width grey bar and
+        reset per-turn renderer state.
+
+        DB bookkeeping (record_user) is handled by the on_get hook on
+        the agent loop thread; this method only does UI work.
+        """
+        assert self._renderer is not None and self._app is not None
+
+        if self._first_message is None:
+            self._first_message = text
+            if (
+                self._session_manager is not None
+                and not self._session_manager.user_named
+                and not (self._session_manager.name or "").strip()
+            ):
+                self._name_session_on_agent_loop(text)
+
+        bar = _build_user_bar(text, self._app, self._colors)
+        full_screen = bool(
+            getattr(getattr(getattr(self, "config", None), "tui", None), "full_screen", False)
+            is True
+        )
+        replay = (
+            (lambda t=text: _build_user_bar(t, self._app, self._colors)) if full_screen else None
+        )
+        emit_kwargs = {}
+        if event_id is not None:
+            emit_kwargs["event_id"] = event_id
+        if tags:
+            emit_kwargs["tags"] = tags
+        if replay is None:
+            self._app.emit_block(bar, **emit_kwargs)
+        else:
+            self._app.emit_block(bar, replay=replay, **emit_kwargs)
+        self._renderer.reset_turn()
+
+    def _loud_handler(self, _loop: asyncio.AbstractEventLoop, context: dict) -> None:
+        """asyncio exception handler that surfaces every swallowed task
+        exception into the scrollback instead of Python's logging.
+
+        Guards against re-entry: if ``emit_block`` itself raises, the
+        asyncio loop would call us back with the new exception, yielding
+        unbounded recursion. On re-entry we fall back to a bare stderr
+        write.
+        """
+        assert self._app is not None
+
+        msg = context.get("message", "")
+        exc = context.get("exception")
+        # --- gl-212 diagnostics: enrich "bound to a different event loop" ---
+        if exc is not None and "bound to a different event loop" in str(exc):
+            startup_loop = getattr(self, "_startup_loop", None)
+            diag_lines = [
+                "[gl-212] asyncio.Lock bound to a different event loop — diagnostic dump:",
+                f"  handler loop: id={id(_loop):#x}",
+                f"  startup loop: id={id(startup_loop):#x} (same={startup_loop is _loop})",
+                f"  exception: {exc!r}",
+            ]
+            # Inspect known Lock instances on the agent
+            try:
+                shell = getattr(self.agent, "shell", None)
+                if shell is not None:
+                    bash = getattr(shell, "_session", None)
+                    if bash is not None:
+                        lock = getattr(bash, "_lock", None)
+                        diag_lines.append(f"  BashSession._lock: {lock!r}")
+                        if lock is not None and hasattr(lock, "_loop"):
+                            diag_lines.append(
+                                f"    lock._loop: id={id(lock._loop):#x} (same={lock._loop is _loop})"
+                            )
+            except Exception as e:
+                diag_lines.append(f"  [BashSession inspection failed: {e}]")
+            try:
+                actor = getattr(self.agent, "_actor", None)
+                if actor is not None:
+                    gen_lock = getattr(actor, "_generation_lock", None)
+                    diag_lines.append(f"  Actor._generation_lock: {gen_lock!r}")
+                    if gen_lock is not None and hasattr(gen_lock, "_loop"):
+                        diag_lines.append(
+                            f"    lock._loop: id={id(gen_lock._loop):#x} (same={gen_lock._loop is _loop})"
+                        )
+            except Exception as e:
+                diag_lines.append(f"  [Actor inspection failed: {e}]")
+            diag_lines.append("  Suggestion: restart the TUI. File details on gl#212.")
+            diag_lines.append("")
+            diag_msg = "\n".join(diag_lines)
+            if self._loud_handler_reentrant:
+                err = sys.__stderr__
+                if err is not None:
+                    err.write(diag_msg)
+                    err.flush()
+            else:
+                self._loud_handler_reentrant = True
+                try:
+                    self._app.emit_block(diag_msg)
+                except Exception:
+                    # emit_block failed (plausible during degraded loop state) —
+                    # fall back to stderr so the diagnostic isn't lost.
+                    err = sys.__stderr__
+                    if err is not None:
+                        err.write(diag_msg)
+                        err.flush()
+                finally:
+                    self._loud_handler_reentrant = False
+            # Fall through to normal handler for the full traceback
+        # litellm's LiteLLMAiohttpTransport recreates its cached aiohttp
+        # ClientSession on error-recovery / loop-mismatch / session-closed
+        # paths without awaiting close() on the old one. When GC reaps the
+        # orphan, aiohttp's finalizer fires this warning via
+        # call_exception_handler. It's upstream noise, not our bug, and
+        # drowns real diagnostics — drop it before formatting.
+        if msg == "Unclosed client session" or msg == "Unclosed connector":
+            return
+        task = context.get("task")
+        # litellm's LoggingWorker._worker_loop tasks get orphaned when the
+        # global singleton detects an event loop change and drops the old
+        # _worker_task reference without cancelling it. Harmless upstream noise.
+        if "Task was destroyed" in msg and task is not None and "LoggingWorker" in repr(task):
+            return
+        future = context.get("future")
+        source_tb = context.get("source_traceback")
+        line = f"[asyncio] {msg}"
+        if exc is not None:
+            line += f" — {type(exc).__name__}: {exc}"
+            if hasattr(exc, "__traceback__"):
+                line += "\n" + "".join(
+                    traceback.format_exception(type(exc), exc, exc.__traceback__)
+                )
+        # Non-exception contexts (e.g. "Task was destroyed but it is pending!")
+        # carry the offending task/future and — when PYTHONASYNCIODEBUG=1 — a
+        # source_traceback pointing at where it was created.
+        if task is not None:
+            line += f"\n  task={task!r}"
+        if future is not None and future is not task:
+            line += f"\n  future={future!r}"
+        if source_tb:
+            line += "\n  source_traceback (where task was created, enable PYTHONASYNCIODEBUG=1):\n"
+            line += "".join(traceback.format_list(source_tb))
+        # Other keys asyncio sometimes supplies (handle, protocol, transport,
+        # socket, peername, client_session, ...). 2000 chars per field covers
+        # aiohttp ``ClientSession`` reprs (~1.1KB — connector/base_url/auth
+        # all land in the middle) without letting a pathologically huge
+        # transport (SSL state, large buffers) swamp the scrollback.
+        from nooa.agentdoc import truncating_pformat
+
+        _known = ("message", "exception", "task", "future", "source_traceback")
+        for k, v in context.items():
+            if k in _known:
+                continue
+            line += f"\n  {k}={truncating_pformat(v, max_chars=2000)}"
+        line += "\n"
+
+        if self._loud_handler_reentrant:
+            err = sys.__stderr__
+            if err is not None:
+                try:
+                    err.write(line)
+                    err.flush()
+                except Exception:
+                    pass
+            return
+        self._loud_handler_reentrant = True
+        try:
+            self._app.emit_block(line)
+        except Exception as inner:
+            err = sys.__stderr__
+            if err is not None:
+                try:
+                    err.write(f"[loud_handler fallback] {inner}\n{line}")
+                    err.flush()
+                except Exception:
+                    pass
+        finally:
+            self._loud_handler_reentrant = False
+
+    def _fire_and_forget(self, coro) -> asyncio.Task:
+        """Schedule a coroutine as a tracked background task.
+
+        Tracked means: cancelled at shutdown by ``_cancel_background_tasks``,
+        and self-removing from the set when it finishes so the set
+        doesn't leak references to completed tasks.
+        """
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
+
+    async def _cancel_background_tasks(self) -> None:
+        """Cancel and await pending fire-and-forget tasks.
+
+        The set is populated by auto-naming and post-compact renaming;
+        tasks that finish remove themselves via ``discard``. At shutdown
+        anything still in the set is stale. We cancel then ``gather``
+        so the cancellation actually propagates before the loop closes —
+        without the await asyncio emits "Task was destroyed but it is
+        pending" on some orderings.
+        """
+        pending = [t for t in self._background_tasks if not t.done()]
+        for t in pending:
+            t.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        self._background_tasks.clear()
+        # Cancel any naming futures dispatched to the agent loop.
+        naming = getattr(self, "_naming_futures", None)
+        if naming:
+            for f in list(naming):
+                f.cancel()
+            naming.clear()
+
+    # ------------------------------------------------------------------
+    # Session manager swap (triggered by /session new)
+    # ------------------------------------------------------------------
+
+    async def _swap_session_manager(self, new_sm: "SessionManager") -> None:
+        """Close the current session and switch to *new_sm*."""
+        app = getattr(self, "_app", None)
+        interrupt_reflection = getattr(app, "interrupt_reflection", None)
+        if callable(interrupt_reflection):
+            await interrupt_reflection()
+
+        # Shut down spawned jobs and flush all queue channels so stale
+        # items from the old session don't leak into the new one.
+        qm = getattr(self.agent, "queue_manager", None)
+        if qm is not None:
+            if app is not None:
+                await app.shutdown_agent_queue_manager(agent=self.agent, flush=True)
+            else:
+                await qm.shutdown()
+                for name in qm.names():
+                    ch = qm.get_channel(name)
+                    if ch.mode == "queue":
+                        ch.flush()
+        if self._session_manager is not None:
+            # Save snapshot before closing so /clear, /session new, and
+            # /session resume don't lose the current session's self.v/todo.
+            storage = getattr(self.agent, "_storage", None)
+            if storage is not None and hasattr(storage, "save_snapshot"):
+                try:
+                    app = getattr(self, "_app", None)
+                    if app is not None:
+                        await app.agent_run_async(lambda: storage.save_snapshot(self.agent))
+                    else:
+                        storage.save_snapshot(self.agent)
+                except Exception:
+                    logger.debug("save_snapshot on session swap failed", exc_info=True)
+            self._session_manager.close()
+        self._session_manager = new_sm
+        # Point the agent at the new storage AND repoint the agent's
+        # stable EventManager at the new backend. The set_backend call
+        # is what keeps subscribers (e.g. AgentEventRenderer) alive
+        # across the swap.
+        if hasattr(self.agent, "_storage"):
+
+            def _do_swap():
+                self.agent._storage = new_sm._storage
+                self.agent.event_manager.set_backend(new_sm._storage.event_backend)
+                self.agent._session_manager = new_sm
+
+                from .bootstrap import configure_tui_memory
+
+                try:
+                    configure_tui_memory(
+                        self.agent,
+                        self.config,
+                        agent_db=new_sm.agent_db_path,
+                        session_id=new_sm.session_id,
+                    )
+                except Exception:
+                    logger.warning("memory reconfiguration on session swap failed", exc_info=True)
+
+            if app is not None:
+                await app.agent_run_async(_do_swap)
+            else:
+                _do_swap()
+        # Propagate to registry and all command instances so /session export etc. use new ID.
+        self.registry.session_manager = new_sm
+        for cmd in self.registry.commands():
+            cmd.session_manager = new_sm
+        # Start a fresh trace for the new session so it gets its own .jsonl file.
+        # Use the first 8 chars of the SQLite session UUID to correlate trace↔storage.
+        try:
+            from nooa.tracing import set_session
+
+            from .session_manager import _make_trace_session_name
+
+            set_session(_make_trace_session_name(new_sm.session_id or ""))
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Session auto-naming
+    # ------------------------------------------------------------------
+
+    def _name_session_on_agent_loop(self, first_message: str) -> None:
+        """Dispatch auto-naming to the agent loop to avoid cross-thread sqlite access."""
+        agent_loop = getattr(self._app, "_agent_loop", None)
+        if isinstance(agent_loop, asyncio.AbstractEventLoop) and agent_loop.is_running():
+            future = asyncio.run_coroutine_threadsafe(
+                self._auto_name_session(first_message), agent_loop
+            )
+            # Track for cancellation on shutdown. concurrent.futures.Future isn't
+            # awaitable so we keep a separate set from _background_tasks.
+            self._naming_futures.add(future)
+            future.add_done_callback(self._naming_futures.discard)
+        else:
+            # No agent loop available — fall back to local scheduling.
+            self._fire_and_forget(self._auto_name_session(first_message))
+
+    async def _auto_name_session(self, first_message: str) -> None:
+        """Generate and persist a session name from the first user message."""
+        if self._session_manager is None or self._session_manager.user_named:
+            return
+        try:
+            name = await self.agent.name_session(first_message[:400])  # type: ignore[union-attr]
+            name = str(name).strip().strip('"').strip("'")[:60]
+            if name and not self._session_manager.user_named:
+                self._session_manager.rename(name, user_named=False)
+        except Exception:
+            # Fallback: first few words of the message
+            words = first_message.split()
+            fallback = " ".join(words[:5])[:60]
+            if fallback:
+                self._session_manager.rename(fallback, user_named=False)
+
+    # ------------------------------------------------------------------
+    # Bang (!) command routing
+    # ------------------------------------------------------------------
+
+    async def _handle_bang(self, user_input: str, *, defer_render: bool = False):
+        from .output import BashOutput, TextOutput
+
+        cmd = user_input[1:].strip()
+        if not cmd:
+            return
+
+        # !commands → run through shell (not recorded as conversation turns)
+        if not hasattr(self.agent, "shell"):
+            output = TextOutput(
+                "Direct bash commands (!) require an agent with shell support.",
+                "warning",
+            )
+            if defer_render:
+
+                async def _render_warning() -> None:
+                    await self.frontend.render(output)
+
+                return _render_warning
+            await self.frontend.render(output)
+            return
+
+        try:
+            shell = await self._get_bang_shell()
+            result = await shell.run(cmd)
+            if result:
+                output = BashOutput(
+                    stdout=result.stdout or "",
+                    stderr=result.stderr or "",
+                    return_code=result.returncode,
+                )
+                if defer_render:
+
+                    async def _render_output() -> None:
+                        await self.frontend.render(output)
+
+                    return _render_output
+                await self.frontend.render(output)
+        except Exception as e:
+            if defer_render:
+                raise
+            await self.frontend.render(TextOutput(f"Bash error: {e}", "error"))
+
+    async def _get_bang_shell(self) -> "ShellTools":
+        """Return (lazily creating) a ShellTools owned by the TUI for bang commands.
+
+        The agent's ShellTools may have its asyncio.Lock bound to a different
+        event loop.  This dedicated instance is created on the TUI's loop,
+        avoiding "attached to a different loop" errors.
+
+        Syncs cwd from the agent's shell on each call so the two stay
+        in step when the agent changes directory during a session.
+        """
+        from nooa.tools.shell_tools import ShellTools
+
+        if self._bang_shell is None:
+            cwd = self.agent.shell.cwd if hasattr(self.agent, "shell") else "."
+            self._bang_shell = ShellTools(cwd=cwd)
+        elif hasattr(self.agent, "shell"):
+            agent_cwd = str(self.agent.shell.cwd)
+            if str(self._bang_shell.cwd) != agent_cwd:
+                await self._bang_shell.run(f"cd {shlex.quote(agent_cwd)}")
+        return self._bang_shell

--- a/packages/nooa-cli/src/nooa_cli/tui/session_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session_explorer.py
@@ -1,0 +1,592 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Session explorer model, renderer, and in-app subview."""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+
+from .explorer_base import (
+    BAR_STYLE,
+    display_line,
+    render_markdown_lines,
+    search_terms,
+    style_bar,
+    style_fts_prompt,
+    style_mode_label,
+    wrap_plain_line,
+)
+from .session_manager import SessionManager, Turn
+from .subapp import SubviewKeyResult
+
+
+@dataclass
+class SessionExplorerRow:
+    id: str
+    name: str
+    model: str
+    agent: str
+    working_dir: str
+    started_at: float
+    last_active: float
+    turn_count: int
+    turns: list[Turn]
+    search_text: str
+
+    @property
+    def title(self) -> str:
+        return self.name or self.id[:8]
+
+
+class SessionExplorerModel:
+    """Searchable, keyboard-navigable session list."""
+
+    def __init__(self, rows: list[SessionExplorerRow]) -> None:
+        self.rows = rows
+        self.session_query = ""
+        self.detail_query = ""
+        self.search_scope = "sessions"
+        self.matches = list(range(len(rows)))
+        self.cursor = 0
+        self.detail_offset = 10**9
+        self.focus = "list"
+        self.search_active = False
+        self._last_detail_line_count = 0
+        self._last_detail_visible_lines = 0
+        self._last_detail_match_lines: list[int] = []
+        self.detail_search_cursor = 0
+        self._pending_detail_match_delta = 0
+        self.detail_tail_skip = 0
+        self._last_detail_count_exact = True
+        self._detail_cache: dict[tuple[str, int], list[str]] = {}
+
+    @property
+    def current_index(self) -> int | None:
+        if not self.matches:
+            return None
+        self.cursor = min(max(self.cursor, 0), len(self.matches) - 1)
+        return self.matches[self.cursor]
+
+    @property
+    def current(self) -> SessionExplorerRow | None:
+        idx = self.current_index
+        return None if idx is None else self.rows[idx]
+
+    @property
+    def query(self) -> str:
+        return self.session_query if self.search_scope == "sessions" else self.detail_query
+
+    def set_query(self, query: str, *, scope: str | None = None) -> None:
+        if scope is not None:
+            self.search_scope = scope
+        words = [w.lower() for w in query.split() if w.strip()]
+        if self.search_scope == "sessions":
+            self.session_query = query
+            if not words:
+                self.matches = list(range(len(self.rows)))
+            else:
+                self.matches = [
+                    i
+                    for i, row in enumerate(self.rows)
+                    if all(word in row.search_text.lower() for word in words)
+                ]
+            self.cursor = 0
+        else:
+            self.detail_query = query
+        self.detail_offset = 0 if words and self.search_scope == "dialog" else 10**9
+        self.detail_search_cursor = 0
+        self._pending_detail_match_delta = 0
+        self.detail_tail_skip = 0
+
+    def clear_query(self) -> None:
+        self.set_query("", scope=self.search_scope)
+
+    def edit_query(self, text: str) -> None:
+        self.set_query(text)
+        self.search_active = True
+
+    def move(self, delta: int) -> None:
+        if not self.matches:
+            return
+        self.cursor = min(max(self.cursor + delta, 0), len(self.matches) - 1)
+        self.detail_offset = 10**9
+        self.detail_search_cursor = 0
+        self._pending_detail_match_delta = 0
+        self.detail_tail_skip = 0
+
+    def move_or_scroll(self, delta: int) -> None:
+        if self.search_active and self.search_scope == "dialog" and self.focus == "dialog":
+            self.move_detail_match(delta)
+        elif self.focus == "list":
+            self.move(delta)
+        else:
+            self.scroll_detail(delta)
+
+    def move_detail_match(self, delta: int) -> None:
+        if not self._last_detail_match_lines:
+            self._pending_detail_match_delta += delta
+            return
+        count = len(self._last_detail_match_lines)
+        self.detail_search_cursor = min(max(self.detail_search_cursor + delta, 0), count - 1)
+        visible = max(self._last_detail_visible_lines, 1)
+        line = self._last_detail_match_lines[self.detail_search_cursor]
+        self.detail_offset = max(line - visible // 2, 0)
+        self.clamp_detail_offset(visible)
+
+    def jump_home(self) -> None:
+        self.cursor = 0
+        self.detail_offset = 10**9
+
+    def jump_end(self) -> None:
+        if self.matches:
+            self.cursor = len(self.matches) - 1
+            self.detail_offset = 10**9
+
+    def toggle_focus(self) -> None:
+        self.focus = "dialog" if self.focus == "list" else "list"
+
+    def scroll_detail(self, delta: int) -> None:
+        visible = max(self._last_detail_visible_lines, 1)
+        if not self._last_detail_count_exact and self.detail_offset >= 10**8:
+            self.detail_tail_skip = max(self.detail_tail_skip - delta, 0)
+            return
+        max_offset = max(self._last_detail_line_count - visible, 0)
+        current = max_offset if self.detail_offset >= 10**8 else self.detail_offset
+        self.detail_offset = min(max(current + delta, 0), max_offset)
+        self.detail_tail_skip = 0
+
+    def page_detail(self, delta: int) -> None:
+        self.scroll_detail(delta)
+
+    def clamp_detail_offset(self, visible_lines: int) -> None:
+        if not self._last_detail_count_exact and self.detail_offset >= 10**8:
+            return
+        max_offset = max(self._last_detail_line_count - max(visible_lines, 1), 0)
+        self.detail_offset = min(max(self.detail_offset, 0), max_offset)
+
+
+class SessionExplorerView:
+    """In-app subview wrapper for browsing stored sessions."""
+
+    title = "sessions"
+
+    def __init__(self, *, limit: int = 100) -> None:
+        self.model = SessionExplorerModel(build_session_rows(limit=limit))
+        self.pending_input: str | None = None
+
+    def render(self, width: int, height: int) -> str:
+        return render_session_explorer(self.model, width, height, ansi=True)
+
+    def handle_key(self, action: str, value: str = "") -> SubviewKeyResult:
+        model = self.model
+        if action == "quit":
+            if model.search_active:
+                model.edit_query(model.query + "q")
+                return "handled"
+            return "close"
+        if action == "resume":
+            if model.search_active:
+                model.edit_query(model.query + "r")
+                return "handled"
+            row = model.current
+            if row is None:
+                return "handled"
+            self.pending_input = f"/session resume {row.id[:8]}"
+            return "close"
+        if action == "escape":
+            if model.search_active:
+                model.search_active = False
+            elif model.query:
+                model.clear_query()
+            else:
+                return "ignored"
+        elif action == "enter":
+            model.search_active = False
+        elif action == "slash":
+            if model.search_active:
+                model.edit_query(model.query + "/")
+            else:
+                model.search_scope = "dialog" if model.focus == "dialog" else "sessions"
+                model.search_active = True
+        elif action == "backspace":
+            if model.search_active:
+                model.edit_query(model.query[:-1])
+        elif action == "tab":
+            old_query = model.query
+            model.toggle_focus()
+            if model.search_active:
+                model.search_scope = "dialog" if model.focus == "dialog" else "sessions"
+                if model.search_scope == "dialog" and not model.detail_query:
+                    model.set_query(old_query, scope="dialog")
+                elif model.search_scope == "sessions" and not model.session_query:
+                    model.set_query(old_query, scope="sessions")
+        elif action in ("down", "j"):
+            if action == "j" and model.search_active:
+                model.edit_query(model.query + "j")
+            else:
+                model.move_or_scroll(+1)
+        elif action in ("up", "k"):
+            if action == "k" and model.search_active:
+                model.edit_query(model.query + "k")
+            else:
+                model.move_or_scroll(-1)
+        elif action == "page_down":
+            if not model.search_active:
+                model.page_detail(+10)
+        elif action == "page_up":
+            if not model.search_active:
+                model.page_detail(-10)
+        elif action == "home":
+            if not model.search_active:
+                model.jump_home()
+        elif action == "end":
+            if not model.search_active:
+                model.jump_end()
+        elif action == "scroll_down":
+            model.focus = "dialog"
+            model.scroll_detail(+3)
+        elif action == "scroll_up":
+            model.focus = "dialog"
+            model.scroll_detail(-3)
+        elif action == "text":
+            if model.search_active and value and value.isprintable():
+                model.edit_query(model.query + value)
+            else:
+                return "ignored"
+        else:
+            return "ignored"
+        return "handled"
+
+    def on_open(self) -> None:
+        pass
+
+    def on_close(self) -> None:
+        pass
+
+
+def build_session_rows(*, limit: int = 100) -> list[SessionExplorerRow]:
+    """Build explorer rows from persisted sessions, newest first."""
+    rows: list[SessionExplorerRow] = []
+    for meta in SessionManager.list_sessions(limit=limit):
+        if meta.turn_count <= 0:
+            continue
+        turns = SessionManager.load_turns(meta.id)
+        search_parts = [
+            meta.id,
+            meta.name or "",
+            meta.model,
+            meta.agent,
+            meta.working_dir,
+            str(meta.turn_count),
+            *[turn.content for turn in turns],
+        ]
+        rows.append(
+            SessionExplorerRow(
+                id=meta.id,
+                name=meta.name or "",
+                model=meta.model,
+                agent=meta.agent,
+                working_dir=meta.working_dir,
+                started_at=meta.started_at,
+                last_active=meta.last_active,
+                turn_count=meta.turn_count,
+                turns=turns,
+                search_text="\n".join(search_parts),
+            )
+        )
+    return rows
+
+
+def _format_time(ts: float) -> str:
+    try:
+        return datetime.datetime.fromtimestamp(ts).strftime("%m/%d %H:%M")
+    except Exception:
+        return "?"
+
+
+def _detail_match_lines(lines: list[str], terms: list[str]) -> list[int]:
+    if not terms:
+        return []
+    lowered = [term.lower() for term in terms]
+    matches: list[int] = []
+    body_matches: list[int] = []
+    in_dialog = False
+    for i, line in enumerate(lines):
+        if line == "Dialog:":
+            in_dialog = True
+            continue
+        lower = line.lower()
+        if any(term in lower for term in lowered):
+            matches.append(i)
+            if in_dialog:
+                body_matches.append(i)
+    return body_matches or matches
+
+
+def _detail_raw_lines(row: SessionExplorerRow) -> list[str]:
+    lines: list[str] = [
+        f"Session: {row.title} ({row.id[:8]})",
+        f"Model: {row.model}",
+        f"Agent: {row.agent}",
+        f"Working dir: {row.working_dir or '(unknown)'}",
+        f"Started: {_format_time(row.started_at)}   Last active: {_format_time(row.last_active)}   Turns: {row.turn_count}",
+        "",
+        "Dialog:",
+    ]
+    for turn in row.turns:
+        lines.append("You:" if turn.role == "user" else "OO:")
+        for raw in turn.content.splitlines() or [""]:
+            lines.append(f"  {raw}")
+        lines.append("")
+    return lines
+
+
+def wrapped_detail_lines(row: SessionExplorerRow, width: int) -> list[str]:
+    width = max(int(width), 20)
+    lines: list[str] = []
+    for raw in _detail_raw_lines(row):
+        lines.extend(wrap_plain_line(raw, width))
+    return lines
+
+
+def _reversed_detail_raw_lines(row: SessionExplorerRow):
+    for turn in reversed(row.turns):
+        yield ""
+        for raw in reversed(turn.content.splitlines() or [""]):
+            yield f"  {raw}"
+        yield "You:" if turn.role == "user" else "OO:"
+    yield "Dialog:"
+    yield ""
+    yield f"Started: {_format_time(row.started_at)}   Last active: {_format_time(row.last_active)}   Turns: {row.turn_count}"
+    yield f"Working dir: {row.working_dir or '(unknown)'}"
+    yield f"Agent: {row.agent}"
+    yield f"Model: {row.model}"
+    yield f"Session: {row.title} ({row.id[:8]})"
+
+
+def _tail_detail_lines(
+    row: SessionExplorerRow, width: int, visible: int, skip: int, *, markdown: bool = False
+) -> list[str]:
+    if visible <= 0:
+        return []
+    width = max(int(width), 20)
+    remaining_skip = max(skip, 0)
+    selected: list[str] = []
+    # Render only a small raw window. With markdown enabled, grab a little extra
+    # context so Rich can format lists/fences while still avoiding whole-session work.
+    target = visible + (8 if markdown else 0)
+    for raw in _reversed_detail_raw_lines(row):
+        wrapped = wrap_plain_line(raw, width)
+        for line in reversed(wrapped):
+            if remaining_skip > 0:
+                remaining_skip -= 1
+                continue
+            selected.append(line)
+            if len(selected) >= target:
+                lines = list(reversed(selected))
+                break
+        else:
+            continue
+        break
+    else:
+        lines = list(reversed(selected))
+    if not markdown:
+        return lines[:visible]
+    rendered: list[str] = []
+    chunk: list[str] = []
+
+    def flush_chunk() -> None:
+        if chunk:
+            rendered.extend(render_markdown_lines("\n".join(chunk), width))
+            chunk.clear()
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped in {"You:", "OO:", "Dialog:"} or stripped.startswith(
+            ("Session:", "Model:", "Agent:", "Working dir:", "Started:")
+        ):
+            flush_chunk()
+            rendered.append(line)
+        elif line.startswith("  "):
+            chunk.append(line[2:])
+        else:
+            chunk.append(line)
+    flush_chunk()
+    return rendered[-visible:]
+
+
+def _cached_detail_lines(
+    model: SessionExplorerModel, row: SessionExplorerRow, width: int
+) -> list[str]:
+    key = (row.id, max(int(width), 20))
+    cached = model._detail_cache.get(key)
+    if cached is not None:
+        return cached
+    lines = wrapped_detail_lines(row, width)
+    if len(model._detail_cache) > 32:
+        model._detail_cache.clear()
+    model._detail_cache[key] = lines
+    return lines
+
+
+def render_session_explorer(
+    model: SessionExplorerModel, width: int, height: int, *, ansi: bool = False
+) -> str:
+    """Render the current session explorer state as text/ANSI."""
+    width = max(int(width), 40)
+    height = max(int(height), 1)
+    row = model.current
+    match_count = len(model.matches)
+    total = len(model.rows)
+    active_query = model.query
+    query = f" {model.search_scope}_search={active_query!r}" if active_query else ""
+    pos = f" {model.cursor + 1}/{match_count}" if match_count else " 0/0"
+    match_label = (
+        f" match {model.cursor + 1}/{match_count}"
+        if model.session_query and model.search_scope == "sessions" and match_count
+        else ""
+    )
+    header = style_bar(
+        f" Session Explorer{pos} of {total}{match_label}{query} ".ljust(width, "─")[:width],
+        ansi=ansi,
+    )
+    pane_label = "sessions" if model.focus == "list" else "session dialog"
+    if model.search_active:
+        mode_text = "FTS MODE"
+        search_prompt = f"FTS {model.search_scope}: {model.query}"
+        enter_hint = "enter exit FTS"
+    else:
+        mode_text = "BROWSE MODE"
+        search_prompt = "/ FTS"
+        enter_hint = ""
+    focus_label = f"{mode_text} · pane={pane_label}"
+    footer_parts = [
+        focus_label,
+        "tab switch pane",
+        "↑/↓ sessions/scroll",
+        search_prompt,
+        enter_hint,
+        "esc clear",
+        "q close",
+    ]
+    footer_plain = (" " + "  ".join(part for part in footer_parts if part) + " ").ljust(width, "─")[
+        :width
+    ]
+    if ansi:
+        before_mode, after_mode = footer_plain.split(mode_text, 1)
+        styled_mode = style_mode_label(mode_text, active=model.search_active, ansi=True)
+        footer = f"{BAR_STYLE}{before_mode}{styled_mode}{BAR_STYLE}{after_mode}\x1b[0m"
+    else:
+        footer = footer_plain
+
+    body_height = max(height - 2, 0)
+    if not total:
+        body = ["No sessions found."]
+    elif row is None:
+        body = [f"No matches for {model.query!r}."]
+    else:
+        list_count = min(10, max(3, body_height // 3))
+        half = list_count // 2
+        start = max(0, model.cursor - half)
+        end = min(match_count, start + list_count)
+        start = max(0, end - list_count)
+        list_terms = search_terms(model.session_query)
+        detail_terms = search_terms(
+            model.detail_query if model.search_scope == "dialog" else model.session_query
+        )
+        body = []
+        for visible_i in range(start, end):
+            row_i = model.matches[visible_i]
+            item = model.rows[row_i]
+            marker = (
+                "❯"
+                if visible_i == model.cursor and model.focus == "list"
+                else "•"
+                if visible_i == model.cursor
+                else " "
+            )
+            line = (
+                f"{marker} {item.id[:8]:<8} {_format_time(item.last_active):<11} "
+                f"{str(item.turn_count):>4} {item.model.split('/')[-1][:18]:<18} {item.title}"
+            )
+            body.append(display_line(line, width, list_terms, ansi=ansi))
+        divider_label = (
+            f"[FTS {model.search_scope}: {model.query}] "
+            if model.search_active or model.query
+            else "[/: FTS current pane] "
+        )
+        divider_plain = divider_label.ljust(width, "─")[:width]
+        if ansi and (model.search_active or model.query):
+            divider = style_fts_prompt(divider_label, active=model.search_active, ansi=True)
+            divider += "─" * max(width - len(divider_label), 0)
+            body.append(divider)
+        else:
+            body.append(divider_plain)
+        available = max(body_height - len(body), 0)
+        detail_visible = max(available - 1, 0)
+        model._last_detail_visible_lines = detail_visible
+        if detail_terms or model.detail_offset < 10**8:
+            plain_detail_lines = _cached_detail_lines(model, row, width)
+            model._last_detail_count_exact = True
+            model._last_detail_match_lines = _detail_match_lines(plain_detail_lines, detail_terms)
+            if model._last_detail_match_lines:
+                cursor = model.detail_search_cursor + model._pending_detail_match_delta
+                model.detail_search_cursor = min(
+                    max(cursor, 0), len(model._last_detail_match_lines) - 1
+                )
+                model._pending_detail_match_delta = 0
+            else:
+                model.detail_search_cursor = 0
+                model._pending_detail_match_delta = 0
+            model._last_detail_line_count = len(plain_detail_lines)
+            if model.search_active and model._last_detail_match_lines:
+                visible = max(model._last_detail_visible_lines, 1)
+                line = model._last_detail_match_lines[model.detail_search_cursor]
+                if (
+                    model.detail_offset >= 10**8
+                    or (model.search_scope == "dialog" and model.focus == "dialog")
+                    and not (model.detail_offset <= line < model.detail_offset + visible)
+                ):
+                    model.detail_offset = max(line - visible // 2, 0)
+            model.clamp_detail_offset(detail_visible)
+            visible_detail_lines = plain_detail_lines[
+                model.detail_offset : model.detail_offset + detail_visible
+            ]
+            if detail_terms:
+                current_match_line = (
+                    model._last_detail_match_lines[model.detail_search_cursor]
+                    if model._last_detail_match_lines
+                    else None
+                )
+                visible_detail_lines = [
+                    display_line(
+                        line,
+                        width,
+                        detail_terms,
+                        ansi=ansi,
+                        current_match=model.detail_offset + i == current_match_line,
+                    )
+                    for i, line in enumerate(visible_detail_lines)
+                ]
+        else:
+            model._last_detail_count_exact = False
+            model._last_detail_match_lines = []
+            model.detail_search_cursor = 0
+            model._last_detail_line_count = 10**9
+            visible_detail_lines = _tail_detail_lines(
+                row, width, detail_visible, model.detail_tail_skip, markdown=ansi
+            )
+        detail_marker = "❯" if model.focus == "dialog" else " "
+        if available > 0:
+            detail_header = f"{detail_marker} dialog: {row.title} ({row.id[:8]})"
+            body.append(detail_header[:width])
+        for line in visible_detail_lines:
+            body.append(line if ansi and "\x1b[" in line else line.ljust(width)[:width])
+    body = [
+        line if ansi and "\x1b[" in line else line.ljust(width)[:width]
+        for line in body[:body_height]
+    ]
+    while len(body) < body_height:
+        body.append("".ljust(width))
+    return "\n".join([header, *body, footer])

--- a/packages/nooa-cli/src/nooa_cli/tui/session_manager.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session_manager.py
@@ -1,0 +1,268 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""TUI presentation adapter for the shared durable session store."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+from nooa.paths import get_project_dir
+from nooa.sessions import SessionHandle, SessionInfo, SessionStore
+from nooa.storage.sqlite import delete_sqlite_database
+
+SESSIONS_DIR = get_project_dir("sessions")
+
+
+def _make_trace_session_name(session_id: str) -> str:
+    """Build a trace name correlated with the durable session UUID."""
+    return f"tui-{datetime.now(UTC).strftime('%Y%m%d-%H%M%S')}-{session_id[:8]}"
+
+
+@dataclass(frozen=True, slots=True)
+class SessionMeta:
+    """Compatibility view used by the TUI's session tables."""
+
+    id: str
+    model: str
+    agent: str
+    started_at: float
+    last_active: float
+    turn_count: int = 0
+    working_dir: str = ""
+    name: str | None = None
+    user_named: bool = False
+
+    @classmethod
+    def from_info(cls, info: SessionInfo) -> SessionMeta:
+        return cls(
+            id=info.id,
+            model=info.model,
+            agent=info.agent,
+            started_at=info.started_at,
+            last_active=info.last_active,
+            turn_count=info.turn_count,
+            working_dir=info.working_directory,
+            name=info.title,
+            user_named=info.title_is_user_set,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Turn:
+    role: Literal["user", "agent"]
+    content: str
+    ts: float
+
+
+class SessionManager:
+    """TUI-facing view of one :class:`nooa.sessions.SessionHandle`.
+
+    The adapter deliberately contains no persistence implementation. Both the
+    native TUI and protocol hosts read and write the same session event schema.
+    """
+
+    def __init__(self, handle: SessionHandle) -> None:
+        self._handle = handle
+        self._storage = handle.storage
+        self.agent_cls = handle.info.agent
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        model: str = "",
+        agent_cls: str = "CodingAgent",
+        working_dir: str = "",
+        session_id: str | None = None,
+    ) -> SessionManager:
+        handle = SessionStore(SESSIONS_DIR).create(
+            model=model,
+            agent=agent_cls,
+            working_directory=working_dir,
+            host="tui",
+            session_id=session_id,
+            check_same_thread=False,
+        )
+        return cls(handle)
+
+    @classmethod
+    def open(cls, session_id: str) -> SessionManager:
+        return cls(SessionStore(SESSIONS_DIR).open(session_id, check_same_thread=False))
+
+    @property
+    def session_id(self) -> str:
+        return self._handle.id
+
+    @property
+    def model(self) -> str:
+        return self._handle.info.model
+
+    @property
+    def working_dir(self) -> str:
+        return self._handle.info.working_directory
+
+    @property
+    def agent_db_path(self) -> Path:
+        return self._handle.path
+
+    @property
+    def name(self) -> str | None:
+        return self._handle.info.title
+
+    @property
+    def user_named(self) -> bool:
+        return self._handle.info.title_is_user_set
+
+    @property
+    def turns(self) -> list[Turn]:
+        return self.load_turns(self.session_id)
+
+    def rename(self, name: str, user_named: bool = False) -> None:
+        self._handle.set_title(name, user_set=user_named)
+
+    def update_agent_cls(self, agent_cls: str) -> None:
+        # Agent class is immutable start metadata. This local value is retained
+        # only so a newly created session can inherit the active custom class.
+        self.agent_cls = agent_cls
+
+    def record_user(self, text: str):
+        return self._handle.record_user_message(text)
+
+    def close(self) -> None:
+        self._handle.close()
+
+    def as_markdown(self) -> str:
+        lines = [f"# Session {self.session_id[:8]}\n"]
+        for turn in self.turns:
+            prefix = "**You:**" if turn.role == "user" else "**NeMo OO Agents:**"
+            lines.append(f"{prefix}\n\n{turn.content}\n")
+        return "\n---\n\n".join(lines)
+
+    @classmethod
+    def list_sessions(cls, limit: int = 20) -> list[SessionMeta]:
+        return [
+            SessionMeta.from_info(info) for info in SessionStore(SESSIONS_DIR).list(limit=limit)
+        ]
+
+    @classmethod
+    def _read_meta(cls, path: Path) -> SessionMeta | None:
+        try:
+            return SessionMeta.from_info(SessionStore(path.parent).get(path.stem))
+        except (OSError, ValueError):
+            return None
+
+    @classmethod
+    def load_turns(cls, session_id: str) -> list[Turn]:
+        return [
+            Turn(role=turn.role, content=turn.content, ts=turn.timestamp)
+            for turn in SessionStore(SESSIONS_DIR).load_turns(session_id)
+        ]
+
+    @classmethod
+    def find_by_prefix(cls, prefix: str) -> list[str]:
+        return SessionStore(SESSIONS_DIR).find_by_prefix(prefix)
+
+    @classmethod
+    def delete_session(cls, session_id: str) -> bool:
+        deleted = SessionStore(SESSIONS_DIR).delete(session_id)
+        # Session-scoped memory is stored in a sidecar SQLite database.
+        delete_sqlite_database(SESSIONS_DIR / f"{session_id}-memory.db")
+        return deleted
+
+
+# Keep startup replay bounded for very long sessions.
+RESUME_MAX_TURNS = 20
+
+
+def build_resume_outputs(
+    session_db_path: Path,
+    session_id: str,
+    *,
+    in_nemo_term: bool = False,
+    max_turns: int | None = None,
+) -> list:
+    """Build interleaved conversation and legacy rich-content replay output."""
+    from .output import HistoryReplay, HistoryTurn, _RichReplayPayload
+
+    if max_turns is None:
+        max_turns = RESUME_MAX_TURNS
+
+    try:
+        connection = sqlite3.connect(str(session_db_path))
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            "SELECT event_type, data FROM events ORDER BY insertion_order"
+        ).fetchall()
+        connection.close()
+    except (OSError, sqlite3.Error):
+        rows = []
+
+    items: list[tuple[str, object]] = []
+    pending: list[HistoryTurn] = []
+    for row in rows:
+        try:
+            raw = json.loads(row["data"])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        event_type = row["event_type"]
+        if event_type in {"SessionUserMessage", "TUIUserInput"}:
+            content = raw.get("content", raw.get("text", ""))
+            if content:
+                pending.append(HistoryTurn(role="user", content=str(content)))
+        elif event_type in {"AgentMessage", "TUIAgentMessage"} and raw.get("content"):
+            pending.append(HistoryTurn(role="agent", content=str(raw["content"])))
+        elif event_type == "RichOutput" and in_nemo_term and raw.get("payload"):
+            if pending:
+                items.append(("turns", pending))
+                pending = []
+            items.append(("rich", raw["payload"]))
+    if pending:
+        items.append(("turns", pending))
+    if not items:
+        return []
+
+    total_turns = sum(len(data) for kind, data in items if kind == "turns")  # type: ignore[arg-type]
+    omitted = max(0, total_turns - max_turns) if max_turns else 0
+    if omitted:
+        remaining = omitted
+        kept: list[tuple[str, object]] = []
+        keeping = False
+        for kind, data in items:
+            if kind == "turns":
+                turns = data  # type: ignore[assignment]
+                if remaining >= len(turns):
+                    remaining -= len(turns)
+                    continue
+                if remaining:
+                    turns = turns[remaining:]
+                    remaining = 0
+                keeping = True
+                kept.append((kind, turns))
+            elif keeping:
+                kept.append((kind, data))
+        items = kept
+
+    turn_indices = [index for index, (kind, _) in enumerate(items) if kind == "turns"]
+    if not turn_indices:
+        return []
+    first, last = turn_indices[0], turn_indices[-1]
+    outputs: list = []
+    for index, (kind, data) in enumerate(items):
+        if kind == "turns":
+            outputs.append(
+                HistoryReplay(
+                    turns=data,
+                    session_id=session_id[:8] if index == first else "",
+                    show_header=index == first,
+                    show_footer=index == last,
+                    omitted_count=omitted if index == first else 0,
+                )
+            )
+        else:
+            outputs.append(_RichReplayPayload(payload=data))
+    return outputs

--- a/packages/nooa-cli/src/nooa_cli/tui/session_manager.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session_manager.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from typing import Literal
 
 from nooa.paths import get_project_dir
-from nooa.sessions import SessionHandle, SessionInfo, SessionStore
 from nooa.storage.sqlite import delete_sqlite_database
+from nooa_cli.sessions import SessionHandle, SessionInfo, SessionStore
 
 SESSIONS_DIR = get_project_dir("sessions")
 
@@ -60,7 +60,7 @@ class Turn:
 
 
 class SessionManager:
-    """TUI-facing view of one :class:`nooa.sessions.SessionHandle`.
+    """TUI-facing view of one :class:`nooa_cli.sessions.SessionHandle`.
 
     The adapter deliberately contains no persistence implementation. Both the
     native TUI and protocol hosts read and write the same session event schema.
@@ -84,7 +84,7 @@ class SessionManager:
             model=model,
             agent=agent_cls,
             working_directory=working_dir,
-            host="tui",
+            origin="tui",
             session_id=session_id,
             check_same_thread=False,
         )

--- a/packages/nooa-cli/src/nooa_cli/tui/settings.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/settings.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Layered YAML settings for the NeMo OO Agents TUI.
+
+This is the TUI half of the project's "one config story": TUI settings
+live in ``settings.yaml`` next to ``llm_config.yaml`` and ``secrets.yaml``,
+share the same directories, and are discovered through the same
+:func:`nooa.layered_config.load_layered_yaml` helper.
+
+The file is a direct serialisation of the :class:`Config` model tree
+(``tui:`` / ``agent:`` sections, Pydantic field names), so it
+round-trips: :func:`dump_settings` writes a config and :func:`load_settings`
+reads it back identically.
+
+Precedence (low → high, last wins) is the shared layered chain:
+
+1. Model defaults (in code).
+2. ``~/.config/nooa/settings.yaml`` (user).
+3. ``<project-root>/.nooa/settings.yaml`` (project).
+4. ``NEMO_OO_SETTINGS`` env var — comma-separated YAML paths.
+
+CLI flags are layered on top of this by :meth:`Config.load`.
+
+.. note::
+   This module lives in the CLI package rather than core because it
+   binds to :class:`Config`/:class:`TUIConfig`, which are defined here;
+   core cannot import them without a circular dependency. The *generic*
+   layered-loading machinery is in
+   :mod:`nooa.layered_config`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from .config import Config
+
+logger = logging.getLogger(__name__)
+
+SETTINGS_FILENAME = "settings.yaml"
+SETTINGS_ENV_VAR = "NEMO_OO_SETTINGS"
+
+# Per-field coercion when reading YAML scalars into config fields. We set
+# fields directly (no assignment-time validation), so Path-typed fields are
+# coerced here. Dotted path (section.field) → callable; unlisted = set as-is.
+_COERCE: dict[str, Any] = {
+    "tui.mcp_file": lambda v: Path(v),
+    "tui.trace_dir": lambda v: Path(v) if v is not None else None,
+}
+
+# Fields that are computed / runtime-only and must NOT be persisted or
+# applied from file (skills_dirs is derived from discovery + CLI in
+# Config.load; the no_* flags are per-invocation).
+_SKIP_FIELDS = {"tui.skills_dirs", "no_splash", "no_trace"}
+
+
+def load_settings(cfg: Config) -> Config:
+    """Apply layered ``settings.yaml`` onto *cfg* in place and return it.
+
+    Reads the merged settings dict (user → project → env, last wins,
+    ``null`` deletes) and sets matching config fields. Unknown keys
+    are warned about and skipped so a stale file never crashes startup.
+    """
+    from nooa.layered_config import load_layered_yaml
+
+    data = load_layered_yaml(SETTINGS_FILENAME, SETTINGS_ENV_VAR)
+    for section in ("tui", "agent"):
+        sect = data.get(section)
+        if isinstance(sect, dict):
+            _apply_section(getattr(cfg, section), sect, section)
+    return cfg
+
+
+def _apply_section(obj: Any, data: dict[str, Any], prefix: str) -> None:
+    """Recursively set config-model fields on *obj* from *data*."""
+    for key, value in data.items():
+        dotted = f"{prefix}.{key}"
+        if dotted in _SKIP_FIELDS:
+            continue
+        if not hasattr(obj, key):
+            logger.warning("Unknown settings key %r — ignoring", dotted)
+            continue
+        current = getattr(obj, key)
+        if isinstance(value, dict) and isinstance(current, BaseModel):
+            _apply_section(current, value, dotted)
+            continue
+        coerce = _COERCE.get(dotted)
+        setattr(obj, key, coerce(value) if coerce else value)
+
+
+def settings_to_dict(cfg: Config) -> dict[str, Any]:
+    """Serialise the persistable fields of *cfg* to a YAML-friendly dict.
+
+    Inverse of :func:`load_settings`: ``load_settings(Config()) ==``
+    a config built by applying ``settings_to_dict(Config())`` back.
+    Paths become strings; ``skills_dirs`` and runtime flags are omitted.
+    """
+    return {
+        "tui": _model_to_dict(cfg.tui, "tui"),
+        "agent": _model_to_dict(cfg.agent, "agent"),
+    }
+
+
+def _model_to_dict(obj: BaseModel, prefix: str) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for name in type(obj).model_fields:
+        dotted = f"{prefix}.{name}"
+        if dotted in _SKIP_FIELDS:
+            continue
+        value = getattr(obj, name)
+        if isinstance(value, BaseModel):
+            out[name] = _model_to_dict(value, dotted)
+        elif isinstance(value, Path):
+            out[name] = str(value)
+        elif isinstance(value, list):
+            out[name] = [str(v) if isinstance(v, Path) else v for v in value]
+        else:
+            out[name] = value
+    return out
+
+
+def dump_settings(cfg: Config) -> str:
+    """Return the YAML text for *cfg* (round-trips with :func:`load_settings`)."""
+    import yaml
+
+    return yaml.safe_dump(settings_to_dict(cfg), sort_keys=False)
+
+
+def settings_present() -> bool:
+    """True if a ``settings.yaml`` exists in any layer (user/project/env)."""
+    from nooa.layered_config import layered_paths
+
+    return bool(layered_paths(SETTINGS_FILENAME, SETTINGS_ENV_VAR))
+
+
+def settings_path(scope: Literal["project", "user"] = "project") -> Path:
+    """Return the writable ``settings.yaml`` path for *scope*."""
+    from nooa.paths import get_project_dir, get_user_dir
+
+    if scope == "project":
+        return get_project_dir(SETTINGS_FILENAME)
+    if scope == "user":
+        return get_user_dir(SETTINGS_FILENAME)
+    raise ValueError(f"Unknown settings scope: {scope!r}")
+
+
+def write_settings_updates(
+    updates: dict[tuple[str, ...], Any],
+    *,
+    scope: Literal["project", "user"] = "project",
+    dry_run: bool = False,
+) -> tuple[Path, dict[str, Any]]:
+    """Apply nested setting updates to one writable settings file.
+
+    ``updates`` maps dotted-path tuples like ``("tui", "default_model")``
+    to YAML-friendly values. Existing sibling keys are preserved. When
+    ``dry_run`` is true, the returned data is what would be written.
+    """
+    import yaml
+
+    path = settings_path(scope)
+    data: dict[str, Any] = {}
+    if path.exists():
+        loaded = yaml.safe_load(path.read_text())
+        if isinstance(loaded, dict):
+            data = loaded
+
+    for setting_path, value in updates.items():
+        _set_mapping_path(data, list(setting_path), value)
+
+    if not dry_run:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return path, data
+
+
+def delete_settings_value(
+    setting_path: tuple[str, ...],
+    *,
+    scope: Literal["project", "user"] = "project",
+    dry_run: bool = False,
+) -> tuple[Path, dict[str, Any], bool]:
+    """Delete one nested setting while preserving all sibling settings."""
+    import yaml
+
+    path = settings_path(scope)
+    data: dict[str, Any] = {}
+    if path.exists():
+        loaded = yaml.safe_load(path.read_text())
+        if isinstance(loaded, dict):
+            data = loaded
+
+    current: dict[str, Any] = data
+    parents: list[tuple[dict[str, Any], str]] = []
+    for part in setting_path[:-1]:
+        child = current.get(part)
+        if not isinstance(child, dict):
+            return path, data, False
+        parents.append((current, part))
+        current = child
+    deleted = current.pop(setting_path[-1], None) is not None
+    if not deleted:
+        return path, data, False
+
+    for parent, key in reversed(parents):
+        child = parent.get(key)
+        if isinstance(child, dict) and not child:
+            parent.pop(key)
+        else:
+            break
+    if not dry_run:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return path, data, True
+
+
+def _set_mapping_path(data: dict[str, Any], path: list[str], value: Any) -> None:
+    """Set ``data[path[0]]...[path[-1]]`` creating dictionaries as needed."""
+    current = data
+    for part in path[:-1]:
+        child = current.get(part)
+        if not isinstance(child, dict):
+            child = {}
+            current[part] = child
+        current = child
+    current[path[-1]] = value
+
+
+# Commented scaffold written on first run. Everything is commented out so
+# the file documents the schema without overriding any defaults.
+SETTINGS_TEMPLATE = """\
+# NeMo OO Agents — TUI settings
+#
+# Layered, last wins:
+#   1. built-in defaults
+#   2. this file (user:    ~/.config/nooa/settings.yaml)
+#   3. project file:        .nooa/settings.yaml
+#   4. $NEMO_OO_SETTINGS    (comma-separated YAML paths)
+#
+# All keys are optional; uncomment only what you want to change.
+# `null` removes a key inherited from a lower layer.
+
+tui:
+  # LLM model alias (from the unifiedllm registry) or a litellm model name.
+  # default_model: {default_model}
+
+  # Show the agent's Python execution panels.
+  # show_python: false
+
+  # Audit DONE turns and continue when autonomous work remains.
+  # Configure the judge model before enabling this.
+  # keep_going: false
+  # keep_going_model: nemotron3-nano-30b
+
+  # Long-term memory. "project" shares one store across project sessions;
+  # "session" uses a sidecar database for only the current session.
+  # Prefer /memory so the choice is persisted per agent.
+  # memory: off                 # off | session | project
+  # memory_path: .nooa/memory/memory.sqlite
+  # memory_owner: coding-agent
+
+  # Consolidate memory during idle windows. Prefer /reflection so the choice
+  # is persisted per agent. Generative reflection uses the current model.
+  # reflection: false
+  # reflection_generative: true
+  # reflection_debounce_s: 10.0
+  # reflection_grace_s: 0.5
+
+  # Vi keybindings in the input prompt.
+  # vi_mode: false
+
+  # Write trace files here (relative to project root, or ":project:").
+  # trace_dir: .nooa/traces
+
+  # Ordered toolbar items. Built-ins: time, model, cwd, context, session.
+  # toolbar_items: [time, model, context, session]
+
+  # MCP servers, declared inline (preferred over a separate .mcp.json).
+  # Keep secrets in the host environment. The TUI resolves ${VAR} only after
+  # you approve the exact server definition with `/mcp approve <name> <code>`.
+  # Repository config cannot approve itself; any config change invalidates trust.
+  # mcp_auto_connect: [maas]
+  # mcp_servers:
+  #   maas:
+  #     url: https://maas.stg.astra.nvidia.com/maas/confluence/mcp
+  #     transport: streamable-http
+  #     headers:
+  #       Authorization: "Bearer ${MAAS_API_KEY}"
+
+# agent:
+#   working_dir: "."
+#   summarization:
+#     policy: token_budget   # token_budget | none
+#     max_tokens: null       # null = 80% of the model's context window
+"""
+
+
+def render_settings_template(cfg: Config) -> str:
+    """Render the commented first-run scaffold for *cfg*.
+
+    Uses ``str.replace`` rather than ``str.format`` because the template
+    contains literal braces (e.g. ``${MAAS_API_KEY}`` in the gated MCP example)
+    that ``format()`` would treat as fields and raise ``KeyError`` on.
+    """
+    return SETTINGS_TEMPLATE.replace("{default_model}", cfg.tui.default_model)

--- a/packages/nooa-cli/src/nooa_cli/tui/splash.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/splash.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Splash screen for the Nemotron Agents TUI.
+
+A side-by-side lockup: the NVIDIA "eye" mark (green on its black square) next to
+the ``NEMOTRON / OO / AGENTS`` wordmark, sized to fit an 80-column terminal.
+
+The eye is half-block art (``█``/``▀``/``▄`` pack two pixel rows per line),
+downsampled from the official logo. The wordmark uses a hand-built full-block
+pixel font (each pixel is one solid ``█``) so the letters stay clean and chunky.
+The logo and the text block are the same height and share top/bottom edges.
+"""
+
+import time
+
+from rich.align import Align
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.text import Text
+
+NVIDIA_GREEN = "#76b900"
+BLACK = "#0a0a0a"
+STEEL_LO = "#6e7d8c"
+
+_EYE_W = 38  # columns
+_WORD_W = 40  # columns
+
+# fmt: off
+# NVIDIA eye mark (green on black square). Sized to the wordmark's full height
+# so the logo and the text block share the same top and bottom edges.
+_EYE_LINES: list[str] = [
+    "              ████████████████████████",
+    "              ████████████████████████",
+    "         ▄▄███      ▀▀████████████████",
+    "     ▄▄██▀▀   ████▄▄    ▀█████████████",
+    "  ▄▄██▀    ▄▄▄   ▀▀███▄   ▀███████████",
+    "▄███▀   ▄██▀▀ ▄▄     ▀██▄   ▀█████████",
+    "▀███   ███    ███▄  ▄███    ██████████",
+    " ▀███   ██▄   ████████▀   ▄███▀▀██████",
+    "  ▀███   ▀██▄ █████▀▀  ▄▄███▀    ▀▀███",
+    "    ▀██▄   ▀██      ▄▄███▀       ▄████",
+    "      ▀██▄▄   ███████▀▀      ▄▄███████",
+    "        ▀▀████          ▄▄▄███████████",
+    "              ▄▄▄▄▄███████████████████",
+    "              ████████████████████████",
+]
+
+# NEMOTRON / OO / AGENTS wordmark. The OO echoes the object-oriented heritage
+# and the eye mark.
+_WORD_LINES: list[str] = [
+    "█  █ ████ █   █ ████ ████ ███  ████ █  █",
+    "██ █ ██   ██ ██ █  █  ██  █  █ █  █ ██ █",
+    "█ ██ █    █ █ █ █  █  ██  ███  █  █ █ ██",
+    "█  █ ████ █   █ ████  ██  █ ██ ████ █  █",
+    "                                        ",
+    "               ████ ████                ",
+    "               █  █ █  █                ",
+    "               █  █ █  █                ",
+    "               ████ ████                ",
+    "                                        ",
+    "     ████ ████ ████ █  █ ████ ████      ",
+    "     █  █ █    ██   ██ █  ██  ██        ",
+    "     ████ █ ██ █    █ ██  ██    ██      ",
+    "     █  █ ████ ████ █  █  ██  ████      ",
+]
+# fmt: on
+
+# Plain-text marker kept for tests / log scraping.
+NEMOTRON_ASCII = "NEMOTRON OO AGENTS"
+NEMO_OO_ASCII = NEMOTRON_ASCII  # backwards-compatible alias
+
+
+def _render_lockup() -> Text:
+    """Render the eye + wordmark side by side as one styled block."""
+    text = Text(justify="left", no_wrap=True)
+    eye_style = f"{NVIDIA_GREEN} on {BLACK}"
+    word_style = NVIDIA_GREEN
+    for i, eye in enumerate(_EYE_LINES):
+        text.append(eye.ljust(_EYE_W), style=eye_style)
+        text.append("  ")
+        text.append(_WORD_LINES[i].ljust(_WORD_W), style=word_style)
+        if i < len(_EYE_LINES) - 1:
+            text.append("\n")
+    return text
+
+
+def show_splash(console: Console, delay: float = 0.8) -> None:
+    """Display the Nemotron Agents splash screen.
+
+    The splash stays on screen and scrolls off naturally as the user chats.
+
+    Args:
+        console: Rich console instance
+        delay: How long to pause after showing splash (seconds)
+    """
+    tagline = Align.center(
+        Text("object-oriented agents · licensed to vibe", style=f"italic {STEEL_LO}")
+    )
+
+    panel = Panel(
+        Group(Align.center(_render_lockup()), Text(""), tagline),
+        border_style=NVIDIA_GREEN,
+        padding=(1, 2),
+        expand=False,
+    )
+
+    console.print(Align.center(panel))
+    time.sleep(delay)

--- a/packages/nooa-cli/src/nooa_cli/tui/stream_forwarder.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/stream_forwarder.py
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Forward stray ``sys.stdout`` / ``sys.stderr`` writes into the TUI scrollback.
+
+Libraries (aiohttp, litellm, warnings, third-party logs, etc.) sometimes
+write directly to ``sys.stdout`` / ``sys.stderr``. Under
+prompt_toolkit those raw writes interleave with the TUI's cursor
+commands and corrupt the display.
+
+``_StrayStreamForwarder`` replaces the real stream with a line-buffered
+wrapper that routes each complete line through ``emit_block`` — the
+same pipeline the TUI uses for code previews and agent messages — so
+the output lands in the transcript above the prompt instead of over
+top of it. Styled with a small prefix (``·`` dim for stdout, ``!`` red
+for stderr) so the user can tell it apart from first-class output.
+
+Deduplication: repeated identical lines are collapsed into a single
+emission with a repeat count (e.g. ``· rate_limit (×5)``), reducing
+noise during LLM retry storms while still surfacing what happened.
+
+Installation order matters: wrap sys.stdout BEFORE the framework
+installs its own ``ContextVarStream`` wrapper. That way the framework's
+wrapper's ``_original`` becomes our forwarder, and agent-cell stdout
+capture still works — the framework only forwards when no contextvar
+buffer is set, i.e. exactly the stray-write case we care about.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+from collections.abc import Callable
+from typing import IO, Any
+
+# Strip ANSI escape sequences for pattern matching.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(s: str) -> str:
+    return _ANSI_RE.sub("", s)
+
+
+class _StrayStreamForwarder:
+    """Thread-safe line-buffered forwarder for stray stdout/stderr writes.
+
+    ``write()`` accumulates partial lines in an internal buffer and flushes
+    each complete line through ``emit_block`` as an ANSI-styled chunk.
+    Non-write attribute access (``encoding``, ``fileno``, etc.) falls
+    through to the wrapped stream so the object passes duck-type checks
+    elsewhere in the process (e.g. ``sys.stdout.isatty()``).
+
+    Deduplication: consecutive identical lines are collapsed. When a new
+    different line arrives (or ``flush()`` is called), the collapsed count
+    is emitted.
+    """
+
+    def __init__(
+        self,
+        original: IO[str],
+        emit_block: Callable[[str], None],
+        *,
+        prefix: str,
+        ansi_color: str,
+        on_stray: Callable[[str, str], None] | None = None,
+    ) -> None:
+        self._original = original
+        self._emit_block = emit_block
+        self._prefix = prefix
+        self._ansi_color = ansi_color
+        self._on_stray: Callable[[str, str], None] | None = on_stray
+        self._pending = ""
+        self._lock = threading.RLock()
+        # Dedup state
+        self._last_stripped: str = ""
+        self._last_line: str = ""
+        self._repeat_count: int = 0
+
+    # ── IO protocol ────────────────────────────────────────────────────
+
+    def write(self, data: str) -> int:
+        """Accept a write; emit each newline-terminated line via ``emit_block``.
+
+        Returns the number of characters accepted (following ``io.TextIOBase``).
+        """
+        if not data:
+            return 0
+        with self._lock:
+            buf = self._pending + data
+            lines = buf.split("\n")
+            self._pending = lines[-1]
+            complete = lines[:-1]
+            for line in complete:
+                self._emit_line(line)
+        return len(data)
+
+    def writelines(self, lines: list[str]) -> None:
+        for line in lines:
+            self.write(line)
+
+    def flush(self) -> None:
+        """Flush any buffered partial line.
+
+        Libraries that write ``"foo"`` then ``flush()`` without a trailing
+        newline still want ``foo`` visible; flushing treats the pending
+        buffer as a complete line.
+        """
+        with self._lock:
+            pending = self._pending
+            self._pending = ""
+            if pending:
+                self._emit_line(pending)
+            self._flush_dedup()
+
+    # ── internals ──────────────────────────────────────────────────────
+
+    # Patterns suppressed entirely — pure noise for TUI users.
+    _NOISE_PATTERNS = (
+        "Give Feedback / Get Help:",
+        "LiteLLM.Info:",
+        "Provider List: https://docs.litellm.ai/docs/providers",
+        "LiteLLM completion()",
+        "litellm.litellm_core_utils",
+    )
+
+    def _emit_line(self, line: str) -> None:
+        """Wrap a single line in the configured ANSI style and emit it."""
+        # Suppress purely empty/whitespace lines.
+        stripped = _strip_ansi(line).strip()
+        if not stripped:
+            return
+
+        # Suppress known noise patterns.
+        if any(pat in stripped for pat in self._NOISE_PATTERNS):
+            self._notify_stray(stripped, "suppressed")
+            return
+
+        # Deduplication: collapse consecutive identical lines.
+        if stripped == self._last_stripped:
+            self._repeat_count += 1
+            self._notify_stray(stripped, "repeated")
+            return
+
+        # Different line — flush any pending dedup, then emit.
+        self._flush_dedup()
+        self._last_stripped = stripped
+        self._last_line = line
+        self._repeat_count = 1
+
+        styled = f"\x1b[{self._ansi_color}m{self._prefix}{line}\x1b[0m\n"
+        try:
+            self._emit_block(styled)
+        except Exception:
+            try:
+                self._original.write(styled)
+                self._original.flush()
+            except Exception:
+                pass
+
+        self._notify_stray(stripped, "emitted")
+
+    def _flush_dedup(self) -> None:
+        """Emit a repeat summary if the last line was seen more than once."""
+        if self._repeat_count > 1:
+            summary = f"{self._last_line} (×{self._repeat_count - 1} more)"
+            styled = f"\x1b[{self._ansi_color}m{self._prefix}{summary}\x1b[0m\n"
+            try:
+                self._emit_block(styled)
+            except Exception:
+                pass
+        self._last_stripped = ""
+        self._last_line = ""
+        self._repeat_count = 0
+
+    def _notify_stray(self, content: str, disposition: str) -> None:
+        """Notify the on_stray callback if registered."""
+        if self._on_stray is not None:
+            try:
+                self._on_stray(content, disposition)
+            except Exception:
+                pass
+
+    # ── duck-type compatibility ────────────────────────────────────────
+
+    def isatty(self) -> bool:
+        """Report non-tty so libraries don't emit ANSI escape sequences
+        (which would otherwise show up as literal characters in the line
+        the forwarder emits)."""
+        return False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._original, name)
+
+
+def install_stray_stream_capture(
+    emit_block: Callable[[str], None],
+    *,
+    on_stray: Callable[[str, str], None] | None = None,
+) -> Callable[[], None]:
+    """Install forwarders on ``sys.stdout`` and ``sys.stderr``.
+
+    Returns a zero-arg ``uninstall`` callable that restores whatever
+    streams were in place *before* this call. Call it in the TUI's
+    shutdown path so post-exit prints go back to the real terminal.
+
+    Args:
+        emit_block: Callable that renders a styled string block in the TUI.
+        on_stray: Optional callback ``(content, disposition)`` invoked for
+            every intercepted line. ``disposition`` is one of ``"emitted"``,
+            ``"repeated"``, or ``"suppressed"``. Use this to emit hidden
+            runtime events for later inspection via ``/events``.
+
+    Must be invoked on the main thread before any agent code runs —
+    otherwise the framework's ``ContextVarStream`` will be layered
+    underneath our wrapper and agent-cell stdout capture will break.
+    """
+    import sys
+
+    prior_stdout = sys.stdout
+    prior_stderr = sys.stderr
+
+    sys.stdout = _StrayStreamForwarder(  # type: ignore[assignment]
+        prior_stdout,
+        emit_block,
+        prefix="· ",
+        ansi_color="2",  # dim
+        on_stray=on_stray,
+    )
+    sys.stderr = _StrayStreamForwarder(  # type: ignore[assignment]
+        prior_stderr,
+        emit_block,
+        prefix="! ",
+        ansi_color="31",  # red
+        on_stray=on_stray,
+    )
+
+    def uninstall() -> None:
+        # Flush any partial lines before restoring original streams.
+        # Always restore even if flush raises, to avoid stale forwarder objects.
+        try:
+            if hasattr(sys.stdout, "flush"):
+                sys.stdout.flush()
+        except Exception:
+            pass
+        try:
+            if hasattr(sys.stderr, "flush"):
+                sys.stderr.flush()
+        except Exception:
+            pass
+        sys.stdout = prior_stdout
+        sys.stderr = prior_stderr
+
+    return uninstall

--- a/packages/nooa-cli/src/nooa_cli/tui/subapp.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/subapp.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Reusable in-app subview primitives for the terminal TUI.
+
+A subview is not a nested prompt_toolkit Application. It is a lightweight
+state/render/key object hosted by the single long-lived TUIApplication so
+terminal ownership, resize handling, mouse input, and focus remain centralized.
+
+Subview conventions:
+
+- ``q`` closes the subview.
+- ``Esc`` is contextual inside the subview (clear/cancel/back), not the generic
+  close key.
+- The host owns resize handling; subviews render to the supplied width/height and
+  must not launch their own prompt_toolkit Application or terminal-size poller.
+"""
+
+from __future__ import annotations
+
+import textwrap
+import unicodedata
+from typing import Literal, Protocol
+
+SubviewKeyResult = Literal["handled", "close", "ignored"]
+
+
+class InAppSubview(Protocol):
+    """A modal/browseable view hosted inside the main TUIApplication."""
+
+    title: str
+
+    def render(self, width: int, height: int) -> str:
+        """Render this view as an ANSI/plain terminal frame."""
+
+    def handle_key(self, action: str, value: str = "") -> SubviewKeyResult:
+        """Handle a semantic key action from the host application."""
+
+    def on_open(self) -> None:
+        """Called after the view becomes active."""
+
+    def on_close(self) -> None:
+        """Called just before the view is removed."""
+
+
+def normalize_key_result(result: SubviewKeyResult | bool | None) -> SubviewKeyResult:
+    """Accept legacy bool-ish handlers while new views return explicit results."""
+    if result == "close":
+        return "close"
+    if result == "ignored" or result is False:
+        return "ignored"
+    return "handled"
+
+
+class SensitiveTextPromptView:
+    """Single-line masked input hosted by the existing TUI application."""
+
+    _TEXT_ACTIONS = {
+        "quit": "q",
+        "resume": "r",
+        "slash": "/",
+        "j": "j",
+        "k": "k",
+    }
+
+    def __init__(self, title: str, message: str) -> None:
+        self.title = title
+        self.message = message
+        self._buffer = ""
+        self._scroll = 0
+        self._max_scroll = 0
+        self._page_size = 1
+        self.value: str | None = None
+
+    def render(self, width: int, height: int) -> str:
+        width = max(int(width), 40)
+        height = max(int(height), 4)
+        header = f" {self.title} ".ljust(width, "─")[:width]
+        footer = " ↑/↓ scroll  Enter submit  Esc cancel ".ljust(width, "─")[:width]
+        message_lines: list[str] = []
+        safe_message = "".join(
+            character
+            for character in self.message
+            if character in "\n\t"
+            or (
+                ord(character) >= 32
+                and not 127 <= ord(character) <= 159
+                and unicodedata.category(character) != "Cf"
+            )
+        )
+        for paragraph in safe_message.splitlines():
+            message_lines.extend(textwrap.wrap(paragraph, width=width) or [""])
+        body_height = max(height - 2, 0)
+        message_height = max(body_height - 2, 0)
+        self._page_size = max(message_height, 1)
+        self._max_scroll = max(len(message_lines) - message_height, 0)
+        self._scroll = min(max(self._scroll, 0), self._max_scroll)
+        visible = message_lines[self._scroll : self._scroll + message_height]
+        visible.extend("" for _ in range(max(message_height - len(visible), 0)))
+        visible.extend(("", "> " + ("•" * len(self._buffer))))
+        return "\n".join([header, *visible, footer])
+
+    def handle_key(self, action: str, value: str = "") -> SubviewKeyResult:
+        if action == "enter":
+            self.value = self._buffer.strip()
+            return "close"
+        if action == "escape":
+            self.value = None
+            return "close"
+        if action == "backspace":
+            self._buffer = self._buffer[:-1]
+            return "handled"
+        if action == "text":
+            self._buffer += value
+            return "handled"
+        if action in ("down", "scroll_down"):
+            self._scroll = min(self._scroll + 1, self._max_scroll)
+            return "handled"
+        if action in ("up", "scroll_up"):
+            self._scroll = max(self._scroll - 1, 0)
+            return "handled"
+        if action == "page_down":
+            self._scroll = min(self._scroll + self._page_size, self._max_scroll)
+            return "handled"
+        if action == "page_up":
+            self._scroll = max(self._scroll - self._page_size, 0)
+            return "handled"
+        if action == "home":
+            self._scroll = 0
+            return "handled"
+        if action == "end":
+            self._scroll = self._max_scroll
+            return "handled"
+        mapped = self._TEXT_ACTIONS.get(action)
+        if mapped is not None:
+            self._buffer += mapped
+            return "handled"
+        return "handled"
+
+    def on_open(self) -> None:
+        pass
+
+    def on_close(self) -> None:
+        pass

--- a/packages/nooa-cli/src/nooa_cli/tui/theme.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Theme system for NeMo OO Agents TUI.
+
+Four built-in palettes — all use the same Catppuccin key names so every
+consumer (frontend.py, console.py, splash.py) works without changes:
+
+  mocha   — Catppuccin Mocha (dark)         [default]
+  latte   — Catppuccin Latte (light)
+  vsdark  — Visual Studio Code Dark+
+  vslight — Visual Studio Code Light
+
+Usage::
+
+    from .theme import set_theme, COLORS, create_theme
+    set_theme("latte")          # switches COLORS in-place
+    console._theme = create_theme()
+"""
+
+from rich.theme import Theme
+
+# ---------------------------------------------------------------------------
+# Palettes — all share the same key names (Catppuccin semantic roles)
+# ---------------------------------------------------------------------------
+
+_MOCHA: dict[str, str] = {
+    "rosewater": "#f5e0dc",
+    "flamingo": "#f2cdcd",
+    "pink": "#f5c2e7",
+    "mauve": "#cba6f7",
+    "red": "#f38ba8",
+    "maroon": "#eba0ac",
+    "peach": "#fab387",
+    "yellow": "#f9e2af",
+    "green": "#a6e3a1",
+    "teal": "#94e2d5",
+    "sky": "#89dceb",
+    "sapphire": "#74c7ec",
+    "blue": "#89b4fa",
+    "lavender": "#b4befe",
+    "text": "#cdd6f4",
+    "subtext1": "#bac2de",
+    "subtext0": "#a6adc8",
+    "overlay2": "#9399b2",
+    "overlay1": "#7f849c",
+    "overlay0": "#6c7086",
+    "surface2": "#585b70",
+    "surface1": "#45475a",
+    "surface0": "#313244",
+    "base": "#1e1e2e",
+    "mantle": "#181825",
+    "crust": "#11111b",
+}
+
+_LATTE: dict[str, str] = {
+    "rosewater": "#dc8a78",
+    "flamingo": "#dd7878",
+    "pink": "#ea76cb",
+    "mauve": "#8839ef",
+    "red": "#d20f39",
+    "maroon": "#e64553",
+    "peach": "#fe640b",
+    "yellow": "#df8e1d",
+    "green": "#40a02b",
+    "teal": "#179299",
+    "sky": "#04a5e5",
+    "sapphire": "#209fb5",
+    "blue": "#1e66f5",
+    "lavender": "#7287fd",
+    "text": "#4c4f69",
+    "subtext1": "#5c5f77",
+    "subtext0": "#6c6f85",
+    "overlay2": "#7c7f93",
+    "overlay1": "#8c8fa1",
+    "overlay0": "#9ca0b0",
+    "surface2": "#acb0be",
+    "surface1": "#bcc0cc",
+    "surface0": "#ccd0da",
+    "base": "#eff1f5",
+    "mantle": "#e6e9ef",
+    "crust": "#dce0e8",
+}
+
+# VS Code Dark+ — keys mapped to Catppuccin semantic roles
+_VS_DARK: dict[str, str] = {
+    "rosewater": "#d4d4d4",
+    "flamingo": "#d4d4d4",
+    "pink": "#c586c0",
+    "mauve": "#c586c0",
+    "red": "#f48771",
+    "maroon": "#f48771",
+    "peach": "#ce9178",
+    "yellow": "#dcdcaa",
+    "green": "#4ec9b0",
+    "teal": "#4ec9b0",
+    "sky": "#9cdcfe",
+    "sapphire": "#9cdcfe",
+    "blue": "#569cd6",
+    "lavender": "#9cdcfe",
+    "text": "#d4d4d4",
+    "subtext1": "#9d9d9d",
+    "subtext0": "#808080",
+    "overlay2": "#6a6a6a",
+    "overlay1": "#5a5a5a",
+    "overlay0": "#4a4a4a",
+    "surface2": "#3e3e42",
+    "surface1": "#333337",
+    "surface0": "#252526",
+    "base": "#1e1e1e",
+    "mantle": "#181818",
+    "crust": "#111111",
+}
+
+# VS Code Light — keys mapped to Catppuccin semantic roles
+_VS_LIGHT: dict[str, str] = {
+    "rosewater": "#000000",
+    "flamingo": "#000000",
+    "pink": "#af00db",
+    "mauve": "#6f42c1",
+    "red": "#a31515",
+    "maroon": "#cd3131",
+    "peach": "#a31515",
+    "yellow": "#795e26",
+    "green": "#008000",
+    "teal": "#267f99",
+    "sky": "#0451a5",
+    "sapphire": "#0451a5",
+    "blue": "#0000ff",
+    "lavender": "#0451a5",
+    "text": "#000000",
+    "subtext1": "#444444",
+    "subtext0": "#6a6a6a",
+    "overlay2": "#737373",
+    "overlay1": "#919191",
+    "overlay0": "#b4b4b4",
+    "surface2": "#cccccc",
+    "surface1": "#e0e0e0",
+    "surface0": "#f0f0f0",
+    "base": "#ffffff",
+    "mantle": "#f8f8f8",
+    "crust": "#ececec",
+}
+
+THEMES: dict[str, dict[str, str]] = {
+    "mocha": _MOCHA,
+    "latte": _LATTE,
+    "vsdark": _VS_DARK,
+    "vslight": _VS_LIGHT,
+}
+
+# ---------------------------------------------------------------------------
+# Active palette — a mutable dict updated in-place so that callers who did
+# `from .theme import COLORS` keep a live reference after set_theme().
+# ---------------------------------------------------------------------------
+
+COLORS: dict[str, str] = dict(_MOCHA)
+_active_name: str = "mocha"
+
+
+def get_theme() -> str:
+    """Return the name of the currently active theme."""
+    return _active_name
+
+
+def set_theme(name: str) -> None:
+    """Switch the active theme.  Updates COLORS in-place.
+
+    Args:
+        name: One of ``mocha``, ``latte``, ``vsdark``, ``vslight``.
+
+    Raises:
+        ValueError: If *name* is not a known theme.
+    """
+    global _active_name
+    if name not in THEMES:
+        raise ValueError(f"Unknown theme {name!r}. Choose from: {', '.join(THEMES)}")
+    _active_name = name
+    COLORS.clear()
+    COLORS.update(THEMES[name])
+
+
+def create_theme() -> Theme:
+    """Build a Rich Theme from the currently active palette."""
+    c = COLORS
+    return Theme(
+        {
+            # NeMo OO Agents branding
+            "nooa": f"bold {c['mauve']}",
+            "tagline": f"italic {c['pink']}",
+            # User interface
+            "user": f"bold {c['green']}",
+            "user.prompt": f"bold {c['green']}",
+            "agent": f"bold {c['mauve']}",
+            "agent.response": c["text"],
+            # Status messages
+            "status": c["overlay1"],
+            "success": f"bold {c['green']}",
+            "error": f"bold {c['red']}",
+            "warning": f"bold {c['yellow']}",
+            "info": f"bold {c['blue']}",
+            # Panels and borders
+            "panel.border": c["mauve"],
+            "panel.title": f"bold {c['mauve']}",
+            # Tables
+            "table.header": f"bold {c['lavender']}",
+            "table.border": c["surface2"],
+            # Commands
+            "command": f"bold {c['sapphire']}",
+            "command.arg": c["sky"],
+            # Spinners
+            "spinner": c["mauve"],
+            "spinner.text": c["subtext1"],
+            # Code/technical
+            "code": c["peach"],
+            "path": c["teal"],
+            "number": c["peach"],
+            # History tags
+            "tag": c["blue"],
+            "tag.summary": c["yellow"],
+            # MCP/Skills
+            "mcp": c["sapphire"],
+            "skill": c["pink"],
+            "skill.active": f"bold {c['green']}",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+CATPPUCCIN_THEME = create_theme()

--- a/packages/nooa-cli/src/nooa_cli/tui/todo_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/todo_explorer.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Todo explorer — browse, inspect, and comment on agent todos."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .explorer_base import (
+    ExplorerConfig,
+    ExplorerModel,
+    ExplorerView,
+    wrap_plain_line,
+)
+from .subapp import SubviewKeyResult
+
+
+@dataclass
+class TodoExplorerRow:
+    """One todo item in the explorer list."""
+
+    id: str
+    title: str
+    status: str
+    deps: list[str]
+    created_at: str
+    notes: str
+    comments: list[Any]
+    search_text: str
+
+
+def build_todo_rows(todo_manager: Any) -> list[TodoExplorerRow]:
+    """Build explorer rows from the agent's TodoManager."""
+    rows: list[TodoExplorerRow] = []
+    if todo_manager is None:
+        return rows
+    for t in todo_manager.list_todos():
+        search_parts = [
+            t.id,
+            t.title,
+            t.status,
+            t.notes,
+            *[getattr(c, "body", str(c)) for c in t.comments],
+        ]
+        rows.append(
+            TodoExplorerRow(
+                id=t.id,
+                title=t.title,
+                status=t.status,
+                deps=list(t.deps),
+                created_at=t.created_at,
+                notes=t.notes,
+                comments=list(t.comments),
+                search_text="\n".join(search_parts),
+            )
+        )
+    return rows
+
+
+class TodoExplorerView(ExplorerView):
+    """In-app subview for browsing and interacting with todos."""
+
+    def __init__(self, todo_manager: Any) -> None:
+        self._todo_manager = todo_manager
+        rows = build_todo_rows(todo_manager)
+        model = ExplorerModel(rows)
+        config = ExplorerConfig(
+            title="Todo Explorer",
+            detail_pane_name="todo detail",
+            empty_message="No todos.",
+            no_match_message="No todos matching {query!r}.",
+            list_ratio=0.4,
+            actions={},
+        )
+        super().__init__(model, config)
+
+    def format_row(self, row: TodoExplorerRow, width: int) -> str:
+        status_icon = {
+            "open": "○",
+            "done": "✓",
+            "blocked": "●",
+        }.get(row.status, "?")
+        dep_hint = f" [needs: {', '.join(d[:8] for d in row.deps)}]" if row.deps else ""
+        comment_hint = f" 💬{len(row.comments)}" if row.comments else ""
+        line = f"{status_icon} [{row.id[:8]}] {row.title}{dep_hint}{comment_hint}"
+        return line[:width]
+
+    def detail_lines(self, row: TodoExplorerRow, width: int) -> list[str]:
+        width = max(int(width), 20)
+        lines: list[str] = [
+            f"Todo: [{row.id[:8]}] {row.title}",
+            f"Status: {row.status}",
+            f"Created: {row.created_at}",
+        ]
+        if row.deps:
+            lines.append(f"Dependencies: {', '.join(d[:8] for d in row.deps)}")
+        lines.append("")
+
+        if row.notes:
+            lines.append("Notes:")
+            for raw in row.notes.splitlines() or [""]:
+                lines.extend(wrap_plain_line(f"  {raw}", width))
+            lines.append("")
+
+        if row.comments:
+            lines.append(f"Comments ({len(row.comments)}):")
+            lines.append("")
+            for comment in row.comments:
+                ts = getattr(comment, "created_at", "")
+                body = getattr(comment, "body", str(comment))
+                lines.append(f"  [{ts}]")
+                for raw in body.splitlines() or [""]:
+                    lines.extend(wrap_plain_line(f"    {raw}", width))
+                lines.append("")
+        else:
+            lines.append("(no comments)")
+
+        return lines
+
+    def handle_action(self, action: str, row: Any) -> SubviewKeyResult:
+        return "ignored"

--- a/packages/nooa-cli/src/nooa_cli/tui/toolbar.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/toolbar.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Structured and extensible terminal toolbar items."""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from importlib.metadata import entry_points
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+TOOLBAR_ENTRY_POINT = "nooa_cli.tui.toolbar_items"
+ToolbarProvider = Callable[["ToolbarContext"], str | None]
+
+
+@dataclass(frozen=True, slots=True)
+class ToolbarContext:
+    model: str
+    working_directory: Path
+    context_usage: str
+    session_id: str | None = None
+    session_title: str | None = None
+    agent: Any = None
+
+
+class ToolbarRegistry:
+    """Named toolbar providers with optional package entry-point extensions."""
+
+    def __init__(self, *, load_plugins: bool = True) -> None:
+        self._providers: dict[str, ToolbarProvider] = {
+            "time": lambda _: datetime.datetime.now().strftime("%H:%M"),
+            "model": lambda context: _short_model_name(context.model),
+            "cwd": lambda context: context.working_directory.name or str(context.working_directory),
+            "context": lambda context: context.context_usage,
+            "session": _session_label,
+        }
+        if load_plugins:
+            self._load_plugins()
+
+    def register(self, name: str, provider: ToolbarProvider) -> None:
+        normalized = name.strip().lower()
+        if not normalized or any(character.isspace() for character in normalized):
+            raise ValueError(f"Invalid toolbar item name {name!r}")
+        self._providers[normalized] = provider
+
+    def names(self) -> tuple[str, ...]:
+        return tuple(sorted(self._providers))
+
+    def render(self, names: Iterable[str], context: ToolbarContext) -> str:
+        values: list[str] = []
+        for name in names:
+            provider = self._providers.get(name)
+            if provider is None:
+                continue
+            try:
+                value = provider(context)
+            except Exception:
+                logger.debug("Toolbar item %r failed", name, exc_info=True)
+                continue
+            if value:
+                values.append(str(value))
+        return " · ".join(values)
+
+    def _load_plugins(self) -> None:
+        try:
+            plugins = entry_points(group=TOOLBAR_ENTRY_POINT)
+        except Exception:
+            logger.debug("Toolbar entry-point discovery failed", exc_info=True)
+            return
+        for plugin in plugins:
+            try:
+                self.register(plugin.name, plugin.load())
+            except Exception:
+                logger.warning(
+                    "Toolbar provider %r could not be loaded", plugin.name, exc_info=True
+                )
+
+
+def _short_model_name(model: str) -> str:
+    return model.split("/")[-1].replace("claude-", "")
+
+
+def _session_label(context: ToolbarContext) -> str:
+    short_id = (context.session_id or "")[:8]
+    if context.session_title and short_id:
+        return f"{context.session_title} [{short_id}]"
+    return f"[{short_id}]" if short_id else ""

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1,0 +1,2217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Single long-lived ``prompt_toolkit.Application`` owning the whole TUI.
+
+This is the "Plan C" rewrite: one Application that holds output
+scrollback, the type-ahead queue region, the input buffer, and the
+status line. No ``patch_stdout`` and no per-turn ``prompt_async`` —
+so no handoff race that drops the first keystroke after the agent
+finishes.
+
+Grown incrementally against the failing tests in
+``tests/cli/test_tui_app_behavior.py``. Each method exists because a
+behaviour test needed it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import logging
+import re
+import shutil
+import threading
+from collections.abc import Awaitable, Callable
+from concurrent.futures import Future as ConcurrentFuture
+from dataclasses import dataclass
+from typing import Any
+
+from prompt_toolkit.application import Application
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.completion import Completer
+from prompt_toolkit.document import Document
+from prompt_toolkit.filters import Condition
+from prompt_toolkit.formatted_text import ANSI
+from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
+from prompt_toolkit.keys import Keys
+from prompt_toolkit.layout import ConditionalContainer, DynamicContainer, HSplit, Layout, Window
+from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
+from prompt_toolkit.layout.dimension import Dimension
+from prompt_toolkit.layout.margins import ScrollbarMargin
+from prompt_toolkit.layout.menus import CompletionsMenuControl
+from prompt_toolkit.layout.processors import BeforeInput
+
+from .completer import expand_mentions
+from .subapp import InAppSubview, normalize_key_result
+
+logger = logging.getLogger(__name__)
+
+
+class DispatcherExit(Exception):
+    """Raised by handle() to signal the dispatcher should exit.
+
+    Used by test harnesses. In the real TUI, exit is triggered by
+    /exit → external task cancellation, not by the LLM.
+    """
+
+
+# CSI + OSC stripper for the plain-text view of output_buffer. We keep
+# the original ANSI in _output_ansi; tests that assert on buffer text
+# don't want escape sequences in their comparisons.
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*\x07")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def terminal_cols(default: int = 120, minimum: int = 20) -> int:
+    """Live terminal column count, clamped to [``minimum``, ∞).
+
+    Wrapped so every caller gets the same fallback behaviour
+    (``(120, 24)`` on stat failure) and clamp. Used by the status-rule
+    renderer here and by the block-rendering helpers in ``Session`` so
+    rich text (user-message bars, full-width rules) spans the live
+    width and doesn't hardcode 120.
+    """
+    try:
+        return max(shutil.get_terminal_size((default, 24)).columns, minimum)
+    except Exception:
+        return default
+
+
+def format_session_rule(cols: int, label: str = "") -> list[tuple[str, str]]:
+    """Build the formatted-text fragments for the session rule.
+
+    The rule is rendered at ``cols - 1`` so it never occupies the terminal's
+    final column. A full-bleed line forces a cursor wrap to the next row on most
+    terminals; when ``run_in_terminal`` (``emit_block``) repaints this
+    non-full-screen app after a SIGWINCH resize, prompt_toolkit's erase is sized
+    to the pre-resize frame and can't reclaim that wrapped cell — leaving a stale
+    rule of the old width plus a blank gap line in the scrollback (the
+    "resize clutter" bug). Reserving the last column keeps the rule on one row so
+    the erase stays correct across resizes.
+    """
+    width = max(cols - 1, 1)
+    if label:
+        # Clamp the whole line (fill + space + label) to ``width`` so an
+        # over-long label can't push the rule into the final column and
+        # re-introduce the resize residue. The dash branch needs room for at
+        # least one dash plus the separating space, i.e. ``len(label) <=
+        # width - 2``; otherwise (including ``len(label) == width - 1``, where
+        # ``max(..., 1)`` would silently round the fill back up and re-bleed to
+        # the final column) fall straight through to truncation, keeping the
+        # label tail (the context-usage / id that matters most).
+        if len(label) > width - 2:
+            return [("class:rule.label", label[-width:])]
+        dashes = width - len(label) - 1  # >= 1 by the guard above
+        return [
+            ("class:rule", "─" * dashes + " "),
+            ("class:rule.label", label),
+        ]
+    return [("class:rule", "─" * width)]
+
+
+PROMPT_MARKER = "❯ "
+
+
+@dataclass
+class ReplayBlock:
+    raw: str
+    replay: Callable[[], str] | None = None
+    event_id: str | None = None
+    tags: frozenset[str] = frozenset()
+    keep: bool = False
+
+
+def _coalesce_string_into_queue(inq: Any, text: str) -> None:
+    """Push *text* onto *inq*, merging into the trailing item if it's a string.
+
+    UX policy, lifted out of ``submit_message``: when a user types
+    multiple lines in quick succession (Enter, type more, Enter), we
+    want one composite multi-line item — not N tiny items the agent
+    handles one-by-one. The trailing queued item is the merge target
+    only if it's a ``str``; non-string items (anything a producer puts
+    that isn't a typed message) are preserved unchanged.
+    """
+    tail = inq.pop_last()
+    if isinstance(tail, str):
+        inq.put(f"{tail}\n{text}")
+        return
+    if tail is not None:
+        inq.put(tail)
+    inq.put(text)
+
+
+async def _stop_litellm_worker() -> None:
+    """Stop litellm's global logging worker so its tasks don't outlive the loop."""
+    try:
+        from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+
+        await GLOBAL_LOGGING_WORKER.stop()
+    except Exception:
+        pass
+
+
+def _short_exception_message(exc: BaseException) -> str:
+    text = str(exc).strip().splitlines()[0] if str(exc).strip() else type(exc).__name__
+    return text[:160]
+
+
+class TUIApplication:
+    """Owns a single, long-lived ``prompt_toolkit.Application`` for the TUI."""
+
+    def __init__(
+        self,
+        agent: Any = None,
+        *,
+        on_command: Callable[[str], Awaitable[None] | None] | None = None,
+        on_bang: Callable[[str], Awaitable[None] | None] | None = None,
+        on_output: Callable[[Any], Awaitable[None] | None] | None = None,
+        completer: Completer | None = None,
+        session_label: Callable[[], str] | None = None,
+        config: Any = None,
+        full_screen: bool = True,
+    ) -> None:
+        """
+        Args:
+            agent: Object with an async ``handle()`` method that pumps
+                input queues (see ``BaseTUIAgent.handle``).
+            on_command: Called with the raw slash text (e.g. ``"/help"``)
+                whenever the user submits one. Session wires this to its
+                CommandRegistry. If omitted, commands still land in
+                ``commands_dispatched()`` for introspection but nothing
+                runs.
+            on_bang: Called with the bang body (e.g. ``"echo hi"`` for
+                ``!echo hi``). Session wires this to run_in_terminal +
+                bash. If omitted, bang commands are only recorded in
+                ``last_bang_command()``.
+            on_output: Called with structured ``Output`` values emitted by
+                dispatcher-level behavior. Session wires this to
+                ``frontend.render(...)``.
+            completer: Optional prompt_toolkit ``Completer`` for Tab
+                completion. When omitted no completion is offered.
+            full_screen: Native-scrollback mode. Transcript output is written to
+                the terminal scrollback; resize only redraws prompt_toolkit's
+                live input/status region.
+
+        The per-message echo ("queued → accepted" transition, user-bar
+        render, SessionUserMessage log) is wired on the agent's
+        ``_user_messages_in`` Channel via ``set_on_get``. The
+        dispatcher itself doesn't call back — that would double-fire
+        the echo when the agent dequeues a message mid-turn.
+        """
+        self.agent = agent
+        self._on_command = on_command
+        self._on_bang = on_bang
+        self._on_output = on_output
+        self._session_label_fn: Callable[[], str] | None = session_label
+        self._config = config
+
+        # Register a QueueManager notify callback to also start the
+        # dispatcher when items arrive on non-user channels while idle.
+        # Without this, slash commands or spawned jobs that produce output
+        # before any user message is typed would queue items indefinitely.
+        # The callback may fire from the agent-loop thread (spawned jobs),
+        # so schedule _ensure_dispatcher_task on the UI loop to avoid
+        # attaching dispatcher state to the wrong event loop.
+        if agent is not None:
+            qm = getattr(agent, "queue_manager", None)
+            if qm is not None:
+                qm.set_notify_callback(self._on_queue_notify)
+        self.full_screen = full_screen
+
+        # Output scrollback. Two parallel stores:
+        #   * ``output_buffer`` — plain-text view, used by tests and by
+        #     callers that want a printable transcript. ANSI stripped.
+        #   * ``_output_ansi`` — raw ANSI chunks rendered into the live
+        #     TUI via FormattedTextControl so Rich styling survives.
+        self.output_buffer = Buffer(read_only=False)
+        self._output_ansi: list[str] = []
+        # Retained transcript replay units. On resize we intentionally clear
+        # the visible screen + terminal scrollback, then rewrite these blocks.
+        self._replay_blocks: list[ReplayBlock] = []
+        self._untagged_replay_tail = 200
+
+        # In-app subview host. These are modal views inside the single
+        # prompt_toolkit Application, so resize/input remain owned by one app.
+        self._active_subview: InAppSubview | None = None
+        self._active_subview_done: asyncio.Future[None] | None = None
+        self._subview_control: FormattedTextControl | None = None
+
+        # Input window: where user keystrokes land. A caller (Session)
+        # passes the real CommandRegistry-backed completer; otherwise
+        # Tab produces no suggestions.
+        from prompt_toolkit.completion import DummyCompleter
+
+        self._completer = completer or DummyCompleter()
+        self.input_buffer = Buffer(
+            multiline=True,
+            completer=self._completer,
+            complete_while_typing=False,
+            accept_handler=self._accept_handler,
+        )
+
+        # History — a plain list of submitted strings and a cursor that
+        # tracks Up/Down navigation. Simpler than prompt_toolkit's async
+        # InMemoryHistory machinery, which requires juggling working_lines
+        # and _load_history_task to survive Buffer.reset().
+        self._history: list[str] = []
+        self._history_cursor: int | None = None
+
+        # Command routing. Slash (/foo) items are appended to
+        # ``_commands_dispatched``; bang (!foo) items set
+        # ``_last_bang_command`` and (in production) run via
+        # ``run_in_terminal``. Tests read both via the accessor methods.
+        self._commands_dispatched: list[str] = []
+        self._last_bang_command: str | None = None
+        # Set by _run_callback on the sync-error path; read by
+        # _drain_next to bail out of a pathological "every queued
+        # command raises" loop instead of dumping N stack traces.
+        self._last_sync_callback_raised: bool = False
+
+        # Status line fields — surfaced via status_text().
+        self._session_label: str = ""
+        self._spinner_frame: str = "⠋"
+        self._spinner_frames = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+        self._spinner_task: asyncio.Task | None = None
+        self._command_status_text: str = ""
+        self._command_queue_texts: list[str] = []
+
+        self._prompt_processor = BeforeInput(PROMPT_MARKER, style="class:prompt")
+        self._agent_task: asyncio.Future | None = None
+        self._agent_thread_future: ConcurrentFuture | None = None
+        self._agent_loop_task: asyncio.Task | None = None
+        self._agent_loop: asyncio.AbstractEventLoop | None = None
+        self._agent_sentinel: asyncio.Task | None = None
+        self._agent_thread: threading.Thread | None = None
+        self._agent_loop_ready = threading.Event()
+        self._agent_loop_stopped = threading.Event()
+        # True while the dispatcher is inside an ``agent.handle()`` call.
+        # ``is_thinking()`` checks this flag rather than the user_messages
+        # queue's waiter count — counting waiters conflated "dispatcher
+        # idle between turns" with "agent mid-turn awaiting clarification
+        # via await self.user_messages.get()". The latter case had the
+        # spinner stop while the agent was genuinely working.
+        self._in_respond: bool = False
+        self._agent_cancel_requested: bool = False
+        self._keep_going_tasks: set[asyncio.Task[Any]] = set()
+        self._keep_going_generation: int = 0
+
+        # Single producer-many-consumers path for transcript content:
+        # emit_block() enqueues one ANSI chunk; a single background task
+        # (started in run_async) drains the queue in order and writes
+        # each chunk via run_in_terminal → sys.__stdout__. Everything
+        # that used to have its own scheduling (patch_stdout proxy,
+        # direct run_in_terminal in _render_message, etc.) now funnels
+        # through this one queue — no races.
+        self._block_queue: asyncio.Queue[str] | None = None
+        self._consumer_task: asyncio.Task | None = None
+        # Diagnostic/test counter for fullscreen clear+rewrite replays.
+        self._fullscreen_invalidate_count = 0
+        self._last_rendered_size: tuple[int, int] | None = None
+        self._replay_columns_override: int | None = None
+        # Captured in run_async; used by emit_block for thread-safe
+        # enqueue without calling the deprecated asyncio.get_event_loop().
+        self._loop: asyncio.AbstractEventLoop | None = None
+        # Set by run_async's stdout/stderr forwarder install; called in
+        # the finally to restore the real streams.
+        self._uninstall_stream_capture: Callable[[], None] | None = None
+
+        # Let the FakeAgent (or real agent) push output into our scrollback
+        # without knowing about our internals.
+        if hasattr(agent, "emit"):
+            agent.emit = self.emit_block  # type: ignore[attr-defined]
+
+        kb = self._build_key_bindings()
+
+        # Transcript output lives in terminal scrollback. In full_screen mode we
+        # still use native scrollback during steady state, but on resize we clear
+        # the visible screen and replay the retained transcript at the new width.
+        self._output_window = None
+
+        # Queue window: shown whenever the agent has unconsumed messages
+        # in its user_messages input queue. Mirrors the pre-rewrite
+        # ``│ foo`` visual. Reads the hidden Channel
+        # (``_user_messages_in``) — the public ``user_messages`` is the
+        # LLM-facing OutputQueue facade and doesn't expose snapshot.
+        def _queue_pending() -> list[str]:
+            if self.agent is None:
+                return []
+            q = getattr(self.agent, "_user_messages_in", None)
+            if q is None:
+                return []
+            return q.snapshot()
+
+        def _queue_formatted():
+            rows = []
+            command_queue = list(self._command_queue_texts)
+            if command_queue:
+                noun = "command" if len(command_queue) == 1 else "commands"
+                rows.append(f"│ {len(command_queue)} {noun} queued")
+                for index, text in enumerate(command_queue):
+                    branch = "└─" if index == len(command_queue) - 1 else "├─"
+                    rows.append(f"{branch} {text}")
+            for text in _queue_pending():
+                for line in str(text).split("\n"):
+                    rows.append(f"│ {line}")
+            if not rows:
+                return []
+            return [("class:queue", "\n".join(rows))]
+
+        queue_window = ConditionalContainer(
+            Window(
+                FormattedTextControl(_queue_formatted, focusable=False),
+                dont_extend_height=True,
+            ),
+            filter=Condition(lambda: bool(_queue_pending()) or bool(self._command_queue_texts)),
+        )
+
+        input_window = Window(
+            BufferControl(
+                self.input_buffer,
+                input_processors=[self._prompt_processor],
+            ),
+            wrap_lines=True,
+            dont_extend_height=True,
+        )
+        self._input_window = input_window
+
+        # Status line at the bottom — shows spinner + session label.
+        def _status_formatted():
+            text = self.status_text()
+            return [("class:status", text)] if text else []
+
+        def _status_height() -> Dimension:
+            lines = self.status_text().splitlines()
+            height = max(1, len(lines))
+            return Dimension(min=height, max=height, preferred=height)
+
+        status_window = Window(
+            FormattedTextControl(_status_formatted, focusable=False),
+            height=_status_height,
+        )
+
+        # Session rule: right above the input, always visible. Shows the
+        # session name + short uuid + context-usage label, right-aligned
+        # on a horizontal rule. Built from formatted text (not a Rich
+        # Rule) so it re-measures with the live terminal width.
+        def _session_rule_formatted():
+            label = self._session_label_fn() if self._session_label_fn is not None else ""
+            return format_session_rule(terminal_cols(minimum=20), label)
+
+        session_rule = Window(
+            FormattedTextControl(_session_rule_formatted, focusable=False), height=1
+        )
+
+        # Completion menu as a real layout region below the input.
+        # Shrinks to the number of completions (with a 12-row cap) so the
+        # HSplit doesn't inflate it with blank space when there are only
+        # 1–4 matches. The stock ``CompletionsMenu`` wraps the control in
+        # a Window with ``Dimension(min=1, max=12)`` and no preferred
+        # size — HSplit then gives it the max height, leading to ugly
+        # gaps below the completions when the list is short. We use
+        # ``CompletionsMenuControl`` directly so we can set a dynamic
+        # ``preferred`` height based on the actual completion count.
+        _COMPLETION_MAX = 12
+
+        def _completions_height() -> Dimension:
+            state = self.input_buffer.complete_state
+            n = len(state.completions) if state is not None else 0
+            exact = min(max(n, 1), _COMPLETION_MAX)
+            # Exact, not a range. Dimension(min=1, max=12) lets HSplit
+            # inflate the window when extra space is available — which
+            # is exactly what causes growing blank gaps between the
+            # prompt and the menu as completions narrow.
+            return Dimension(min=exact, max=exact, preferred=exact)
+
+        completions_window = ConditionalContainer(
+            Window(
+                content=CompletionsMenuControl(),
+                width=Dimension(min=8),
+                height=_completions_height,
+                dont_extend_height=True,
+                right_margins=[ScrollbarMargin(display_arrows=True)],
+            ),
+            filter=Condition(lambda: self.input_buffer.complete_state is not None),
+        )
+
+        # Active bottom region (top → bottom):
+        #   status (spinner + optional badges)
+        #   queued command/type-ahead lines
+        #   session rule — always visible while at the transcript tail
+        #   input
+        #   completions (only while completing)
+        main_container = HSplit(
+            [
+                status_window,
+                queue_window,
+                session_rule,
+                input_window,
+                completions_window,
+            ],
+        )
+
+        def _subview_formatted():
+            view = self._active_subview
+            if view is None:
+                return ANSI("")
+            try:
+                size = self._app.output.get_size()
+                width, height = int(size.columns), int(size.rows)
+            except Exception:
+                width, height = terminal_cols(minimum=80), 24
+            return ANSI(view.render(width, height))
+
+        self._subview_control = FormattedTextControl(
+            _subview_formatted,
+            focusable=True,
+            show_cursor=False,
+        )
+        subview_window = Window(
+            self._subview_control,
+            wrap_lines=False,
+            always_hide_cursor=True,
+        )
+
+        def _root_container():
+            return subview_window if self._active_subview is not None else main_container
+
+        self._app = Application(
+            layout=Layout(
+                DynamicContainer(_root_container),
+                focused_element=input_window,
+            ),
+            key_bindings=kb,
+            full_screen=False,
+            before_render=self._before_render,
+            # When the Application exits (e.g. /exit), erase the live
+            # region so the final screen is just the committed
+            # scrollback. Otherwise the empty ❯ from the input line
+            # gets a final redraw right before exit and appears as a
+            # ghost prompt above '❯ /exit' in the transcript.
+            erase_when_done=True,
+            mouse_support=Condition(lambda: self._active_subview is not None),
+            # SIGWINCH already invalidates the app; the fallback poll creates a
+            # delayed second redraw (~0.5–0.75s later), which is visible in
+            # fullscreen subviews after terminal resize.
+            terminal_size_polling_interval=None,
+        )
+
+    async def open_event_explorer(self, event_manager: Any) -> None:
+        """Open the event explorer as an in-app subview."""
+        from .event_explorer import EventExplorerView
+
+        await self.open_subview(EventExplorerView(event_manager))
+
+    async def open_session_explorer(self) -> None:
+        """Open the session explorer as an in-app subview."""
+        from .session_explorer import SessionExplorerView
+
+        await self.open_subview(SessionExplorerView())
+
+    async def open_activity_overlay(self, outputs: list[Any]) -> None:
+        """Open the activity snapshot as an in-app subview."""
+        from .activity_overlay import ActivityOverlayView
+
+        await self.open_subview(ActivityOverlayView(outputs))
+
+    async def prompt_sensitive(self, title: str, message: str) -> str:
+        """Collect masked text without launching a nested terminal application."""
+        from .subapp import SensitiveTextPromptView
+
+        view = SensitiveTextPromptView(title, message)
+        await self.open_subview(view)
+        return view.value or ""
+
+    async def open_job_explorer(self) -> None:
+        """Open the job explorer as an in-app subview."""
+        from .job_explorer import JobExplorerView
+
+        qm = getattr(self.agent, "queue_manager", None) if self.agent else None
+        await self.open_subview(JobExplorerView(qm))
+
+    async def open_todo_explorer(self) -> None:
+        """Open the todo explorer as an in-app subview."""
+        from .todo_explorer import TodoExplorerView
+
+        todo_mgr = getattr(self.agent, "todo", None) if self.agent else None
+        await self.open_subview(TodoExplorerView(todo_mgr))
+
+    async def open_memory_explorer(self) -> None:
+        """Open the memory explorer as an in-app subview."""
+        from .memory_explorer import (
+            MemoryExplorerView,
+            build_memory_rows,
+            last_reflection_summary,
+        )
+
+        agent = self.agent
+        memory_skill = getattr(agent, "memory", None) if agent else None
+        manager = memory_skill._mgr if memory_skill is not None else None
+        if manager is None:
+            raise RuntimeError("Memory is not enabled for this agent (see /memory).")
+
+        rows, reflection_line = await self.agent_run_async(
+            lambda: (build_memory_rows(agent, manager), last_reflection_summary(manager))
+        )
+
+        def _forget(memory_id: str) -> None:
+            self.agent_run(lambda: manager.forget(memory_id))
+
+        def _mark_done(memory_id: str) -> None:
+            self.agent_run(lambda: manager.update(memory_id, status="done"))
+
+        await self.open_subview(
+            MemoryExplorerView(
+                rows,
+                forget=_forget,
+                mark_done=_mark_done,
+                last_reflection=reflection_line,
+            )
+        )
+
+    async def open_subview(self, view: InAppSubview) -> None:
+        """Open *view* inside the existing prompt_toolkit Application.
+
+        This is the reusable seam for future ToDo, Sessions, Jobs, Artifacts,
+        and similar browse/edit/comment panes. It deliberately does not launch
+        a nested Application; the host owns focus, key dispatch, resize, mouse,
+        and restoration to the main prompt. Host-level convention: ``q`` closes
+        the subview; ``Esc`` is reserved for contextual clear/cancel/back inside
+        the active view.
+        """
+        if self._active_subview_done is not None and not self._active_subview_done.done():
+            return
+        self._active_subview = view
+        loop = asyncio.get_running_loop()
+        self._active_subview_done = loop.create_future()
+        view.on_open()
+        if self._subview_control is not None:
+            self._app.layout.focus(self._subview_control)
+        if self._app.is_running:
+            self._app.invalidate()
+        try:
+            await self._active_subview_done
+        finally:
+            active = self._active_subview
+            if active is not None:
+                active.on_close()
+            self._active_subview = None
+            self._active_subview_done = None
+            try:
+                self._app.layout.focus(self._input_window)
+            except Exception:
+                pass
+            if self._app.is_running:
+                self._app.invalidate()
+
+    def _prefill_input(self, text: str) -> None:
+        self.input_buffer.text = text
+        self.input_buffer.cursor_position = len(text)
+        try:
+            self.input_buffer.cancel_completion()
+        except Exception:
+            pass
+
+    def _close_subview(self) -> None:
+        done = self._active_subview_done
+        if done is not None and not done.done():
+            done.get_loop().call_soon_threadsafe(done.set_result, None)
+        else:
+            active = self._active_subview
+            if active is not None:
+                active.on_close()
+            self._active_subview = None
+        if self._app.is_running:
+            self._app.invalidate()
+
+    @property
+    def active_subview(self) -> InAppSubview | None:
+        """Currently hosted in-app subview, if any."""
+        return self._active_subview
+
+    @property
+    def _event_explorer_model(self) -> Any | None:
+        """Compatibility accessor for tests while /events moves to subviews."""
+        view = self._active_subview
+        return getattr(view, "model", None)
+
+    def _subview_key(self, event, action: str, value: str = "") -> bool:
+        view = self._active_subview
+        if view is None:
+            return False
+        result = normalize_key_result(view.handle_key(action, value))
+        if result == "close":
+            pending_input = getattr(view, "pending_input", None)
+            self._close_subview()
+            if pending_input:
+                self._prefill_input(str(pending_input))
+        elif result == "ignored":
+            return False
+        if self._app.is_running:
+            self._app.invalidate()
+        return True
+
+    # ── key bindings --------------------------------------------------
+
+    def _build_key_bindings(self):  # returns KeyBindingsBase (union of KB + merged)
+        from .input_handler import create_key_bindings as _legacy_kb
+
+        # The legacy bindings handle Enter (accept_handler dispatches to
+        # our _accept_handler), Alt+Enter / Ctrl+J (newline), Tab (via
+        # default bindings), and the slash/bang auto-trigger that re-opens
+        # the completion menu as the user types a command.
+        legacy = _legacy_kb(vi_mode=False)
+
+        kb = KeyBindings()
+        subview_active = Condition(lambda: self._active_subview is not None)
+        subview_inactive = ~subview_active
+
+        @kb.add(Keys.Any, filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "text", event.data)
+
+        @kb.add(Keys.BracketedPaste, filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "text", event.data)
+
+        @kb.add("escape", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "escape")
+
+        @kb.add("q", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "quit")
+
+        @kb.add("r", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "resume")
+
+        @kb.add("enter", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "enter")
+
+        @kb.add("/", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "slash")
+
+        @kb.add("backspace", filter=subview_active, eager=True)
+        @kb.add("c-h", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "backspace")
+
+        @kb.add("tab", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "tab")
+
+        @kb.add("down", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "down")
+
+        @kb.add("j", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "j")
+
+        @kb.add("up", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "up")
+
+        @kb.add("k", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "k")
+
+        @kb.add("pagedown", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "page_down")
+
+        @kb.add("pageup", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "page_up")
+
+        @kb.add("home", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "home")
+
+        @kb.add("end", filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "end")
+
+        @kb.add(Keys.ScrollDown, filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "scroll_down")
+
+        @kb.add(Keys.ScrollUp, filter=subview_active, eager=True)
+        def _(event):
+            self._subview_key(event, "scroll_up")
+
+        @kb.add("c-c", filter=subview_active, eager=True)
+        def _(event):
+            self._close_subview()
+
+        @kb.add("c-c", filter=subview_inactive)
+        def _(event):
+            # If an agent is running, C-c cancels the task and keeps the
+            # buffer. Otherwise it exits the app.
+            if self.request_agent_cancel(source="ctrl-c"):
+                return
+            event.app.exit()
+
+        @kb.add("c-d", filter=subview_inactive)
+        def _(event):
+            event.app.exit()
+
+        @kb.add("tab", filter=subview_inactive)
+        def _(event):
+            # Standard Tab: open the menu if closed, advance to the
+            # next option if already open. start_completion doesn't
+            # advance on repeat presses — complete_next does both.
+            buf = event.current_buffer
+            if buf.complete_state is None:
+                buf.start_completion(select_first=True)
+            else:
+                buf.complete_next()
+
+        @kb.add("s-tab", filter=subview_inactive)
+        def _(event):
+            buf = event.current_buffer
+            if buf.complete_state is not None:
+                buf.complete_previous()
+
+        # Empty-buffer Up: queue pop wins over history — matches the
+        # pre-rewrite typeahead UX (pop the last thing you typed while
+        # the agent was working so you can edit it). In the forever-loop
+        # model we pop from the agent's user_messages queue; items
+        # already consumed by the agent can't be edited.
+        empty_buffer = Condition(lambda: self.input_buffer.text == "") & subview_inactive
+
+        def _pop_last_queued() -> str | None:
+            if self.agent is None:
+                return None
+            q = getattr(self.agent, "_user_messages_in", None)
+            if q is None:
+                return None
+            item = q.pop_last()
+            return None if item is None else str(item)
+
+        @kb.add("up", filter=empty_buffer)
+        def _(event):
+            popped = _pop_last_queued()
+            if popped is not None:
+                self.input_buffer.text = popped
+                self.input_buffer.cursor_position = len(popped)
+                return
+            self._history_navigate(-1)
+
+        @kb.add("down", filter=empty_buffer)
+        def _(event):
+            self._history_navigate(+1)
+
+        # Esc: soft-cancel the agent while preserving the queue. Any
+        # messages already submitted during the turn are delivered as
+        # the next respond() via the done-callback.
+        @kb.add("escape", filter=subview_inactive)
+        def _(event):
+            self.request_agent_cancel(source="escape")
+
+        # Merge so our bindings (C-c with is_thinking awareness, Tab
+        # trigger, Esc cancel, empty-buffer Up/Down for queue+history)
+        # override the legacy bindings for the same keys, while legacy
+        # still provides Enter → accept_handler, Alt+Enter newline, and
+        # the slash auto-trigger characters.
+        return merge_key_bindings([legacy, kb])
+
+    # ── submission pipeline -------------------------------------------
+
+    def _accept_handler(self, buffer: Buffer) -> bool:
+        """prompt_toolkit accept_handler — invoked by ``validate_and_handle()``.
+
+        Slash/bang commands dispatch immediately. Plain text is pushed
+        onto ``agent.user_messages`` via ``submit_message`` — the agent's
+        forever-loop ``handle()`` picks it up when it calls
+        ``self.get_next_input(...)``.
+
+        Returning False tells prompt_toolkit to reset the buffer (clear
+        the text, don't keep it as the working-lines tip).
+        """
+        text = buffer.text
+        if not text.strip():
+            return False
+        if not self._history or self._history[-1] != text:
+            self._history.append(text)
+        self._history_cursor = None
+
+        if text.startswith("/"):
+            self._commands_dispatched.append(text)
+            self._run_callback(self._on_command, text)
+            return False
+        if text.startswith("!"):
+            body = text[1:].strip()
+            self._last_bang_command = body
+            self._run_callback(self._on_bang, body)
+            return False
+
+        self.submit_message(expand_mentions(text))
+        return False
+
+    def _run_callback(
+        self,
+        cb: Callable[[str], Awaitable[None] | None] | None,
+        arg: str,
+    ) -> asyncio.Task | None:
+        """Invoke one user callback; return the scheduled Task or None.
+
+        Used by every "call an out-of-band function from the TUI" site
+        (``on_command``, ``on_bang``).
+
+        - Synchronous callback (``None``, a regular function, or one
+          that raised): returns ``None``. Errors are surfaced into the
+          scrollback so an unhandled exception doesn't vanish into
+          asyncio's default handler. Sets
+          ``self._last_sync_callback_raised = True`` so callers that
+          loop (``_drain_next``) can stop after a failure.
+        - Coroutine callback: scheduled as a Task and returned. The
+          caller can ``add_done_callback`` on it to chain follow-up
+          work (e.g. ``_drain_next`` for queued commands). Errors
+          inside the coroutine are surfaced via a done-callback
+          installed here.
+        """
+        self._last_sync_callback_raised = False
+        if cb is None:
+            return None
+        try:
+            result = cb(arg)
+        except BaseException as exc:
+            self.emit_block(f"[callback error] {type(exc).__name__}: {exc}\n")
+            self._last_sync_callback_raised = True
+            return None
+        if not asyncio.iscoroutine(result):
+            return None
+        task = asyncio.ensure_future(result)
+
+        def _report(t: asyncio.Task) -> None:
+            if t.cancelled():
+                return
+            exc = t.exception()
+            if exc is not None:
+                self.emit_block(f"[callback error] {type(exc).__name__}: {exc}\n")
+
+        task.add_done_callback(_report)
+        return task
+
+    def _ensure_spinner_task(self) -> None:
+        """Start a background task cycling the spinner frame while the
+        agent is thinking. Invalidates the app each tick so the status
+        line redraws; exits when ``is_thinking()`` becomes False."""
+        if self._spinner_task is not None and not self._spinner_task.done():
+            return
+
+        async def _animate() -> None:
+            i = 0
+            try:
+                while self.is_thinking():
+                    self._spinner_frame = self._spinner_frames[i % len(self._spinner_frames)]
+                    if self._app.is_running:
+                        self._app.invalidate()
+                    i += 1
+                    await asyncio.sleep(0.08)
+            finally:
+                # Paint once after the agent stops so "thinking…" clears.
+                if self._app.is_running:
+                    self._app.invalidate()
+
+        self._spinner_task = asyncio.ensure_future(_animate())
+
+    def _history_navigate(self, direction: int) -> None:
+        """Move the history cursor by ``direction`` (-1=older, +1=newer)."""
+        if not self._history:
+            return
+        if self._history_cursor is None:
+            if direction < 0:
+                self._history_cursor = len(self._history) - 1
+            else:
+                return
+        else:
+            new = self._history_cursor + direction
+            if new < 0 or new >= len(self._history):
+                return
+            self._history_cursor = new
+        self.input_buffer.text = self._history[self._history_cursor]
+        self.input_buffer.cursor_position = len(self.input_buffer.text)
+
+    async def swap_agent(self, new_agent: Any) -> None:
+        """Hot-swap the agent the dispatcher drives (slash-inception).
+
+        The dispatcher loop binds ``agent = self.agent`` once per loop and
+        then calls ``agent.handle()`` each turn, so a bare ``self.agent =
+        new`` reassignment does NOT redirect a *running* loop. This method
+        performs the supported swap: acknowledge-cancel the current dispatcher,
+        re-point ``self.agent``, and lazy-restart it bound to the new agent.
+
+        The new agent is expected to already share the OLD agent's live
+        channels (``queue_manager`` / ``_user_messages_in`` / readers) and
+        ``_render_message`` callback, so input routing + output rendering are
+        unchanged. Any messages already queued on the shared
+        ``_user_messages_in`` (e.g. an inception seed prompt) are drained by
+        the fresh dispatcher and delivered to ``new_agent.handle``.
+
+        Call via ``await app.agent_run_async(lambda: app.swap_agent(new))`` so
+        cancellation is acknowledged before the new dispatcher starts.
+        """
+        self._swapping = True
+        old_task = self._agent_task
+        old_thread_future = self._agent_thread_future
+        await self.cancel_agent_turn(source="swap")
+
+        # In the two-loop TUI, the UI-loop wrapper future's done callback can
+        # lag behind the acknowledged agent-loop cancellation. Detach the old
+        # wrapper before re-arming so a stale callback cannot block or clobber
+        # the dispatcher bound to the new agent.
+        if old_task is self._agent_task:
+            self._agent_task = None
+        if old_thread_future is self._agent_thread_future:
+            self._agent_thread_future = None
+        self._agent_cancel_requested = False
+        self._agent_loop_task = None
+        self._swapping = False
+        self.agent = new_agent
+
+        # Re-arm a fresh dispatcher bound to the new agent if there's pending
+        # input (the inception seed prompt is already queued by the caller).
+        q = getattr(new_agent, "_user_messages_in", None)
+        if q is not None and q.qsize() > 0:
+            self._ensure_dispatcher_task()
+
+    def submit_message(self, user_message: str) -> None:
+        """Treat ``user_message`` as if the user just typed and submitted it.
+
+        Pushes the text onto the agent's user_messages Channel and
+        lazy-starts the dispatcher task. The user-bar echo + session
+        bookkeeping fire later — on the Channel's ``on_get`` hook,
+        when the message is actually dequeued — so a message typed
+        while the agent is working only shows in the queue pane until
+        its turn comes up. The hook fires identically whether the
+        dispatcher or agent code pulls the item.
+
+        Consecutive submissions that land while the dispatcher is
+        still busy are *merged* into the trailing queue item with a
+        ``\\n`` separator. That preserves the old "type, Enter, type,
+        Enter → one message" UX where the user is composing a
+        multi-line thought across several Enters.
+
+        Public so ``Session`` can submit a message programmatically —
+        e.g. a slash command that returns an ``agent_message``
+        (``/compact``) and wants to drive the same path as a typed
+        message.
+        """
+        if self.agent is None:
+            return
+        inq = getattr(self.agent, "_user_messages_in", None)
+        if inq is None:
+            self.emit_block("[submit_message dropped] agent has no user_messages queue\n")
+            return
+        _coalesce_string_into_queue(inq, user_message)
+        self._ensure_dispatcher_task()
+
+    def _ensure_dispatcher_task(self, *, start_with_race: bool = False) -> None:
+        """Start the per-turn dispatcher if not already live.
+
+        The dispatcher is the outer loop around ``agent.handle()``:
+        it reads the result's ``kind`` and waits on the appropriate
+        queue before calling ``handle()`` again with the new
+        ``(queue_name, item)`` notification.
+
+        Lazy-started: on session load there's no task. The first user
+        message triggers submit_message → put onto user_messages →
+        _ensure_dispatcher_task → dispatcher loops until exit or cancel.
+        """
+        if self.agent is None:
+            return
+        if self._agent_task is not None and not self._agent_task.done():
+            return
+        if self._agent_cancel_requested:
+            return
+        if self._loop is None:
+            # Unit tests call submit_message() without running the prompt_toolkit
+            # app. In that mode there is no UI loop to protect, so preserve the
+            # old same-loop dispatcher semantics.
+            self._agent_task = asyncio.ensure_future(
+                self._dispatcher_loop(start_with_race=start_with_race)
+            )
+            self._agent_loop_task = self._agent_task
+        else:
+            agent_loop = self._ensure_agent_loop()
+
+            async def _run_dispatcher() -> None:
+                self._agent_loop_task = asyncio.current_task()
+                try:
+                    await self._dispatcher_loop(start_with_race=start_with_race)
+                finally:
+                    self._agent_loop_task = None
+
+            self._agent_thread_future = asyncio.run_coroutine_threadsafe(
+                _run_dispatcher(), agent_loop
+            )
+            self._agent_task = asyncio.wrap_future(self._agent_thread_future)
+        self._agent_task.add_done_callback(self._on_agent_done)
+        self._ensure_spinner_task()
+
+    def _ensure_agent_loop(self) -> asyncio.AbstractEventLoop:
+        """Return the dedicated event loop used for agent dispatch.
+
+        prompt_toolkit stays on the main/UI loop. Agent turns run here so
+        synchronous work inside ``agent.handle()`` cannot freeze input or
+        spinner redraws.
+
+        A sentinel task keeps the loop alive even when the dispatcher exits
+        (gl-212). Without it, run_forever() returns when the last task
+        finishes, closing the loop and invalidating BashSession pipes.
+        """
+        if self._agent_loop is not None and self._agent_loop.is_running():
+            return self._agent_loop
+
+        self._agent_loop_ready.clear()
+        self._agent_loop_stopped.clear()
+        loop = asyncio.new_event_loop()
+        self._agent_loop = loop
+
+        def _run() -> None:
+            asyncio.set_event_loop(loop)
+
+            def _suppress_litellm_task_destroyed(
+                loop_: asyncio.AbstractEventLoop, context: dict
+            ) -> None:
+                msg = context.get("message", "")
+                if "Task was destroyed" in msg:
+                    task = context.get("task")
+                    if task is not None and "LoggingWorker" in repr(task):
+                        return
+                loop_.default_exception_handler(context)
+
+            loop.set_exception_handler(_suppress_litellm_task_destroyed)
+
+            # gl-212 sentinel: keeps run_forever() alive across dispatcher restarts.
+            async def _sentinel():
+                await asyncio.Future()
+
+            self._agent_sentinel = loop.create_task(_sentinel(), name="agent-loop-sentinel")
+            self._agent_loop_ready.set()
+            try:
+                loop.run_forever()
+            finally:
+                try:
+                    pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+                    for task in pending:
+                        task.cancel()
+                    if pending:
+                        loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+                    loop.run_until_complete(loop.shutdown_asyncgens())
+                finally:
+                    loop.close()
+                    self._agent_loop_stopped.set()
+
+        self._agent_thread = threading.Thread(
+            target=_run,
+            name="nemo-tui-agent-loop",
+            daemon=True,
+        )
+        self._agent_thread.start()
+        if not self._agent_loop_ready.wait(timeout=5.0):
+            raise RuntimeError("Agent event loop thread failed to start within 5s")
+        return loop
+
+    async def _stop_agent_loop(self) -> None:
+        """Stop the dedicated agent loop without blocking prompt_toolkit."""
+        loop = self._agent_loop
+        thread = self._agent_thread
+        if loop is None:
+            return
+        if self._agent_thread_future is not None and not self._agent_thread_future.done():
+            self._agent_thread_future.cancel()
+        # Cancel the sentinel so run_forever() can exit (gl-212).
+        # Use call_soon_threadsafe: sentinel lives on the agent loop thread.
+        if self._agent_sentinel is not None:
+            loop.call_soon_threadsafe(self._agent_sentinel.cancel)
+            self._agent_sentinel = None
+        # Gracefully stop litellm's global logging worker so its tasks are
+        # cancelled before we tear down the loop (prevents "Task was destroyed
+        # but it is pending!" warnings from orphaned _worker_loop tasks).
+        try:
+            fut = asyncio.run_coroutine_threadsafe(_stop_litellm_worker(), loop)
+            await asyncio.wait_for(asyncio.wrap_future(fut), timeout=2.0)
+        except Exception:
+            pass
+        loop.call_soon_threadsafe(loop.stop)
+        if thread is not None and thread.is_alive():
+            await asyncio.to_thread(thread.join, 5.0)
+            if thread.is_alive():
+                logger.warning("Agent loop thread did not stop within 5s — abandoning")
+        self._agent_loop = None
+        self._agent_thread = None
+        self._agent_thread_future = None
+
+    async def _dispatcher_loop(self, *, start_with_race: bool = False) -> None:
+        """Drive ``agent.handle()`` turn-by-turn until DispatcherExit or cancellation.
+
+        The "queued → accepted" echo (user-bar render, SessionUserMessage
+        log) is fired by the user_messages channel's ``on_get`` hook —
+        installed by ``Session`` — not from this dispatcher loop. That
+        way the echo is symmetric: it fires both when the dispatcher
+        takes the next user_messages item AND when the agent dequeues
+        one mid-turn via ``await self.user_messages.get()``. Calling
+        the hook here would double-render the dispatcher case.
+
+        ``QueueManager.race()`` returns ``list[(name, item)]`` —
+        currently always length 1, but the list shape is the contract
+        so future ``deliver=`` modes can return more items per call
+        without changing the dispatcher's loop body.
+        """
+        from nooa.runtime.channels import Channel
+
+        from .output import StopReasonOutput
+
+        agent = self.agent
+        assert agent is not None
+
+        user_messages_in: Channel = agent._user_messages_in
+        qm = agent.queue_manager
+
+        if start_with_race:
+            notification = await self._next_race_notification(qm)
+            if not notification:
+                return
+        else:
+            # Wait for the first user message (already queued by submit_message
+            # that started us). qsize()>0 → get() returns immediately.
+            item = await user_messages_in.get()
+            notification: dict[str, list] = {"user_messages": [item]}
+        self._in_respond = True
+        self._on_dispatcher_dequeued()
+
+        while True:
+            self._in_respond = True
+            try:
+                # Reflection owns only idle windows. Any channel notification
+                # that is about to start a turn interrupts it first.
+                runner = self._reflection_runner()
+                if runner is not None:
+                    await runner.interrupt()
+                result = await agent.handle(notification)
+            except DispatcherExit:
+                return
+            finally:
+                self._in_respond = False
+
+            result_explanation = getattr(result, "explanation", "")
+            logger.info(
+                "[DISPATCHER] handle() returned kind=%r explanation=%r",
+                result.kind,
+                result_explanation,
+            )
+
+            reflection_deferred = False
+            keep_going_enabled, keep_going_model = self._keep_going_state(agent)
+            if keep_going_enabled and str(result.kind) == "DONE":
+                if keep_going_model:
+                    reflection_deferred = True
+                    generation = self._keep_going_generation
+                    task = asyncio.create_task(
+                        self._run_keep_going_audit(
+                            agent,
+                            result,
+                            keep_going_model,
+                            generation,
+                        ),
+                        name="keep-going-audit",
+                    )
+                    self._keep_going_tasks.add(task)
+                    task.add_done_callback(self._keep_going_tasks.discard)
+                    logger.info("[DISPATCHER] keep-going audit scheduled")
+                else:
+                    logger.warning("keep-going enabled without keep_going_model; audit skipped")
+                    await self._emit_structured_output(
+                        StopReasonOutput(
+                            "KEEP_GOING",
+                            "disabled: configure a model with /keep-going model <model-id>",
+                        )
+                    )
+
+            if not reflection_deferred:
+                self._schedule_reflection(agent)
+
+            if result_explanation:
+                await self._emit_structured_output(
+                    StopReasonOutput(result.kind, result_explanation)
+                )
+
+            # Every stop reason uses the same dispatcher wake path: race all
+            # declared channels/events and re-enter with the first arrival.
+            # ``kind`` explains why the agent stopped; it does not select a
+            # different queue primitive.
+            running = qm.running_handles()
+            if running:
+                now = datetime.datetime.now().strftime("%H:%M:%S")
+                lines = "".join(f"  ⠿ {h.label}\n" for h in running)
+                self.emit_block(
+                    f"\x1b[2m{now} waiting — {len(running)} job(s) running:\n{lines}\x1b[0m"
+                )
+
+            # Race all channels for the next item(s). Returns
+            # [(name, item)] for queue-mode winners or [] for
+            # event-triggered wakes (events already in the prompt).
+            try:
+                items = await qm.race()
+            except ValueError:
+                return
+            # Show which job(s) fired.
+            if running and items:
+                now = datetime.datetime.now().strftime("%H:%M:%S")
+                fired_names = {name for name, _ in items}
+                fired = [h for h in running if h.name in fired_names]
+                for h in fired:
+                    self.emit_block(f"\x1b[32m  ✓ {h.label} — {now}\x1b[0m\n")
+
+            # Drain all pending items across all channels, grouped by name.
+            pending = self._drain_pending_queue_items(qm, items)
+            if "user_messages" in pending or "slash_commands" in pending:
+                self._invalidate_keep_going_audits()
+            self._in_respond = True
+            self._on_dispatcher_dequeued()
+            notification = pending
+
+    async def _emit_structured_output(self, output: Any) -> None:
+        """Emit dispatcher-owned structured output through the frontend path.
+
+        Unit tests and minimal harnesses may construct ``TUIApplication``
+        without a frontend callback; in that case keep the terminal fallback so
+        existing same-loop dispatcher tests can inspect ``emit_block`` output.
+        """
+        if self._on_output is not None:
+            result = self._on_output(output)
+            if result is not None:
+                await result
+            return
+        display_text = getattr(output, "display_text", None)
+        if callable(display_text):
+            self.emit_block(f"\x1b[2m{display_text()}\x1b[0m\n")
+
+    def _keep_going_state(self, agent: Any) -> tuple[bool, str | None]:
+        vars_obj = getattr(agent, "vars", None)
+        if vars_obj is not None and "tui_keep_going" in vars_obj:
+            enabled = bool(vars_obj.get("tui_keep_going"))
+        else:
+            enabled = bool(
+                self._config is not None
+                and getattr(getattr(self._config, "tui", None), "keep_going", False)
+            )
+
+        if vars_obj is not None and "tui_keep_going_model" in vars_obj:
+            value = vars_obj.get("tui_keep_going_model")
+        else:
+            value = getattr(getattr(self._config, "tui", None), "keep_going_model", None)
+        model = str(value).strip() if value is not None else ""
+        if not model or model.lower() == "none":
+            model = ""
+        return enabled, model or None
+
+    def _invalidate_keep_going_audits(self) -> None:
+        """Make in-flight audits stale and cancel them on their owning loop."""
+        self._keep_going_generation += 1
+        loop = self._agent_loop
+        for task in list(self._keep_going_tasks):
+            try:
+                task_loop = task.get_loop()
+            except RuntimeError:
+                task_loop = None
+            if loop is not None and loop.is_running() and task_loop is loop:
+                loop.call_soon_threadsafe(task.cancel)
+            else:
+                task.cancel()
+
+    async def _run_keep_going_audit(
+        self, agent: Any, result: Any, model: str, generation: int
+    ) -> None:
+        """Audit DONE in the background and queue a current continuation."""
+        from .output import StopReasonOutput
+
+        try:
+            from .keep_going import build_keep_going_prompt
+
+            keep_going_prompt = await build_keep_going_prompt(agent, result, model=model)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if generation != self._keep_going_generation:
+                return
+            message = _short_exception_message(exc)
+            logger.warning("keep-going audit failed: %s", message)
+            await self._emit_structured_output(
+                StopReasonOutput(
+                    "KEEP_GOING",
+                    f"judge failed: {message}; use /keep-going off or /keep-going model <model-id>",
+                )
+            )
+            self._schedule_reflection(agent)
+            return
+        if generation != self._keep_going_generation:
+            return
+        if not keep_going_prompt:
+            self._schedule_reflection(agent)
+            return
+        enabled, current_model = self._keep_going_state(agent)
+        if not enabled or current_model != model:
+            self._schedule_reflection(agent)
+            return
+
+        prompt_text = getattr(keep_going_prompt, "prompt", keep_going_prompt)
+        display_reason = getattr(
+            keep_going_prompt,
+            "display_reason",
+            "continuing unfinished work",
+        )
+        if display_reason:
+            await self._emit_structured_output(StopReasonOutput("KEEP_GOING", str(display_reason)))
+
+        system_messages_in = getattr(agent, "_system_messages_in", None)
+        if system_messages_in is not None:
+            system_messages_in.put(str(prompt_text))
+            logger.info("[DISPATCHER] keep-going queued system continuation prompt")
+            return
+
+        user_messages_in = getattr(agent, "_user_messages_in", None)
+        if user_messages_in is not None:
+            user_messages_in.put(str(prompt_text))
+            logger.info("[DISPATCHER] keep-going queued fallback user continuation prompt")
+            return
+        self._schedule_reflection(agent)
+
+    def _reflection_runner(self) -> Any | None:
+        """Return the configured runner and wire its thread-safe repaint hook."""
+        agent = self.agent
+        runner = getattr(agent, "_tui_reflection_runner", None) if agent is not None else None
+        if runner is not None:
+            runner.invalidate = self._invalidate_for_reflection
+        return runner
+
+    def _schedule_reflection(self, agent: Any) -> None:
+        runner = getattr(agent, "_tui_reflection_runner", None)
+        if runner is not None:
+            runner.invalidate = self._invalidate_for_reflection
+            runner.on_response_done()
+
+    def _invalidate_for_reflection(self) -> None:
+        loop = self._loop
+
+        def _invalidate() -> None:
+            if self._app.is_running:
+                self._app.invalidate()
+
+        if loop is not None and loop.is_running():
+            loop.call_soon_threadsafe(_invalidate)
+        else:
+            _invalidate()
+
+    async def interrupt_reflection(self, *, teardown: bool = False) -> None:
+        """Stop idle reflection on its owning loop, optionally detaching it."""
+        runner = self._reflection_runner()
+        if runner is None:
+            return
+
+        async def _stop() -> None:
+            await runner.interrupt()
+            if teardown:
+                runner.teardown()
+
+        await self.agent_run_async(_stop)
+
+    async def _next_race_notification(self, qm: Any) -> dict[str, list]:
+        """Wait for QueueManager output and drain all pending queue items."""
+        try:
+            items = await qm.race()
+        except ValueError:
+            return {}
+        return self._drain_pending_queue_items(qm, items)
+
+    def _on_queue_notify(self) -> None:
+        """QueueManager notify callback: (re)start the dispatcher on any put.
+
+        Registered via ``QueueManager.set_notify_callback``. May fire from
+        the agent-loop thread (spawned jobs), so marshal onto the UI loop
+        before touching dispatcher state to avoid attaching it to the wrong
+        event loop.
+
+        Fires for every channel put (user/system messages included), but
+        ``_ensure_dispatcher_task`` is idempotent — it early-returns when a
+        dispatcher is already running — so an extra call when a turn is
+        already in flight is a harmless no-op.
+        """
+        ui_loop = self._loop
+        if ui_loop is not None and ui_loop.is_running():
+            ui_loop.call_soon_threadsafe(lambda: self._ensure_dispatcher_task(start_with_race=True))
+        else:
+            self._ensure_dispatcher_task(start_with_race=True)
+
+    def _drain_pending_queue_items(self, qm: Any, items: list[tuple[str, Any]]) -> dict[str, list]:
+        """Group race winners and already-buffered queue items by channel name."""
+        pending: dict[str, list] = {}
+        for name, value in items:
+            pending.setdefault(name, []).append(value)
+        for ch in qm.channels().values():
+            if ch.mode == "queue":
+                for val in ch.drain():
+                    pending.setdefault(ch.name, []).append(val)
+        return pending
+
+    def _restart_dispatcher_if_pending(self) -> None:
+        """Restart the dispatcher if user messages or non-user work is pending."""
+        q = getattr(self.agent, "_user_messages_in", None) if self.agent else None
+        if q is not None and q.qsize() > 0:
+            self._ensure_dispatcher_task()
+        elif self._has_pending_or_running_non_user_work():
+            self._ensure_dispatcher_task(start_with_race=True)
+
+    def _has_pending_or_running_non_user_work(self) -> bool:
+        """True when post-cancel background channel work should wake the agent."""
+        agent = self.agent
+        qm = getattr(agent, "queue_manager", None) if agent is not None else None
+        if qm is None:
+            return False
+        if qm.running_handles():
+            return True
+        for name, ch in qm.channels().items():
+            if name == "user_messages":
+                continue
+            if ch.mode == "queue" and not ch.is_empty():
+                return True
+        return False
+
+    def request_agent_cancel(self, *, source: str = "escape") -> bool:
+        """Request cancellation of the current agent turn.
+
+        Esc/Ctrl-C cancel the active agent turn only. They deliberately do
+        not cancel ``QueueManager.spawn`` jobs: those are background work and
+        remain controlled by ``queue_manager.cancel(...)``/``shutdown()``.
+
+        The TUI runs agent turns on a dedicated event loop in production. Do
+        not cancel the UI-loop ``wrap_future`` proxy directly; that proxy can
+        look done before the real agent-loop task has observed cancellation
+        and finished cleanup. Cancelling the source task keeps the status in
+        ``cancelling...`` until the done callback receives acknowledgement.
+        """
+        task = self._agent_task
+        if task is None or task.done():
+            return False
+        if self._agent_cancel_requested:
+            return source != "ctrl-c"
+        if not self._in_respond and source not in {"swap", "session"}:
+            return False
+
+        self._agent_cancel_requested = True
+        self._invalidate_keep_going_audits()
+        if self._app.is_running:
+            self._app.invalidate()
+        self._ensure_spinner_task()
+
+        loop_task = self._agent_loop_task
+        if loop_task is not None:
+            try:
+                target_loop = loop_task.get_loop()
+            except RuntimeError:
+                target_loop = None
+            if target_loop is not None and target_loop.is_running():
+
+                def _cancel_loop_task() -> None:
+                    if not loop_task.done():
+                        loop_task.cancel()
+
+                target_loop.call_soon_threadsafe(_cancel_loop_task)
+            else:
+                loop_task.cancel()
+        elif self._agent_thread_future is not None and not self._agent_thread_future.done():
+            # The dispatcher coroutine may be running before its task pointer is
+            # published back to the UI thread. Cancel the source future rather
+            # than the UI wrapper so cancellation is still delivered to the
+            # agent loop and acknowledged through _on_agent_done.
+            self._agent_thread_future.cancel()
+        else:
+            task.cancel()
+        return True
+
+    async def cancel_agent_turn(self, *, source: str = "escape") -> bool:
+        """Request turn cancellation and await the dispatcher acknowledgement."""
+        task = self._agent_task
+        if task is None or task.done():
+            return False
+        if not self.request_agent_cancel(source=source):
+            return False
+        try:
+            current_loop = asyncio.get_running_loop()
+            current_task = asyncio.current_task()
+            task_loop = task.get_loop() if hasattr(task, "get_loop") else None
+            loop_task = self._agent_loop_task
+            loop_task_loop = loop_task.get_loop() if loop_task is not None else None
+
+            if task_loop is current_loop and task is not current_task:
+                await task
+            elif (
+                loop_task is not None
+                and loop_task is not current_task
+                and loop_task_loop is current_loop
+            ):
+                await loop_task
+            elif self._agent_thread_future is not None:
+                await asyncio.wrap_future(self._agent_thread_future)
+            elif task is not current_task:
+                while not task.done():
+                    await asyncio.sleep(0)
+        except asyncio.CancelledError:
+            pass
+        return True
+
+    async def shutdown_agent_queue_manager(
+        self, *, agent: Any | None = None, flush: bool = False
+    ) -> None:
+        """Shutdown an agent's QueueManager on the loop that owns spawned jobs."""
+        target = self.agent if agent is None else agent
+        qm = getattr(target, "queue_manager", None) if target is not None else None
+        if qm is None:
+            return
+
+        async def _shutdown_and_flush() -> None:
+            await qm.shutdown()
+            if flush:
+                for name in qm.names():
+                    ch = qm.get_channel(name)
+                    if ch.mode == "queue":
+                        ch.flush()
+
+        loop = self._agent_loop
+        if loop is not None and loop.is_running():
+            await self.agent_run_async(_shutdown_and_flush)
+        else:
+            await _shutdown_and_flush()
+
+    def _on_dispatcher_dequeued(self) -> None:
+        """React to a just-dequeued item: redraw queue pane, restart spinner.
+
+        Without this, the queue pane can show stale contents until the
+        next event happens to trigger a redraw (spinner tick, user key,
+        scrollback write). And the spinner animation task exits when
+        ``is_thinking()`` was False between turns — a new turn wants
+        it running again.
+        """
+        ui_loop = self._loop
+        try:
+            on_ui_loop = asyncio.get_running_loop() is ui_loop
+        except RuntimeError:
+            on_ui_loop = False
+        if ui_loop is not None and not on_ui_loop:
+            ui_loop.call_soon_threadsafe(self._on_dispatcher_dequeued)
+            return
+        if self._app.is_running:
+            self._app.invalidate()
+        self._ensure_spinner_task()
+
+    def _on_agent_done(self, task: asyncio.Task) -> None:
+        """Fired when the dispatcher exits (STOP, error, or cancellation).
+
+        On cancellation OR exception with messages still pending we
+        lazy-restart so neither soft-cancel (Esc) nor a crashed turn
+        strands queued input — the user can keep typing and the next
+        message wakes the dispatcher again. STOP exits cleanly.
+        """
+        if task is not self._agent_task:
+            return
+        if task.cancelled():
+            self._agent_cancel_requested = False
+            self._agent_loop_task = None
+            was_swapping = getattr(self, "_swapping", False)
+            was_session_transition = getattr(self, "_session_transitioning", False)
+            suppress_cancel_restart = was_swapping or was_session_transition
+            if was_swapping:
+                self._swapping = False
+            if not suppress_cancel_restart:
+                self.emit_block("\x1b[33m✗ Interrupted agent turn.\x1b[0m\n")
+            if self._app.is_running:
+                self._app.invalidate()
+            q = getattr(self.agent, "_user_messages_in", None) if self.agent else None
+            if not suppress_cancel_restart:
+                if q is not None and q.qsize() > 0:
+                    self._ensure_dispatcher_task()
+                elif self._has_pending_or_running_non_user_work():
+                    self._ensure_dispatcher_task(start_with_race=True)
+            return
+        self._agent_cancel_requested = False
+        self._agent_loop_task = None
+        exc = task.exception()
+        if exc is not None:
+            self.emit_block(f"Agent error: {exc}\n")
+        self._restart_dispatcher_if_pending()
+
+    # ── agent_run: dispatch to agent thread ----------------------------
+
+    def agent_run(self, fn):
+        """Run *fn* on the agent-loop thread, blocking the caller until done.
+
+        Use for any operation that mutates agent state from outside the
+        dispatcher loop (slash commands, shutdown, renderer attach/detach).
+        If no agent loop is running (unit tests, pre-startup), executes
+        inline on the caller's thread.
+
+        *fn* is a zero-arg callable. If it returns a coroutine, the
+        coroutine is awaited on the agent loop. Otherwise the callable
+        itself is scheduled on the agent loop via ``call_soon_threadsafe``.
+
+        Returns whatever *fn* (or the coroutine) returns. Propagates
+        exceptions. Times out after 30 seconds.
+        """
+        loop = self._agent_loop
+        if loop is None or not loop.is_running():
+            # No agent loop (tests or pre-startup) — run inline.
+            result = fn()
+            if asyncio.iscoroutine(result):
+                raise TypeError("agent_run() with a coroutine requires a running agent loop")
+            return result
+
+        # Guard: if already on the agent loop, run inline to avoid deadlock.
+        # (agent_run blocks the caller waiting for the loop to execute the
+        # wrapper — if the caller IS the loop, that's a guaranteed hang.)
+        import threading
+
+        if getattr(loop, "_thread_id", None) == threading.current_thread().ident:
+            result = fn()
+            if asyncio.iscoroutine(result):
+                raise TypeError(
+                    "agent_run() called from agent loop with a coroutine — "
+                    "use 'await' directly instead"
+                )
+            return result
+
+        # Schedule on agent loop. Use an async wrapper so both sync and
+        # async callables go through run_coroutine_threadsafe uniformly.
+        async def _wrapper():
+            result = fn()
+            if asyncio.iscoroutine(result):
+                return await result
+            return result
+
+        future = asyncio.run_coroutine_threadsafe(_wrapper(), loop)
+        try:
+            return future.result(timeout=30)
+        except TimeoutError:
+            future.cancel()
+            raise
+
+    async def agent_run_async(self, fn):
+        """Like ``agent_run``, but awaitable — never blocks the calling loop.
+
+        Slash commands run as tasks on the prompt_toolkit UI loop. Calling the
+        blocking ``agent_run`` from there freezes the UI loop (``future.result``)
+        while the agent loop is busy — starving the block-queue consumer
+        (``self.message()`` output stops appearing) and wedging prompt_toolkit's
+        redraw (status-bar / input flicker). Awaiting the cross-loop future
+        instead yields control so the UI keeps painting and draining output.
+
+        Falls back to inline execution when there is no separate agent loop
+        (tests / pre-startup) or when already on the agent loop.
+        """
+        loop = self._agent_loop
+        if loop is None or not loop.is_running():
+            result = fn()
+            if asyncio.iscoroutine(result):
+                return await result
+            return result
+
+        import threading
+
+        if getattr(loop, "_thread_id", None) == threading.current_thread().ident:
+            result = fn()
+            if asyncio.iscoroutine(result):
+                return await result
+            return result
+
+        async def _wrapper():
+            result = fn()
+            if asyncio.iscoroutine(result):
+                return await result
+            return result
+
+        future = asyncio.run_coroutine_threadsafe(_wrapper(), loop)
+        try:
+            return await asyncio.wait_for(asyncio.wrap_future(future), timeout=30)
+        except TimeoutError:
+            future.cancel()
+            raise
+
+    # ── output pipeline -----------------------------------------------
+
+    def clear_transcript(self) -> None:
+        """Clear live transcript buffers and fullscreen resize replay retention."""
+        self._output_ansi.clear()
+        self._replay_blocks.clear()
+        self.output_buffer.set_document(Document(""), bypass_readonly=True)
+
+    def _on_stray_output(self, content: str, disposition: str) -> None:
+        """Record stray stdout/stderr intercepts as hidden runtime events."""
+        agent = self.agent
+        if agent is None:
+            return
+        em = getattr(agent, "event_manager", None)
+        if em is None:
+            return
+        try:
+            from nooa.events import DebugTrace
+
+            em.add(DebugTrace(content=f"[stray:{disposition}] {content[:200]}"))
+        except Exception:
+            pass
+
+    def emit_block(
+        self,
+        text: str,
+        replay: Callable[[], str] | None = None,
+        *,
+        event_id: str | None = None,
+        tags: set[str] | frozenset[str] | None = None,
+        keep: bool = False,
+    ) -> None:
+        """Enqueue one ANSI-bearing block for the transcript.
+
+        This is the ONE public contract for writing to the transcript:
+        all producers (activity lines, code cells, agent markdown,
+        interrupt notices, user echo) call this. A single consumer
+        task drains the queue and writes each block in FIFO order via
+        ``run_in_terminal`` → ``sys.__stdout__``. No races.
+
+        Thread-safe: any mutation of prompt_toolkit state (``Buffer``
+        document, which fires callbacks synchronously) is routed through
+        ``call_soon_threadsafe`` so it always runs on the loop thread.
+        ``list.append`` on ``_output_ansi`` is already GIL-safe.
+        """
+        if not text:
+            return
+
+        # GIL-safe: list.append is atomic. Reading from off-thread is fine.
+        self._output_ansi.append(text)
+        self._replay_blocks.append(
+            ReplayBlock(
+                raw=text,
+                replay=replay,
+                event_id=str(event_id) if event_id is not None else None,
+                tags=frozenset(str(t) for t in (tags or ())),
+                keep=keep,
+            )
+        )
+
+        # Before the consumer is up (pre-run_async) we're single-threaded
+        # by construction — safe to touch the buffer directly + emit to
+        # stdout. After run_async, route everything via the loop.
+        if self._block_queue is None or self._loop is None:
+            self._append_stripped_to_buffer(text)
+            import sys as _sys
+
+            try:
+                _sys.stdout.write(text)
+                _sys.stdout.flush()
+            except Exception:
+                pass
+            return
+
+        # On-thread fast path: mutate buffer directly so tests that
+        # inspect ``output_buffer.text`` right after a call see the
+        # update without waiting for a loop tick.
+        try:
+            on_thread = asyncio.get_running_loop() is self._loop
+        except RuntimeError:
+            on_thread = False
+        if on_thread:
+            self._append_stripped_to_buffer(text)
+            self._block_queue.put_nowait(text)
+            return
+
+        # Off-thread: route everything through the loop so off-thread
+        # producers (e.g. background workers, OTEL exporter) never touch
+        # prompt_toolkit state directly.
+        self._loop.call_soon_threadsafe(self._append_stripped_to_buffer, text)
+        self._loop.call_soon_threadsafe(self._block_queue.put_nowait, text)
+
+    def _append_stripped_to_buffer(self, text: str) -> None:
+        """Append the ANSI-stripped transcript text to ``output_buffer``.
+
+        Runs on the event loop thread (either because ``emit_block``
+        scheduled it via ``call_soon_threadsafe`` or because we're still
+        in the pre-consumer, single-threaded bootstrap phase).
+        """
+        stripped = _strip_ansi(text)
+        existing = self.output_buffer.text
+        appended = stripped if not existing or existing.endswith("\n") else "\n" + stripped
+        joined = existing + appended
+        self.output_buffer.document = Document(text=joined, cursor_position=len(joined))
+
+    # ── surface the harness (and real callers) rely on ----------------
+
+    @property
+    def is_running(self) -> bool:
+        return self._app.is_running
+
+    async def run_async(self) -> None:
+        # Capture the loop once so emit_block can enqueue safely from
+        # any thread without calling the deprecated get_event_loop().
+        self._loop = asyncio.get_running_loop()
+        self._block_queue = asyncio.Queue()
+        self._consumer_task = asyncio.ensure_future(self._consume_blocks())
+
+        # Route stray sys.stdout / sys.stderr writes (aiohttp warnings,
+        # litellm noise, stray prints) into the scrollback instead of
+        # letting them corrupt prompt_toolkit's paint. Must install here
+        # — before the first agent cell runs and before the framework
+        # wraps sys.stdout with ContextVarStream — so agent-cell stdout
+        # capture layers on top and still works unchanged.
+        from .stream_forwarder import install_stray_stream_capture
+
+        self._uninstall_stream_capture = install_stray_stream_capture(
+            self.emit_block, on_stray=self._on_stray_output
+        )
+        try:
+            # set_exception_handler=False keeps the handler Session installed
+            # (_loud_handler) active for the whole app lifetime. Otherwise
+            # prompt_toolkit replaces it with its own, which prints "Exception
+            # None\nPress ENTER to continue..." for non-exception asyncio
+            # contexts (e.g. "Task was destroyed but it is pending!") and
+            # swallows every other diagnostic field.
+            await self._app.run_async(set_exception_handler=False)
+        finally:
+            # Restore sys.stdout / sys.stderr FIRST so any post-exit
+            # prints from teardown code (spinner cleanup, snapshot save,
+            # goodbye message) go straight to the real terminal rather
+            # than back into the dying block queue.
+            uninstall = getattr(self, "_uninstall_stream_capture", None)
+            if uninstall is not None:
+                try:
+                    uninstall()
+                except Exception:
+                    pass
+                self._uninstall_stream_capture = None
+
+            try:
+                await self.interrupt_reflection(teardown=True)
+            except Exception:
+                logger.debug("reflection shutdown during TUI teardown failed", exc_info=True)
+
+            try:
+                await self.shutdown_agent_queue_manager()
+            except Exception:
+                logger.debug("queue manager shutdown during TUI teardown failed", exc_info=True)
+
+            # Drain any blocks queued during teardown (e.g. 'Goodbye!
+            # Stay vibing.' from /exit) straight to the real stdout —
+            # the consumer task's run_in_terminal no longer works once
+            # the app has exited.
+            import sys as _sys
+
+            q = self._block_queue
+            if q is not None:
+                while not q.empty():
+                    try:
+                        chunk = q.get_nowait()
+                    except asyncio.QueueEmpty:
+                        break
+                    out = _sys.__stdout__
+                    if out is not None:
+                        try:
+                            out.write(chunk)
+                            out.flush()
+                        except Exception:
+                            pass
+            if self._consumer_task is not None:
+                self._consumer_task.cancel()
+                try:
+                    await self._consumer_task
+                except asyncio.CancelledError:
+                    pass
+                except BaseException:
+                    pass
+            if self._spinner_task is not None and not self._spinner_task.done():
+                self._spinner_task.cancel()
+                # Await so the spinner's finally block runs (invalidate())
+                # and asyncio doesn't emit "Task was destroyed" on loop
+                # close. CancelledError on a cancelled task is expected.
+                try:
+                    await self._spinner_task
+                except (asyncio.CancelledError, BaseException):
+                    pass
+            await self._stop_agent_loop()
+            self._consumer_task = None
+            self._spinner_task = None
+            self._block_queue = None
+            self._loop = None
+
+    async def _consume_blocks(self) -> None:
+        """Drain ``_block_queue`` forever; write each block above the
+        prompt via ``run_in_terminal`` → ``sys.__stdout__``.
+
+        One consumer, FIFO order, no races. Writing to ``__stdout__``
+        (not ``sys.stdout``) bypasses the framework's ContextVarStream
+        wrapper so ``self.message()`` content never gets captured as
+        cell stdout.
+        """
+        import sys as _sys
+
+        from prompt_toolkit.application import run_in_terminal
+
+        assert self._block_queue is not None
+        while True:
+            text = await self._block_queue.get()
+
+            def _write(t: str = text) -> None:
+                out = _sys.__stdout__
+                if out is not None:
+                    out.write(t)
+                    out.flush()
+
+            try:
+                await run_in_terminal(_write)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # Best-effort — a single failed write shouldn't wedge
+                # the consumer. Fall through and pick up the next block.
+                continue
+
+    def output_columns(self, minimum: int = 20) -> int:
+        """Current transcript render width, including forced resize replays."""
+        if self._replay_columns_override is not None:
+            return max(int(self._replay_columns_override), minimum)
+        try:
+            return max(int(self._app.output.get_size().columns), minimum)
+        except Exception:
+            return terminal_cols(minimum=minimum)
+
+    def _before_render(self, _app) -> None:
+        """Replay retained transcript when fullscreen mode sees a terminal resize."""
+        if not self.full_screen:
+            return
+        try:
+            size = self._app.output.get_size()
+            current = (int(size.columns), int(size.rows))
+        except Exception:
+            return
+        if self._last_rendered_size is None:
+            self._last_rendered_size = current
+            return
+        if current != self._last_rendered_size:
+            self._last_rendered_size = current
+            if self._active_subview is not None:
+                return
+            self._replay_fullscreen_transcript()
+
+    @staticmethod
+    def _tag_range(tag: str) -> tuple[int, int] | None:
+        try:
+            if ".." in tag:
+                a, b = tag.split("..", 1)
+                return int(a), int(b)
+            n = int(tag)
+            return n, n
+        except Exception:
+            return None
+
+    def _active_replay_identity(self) -> tuple[set[str], list[tuple[int, int]]]:
+        em = getattr(self.agent, "event_manager", None)
+        if em is None or not hasattr(em, "items"):
+            return set(), []
+        active_ids: set[str] = set()
+        ranges: list[tuple[int, int]] = []
+        try:
+            items = list(em.items())
+        except Exception:
+            return active_ids, ranges
+        for tag, event in items:
+            rng = self._tag_range(str(tag))
+            if rng is not None:
+                ranges.append(rng)
+            event_id = getattr(event, "id", None)
+            if event_id is not None:
+                active_ids.add(str(event_id))
+        return active_ids, ranges
+
+    def _tag_is_active(self, tag: str, active_ranges: list[tuple[int, int]]) -> bool:
+        rng = self._tag_range(tag)
+        if rng is None:
+            return False
+        start, end = rng
+        return any(
+            start <= active_end and end >= active_start
+            for active_start, active_end in active_ranges
+        )
+
+    def _prune_replay_blocks_for_active_events(self) -> None:
+        if not self._replay_blocks:
+            return
+        active_ids, active_ranges = self._active_replay_identity()
+        if not active_ids and not active_ranges:
+            return
+        keep_indexes: set[int] = set()
+        untagged_indexes: list[int] = []
+        for i, block in enumerate(self._replay_blocks):
+            if block.keep:
+                keep_indexes.add(i)
+            elif block.event_id is not None:
+                if block.event_id in active_ids:
+                    keep_indexes.add(i)
+            elif block.tags:
+                if any(self._tag_is_active(tag, active_ranges) for tag in block.tags):
+                    keep_indexes.add(i)
+            else:
+                untagged_indexes.append(i)
+        keep_indexes.update(untagged_indexes[-self._untagged_replay_tail :])
+        self._replay_blocks = [
+            block for i, block in enumerate(self._replay_blocks) if i in keep_indexes
+        ]
+
+    def _replay_fullscreen_transcript(self) -> None:
+        if not self.full_screen or not self._replay_blocks:
+            return
+        import sys as _sys
+
+        out = _sys.__stdout__
+        if out is None:
+            return
+        self._prune_replay_blocks_for_active_events()
+        chunks: list[str] = []
+        for block in self._replay_blocks:
+            if block.replay is None:
+                chunks.append(block.raw)
+                continue
+            try:
+                chunks.append(block.replay())
+            except Exception:
+                chunks.append(block.raw)
+        try:
+            out.write("\x1b[H\x1b[2J\x1b[3J")
+            out.write("".join(chunks))
+            out.flush()
+            self._fullscreen_invalidate_count += 1
+        except Exception:
+            return
+
+    def exit(self) -> None:
+        if self._app.is_running:
+            self._app.exit()
+
+    def prompt_char_visible(self) -> bool:
+        """True once the prompt-marker processor is attached to the input."""
+        return self._prompt_processor is not None
+
+    def input_cursor_position(self) -> int:
+        """Current cursor position within the input buffer (0-indexed)."""
+        return self.input_buffer.cursor_position
+
+    def is_thinking(self) -> bool:
+        """True while the dispatcher is inside ``agent.handle()``.
+
+        Tracked by the ``_in_respond`` flag rather than the user_messages
+        queue's waiter count: the agent can ``await self.user_messages.get()``
+        mid-turn (clarification flow), and during that wait the queue has
+        a waiter — but the agent is genuinely thinking, not idle. The
+        flag captures the dispatcher → handle() boundary directly.
+        """
+        if self._agent_cancel_requested:
+            return True
+        if self._agent_task is None or self._agent_task.done():
+            return False
+        return self._in_respond
+
+    def commands_dispatched(self) -> list[str]:
+        """Slash commands the user has submitted, in order."""
+        return list(self._commands_dispatched)
+
+    def last_bang_command(self) -> str | None:
+        """Most recent ``!shell-command`` the user submitted, or None."""
+        return self._last_bang_command
+
+    def completion_candidates(self) -> list[str]:
+        """Completion candidates currently offered for the input buffer text.
+
+        Returns each candidate as the *full* replacement string (i.e. what
+        the buffer would contain if that candidate were applied) — so a
+        Completion(text='/help', start_position=-3) against buffer '/he'
+        reads back as '/help', not '/he/help'.
+        """
+        from prompt_toolkit.completion import CompleteEvent
+
+        doc = self.input_buffer.document
+        before = doc.text_before_cursor
+        result = []
+        for c in self._completer.get_completions(doc, CompleteEvent()):
+            prefix = before[: c.start_position] if c.start_position < 0 else before
+            result.append(prefix + c.text)
+        return result
+
+    def set_command_status(self, text: str) -> None:
+        """Set transient command lifecycle text in the dynamic status area."""
+        self._command_status_text = text
+        app = getattr(self, "_app", None)
+        if app is not None and app.is_running:
+            app.invalidate()
+
+    def set_command_queue(self, commands: list[str]) -> None:
+        """Set queued command text shown in the dynamic queue area."""
+        self._command_queue_texts = list(commands)
+        app = getattr(self, "_app", None)
+        if app is not None and app.is_running:
+            app.invalidate()
+
+    def status_text(self) -> str:
+        """One-line status area text.
+
+        Shows ``<spinner> thinking...`` while the agent is working,
+        ``<spinner> cancelling agent turn...`` while cancellation is awaiting
+        acknowledgement, and a bracketed session label when one is set. Example::
+
+            ⠋ thinking...    [session-abc]
+
+        """
+        lines: list[str] = []
+        if self._agent_cancel_requested:
+            lines.append(f"{self._spinner_frame} cancelling agent turn...")
+        elif self.is_thinking():
+            lines.append(f"{self._spinner_frame} thinking...")
+        reflection_frame = ""
+        runner = self._reflection_runner()
+        if runner is not None:
+            reflection_frame = runner.indicator_frame()
+        if reflection_frame:
+            lines.append(reflection_frame)
+        if self._command_status_text:
+            lines.append(self._command_status_text)
+        if self._session_label:
+            if lines:
+                lines[-1] = f"{lines[-1]}   [{self._session_label}]"
+            else:
+                lines.append(f"[{self._session_label}]")
+        return "\n\n".join(lines)
+
+    def set_session_label(self, label: str) -> None:
+        """Set the bracketed label shown on the right of the status line."""
+        self._session_label = label
+
+    def handle_resize(self, cols: int, rows: int) -> None:
+        """Hint the app to re-layout for a new terminal size.
+
+        prompt_toolkit handles real resize events internally; this hook
+        exists for tests (and callers that want to force a redraw after
+        a non-SIGWINCH layout change).
+        """
+        if self.full_screen:
+            size = (int(cols), int(rows))
+            if self._last_rendered_size != size:
+                self._last_rendered_size = size
+                if self._active_subview is None:
+                    self._replay_columns_override = int(cols)
+                    try:
+                        self._replay_fullscreen_transcript()
+                    finally:
+                        self._replay_columns_override = None
+        if self._app.is_running:
+            self._app.invalidate()

--- a/packages/nooa-cli/tests/test_cli_smoke.py
+++ b/packages/nooa-cli/tests/test_cli_smoke.py
@@ -18,3 +18,4 @@ def test_commands_discoverable():
     assert "start-dev" in names
     assert "eval" in names
     assert "config" in names
+    assert "tui" in names

--- a/packages/nooa-cli/tests/test_coding_agent.py
+++ b/packages/nooa-cli/tests/test_coding_agent.py
@@ -5,6 +5,7 @@
 from types import SimpleNamespace
 
 from nooa_cli.coding import CodingAgent, discover_agent_instruction_files
+from nooa_cli.tui.bootstrap import _instantiate_custom_agent
 
 from nooa.skill import Skill, get_slash_commands, slash_command
 from nooa.unifiedllm import FakeLLMClient
@@ -114,3 +115,35 @@ async def test_library_directory_can_be_scoped_by_the_host(tmp_path):
         assert agent.libs._path == libs_dir
     finally:
         await agent.close()
+
+
+def test_custom_coding_agent_receives_workspace_extension_arguments(tmp_path):
+    captured = {}
+
+    class CustomAgent:
+        def __init__(self, *, llm, storage, cwd, skills_dirs):
+            captured.update(
+                llm=llm,
+                storage=storage,
+                cwd=cwd,
+                skills_dirs=skills_dirs,
+            )
+
+    llm = object()
+    storage = object()
+    skills_dirs = [tmp_path / "skills"]
+    agent = _instantiate_custom_agent(
+        CustomAgent,
+        llm=llm,
+        storage=storage,
+        working_directory=tmp_path,
+        skills_dirs=skills_dirs,
+    )
+
+    assert isinstance(agent, CustomAgent)
+    assert captured == {
+        "llm": llm,
+        "storage": storage,
+        "cwd": tmp_path,
+        "skills_dirs": skills_dirs,
+    }

--- a/packages/nooa-cli/tests/test_command_plugins.py
+++ b/packages/nooa-cli/tests/test_command_plugins.py
@@ -18,7 +18,7 @@ import pytest
 from nooa_cli import commands as commands_pkg
 from nooa_cli.commands import PLUGIN_ENTRY_POINT_GROUP, discover_commands
 
-BUILTIN_NAMES = {"eval", "config", "start-dev"}
+BUILTIN_NAMES = {"eval", "config", "start-dev", "tui"}
 
 
 class FakeEntryPoint:
@@ -85,11 +85,11 @@ def test_group_name_is_stable():
 
 def test_plugin_command_is_registered_alongside_builtins(monkeypatch):
     plugin = make_command()
-    patch_entry_points(monkeypatch, [FakeEntryPoint("tui", plugin)])
+    patch_entry_points(monkeypatch, [FakeEntryPoint("chat", plugin)])
 
     found = dict(discover_commands())
 
-    assert found["tui"] is plugin
+    assert found["chat"] is plugin
     assert BUILTIN_NAMES <= set(found)
 
 
@@ -148,17 +148,17 @@ def test_two_plugins_with_the_same_name_yield_one_command(monkeypatch, caplog):
     first, second = make_command(), make_command()
     patch_entry_points(
         monkeypatch,
-        [FakeEntryPoint("tui", first), FakeEntryPoint("tui", second)],
+        [FakeEntryPoint("chat", first), FakeEntryPoint("chat", second)],
     )
 
     with caplog.at_level(logging.WARNING, logger="nooa_cli.commands"):
         pairs = list(discover_commands())
 
     names = [name for name, _ in pairs]
-    assert names.count("tui") == 1
-    assert dict(pairs)["tui"] is first
+    assert names.count("chat") == 1
+    assert dict(pairs)["chat"] is first
     assert any(
-        "shadows" in record.getMessage() and "tui" in record.getMessage()
+        "shadows" in record.getMessage() and "chat" in record.getMessage()
         for record in caplog.records
     )
 

--- a/packages/nooa-cli/tests/test_tui_command_surface.py
+++ b/packages/nooa-cli/tests/test_tui_command_surface.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The deliberately retained built-in TUI slash-command surface."""
+
+from nooa_cli.tui.commands import CommandRegistry
+
+
+def test_builtin_command_surface_is_explicit_and_pruned():
+    assert set(CommandRegistry.get_all_command_classes()) == {
+        "activity",
+        "clear",
+        "compact",
+        "context",
+        "edit",
+        "events",
+        "exit",
+        "help",
+        "history",
+        "jobs",
+        "keep-going",
+        "memory",
+        "memories",
+        "mcp",
+        "model",
+        "models",
+        "python",
+        "quit",
+        "reasoning",
+        "reflection",
+        "session",
+        "skills",
+        "theme",
+        "todos",
+        "toolbar",
+        "trace-url",
+    }

--- a/packages/nooa-cli/tests/test_tui_mcp_config.py
+++ b/packages/nooa-cli/tests/test_tui_mcp_config.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Persistent MCP add/remove and user-owned approval command paths."""
+
+from types import SimpleNamespace
+
+import yaml
+from nooa_cli.tui import settings
+from nooa_cli.tui.commands import MCPCommand
+from nooa_cli.tui.config import TUIConfig
+from nooa_cli.tui.mcp_registry import MCPRegistry
+
+from nooa.skill import get_slash_commands
+
+
+def _project_settings(monkeypatch, tmp_path):
+    path = tmp_path / ".nooa" / "settings.yaml"
+    monkeypatch.setattr(settings, "settings_path", lambda scope="project": path)
+    return path
+
+
+def _command(registry):
+    return MCPCommand(object(), TUIConfig(), SimpleNamespace(mcp=registry))
+
+
+async def test_mcp_add_and_remove_round_trip_project_settings(monkeypatch, tmp_path):
+    path = _project_settings(monkeypatch, tmp_path)
+    registry = MCPRegistry(
+        servers={"keep": {"url": "https://keep.example/mcp"}},
+        approval_path=tmp_path / "approvals.json",
+    )
+    command = _command(registry)
+
+    added = await command.execute(["add", "docs", "https://docs.example/mcp"])
+    assert added.success
+    assert "Added HTTP MCP server 'docs'" in added.outputs[0].content
+    data = yaml.safe_load(path.read_text())
+    assert data["tui"]["mcp_servers"]["docs"] == {
+        "url": "https://docs.example/mcp",
+        "transport": "streamable-http",
+    }
+    assert registry._is_approved("docs") is False
+
+    removed = await command.execute(["remove", "docs"])
+    assert removed.success
+    data = yaml.safe_load(path.read_text())
+    assert "docs" not in data.get("tui", {}).get("mcp_servers", {})
+    assert registry._servers == {"keep": {"url": "https://keep.example/mcp"}}
+
+
+async def test_mcp_add_stdio_command_requires_later_approval(monkeypatch, tmp_path):
+    path = _project_settings(monkeypatch, tmp_path)
+    registry = MCPRegistry(approval_path=tmp_path / "approvals.json")
+
+    result = await _command(registry).execute(["add", "local", "my-mcp-server"])
+
+    assert result.success
+    assert "Review it with /mcp approve local" in result.outputs[0].content
+    data = yaml.safe_load(path.read_text())
+    assert data["tui"]["mcp_servers"]["local"] == {"command": "my-mcp-server"}
+    assert registry._is_approved("local") is False
+
+
+async def test_mcp_add_rejects_unsafe_name_before_persisting(monkeypatch, tmp_path):
+    path = _project_settings(monkeypatch, tmp_path)
+    registry = MCPRegistry(approval_path=tmp_path / "approvals.json")
+
+    result = await _command(registry).execute(
+        ["add", "evil\x1b[2J", "https://docs.example/mcp"]
+    )
+
+    assert result.success is False
+    assert not path.exists()
+    assert registry.discovered() == []
+
+
+async def test_mcp_remove_does_not_edit_external_mcp_file(monkeypatch, tmp_path):
+    _project_settings(monkeypatch, tmp_path)
+    mcp_file = tmp_path / ".mcp.json"
+    original = '{"mcpServers":{"external":{"url":"https://example/mcp"}}}'
+    mcp_file.write_text(original)
+    registry = MCPRegistry(
+        mcp_file=mcp_file,
+        approval_path=tmp_path / "approvals.json",
+    )
+
+    result = await _command(registry).execute(["remove", "external"])
+
+    assert result.success is False
+    assert "comes from" in result.outputs[0].content
+    assert mcp_file.read_text() == original
+
+
+async def test_mcp_approve_without_code_only_reviews_configuration(tmp_path):
+    registry = MCPRegistry(
+        servers={"docs": {"url": "https://docs.example/mcp"}},
+        approval_path=tmp_path / "approvals.json",
+    )
+
+    result = await _command(registry).execute(["approve", "docs"])
+
+    assert result.success
+    assert "Config fingerprint: sha256:" in result.outputs[0].content
+    assert "/mcp approve docs " in result.outputs[0].content
+    assert registry._is_approved("docs") is False
+
+
+def test_mcp_registry_exposes_only_agent_assisted_add_command():
+    commands = [(meta.name, meta.output_to_agent) for meta, _ in get_slash_commands(MCPRegistry())]
+    assert commands == [("mcp-add", True)]

--- a/packages/nooa-cli/tests/test_tui_mcp_config.py
+++ b/packages/nooa-cli/tests/test_tui_mcp_config.py
@@ -65,9 +65,7 @@ async def test_mcp_add_rejects_unsafe_name_before_persisting(monkeypatch, tmp_pa
     path = _project_settings(monkeypatch, tmp_path)
     registry = MCPRegistry(approval_path=tmp_path / "approvals.json")
 
-    result = await _command(registry).execute(
-        ["add", "evil\x1b[2J", "https://docs.example/mcp"]
-    )
+    result = await _command(registry).execute(["add", "evil\x1b[2J", "https://docs.example/mcp"])
 
     assert result.success is False
     assert not path.exists()

--- a/packages/nooa-cli/tests/test_tui_toolbar.py
+++ b/packages/nooa-cli/tests/test_tui_toolbar.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Structured TUI toolbar providers."""
+
+from pathlib import Path
+
+from nooa_cli.tui.toolbar import ToolbarContext, ToolbarRegistry
+
+
+def test_toolbar_renders_configured_items_in_order():
+    registry = ToolbarRegistry(load_plugins=False)
+    context = ToolbarContext(
+        model="provider/claude-example",
+        working_directory=Path("/work/repo"),
+        context_usage="ctx 20%",
+        session_id="12345678-abcd",
+        session_title="migration",
+    )
+
+    assert registry.render(["model", "cwd", "context", "session"], context) == (
+        "example · repo · ctx 20% · migration [12345678]"
+    )
+
+
+def test_toolbar_accepts_registered_extension():
+    registry = ToolbarRegistry(load_plugins=False)
+    registry.register("branch", lambda context: "dev/tui")
+
+    assert registry.render(["branch"], ToolbarContext("model", Path("."), "")) == "dev/tui"

--- a/packages/nooa-cli/tests/tui/__init__.py
+++ b/packages/nooa-cli/tests/tui/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the nooa CLI and TUI components."""

--- a/packages/nooa-cli/tests/tui/test_activity_command.py
+++ b/packages/nooa-cli/tests/tui/test_activity_command.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the /activity slash command (ActivityCommand)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from nooa_cli.tui.commands import ActivityCommand
+from nooa_cli.tui.output import TableOutput, TextOutput
+
+
+def _reset_activity_state():
+    import nooa.runtime.debug_handler as dh
+
+    dh._pending_llm_calls.clear()
+    dh._llm_call_counter = 0
+    dh._pending_code_execs.clear()
+    dh._code_exec_counter = 0
+
+
+@pytest.fixture
+def command():
+    _reset_activity_state()
+    cmd = ActivityCommand(frontend=AsyncMock(), config=MagicMock(), agent=MagicMock())
+    yield cmd
+    _reset_activity_state()
+
+
+@pytest.mark.asyncio
+async def test_idle(command):
+    """With nothing in flight, /activity is a single status one-liner."""
+    result = await command.execute([])
+    assert result.success
+    assert len(result.outputs) == 1
+    out = result.outputs[0]
+    assert isinstance(out, TextOutput)
+    assert not isinstance(out, TableOutput)
+    assert "idle" in out.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_executing_python(command):
+    """A running code cell reports Executing Python with a preview row."""
+    from nooa.runtime.debug_handler import code_exec_context
+
+    with code_exec_context("x = 1\nprint(x)"):
+        result = await command.execute([])
+    table = result.outputs[0]
+    assert table.rows[0] == ["Phase", "Executing Python"]
+    # second row carries the cell preview
+    assert table.rows[1][1] == "x = 1"
+    assert table.rows[1][0].startswith("  python (")
+    assert table.footer == "In a code cell — not waiting on the model."
+
+
+@pytest.mark.asyncio
+async def test_preview_fallback_for_blank_cell(command):
+    """A blank/whitespace cell falls back to the "(code cell)" preview label."""
+    from nooa.runtime.debug_handler import code_exec_context
+
+    with code_exec_context(""):
+        result = await command.execute([])
+    table = result.outputs[0]
+    assert table.rows[1][1] == "(code cell)"
+
+
+@pytest.mark.asyncio
+async def test_waiting_llm(command):
+    """An in-flight LLM call reports Waiting on LLM call with the model row."""
+    from nooa.runtime.debug_handler import llm_call_context
+
+    with llm_call_context(model="gpt-test"):
+        result = await command.execute([])
+    table = result.outputs[0]
+    assert table.rows[0] == ["Phase", "Waiting on LLM call"]
+    assert table.rows[1][1] == "gpt-test"
+    assert table.rows[1][0].startswith("  llm (")
+    assert table.footer == "Blocked waiting for the model to respond."
+
+
+@pytest.mark.asyncio
+async def test_llm_model_unknown_fallback(command):
+    """An in-flight LLM call missing its ``model`` key renders as 'unknown'."""
+    import nooa.runtime.debug_handler as dh
+    from nooa.runtime.debug_handler import register_llm_call
+
+    call_id = register_llm_call(model="x")
+    with dh._llm_call_lock:
+        dh._pending_llm_calls[call_id].pop("model")
+    result = await command.execute([])
+    table = result.outputs[0]
+    assert table.rows[1][1] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_python_and_llm_nested(command):
+    """A cell blocked on an LLM call: phase is Executing Python, both rows shown."""
+    from nooa.runtime.debug_handler import code_exec_context, llm_call_context
+
+    with code_exec_context("y = 2"):
+        with llm_call_context(model="gpt-test"):
+            result = await command.execute([])
+    table = result.outputs[0]
+    assert table.rows[0] == ["Phase", "Executing Python"]
+    # both a python row and an llm row are present
+    kinds = [r[0].strip().split()[0] for r in table.rows[1:]]
+    assert "python" in kinds and "llm" in kinds
+    assert table.footer == "Running a code cell that is itself blocked on an LLM call."
+
+
+@pytest.mark.asyncio
+async def test_import_error_fallback(command, monkeypatch):
+    """If debug_handler can't be imported, /activity returns a graceful error."""
+    import builtins as _builtins
+
+    real_import = _builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "nooa.runtime.debug_handler":
+            raise ImportError("boom")
+        return real_import(name, *args, **kwargs)
+
+    # Scoped to just the call under test: the `command` fixture's teardown
+    # imports nooa.runtime.debug_handler to reset module state, so leaving
+    # __import__ patched past this block makes teardown explode. Whether that
+    # happened used to depend on the order pytest instantiated `command` vs
+    # `monkeypatch` — an autouse fixture requesting monkeypatch was enough to
+    # flip it. A context manager makes the test independent of that ordering.
+    with monkeypatch.context() as patched:
+        patched.setattr(_builtins, "__import__", _fake_import)
+        result = await command.execute([])
+
+    assert not result.success
+    assert isinstance(result.outputs[0], TextOutput)
+
+
+@pytest.mark.asyncio
+async def test_activity_command_opens_overlay_when_frontend_supports_it():
+    """Terminal-like frontends show /activity in the full-screen overlay."""
+
+    class OverlayFrontend:
+        def __init__(self) -> None:
+            self.outputs = None
+
+        async def open_activity_overlay(self, outputs):
+            self.outputs = outputs
+
+    _reset_activity_state()
+    frontend = OverlayFrontend()
+    cmd = ActivityCommand(frontend=frontend, config=MagicMock(), agent=MagicMock())
+
+    result = await cmd.execute([])
+
+    assert result.success
+    assert isinstance(result.outputs[0], TextOutput)
+    assert "closed" in result.outputs[0].content
+    assert frontend.outputs is not None
+    assert isinstance(frontend.outputs[0], TextOutput)
+    assert "idle" in frontend.outputs[0].content.lower()

--- a/packages/nooa-cli/tests/tui/test_activity_no_block.py
+++ b/packages/nooa-cli/tests/tui/test_activity_no_block.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: /activity must not freeze the UI loop while the agent is busy.
+
+Root cause of the reported flicker: ``ActivityCommand`` probed the agent
+location via the *blocking* ``agent_run`` (``future.result(timeout=30)``),
+which froze the prompt_toolkit UI loop while the agent loop was busy —
+starving the block-queue consumer (``self.message()`` output stopped
+appearing) and wedging the prompt redraw (status-bar / input flicker).
+
+The fix routes the probe through the awaitable ``agent_run_async`` so the UI
+loop keeps spinning. These tests pin that behaviour at the unit level.
+"""
+
+import asyncio
+import threading
+
+import pytest
+
+
+def _make_busy_agent_loop():
+    """Start an event loop on its own thread with a long-running task hogging it.
+
+    Returns (loop, stop_event, thread). The loop is "busy" in the sense that a
+    blocking ``future.result`` against it would have to wait for the hog task
+    to yield — modelling the agent mid-LLM-call / mid-cell.
+    """
+    loop = asyncio.new_event_loop()
+    started = threading.Event()
+    stop = asyncio.Event()
+
+    def run():
+        asyncio.set_event_loop(loop)
+        loop.call_soon(started.set)
+        loop.run_forever()
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+    started.wait(2.0)
+    return loop, stop, t
+
+
+@pytest.mark.asyncio
+async def test_agent_run_async_does_not_block_calling_loop():
+    """``agent_run_async`` yields to the calling loop while the agent loop works.
+
+    We schedule a probe that only completes after a delay, and concurrently run
+    a "UI heartbeat" coroutine on the calling loop. If ``agent_run_async``
+    blocked the loop (the old ``future.result`` behaviour), the heartbeat would
+    not tick until the probe returned. We assert it ticks meanwhile.
+    """
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    app = TUIApplication.__new__(TUIApplication)  # avoid full prompt_toolkit init
+    loop, _stop, _t = _make_busy_agent_loop()
+    app._agent_loop = loop
+
+    probe_done = asyncio.Event()
+
+    def slow_probe():
+        # Runs on the agent loop; sleeps to model an in-flight turn.
+        async def _inner():
+            await asyncio.sleep(0.3)
+            return "located"
+
+        return _inner()
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        while not probe_done.is_set():
+            ticks += 1
+            await asyncio.sleep(0.02)
+
+    hb = asyncio.ensure_future(heartbeat())
+
+    result = await app.agent_run_async(slow_probe)
+    probe_done.set()
+    await hb
+
+    loop.call_soon_threadsafe(loop.stop)
+
+    assert result == "located"
+    # The UI loop kept ticking during the 0.3s probe — proof it was not blocked.
+    assert ticks >= 5
+
+
+@pytest.mark.asyncio
+async def test_agent_run_async_inline_without_loop():
+    """With no agent loop (tests / pre-startup) it runs inline, no await needed."""
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    app = TUIApplication.__new__(TUIApplication)
+    app._agent_loop = None
+
+    assert await app.agent_run_async(lambda: 42) == 42
+
+
+@pytest.mark.asyncio
+async def test_activity_probe_uses_async_dispatch():
+    """ActivityCommand routes the location probe through agent_run_async.
+
+    Guards against a regression to the blocking ``agent_run`` call, which is
+    what froze the UI loop. We record which dispatcher the command used.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nooa_cli.tui.commands import ActivityCommand
+
+    cmd = ActivityCommand(frontend=AsyncMock(), config=MagicMock(), agent=MagicMock())
+
+    used = {"sync": False, "async": False}
+
+    def sync_run(fn):
+        used["sync"] = True
+        return None
+
+    async def async_run(fn):
+        used["async"] = True
+        return None
+
+    cmd._agent_run = sync_run
+    cmd._agent_run_async = async_run
+
+    await cmd.execute([])
+
+    assert used["async"] is True
+    assert used["sync"] is False
+
+
+@pytest.mark.asyncio
+async def test_agent_mutating_commands_use_async_dispatch():
+    """UI-loop commands must not call blocking agent_run while the agent is busy."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from nooa_cli.tui.commands import (
+        CompactCommand,
+        ModelCommand,
+    )
+
+    async def assert_uses_async_dispatch(cmd, execute_args):
+        used = {"sync": False, "async": False}
+
+        def sync_run(fn):
+            used["sync"] = True
+            return fn()
+
+        async def async_run(fn):
+            used["async"] = True
+            return fn()
+
+        cmd._agent_run = sync_run
+        cmd._agent_run_async = async_run
+        result = await cmd.execute(execute_args)
+        assert result.success
+        assert used["async"] is True
+        assert used["sync"] is False
+
+    config = MagicMock()
+    config.default_model = "old/model"
+    agent = MagicMock()
+    agent.event_manager.keys.return_value = ["1", "2"]
+    agent.context_stats = None
+
+    with patch("nooa.unifiedllm.get_llm_client", return_value=MagicMock()):
+        await assert_uses_async_dispatch(ModelCommand(AsyncMock(), config, agent), ["new/model"])
+
+    compact = CompactCommand(AsyncMock(), config, agent)
+    agent._summarizers = []
+    await assert_uses_async_dispatch(compact, [])
+
+
+@pytest.mark.asyncio
+async def test_session_swap_uses_async_agent_dispatch():
+    """Session manager swaps run agent mutations without blocking the UI loop."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session.agent = MagicMock()
+    session.agent.queue_manager = None
+    session.agent.event_manager = MagicMock()
+    session.registry = MagicMock()
+    session.registry.commands.return_value = []
+    old_storage = MagicMock()
+    session.agent._storage = old_storage
+    old_manager = MagicMock()
+    old_manager.close = MagicMock()
+    session._session_manager = old_manager
+    new_manager = MagicMock()
+    new_manager._storage = SimpleNamespace(event_backend=object())
+
+    used = {"async": 0, "sync": 0}
+
+    async def async_run(fn):
+        used["async"] += 1
+        return fn()
+
+    def sync_run(fn):
+        used["sync"] += 1
+        return fn()
+
+    session._app = SimpleNamespace(agent_run_async=async_run, agent_run=sync_run)
+
+    await session._swap_session_manager(new_manager)
+
+    assert used["async"] == 2
+    assert used["sync"] == 0
+
+
+@pytest.mark.asyncio
+async def test_python_skill_slash_commands_use_async_agent_dispatch():
+    """@slash_command methods run on the agent loop, not directly on the UI loop.
+
+    Mesh slash commands mutate the live AgentMesh client/QueueManager and can do
+    slow connect/list/cert work. Running those methods directly in
+    CommandHandler ties the work to prompt_toolkit's UI loop; routing them
+    through agent_run_async keeps input/redraw/output draining responsive while
+    the agent loop performs the operation.
+    """
+    from unittest.mock import AsyncMock
+
+    from nooa_cli.tui.commands import CommandHandler, _UserSkill
+
+    class Registry:
+        def __init__(self):
+            self.skill_called = False
+
+        def get_user_skill(self, name):
+            if name != "mesh-list":
+                return None
+
+            def mesh_list(args: str = ""):
+                self.skill_called = True
+                return f"mesh roster for {args}"
+
+            return _UserSkill(
+                name="mesh-list",
+                body="",
+                description="Show the live mesh roster",
+                _method=mesh_list,
+            )
+
+        def get_command(self, name):
+            return None
+
+        def get_all_command_classes(self):
+            return {}
+
+    registry = Registry()
+    used = {"async": False}
+
+    async def agent_run_async(fn):
+        used["async"] = True
+        return fn()
+
+    handler = CommandHandler(
+        registry=registry,
+        frontend=AsyncMock(),
+        agent_run_async=agent_run_async,
+    )
+
+    result = await handler.handle("/mesh-list now")
+
+    assert result.success is True
+    assert used["async"] is True
+    assert registry.skill_called is True
+    assert result.slash_result is not None
+    assert result.slash_result.value == "mesh roster for now"

--- a/packages/nooa-cli/tests/tui/test_activity_render.py
+++ b/packages/nooa-cli/tests/tui/test_activity_render.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for /activity rendering: no flicker (batched output), no empty header band."""
+
+import asyncio
+
+import pytest
+from nooa_cli.tui.session import _EmitStream
+
+
+def test_emit_stream_hold_coalesces_into_one_block():
+    """Multiple flush()es inside hold() emit a single block on release."""
+    blocks: list[str] = []
+    stream = _EmitStream(blocks.append)
+
+    def render(text: str) -> None:
+        stream.write(text)
+        stream.flush()
+
+    # Without hold: one block per render.
+    render("a\n")
+    render("b\n")
+    assert blocks == ["a\n", "b\n"]
+
+    blocks.clear()
+    with stream.hold():
+        render("table\n")
+        render("code\n")
+        render("footer\n")
+    assert blocks == ["table\ncode\nfooter\n"]
+
+
+def test_emit_stream_hold_is_reentrant():
+    """Nested holds only release on the outermost exit."""
+    blocks: list[str] = []
+    stream = _EmitStream(blocks.append)
+    with stream.hold():
+        stream.write("x")
+        stream.flush()
+        with stream.hold():
+            stream.write("y")
+            stream.flush()
+        assert blocks == []  # inner exit must not flush
+    assert blocks == ["xy"]
+
+
+def test_table_output_show_header_false_drops_header():
+    """A header-less key/value table renders no empty header band."""
+    import io
+
+    from nooa_cli.tui.console import TUIConsole
+    from rich.console import Console
+
+    tc = TUIConsole()
+    buf = io.StringIO()
+    tc.console = Console(file=buf, width=60, force_terminal=False)
+    tc.print_table("", ["", ""], [["Phase", "Idle"]], show_header=False)
+    out = buf.getvalue()
+    # No title line, and the only content row is the data row.
+    assert "Agent Activity" not in out
+    assert "Phase" in out and "Idle" in out
+    # The box should have no header separator (┡/╇) since show_header=False.
+    assert "╇" not in out
+
+
+@pytest.mark.asyncio
+async def test_activity_idle_is_one_liner():
+    """Idle /activity is a single status line, not a table."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nooa_cli.tui.commands import ActivityCommand
+    from nooa_cli.tui.output import TableOutput, TextOutput
+
+    cmd = ActivityCommand(frontend=AsyncMock(), config=MagicMock(), agent=MagicMock())
+
+    async def _idle_locate():
+        return None
+
+    cmd._locate_agent = _idle_locate  # type: ignore[method-assign]
+
+    result = await cmd.execute([])
+    assert len(result.outputs) == 1
+    out = result.outputs[0]
+    assert isinstance(out, TextOutput)
+    assert not isinstance(out, TableOutput)
+
+
+@pytest.mark.asyncio
+async def test_activity_table_has_no_header():
+    """The activity table is emitted header-less (show_header=False, no title)."""
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nooa_cli.tui.commands import ActivityCommand
+    from nooa_cli.tui.output import TableOutput
+
+    cmd = ActivityCommand(frontend=AsyncMock(), config=MagicMock(), agent=MagicMock())
+
+    async def tool_layer():
+        await asyncio.sleep(5)
+
+    async def handle():
+        await tool_layer()
+
+    task = asyncio.ensure_future(handle())
+    await asyncio.sleep(0.02)
+    try:
+        result = await cmd.execute([])
+        table = next(o for o in result.outputs if isinstance(o, TableOutput))
+        assert table.show_header is False
+        assert table.title == ""
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+def test_batch_render_ctx_tolerates_mock_frontend():
+    """_batch_render_ctx falls back to a no-op for non-context batch_render().
+
+    Regression: ``with self.frontend.batch_render()`` raised ``TypeError:
+    'coroutine' object does not support the context manager protocol`` when the
+    frontend was an AsyncMock (its ``batch_render()`` returns a coroutine). The
+    helper must return an enter/exit-able context in every case.
+    """
+    from unittest.mock import AsyncMock
+
+    from nooa_cli.tui.commands import _batch_render_ctx
+
+    # AsyncMock.batch_render() returns a coroutine — must not be entered.
+    ctx = _batch_render_ctx(AsyncMock())
+    with ctx:
+        pass  # no raise
+
+    # A frontend without batch_render at all → still a usable context.
+    class _NoBatch:
+        pass
+
+    with _batch_render_ctx(_NoBatch()):
+        pass
+
+
+def test_batch_render_ctx_uses_real_context():
+    """When batch_render returns a real context manager, the helper passes it through."""
+    from contextlib import contextmanager
+
+    entered = []
+
+    @contextmanager
+    def _real():
+        entered.append("enter")
+        yield
+        entered.append("exit")
+
+    class _Frontend:
+        def batch_render(self):
+            return _real()
+
+    from nooa_cli.tui.commands import _batch_render_ctx
+
+    with _batch_render_ctx(_Frontend()):
+        pass
+    assert entered == ["enter", "exit"]
+
+
+def test_activity_overlay_renders_table_code_and_scrolls():
+    from nooa_cli.tui.activity_overlay import ActivityOverlayView, render_activity_overlay
+    from nooa_cli.tui.output import CodeExecution, TableOutput
+
+    view = ActivityOverlayView(
+        [
+            TableOutput(
+                columns=["", ""],
+                rows=[["Phase", "Executing Python"], ["  python (1.2s)", "print('hello')"]],
+                footer="In a code cell — not waiting on the model.",
+                show_header=False,
+            ),
+            CodeExecution(
+                tool_call_id="activity:test.py:2",
+                code="line1\nline2\nline3",
+                start_line=1,
+                highlight_line=2,
+            ),
+        ]
+    )
+
+    rendered = render_activity_overlay(view, width=80, height=10, ansi=False)
+
+    assert "Activity" in rendered
+    assert "Executing Python" in rendered
+    assert "print('hello')" in rendered
+    assert "Enter/Esc/q close" in rendered
+    assert view.handle_key("down") == "handled"
+    assert view.offset >= 0
+    assert view.handle_key("quit") == "close"
+
+
+@pytest.mark.asyncio
+async def test_tui_app_opens_and_closes_activity_overlay() -> None:
+    from nooa_cli.tui.output import TextOutput
+
+    from .tui_app_harness import TUIHarness
+
+    async with TUIHarness() as h:
+        task = asyncio.create_task(h.app.open_activity_overlay([TextOutput("Agent idle")]))
+        await h.wait_for(lambda: h.app.active_subview is not None)
+
+        rendered = h.app.active_subview.render(80, 10)
+        assert "Activity" in rendered
+        assert "Agent idle" in rendered
+
+        await h.press("q")
+        await asyncio.wait_for(task, timeout=1)
+        assert h.app.active_subview is None

--- a/packages/nooa-cli/tests/tui/test_agent_event_renderer.py
+++ b/packages/nooa-cli/tests/tui/test_agent_event_renderer.py
@@ -1,0 +1,401 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``AgentEventRenderer``.
+
+The renderer owns one piece of per-turn state (``_agent_has_messaged``)
+and three event handlers. These tests construct the renderer directly
+with a ``_FakeAgent`` and a list-append ``emit_text`` so we can assert
+on the exact sequence of emitted Rich renderables — no prompt_toolkit,
+no block queue, no frontend.
+
+Covers:
+- ``self.message()`` emits inline as a Markdown block the moment it's
+  called — no buffering. (See the module docstring for why the old
+  buffer-until-next-PythonOutput scheme was removed.)
+- The first ``self.message()`` of a turn emits the ``"OO ─"`` rule
+  once; subsequent messages don't re-emit it until ``reset_turn()``.
+- prefill tool-call-ids short-circuit the full-cell render (no
+  user-visible code / stdout for internal inspection calls).
+- ``show_python=True`` path renders the full cell
+  (``oo python`` / ``oo stdout``).
+- ``detach()`` restores any prior ``_render_message`` hook.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from nooa_cli.tui.agent_event_renderer import AgentEventRenderer
+from nooa_cli.tui.theme import COLORS
+from rich.markdown import Markdown
+from rich.rule import Rule
+from rich.syntax import Syntax
+from rich.text import Text
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+class _FakeEventManager:
+    """Records ``.on(type, handler)`` calls so we can drive the handlers
+    directly — we don't need a real EventManager's dispatch path to
+    unit-test the renderer's *reactions* to events."""
+
+    def __init__(self) -> None:
+        self.handlers: dict[str, list[Any]] = {}
+
+    def on(self, event_type: str, handler: Any) -> Any:
+        self.handlers.setdefault(event_type, []).append(handler)
+
+        def _unsub() -> None:
+            self.handlers.get(event_type, []).remove(handler)
+
+        return _unsub
+
+    def fire(self, event_type: str, event: Any) -> None:
+        for h in self.handlers.get(event_type, []):
+            h(event)
+
+
+class _FakeAgent:
+    """Minimal agent surface the renderer touches: event_manager + render hook."""
+
+    def __init__(self) -> None:
+        self.event_manager = _FakeEventManager()
+        self._render_message: Any = None
+
+
+def _mk(show_python: bool = False) -> tuple[_FakeAgent, list[Any], AgentEventRenderer]:
+    agent = _FakeAgent()
+    emitted: list[Any] = []
+    pending_code: dict[str, str] = {}
+    r = AgentEventRenderer(
+        agent=agent,  # type: ignore[arg-type]
+        emit_text=emitted.append,
+        show_python=lambda: show_python,
+        pending_code=pending_code,
+        colors=COLORS,
+    )
+    return agent, emitted, r
+
+
+def _fire_reasoning(em: _FakeEventManager, content: str) -> None:
+    em.fire("Reasoning", SimpleNamespace(content=content))
+
+
+def _fire_tool_call(em: _FakeEventManager, code: str, tool_call_id: str = "t1") -> None:
+    em.fire(
+        "ToolCallEvent",
+        SimpleNamespace(
+            name="execute_python",
+            tool_call_id=tool_call_id,
+            arguments={"code": code},
+        ),
+    )
+
+
+def _fire_python_output(
+    em: _FakeEventManager, stdout: str = "", stderr: str = "", tool_call_id: str = "t1"
+) -> None:
+    em.fire(
+        "PythonOutput",
+        SimpleNamespace(tool_call_id=tool_call_id, stdout=stdout, stderr=stderr),
+    )
+
+
+def _fire_summary(
+    em: _FakeEventManager,
+    *,
+    summary_tag: str = "1..10",
+    replaced_range: tuple[int, int] = (1, 10),
+    children_tags: list[str] | None = None,
+    summary_text: str | None = "Summary of events.",
+) -> None:
+    em.fire(
+        "Summary",
+        SimpleNamespace(
+            summary_tag=summary_tag,
+            replaced_range=replaced_range,
+            children_tags=children_tags
+            if children_tags is not None
+            else [str(i) for i in range(1, 11)],
+            summary_text=summary_text,
+        ),
+    )
+
+
+# ── tests ──────────────────────────────────────────────────────────────
+
+
+def test_message_emits_inline_not_buffered() -> None:
+    """Regression: ``self.message()`` renders inline the moment it's
+    called, rather than being buffered until the next
+    ``PythonOutput``. The old buffer-then-flush scheme stranded
+    messages for the full lifetime of the last turn whenever the
+    flush triggers (``PythonOutput``, ``return_result``) didn't fire
+    after the final ``self.message()`` — the user only saw them after
+    typing their next input. Inline emit kills that class of bug.
+    """
+    agent, emitted, r = _mk(show_python=False)
+    r.attach()
+
+    _fire_tool_call(agent.event_manager, "print('hi')")
+    assert agent._render_message is not None
+    agent._render_message("mid-cell note")
+
+    # Message must have rendered immediately — not held until the
+    # cell completes.
+    markdowns = [e for e in emitted if isinstance(e, Markdown)]
+    assert len(markdowns) == 1
+    assert "mid-cell note" in str(markdowns[0].markup)
+
+    # Subsequent PythonOutput shouldn't add more Markdown renderables
+    # (no buffer to flush any more).
+    _fire_python_output(agent.event_manager, stderr="warn")
+    markdowns_after = [e for e in emitted if isinstance(e, Markdown)]
+    assert len(markdowns_after) == 1
+
+
+def test_message_between_preview_and_cell_output_preserves_natural_order() -> None:
+    """``self.message()`` is called *inside* the cell body, so the
+    ``∴`` code preview (fired on the enclosing ``ToolCallEvent``)
+    renders first, then the message renders inline, and finally the
+    cell's stderr/stdout lands when the ``PythonOutput`` event
+    arrives. This is the natural ordering inline emit produces.
+    """
+    agent, emitted, r = _mk(show_python=False)
+    r.attach()
+
+    _fire_tool_call(agent.event_manager, "print('hi')")
+    agent._render_message("mid-cell note")
+    _fire_python_output(agent.event_manager, stderr="warn")
+
+    preview_idx = next(
+        i for i, e in enumerate(emitted) if isinstance(e, Text) and "print" in str(e)
+    )
+    message_idx = next(i for i, e in enumerate(emitted) if isinstance(e, Markdown))
+    stderr_idx = next(i for i, e in enumerate(emitted) if isinstance(e, Text) and "warn" in str(e))
+    assert preview_idx < message_idx < stderr_idx, (
+        "expected preview → message → stderr; got "
+        f"preview={preview_idx} message={message_idx} stderr={stderr_idx}"
+    )
+
+
+def test_return_result_tool_call_is_a_renderer_noop() -> None:
+    """``return_result`` as its own tool call emits no user-visible
+    rendering from this class — ``self.message()`` output, if any,
+    was already emitted inline when the agent called it, so there is
+    nothing for ``_on_tool_call(name='return_result')`` to do.
+    """
+    agent, emitted, r = _mk(show_python=False)
+    r.attach()
+
+    agent._render_message("Final word")
+    # Inline emit — the message is already on the transcript.
+    assert any(isinstance(e, Markdown) and "Final word" in str(e.markup) for e in emitted)
+
+    before = list(emitted)
+    agent.event_manager.fire(
+        "ToolCallEvent",
+        SimpleNamespace(name="return_result", tool_call_id="rr1", arguments={"result": {}}),
+    )
+    assert emitted == before, (
+        "return_result must be a no-op; nothing to flush in the inline-emit world"
+    )
+
+
+def test_prefill_tool_call_does_not_render_code_output() -> None:
+    """Prefill executions (internal inspection, e.g. ``prefill_abc``)
+    show a friendly preview instead of code — and the matching
+    ``PythonOutput`` short-circuits the full cell render so stdout
+    from the prefill doesn't leak into the transcript."""
+    agent, emitted, r = _mk(show_python=False)
+    r.attach()
+
+    _fire_tool_call(agent.event_manager, "inspect(x)", tool_call_id="prefill_a")
+    agent._render_message("post-inspect")
+    _fire_python_output(agent.event_manager, stdout="noise", tool_call_id="prefill_a")
+
+    # Prefill preview is suppressed — no "Inspecting inputs" text emitted.
+    assert not any(isinstance(e, Text) and "Inspecting inputs" in str(e) for e in emitted)
+    # The stdout from the prefill should NOT render — it's internal noise.
+    assert not any(isinstance(e, Text) and "noise" in str(e) for e in emitted)
+    # self.message() between preview and prefill-output rendered inline.
+    assert any(isinstance(e, Markdown) for e in emitted)
+
+
+def test_show_python_true_renders_full_cell() -> None:
+    """With show_python=True, PythonOutput emits a notebook-style cell:
+    'oo python' rule, Syntax(code), 'oo stdout' rule, stdout Text."""
+    agent, emitted, r = _mk(show_python=True)
+    r.attach()
+
+    _fire_tool_call(agent.event_manager, "print('ok')")
+    _fire_python_output(agent.event_manager, stdout="ok\n")
+
+    # Exactly one Syntax renderable for the code.
+    syntaxes = [e for e in emitted if isinstance(e, Syntax)]
+    assert len(syntaxes) == 1
+
+    # 'oo python' rule precedes syntax; 'oo stdout' rule precedes stdout.
+    rules = [e for e in emitted if isinstance(e, Rule)]
+    titles = [str(r.title) if r.title is not None else "" for r in rules]
+    assert any("python" in t for t in titles)
+    assert any("stdout" in t for t in titles)
+
+
+def test_detach_restores_prior_render_message_hook() -> None:
+    """``attach`` chains onto any prior ``_render_message`` so observers
+    (e.g. a web mirror) still fire. ``detach`` restores the prior hook
+    verbatim so a post-shutdown ``agent.message()`` doesn't invoke a
+    dead renderer."""
+    agent, emitted, r = _mk(show_python=False)
+
+    observer_calls: list[str] = []
+    agent._render_message = observer_calls.append
+
+    r.attach()
+    assert agent._render_message is not observer_calls.append  # chained
+
+    # A message fires the observer AND the renderer emits it inline.
+    agent._render_message("hi")
+    assert observer_calls == ["hi"]
+    assert any(isinstance(e, Markdown) and "hi" in str(e.markup) for e in emitted)
+
+    r.detach()
+    # Prior hook restored — observer still works, renderer does not
+    # queue (any more messages go only to the observer).
+    emitted.clear()
+    observer_calls.clear()
+    agent._render_message("post-shutdown")
+    assert observer_calls == ["post-shutdown"]
+    assert emitted == []  # renderer is gone
+
+
+def test_reasoning_event_emits_dim_italic_text() -> None:
+    """``Reasoning`` content is emitted as a dim italic ``Text`` block."""
+    agent, emitted, r = _mk(show_python=False)
+    r.attach()
+
+    _fire_reasoning(agent.event_manager, "thinking...")
+
+    texts = [e for e in emitted if isinstance(e, Text)]
+    assert len(texts) == 1
+    assert "thinking" in str(texts[0])
+
+
+def test_empty_reasoning_content_is_ignored() -> None:
+    """Blank reasoning events don't emit anything."""
+    agent, emitted, r = _mk(show_python=False)
+    r.attach()
+
+    _fire_reasoning(agent.event_manager, "")
+    _fire_reasoning(agent.event_manager, "   \n ")
+
+    assert emitted == []
+
+
+def test_reset_turn_is_quiet() -> None:
+    """``reset_turn`` just clears the per-turn ``OO ─`` guard flag —
+    it must never emit a stray rule or re-render anything."""
+    agent, emitted, r = _mk(show_python=False)
+    r.attach()
+
+    # First turn: one message renders inline + fires the OO rule once.
+    agent._render_message("turn 1")
+    assert any(isinstance(e, Rule) for e in emitted)
+    emitted.clear()
+
+    # reset_turn is a no-op on the emission side.
+    r.reset_turn()
+    assert emitted == []
+
+    # Next turn's first message fires a fresh OO rule (guard was reset).
+    agent._render_message("turn 2")
+    assert any(isinstance(e, Rule) for e in emitted)
+
+
+def test_attach_is_idempotent() -> None:
+    """A second ``attach`` call while already attached is a no-op —
+    handlers aren't double-subscribed."""
+    agent, emitted, r = _mk(show_python=False)
+    r.attach()
+    r.attach()  # second call
+
+    _fire_reasoning(agent.event_manager, "x")
+
+    texts = [e for e in emitted if isinstance(e, Text)]
+    assert len(texts) == 1  # not 2
+
+
+def test_summary_event_emits_dim_preview_line() -> None:
+    """Applied summaries surface as ``∴ summarized <tag> · N events → NB
+    summary`` so the user can see each collapse live.
+
+    Regression guard: if Summary events stop being emitted by
+    ``event_manager.collapse``, the TUI silently loses visibility into the
+    summarizer (which is how a pathological cascade bug went undiagnosed
+    until a DB audit).
+    """
+    agent, emitted, r = _mk(show_python=False)
+    r.attach()
+
+    _fire_summary(
+        agent.event_manager,
+        summary_tag="1..600",
+        replaced_range=(1, 600),
+        children_tags=[str(i) for i in range(1, 601)],
+        summary_text="x" * 2501,
+    )
+
+    texts = [e for e in emitted if isinstance(e, Text) and "∴" in str(e)]
+    assert len(texts) == 1
+    line = str(texts[0])
+    assert "summarized" in line
+    assert "1..600" in line
+    assert "600 events" in line
+    # 2501 chars → "2.4KB" (2501/1024 ≈ 2.4)
+    assert "KB" in line
+
+
+def test_summary_event_without_text_shows_truncation() -> None:
+    """A collapse with ``summary_text=None`` is a truncation — shown with
+    ``truncated`` and a ``(no summary)`` tail so it's visually distinct
+    from a real summarization."""
+    agent, emitted, r = _mk(show_python=False)
+    r.attach()
+
+    _fire_summary(
+        agent.event_manager,
+        summary_tag="1..50",
+        replaced_range=(1, 50),
+        children_tags=[str(i) for i in range(1, 51)],
+        summary_text=None,
+    )
+
+    texts = [e for e in emitted if isinstance(e, Text) and "∴" in str(e)]
+    assert len(texts) == 1
+    line = str(texts[0])
+    assert "truncated" in line
+    assert "1..50" in line
+    assert "no summary" in line
+
+
+@pytest.mark.parametrize(
+    "code,expected_fragment",
+    [
+        ("x = 1", "x = 1"),
+        ("# explain what this does\nrun_it()", "explain"),
+    ],
+)
+def test_code_preview_first_line_shape(code: str, expected_fragment: str) -> None:
+    """The ∴ code-preview line includes the first (comment or code) line."""
+    agent, emitted, r = _mk(show_python=False)
+    r.attach()
+
+    _fire_tool_call(agent.event_manager, code)
+
+    preview_texts = [e for e in emitted if isinstance(e, Text) and "∴" in str(e)]
+    assert preview_texts, "expected a ∴ preview line"
+    assert expected_fragment in str(preview_texts[0])

--- a/packages/nooa-cli/tests/tui/test_agent_location.py
+++ b/packages/nooa-cli/tests/tui/test_agent_location.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the agent-location probe and its use in /activity."""
+
+import asyncio
+import linecache
+
+import pytest
+from nooa_cli.tui.agent_location import (
+    AgentLocation,
+    FrameInfo,
+    _source_context,
+    locate_agent_on_loop,
+)
+from nooa_cli.tui.commands import ActivityCommand
+from nooa_cli.tui.output import CodeExecution, TableOutput
+
+
+@pytest.mark.asyncio
+async def test_locate_walks_full_await_chain():
+    """The probe follows cr_await down to the actual suspend point."""
+
+    async def tool_layer():
+        await asyncio.sleep(5)
+
+    async def cell_layer():
+        await tool_layer()
+
+    # The probe matches tasks whose coroutine/name contains the turn method.
+    async def handle():  # noqa: ANN202 - name is what the probe matches on
+        await cell_layer()
+
+    task = asyncio.ensure_future(handle())
+    await asyncio.sleep(0.02)  # let it suspend inside asyncio.sleep
+    try:
+        loc = locate_agent_on_loop()
+        assert isinstance(loc, AgentLocation)
+        quals = [f.qualname for f in loc.stack]
+        # outermost-first: handle -> cell_layer -> tool_layer -> sleep
+        assert any("handle" in q for q in quals)
+        assert any("cell_layer" in q for q in quals)
+        assert any("tool_layer" in q for q in quals)
+        # innermost is the suspend point
+        assert loc.innermost is loc.stack[-1]
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_locate_descends_into_awaited_task():
+    """A directly-awaited child Task is followed, not stopped at."""
+
+    async def child():
+        await asyncio.sleep(5)
+
+    async def handle():
+        await asyncio.ensure_future(child())
+
+    task = asyncio.ensure_future(handle())
+    await asyncio.sleep(0.02)
+    try:
+        loc = locate_agent_on_loop()
+        assert loc is not None
+        quals = [f.qualname for f in loc.stack]
+        assert any("handle" in q for q in quals)
+        assert any("child" in q for q in quals)
+    finally:
+        task.cancel()
+        # handle awaits a child task; cancelling parent cancels the await
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_locate_returns_none_when_no_turn_running():
+    """With no matching turn task, the probe returns None (idle)."""
+    loc = locate_agent_on_loop(turn_method="__no_such_method__")
+    assert loc is None
+
+
+@pytest.mark.asyncio
+async def test_activity_command_includes_suspend_location():
+    """/activity surfaces the await stack when a turn is in flight."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nooa_cli.tui.commands import ActivityCommand
+    from nooa_cli.tui.output import TableOutput
+
+    cmd = ActivityCommand(frontend=AsyncMock(), config=MagicMock(), agent=MagicMock())
+
+    async def tool_layer():
+        await asyncio.sleep(5)
+
+    async def handle():
+        await tool_layer()
+
+    task = asyncio.ensure_future(handle())
+    await asyncio.sleep(0.02)
+    try:
+        result = await cmd.execute([])
+        assert result.success
+        table = result.outputs[0]
+        assert isinstance(table, TableOutput)
+        flat = "\n".join(cell for row in table.rows for cell in row)
+        assert "Suspended at" in flat
+        assert "tool_layer" in flat
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_innermost_frame_has_source_context():
+    """The suspend-point frame carries ±3 lines of source (this test file)."""
+
+    async def handle():
+        await asyncio.sleep(5)
+
+    task = asyncio.ensure_future(handle())
+    await asyncio.sleep(0.02)
+    try:
+        loc = locate_agent_on_loop()
+        assert loc is not None and loc.innermost is not None
+        ctx = loc.innermost.context
+        # asyncio.sleep is C-adjacent but resolves to the sleep() coroutine in
+        # the stdlib, which has real source — so context should be non-empty.
+        assert ctx, "expected source context for the suspend frame"
+        current = [s for s in ctx if s.is_current]
+        assert len(current) == 1
+        assert current[0].lineno == loc.innermost.lineno
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_activity_command_emits_highlighted_code(monkeypatch):
+    """/activity emits the suspend-point source as a CodeExecution block.
+
+    Simulates a CodeAct/REPL cell by registering fake source in linecache under
+    the frame's co_filename and pointing the probe's innermost frame at it. The
+    code block is a separate output so the frontend can syntax-highlight it.
+    """
+    cell_name = "Cell In[42]"
+    cell_src = "a = 1\nb = 2\nc = await tool()\nd = 4\ne = 5\n"
+    linecache.cache[cell_name] = (
+        len(cell_src),
+        None,
+        cell_src.splitlines(keepends=True),
+        cell_name,
+    )
+
+    fake = AgentLocation(
+        task_name="TUIAgent.handle",
+        stack=[FrameInfo("handle", 3, cell_name)],
+    )
+    fake.stack[-1].context = _source_context(cell_name, 3)
+
+    from unittest.mock import AsyncMock, MagicMock
+
+    cmd = ActivityCommand(frontend=AsyncMock(), config=MagicMock(), agent=MagicMock())
+
+    async def _fake_locate():
+        return fake
+
+    monkeypatch.setattr(cmd, "_locate_agent", _fake_locate)
+
+    try:
+        result = await cmd.execute([])
+        # First output is the activity table; second is the code block.
+        assert isinstance(result.outputs[0], TableOutput)
+        code = next(o for o in result.outputs if isinstance(o, CodeExecution))
+        # the snippet covers the suspend line plus context, in source order
+        assert "c = await tool()" in code.code
+        assert "a = 1" in code.code
+        assert code.code.splitlines() == ["a = 1", "b = 2", "c = await tool()", "d = 4", "e = 5"]
+        # numbered from the real file offset, with the suspend line highlighted
+        assert code.start_line == 1  # context starts at file line 1 here
+        assert code.highlight_line == 3  # "c = await tool()" is file line 3
+    finally:
+        linecache.cache.pop(cell_name, None)
+
+
+@pytest.mark.asyncio
+async def test_activity_idle_is_one_liner():
+    """When idle with no turn running, /activity is a single status line."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nooa_cli.tui.commands import ActivityCommand
+    from nooa_cli.tui.output import TableOutput, TextOutput
+
+    cmd = ActivityCommand(frontend=AsyncMock(), config=MagicMock(), agent=MagicMock())
+
+    async def _idle_locate():  # probe returns None when idle
+        return None
+
+    cmd._locate_agent = _idle_locate  # type: ignore[method-assign]
+
+    result = await cmd.execute([])
+    assert result.success
+    assert len(result.outputs) == 1
+    out = result.outputs[0]
+    assert isinstance(out, TextOutput)
+    assert not isinstance(out, TableOutput)
+    assert "idle" in out.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_innermost_cell_prefers_agent_cell_frame():
+    """innermost_cell returns the agent's own ``Cell In[N]`` frame, not plumbing.
+
+    The real suspend point is usually framework/stdlib code the cell is blocked
+    in (e.g. asyncio.to_thread -> run_in_executor). The agent's own line lives in
+    a ``Cell In[N]`` frame further up the chain; that is what /activity should
+    highlight when a user asks "which line of my cell is running?".
+    """
+    cell_name = "Cell In[7]"
+    loc = AgentLocation(
+        task_name="TUIAgent.handle",
+        stack=[
+            FrameInfo("TUIAgent.handle", 1, "actor.py"),
+            FrameInfo("__repl_wrapper__", 9, cell_name),
+            FrameInfo("to_thread", 25, "/usr/lib/python3.12/asyncio/threads.py"),
+        ],
+    )
+    assert loc.innermost.qualname == "to_thread"  # true suspend point
+    assert loc.innermost_cell is loc.stack[1]  # the cell frame
+    assert loc.innermost_cell.filename == cell_name
+    assert loc.highlight is loc.innermost_cell  # highlight prefers the cell
+
+
+@pytest.mark.asyncio
+async def test_innermost_cell_none_without_cell_frame():
+    """No cell frame on the stack -> innermost_cell is None, highlight falls back."""
+    loc = AgentLocation(
+        task_name="TUIAgent.handle",
+        stack=[
+            FrameInfo("TUIAgent.handle", 1, "actor.py"),
+            FrameInfo("sleep", 3, "/usr/lib/python3.12/asyncio/tasks.py"),
+        ],
+    )
+    assert loc.innermost_cell is None
+    assert loc.highlight is loc.innermost
+
+
+@pytest.mark.asyncio
+async def test_activity_highlights_cell_line_below_plumbing(monkeypatch):
+    """/activity highlights the agent's cell line even when suspended in plumbing.
+
+    Mirrors the real bug: the cell did ``await asyncio.to_thread(...)`` so the
+    suspend point is to_thread's run_in_executor, but the user wants the cell
+    line. The code block must highlight the cell line and the stack must mark it.
+    """
+    cell_name = "Cell In[7]"
+    cell_src = "wt = setup()\nimport os\ntool = await asyncio.to_thread(_connect)\nprint(tool)\n"
+    linecache.cache[cell_name] = (
+        len(cell_src),
+        None,
+        cell_src.splitlines(keepends=True),
+        cell_name,
+    )
+
+    fake = AgentLocation(
+        task_name="TUIAgent.handle",
+        stack=[
+            FrameInfo("TUIAgent.handle", 1, "actor.py"),
+            FrameInfo("__repl_wrapper__", 3, cell_name),
+            FrameInfo("to_thread", 25, "/usr/lib/python3.12/asyncio/threads.py"),
+        ],
+    )
+    fake.stack[1].context = _source_context(cell_name, 3)
+
+    from unittest.mock import AsyncMock, MagicMock
+
+    cmd = ActivityCommand(frontend=AsyncMock(), config=MagicMock(), agent=MagicMock())
+
+    async def _fake_locate():
+        return fake
+
+    monkeypatch.setattr(cmd, "_locate_agent", _fake_locate)
+
+    try:
+        result = await cmd.execute([])
+        code = next(o for o in result.outputs if isinstance(o, CodeExecution))
+        # highlight is the cell's await line, not to_thread's line 25
+        assert code.highlight_line == 3
+        assert "await asyncio.to_thread(_connect)" in code.code
+        # the stack still lists the deeper plumbing frame, marked as such
+        table = result.outputs[0]
+        flat = "\n".join(cell for row in table.rows for cell in row)
+        assert "to_thread" in flat
+        assert "\u2192 __repl_wrapper__" in flat  # cell frame marked with arrow
+    finally:
+        linecache.cache.pop(cell_name, None)
+
+
+@pytest.mark.asyncio
+async def test_locate_attaches_context_to_cell_frame_not_plumbing():
+    """The real probe attaches source to the highlight (cell) frame, not plumbing.
+
+    Regression guard for the bug where ``locate_agent_on_loop`` attached source
+    context only to ``stack[-1]`` (the framework suspend point), leaving the
+    cell frame — which the renderer highlights — without source, so the code
+    block silently vanished. Here a cell frame (registered in linecache) sits
+    above an ``asyncio.sleep`` suspend point; the cell frame must carry context.
+    """
+    cell_name = "Cell In[99]"
+
+    # A coroutine whose frame reports the cell filename, awaiting sleep. Only
+    # ``co_filename`` is rewritten — we deliberately do NOT touch
+    # ``co_firstlineno``, since the suspended frame's ``f_lineno`` is computed
+    # relative to it and remapping makes the reported line version-fragile.
+    async def cell_coro():
+        await asyncio.sleep(5)
+
+    cell_coro.__code__ = cell_coro.__code__.replace(co_filename=cell_name)
+
+    async def handle():
+        await cell_coro()
+
+    task = asyncio.ensure_future(handle())
+    await asyncio.sleep(0.02)
+    try:
+        loc = locate_agent_on_loop()
+        assert loc is not None
+        cell = loc.innermost_cell
+        assert cell is not None, "expected the Cell In[N] frame in the stack"
+        assert cell.filename == cell_name
+        assert loc.highlight is cell
+
+        # Register enough linecache lines to cover the frame's *real* f_lineno
+        # (whatever the running interpreter reports), then re-run the probe so
+        # the source-context attach has source to find. Robust across CPython
+        # line-number-table changes — we never assume a specific line.
+        n = cell.lineno + 5
+        src = "".join(f"line {i}\n" for i in range(1, n + 1))
+        linecache.cache[cell_name] = (
+            len(src),
+            None,
+            src.splitlines(keepends=True),
+            cell_name,
+        )
+        loc = locate_agent_on_loop()
+        cell = loc.innermost_cell
+        # The bug: context was attached to stack[-1] (sleep), not the cell frame.
+        assert cell.context, "highlight (cell) frame must carry source context"
+        current = [s for s in cell.context if s.is_current]
+        assert len(current) == 1 and current[0].lineno == cell.lineno
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        linecache.cache.pop(cell_name, None)

--- a/packages/nooa-cli/tests/tui/test_bang_command.py
+++ b/packages/nooa-cli/tests/tui/test_bang_command.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Test that TUI bang (!) commands work with ShellTools-based agents."""
+
+import tempfile
+from unittest.mock import AsyncMock, MagicMock
+
+from nooa_cli.tui.session import Session
+
+
+class TestBangCommand:
+    """Verify that ! commands route through the TUI's own ShellTools."""
+
+    async def test_bang_command_works_with_shell_agent(self):
+        """An agent with self.shell must handle ! commands via TUI-owned shell."""
+        # Create a mock agent with shell but no bash
+        agent = MagicMock()
+        del agent.bash  # ensure no bash attribute
+        agent.shell = MagicMock()
+        agent.shell.cwd = tempfile.gettempdir()
+
+        # Create a minimal session with a pre-set _bang_shell mock
+        session = object.__new__(Session)
+        session.agent = agent
+        bang_shell = MagicMock()
+        bang_shell.cwd = tempfile.gettempdir()  # match agent.shell.cwd so no sync cd happens
+        bang_shell.run = AsyncMock(
+            return_value=MagicMock(
+                stdout="hello",
+                stderr="",
+                returncode=0,
+            )
+        )
+        session._bang_shell = bang_shell
+
+        # The session should detect shell support
+        assert hasattr(session.agent, "shell")
+        assert not hasattr(session.agent, "bash")
+
+        # Call _handle_bang — this should NOT show the warning
+        frontend = AsyncMock()
+        session.frontend = frontend
+
+        await session._handle_bang("!echo hello")
+
+        # Should have called the TUI's own bang shell, not the agent's
+        bang_shell.run.assert_called_once_with("echo hello")
+        agent.shell.run.assert_not_called()
+
+    @staticmethod
+    def _session_with_bang_shell() -> Session:
+        agent = MagicMock()
+        del agent.bash
+        agent.shell = MagicMock()
+        agent.shell.cwd = tempfile.gettempdir()
+
+        session = object.__new__(Session)
+        session.agent = agent
+        bang_shell = MagicMock()
+        bang_shell.cwd = tempfile.gettempdir()
+        bang_shell.run = AsyncMock(return_value=MagicMock(stdout="", stderr="", returncode=0))
+        session._bang_shell = bang_shell
+        session.frontend = AsyncMock()
+        return session
+
+    async def test_bang_strips_whitespace(self):
+        """Leading/trailing whitespace after ! is stripped before running."""
+        session = self._session_with_bang_shell()
+
+        await session._handle_bang("!  git status  ")
+
+        session._bang_shell.run.assert_called_once_with("git status")
+
+    async def test_bang_empty_command_does_not_run(self):
+        """! with no command returns early without calling the shell."""
+        session = self._session_with_bang_shell()
+
+        assert await session._handle_bang("!") is None
+        session._bang_shell.run.assert_not_called()
+
+    async def test_bang_whitespace_only_does_not_run(self):
+        """! followed by only whitespace returns early without calling the shell."""
+        session = self._session_with_bang_shell()
+
+        assert await session._handle_bang("!   ") is None
+        session._bang_shell.run.assert_not_called()

--- a/packages/nooa-cli/tests/tui/test_bootstrap_scaffold.py
+++ b/packages/nooa-cli/tests/tui/test_bootstrap_scaffold.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for first-run settings scaffolding.
+
+These cover ``_scaffold_settings``, which writes the starter
+``~/.config/nooa/settings.yaml`` the first time the TUI launches (when no
+settings file exists in any layer). The template contains literal braces
+(e.g. ``${MAAS_API_KEY}`` in the inline-MCP example), so it must be rendered
+with ``str.replace`` — ``str.format`` would raise ``KeyError`` on the
+unrelated brace and crash startup before any config is written.
+"""
+
+from nooa_cli.tui.bootstrap import _scaffold_settings
+from nooa_cli.tui.config import Config
+from nooa_cli.tui.settings import SETTINGS_TEMPLATE, render_settings_template
+
+
+def _isolate(tmp_path, monkeypatch):
+    """Point user + project dirs at empty temp dirs; clear the env override."""
+    user = tmp_path / "user"
+    proj = tmp_path / "proj"
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(user))
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(proj))
+    monkeypatch.delenv("NEMO_OO_SETTINGS", raising=False)
+    return user
+
+
+def test_scaffold_writes_settings_with_model_and_preserves_literal_braces(tmp_path, monkeypatch):
+    """First-run scaffold writes settings.yaml without choking on literal braces."""
+    user = _isolate(tmp_path, monkeypatch)
+
+    config = Config()
+    config.tui.default_model = "nvidia/llama-3.3"
+    _scaffold_settings(config)
+
+    settings_path = user / "settings.yaml"
+    assert settings_path.exists()
+    written = settings_path.read_text()
+
+    # The {default_model} placeholder is substituted...
+    assert "nvidia/llama-3.3" in written
+    assert "{default_model}" not in written
+    # ...while literal braces from the inline-MCP example survive verbatim.
+    assert "${MAAS_API_KEY}" in written
+
+
+def test_scaffold_skips_when_settings_present(tmp_path, monkeypatch):
+    """An existing settings.yaml (any layer) is never overwritten."""
+    user = _isolate(tmp_path, monkeypatch)
+    user.mkdir(parents=True)
+    settings_path = user / "settings.yaml"
+    settings_path.write_text("# user edits\n")
+
+    _scaffold_settings(Config())
+
+    assert settings_path.read_text() == "# user edits\n"
+
+
+def test_template_has_only_the_default_model_field():
+    """Guard: {default_model} is the only single-brace field in the template.
+
+    If a future edit adds another ``{field}`` it would silently break the
+    plain .replace() substitution, so flag it here.
+    """
+    import re
+
+    # Drop ${...} shell-style refs, then the known placeholder, then assert no
+    # other single-brace {token} survives.
+    stripped = re.sub(r"\$\{[^}]*\}", "", SETTINGS_TEMPLATE)
+    stripped = stripped.replace("{default_model}", "")
+    assert re.search(r"(?<!\{)\{[A-Za-z_][A-Za-z0-9_]*\}", stripped) is None
+
+
+def test_render_does_not_raise_on_literal_braces():
+    """render_settings_template must not str.format() the ${...} examples."""
+    out = render_settings_template(Config())
+    assert "${MAAS_API_KEY}" in out

--- a/packages/nooa-cli/tests/tui/test_clear_preserves_sqlite.py
+++ b/packages/nooa-cli/tests/tui/test_clear_preserves_sqlite.py
@@ -1,0 +1,472 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Integration-level tests proving ``/clear`` and ``/session new`` don't
+destroy the previous session's SQLite data.
+
+**Why this exists.** An earlier bug had ``ClearCommand`` call
+``agent.event_manager.clear()``, which wiped the *current* SQLite
+storage's events before ``Session._swap_session_manager`` could close
+and preserve them. Mock-based tests elsewhere (e.g.
+``test_commands.py::test_clear_command_output``) assert
+``event_manager.clear`` wasn't called — a negative mock check, not
+proof of persistence. These tests use a real ``SQLiteStorageManager``
++ real ``SessionManager`` to prove the positive invariant: old-session
+rows stay on disk and reload correctly after the command runs.
+
+Rewritten from the original ``test_clear_bug.py`` after that file was
+over-broadly removed during a typeahead-loop cleanup. The integration
+path through ``Session.run`` + ``TestFrontend`` isn't restored here —
+the unit tests below are what pin the data-preservation invariant;
+the full-REPL path is covered indirectly by the other TUI behaviour
+tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from nooa_cli.tui.commands import (
+    ClearCommand,
+    CommandHandler,
+    CommandRegistry,
+)
+from nooa_cli.tui.output import ClearScreen
+from nooa_cli.tui.session_manager import SessionManager
+
+from nooa.storage import SQLiteStorageManager
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def _make_sm(tmp_path, *, model="m", agent_cls="A", working_dir="", session_id=None):
+    """Create a real SQLite-backed ``SessionManager`` in ``tmp_path``."""
+    return SessionManager.create(
+        session_id=session_id,
+        model=model,
+        agent_cls=agent_cls,
+        working_dir=working_dir,
+    )
+
+
+def _make_mock_agent(storage: SQLiteStorageManager) -> MagicMock:
+    """Mock agent wired to a real ``SQLiteStorageManager``.
+
+    The agent owns a real ``EventManager`` bound to the storage's
+    backend so ``clear()`` would actually destroy data (proves the bug
+    was real) and so survival is verifiable (proves the fix works).
+    """
+    from nooa.runtime.event_manager import EventManager
+
+    agent = MagicMock()
+    agent._storage = storage
+    agent.event_manager = EventManager(backend=storage.event_backend)
+    agent.handle = AsyncMock()
+    # on() must return a callable (unsubscribe fn) for any renderer wiring.
+    agent.event_manager.on = MagicMock(return_value=lambda: None)
+    return agent
+
+
+async def _apply_post_session_swap(result):
+    assert result.post_session_swap is not None
+    value = result.post_session_swap()
+    if hasattr(value, "__await__"):
+        await value
+
+
+# ── /clear preserves old session's SQLite rows ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clear_does_not_destroy_old_session_data(tmp_path):
+    """``ClearCommand`` must leave the old session's events on disk.
+
+    Positive assertion: after ``/clear`` runs and the old session
+    manager closes, ``SessionManager.load_turns(old_sid)`` returns the
+    turn recorded before the command fired.
+    """
+    with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+        old_sm = _make_sm(tmp_path)
+        old_sm.record_user("remember me")
+        old_sid = old_sm.session_id
+
+        agent = _make_mock_agent(old_sm._storage)
+
+        cmd = ClearCommand(
+            agent=agent,
+            config=MagicMock(default_model="test"),
+            frontend=AsyncMock(),
+            session_manager=old_sm,
+        )
+
+        result = await cmd.execute([])
+
+        assert result.success is True
+        assert any(isinstance(o, ClearScreen) for o in result.outputs)
+
+        # Close the newly-created session manager so we can reload the
+        # old one's data cleanly.
+        if result.new_session_manager is not None:
+            result.new_session_manager.close()
+        old_sm.close()
+
+        turns = SessionManager.load_turns(old_sid)
+
+    assert len(turns) == 1, (
+        f"/clear destroyed the old session's data — expected 1 turn, got {len(turns)}"
+    )
+    assert turns[0].content == "remember me"
+
+
+@pytest.mark.asyncio
+async def test_clear_resets_in_memory_todos(tmp_path):
+    """``/clear`` must wipe the agent's in-memory todo state.
+
+    Swapping storage alone only clears conversation history (events).
+    ``TodoManager._todos`` lives on the agent instance, so a naive
+    storage swap lets old todos bleed into the new "fresh" session.
+    """
+    from nooa.tools.todo import TodoManager
+
+    with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+        old_sm = _make_sm(tmp_path)
+        agent = _make_mock_agent(old_sm._storage)
+        agent.todo = TodoManager()
+        agent.todo.add("task from previous session")
+        assert len(agent.todo._todos) == 1
+
+        cmd = ClearCommand(
+            agent=agent,
+            config=MagicMock(default_model="test"),
+            frontend=AsyncMock(),
+            session_manager=old_sm,
+        )
+        result = await cmd.execute([])
+        await _apply_post_session_swap(result)
+
+        if result.new_session_manager is not None:
+            result.new_session_manager.close()
+        old_sm.close()
+
+    assert agent.todo._todos == {}, "/clear left stale todos in memory"
+    assert agent.todo._order == []
+
+
+@pytest.mark.asyncio
+async def test_clear_without_todo_skill_is_safe(tmp_path):
+    """Agents without a ``todo`` attribute still work — the reset helper
+    is guarded."""
+    with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+        old_sm = _make_sm(tmp_path)
+        agent = _make_mock_agent(old_sm._storage)
+        if hasattr(agent, "todo"):
+            del agent.todo
+
+        cmd = ClearCommand(
+            agent=agent,
+            config=MagicMock(default_model="test"),
+            frontend=AsyncMock(),
+            session_manager=old_sm,
+        )
+        result = await cmd.execute([])
+        assert result.success is True
+
+        if result.new_session_manager is not None:
+            result.new_session_manager.close()
+        old_sm.close()
+
+
+@pytest.mark.asyncio
+async def test_clear_creates_new_session_with_different_id(tmp_path):
+    """``/clear`` result carries a fresh ``SessionManager`` distinct
+    from the old one — i.e. the caller has something to swap to."""
+    with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+        old_sm = _make_sm(tmp_path)
+        old_sid = old_sm.session_id
+
+        agent = _make_mock_agent(old_sm._storage)
+        cmd = ClearCommand(
+            agent=agent,
+            config=MagicMock(default_model="test"),
+            frontend=AsyncMock(),
+            session_manager=old_sm,
+        )
+
+        result = await cmd.execute([])
+
+        assert result.new_session_manager is not None
+        assert result.new_session_manager.session_id != old_sid
+
+        result.new_session_manager.close()
+        old_sm.close()
+
+
+# ── /session new preserves old session's SQLite rows ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_session_new_does_not_destroy_old_session_data(tmp_path):
+    """``/session new`` has the same preservation contract as ``/clear``
+    — dispatched via the full ``CommandHandler`` path so any registry
+    wiring regressions are caught here too."""
+    with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+        old_sm = _make_sm(tmp_path)
+        old_sm.record_user("keep this")
+        old_sid = old_sm.session_id
+
+        agent = _make_mock_agent(old_sm._storage)
+
+        registry = CommandRegistry(
+            frontend=AsyncMock(),
+            config=MagicMock(default_model="test"),
+            agent=agent,
+            session_manager=old_sm,
+            skills_dirs=None,
+            mcp_file=None,
+        )
+        handler = CommandHandler(registry=registry, frontend=AsyncMock())
+
+        result = await handler.handle("/session new")
+
+        assert result.success is True
+
+        if result.new_session_manager is not None:
+            result.new_session_manager.close()
+        old_sm.close()
+
+        turns = SessionManager.load_turns(old_sid)
+
+    assert len(turns) == 1, (
+        f"/session new destroyed the old session's data — expected 1 turn, got {len(turns)}"
+    )
+    assert turns[0].content == "keep this"
+
+
+# ── subscriber survives storage swap (the original silent-preview bug) ─
+
+
+@pytest.mark.asyncio
+async def test_subscriber_survives_clear_swap(tmp_path):
+    """Pins the original silent-preview bug: a handler subscribed once
+    on ``agent.event_manager`` keeps firing after ``/clear`` swaps the
+    storage underneath. Before the structural fix this test would fail
+    because ``agent.event_manager`` was a property and the swap would
+    orphan the subscription on the abandoned manager."""
+    from nooa.events import Task
+
+    with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+        old_sm = _make_sm(tmp_path)
+        agent = _make_mock_agent(old_sm._storage)
+        # Replace the renderer-style mocked subscription with a real
+        # handler so we can prove it fires across the swap.
+        from nooa.runtime.event_manager import EventManager
+
+        agent.event_manager = EventManager(backend=old_sm._storage.event_backend)
+        received: list[str] = []
+        agent.event_manager.on("Task", lambda e: received.append(e.prompt))
+
+        # Pre-swap: handler fires.
+        agent.event_manager.add(Task(prompt="before"))
+        assert received == ["before"]
+
+        # Run /clear and apply the swap that Session._swap_session_manager would do.
+        cmd = ClearCommand(
+            agent=agent,
+            config=MagicMock(default_model="test"),
+            frontend=AsyncMock(),
+            session_manager=old_sm,
+        )
+        result = await cmd.execute([])
+        new_sm = result.new_session_manager
+        assert new_sm is not None
+        agent._storage = new_sm._storage
+        agent.event_manager.set_backend(new_sm._storage.event_backend)
+
+        # Post-swap: handler still fires; event lands in the new backend.
+        agent.event_manager.add(Task(prompt="after"))
+        assert received == ["before", "after"]
+        new_tags = [e.tag for e in new_sm._storage.event_backend.all_events()]
+        assert any(
+            isinstance(e, Task) and e.prompt == "after"
+            for e in new_sm._storage.event_backend.all_events()
+        ), f"'after' event missing from new backend; tags present: {new_tags}"
+
+        new_sm.close()
+        old_sm.close()
+
+
+@pytest.mark.asyncio
+async def test_clear_resets_agent_vars(tmp_path):
+    """``/clear`` must wipe ``agent.vars`` so ``self.v`` starts fresh."""
+    with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+        old_sm = _make_sm(tmp_path)
+        agent = _make_mock_agent(old_sm._storage)
+        agent.vars = {"spec": "old plan", "cursor": 42}
+
+        cmd = ClearCommand(
+            agent=agent,
+            config=MagicMock(default_model="test"),
+            frontend=AsyncMock(),
+            session_manager=old_sm,
+        )
+        result = await cmd.execute([])
+        await _apply_post_session_swap(result)
+
+        if result.new_session_manager is not None:
+            result.new_session_manager.close()
+        old_sm.close()
+
+    assert agent.vars == {}, f"/clear left stale vars: {agent.vars}"
+
+
+@pytest.mark.asyncio
+async def test_clear_resets_user_context_blocks(tmp_path):
+    """``/clear`` must remove user-set context blocks but keep protected ones."""
+    from nooa.runtime.context_manager import ContextManager
+
+    with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+        old_sm = _make_sm(tmp_path)
+        agent = _make_mock_agent(old_sm._storage)
+
+        cm = ContextManager()
+        cm.set_static_protected("system_prompt", "you are an agent")
+        cm["user_note"] = "remember this"
+        cm["plan"] = "step 1, step 2"
+        agent.context_manager = cm
+
+        cmd = ClearCommand(
+            agent=agent,
+            config=MagicMock(default_model="test"),
+            frontend=AsyncMock(),
+            session_manager=old_sm,
+        )
+        result = await cmd.execute([])
+        await _apply_post_session_swap(result)
+
+        if result.new_session_manager is not None:
+            result.new_session_manager.close()
+        old_sm.close()
+
+    assert "system_prompt" in cm, "protected block was removed"
+    assert "user_note" not in cm, "/clear left user context block 'user_note'"
+    assert "plan" not in cm, "/clear left user context block 'plan'"
+
+
+@pytest.mark.asyncio
+async def test_clear_resets_shell(tmp_path):
+    """``/clear`` must reset the shell session."""
+    with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+        old_sm = _make_sm(tmp_path)
+        agent = _make_mock_agent(old_sm._storage)
+        agent.shell = MagicMock()
+        agent.shell.reset = AsyncMock()
+
+        cmd = ClearCommand(
+            agent=agent,
+            config=MagicMock(default_model="test"),
+            frontend=AsyncMock(),
+            session_manager=old_sm,
+        )
+        result = await cmd.execute([])
+        await _apply_post_session_swap(result)
+
+        if result.new_session_manager is not None:
+            result.new_session_manager.close()
+        old_sm.close()
+
+    agent.shell.reset.assert_awaited_once()
+
+
+# ── /session new resets agent state ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_session_new_resets_agent_vars(tmp_path):
+    """``/session new`` must wipe ``agent.vars`` so ``self.v`` starts fresh."""
+    with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+        old_sm = _make_sm(tmp_path)
+        agent = _make_mock_agent(old_sm._storage)
+        agent.vars = {"spec": "old plan", "cursor": 42}
+
+        registry = CommandRegistry(
+            frontend=AsyncMock(),
+            config=MagicMock(default_model="test"),
+            agent=agent,
+            session_manager=old_sm,
+            skills_dirs=None,
+            mcp_file=None,
+        )
+        handler = CommandHandler(registry=registry, frontend=AsyncMock())
+
+        result = await handler.handle("/session new")
+        await _apply_post_session_swap(result)
+
+        if result.new_session_manager is not None:
+            result.new_session_manager.close()
+        old_sm.close()
+
+    assert agent.vars == {}, f"/session new left stale vars: {agent.vars}"
+
+
+@pytest.mark.asyncio
+async def test_session_new_resets_user_context_blocks(tmp_path):
+    """``/session new`` must remove user-set context blocks but keep protected ones."""
+    from nooa.runtime.context_manager import ContextManager
+
+    with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+        old_sm = _make_sm(tmp_path)
+        agent = _make_mock_agent(old_sm._storage)
+
+        cm = ContextManager()
+        cm.set_static_protected("system_prompt", "you are an agent")
+        cm["user_note"] = "remember this"
+        agent.context_manager = cm
+
+        registry = CommandRegistry(
+            frontend=AsyncMock(),
+            config=MagicMock(default_model="test"),
+            agent=agent,
+            session_manager=old_sm,
+            skills_dirs=None,
+            mcp_file=None,
+        )
+        handler = CommandHandler(registry=registry, frontend=AsyncMock())
+
+        result = await handler.handle("/session new")
+        await _apply_post_session_swap(result)
+
+        if result.new_session_manager is not None:
+            result.new_session_manager.close()
+        old_sm.close()
+
+    assert "system_prompt" in cm, "protected block was removed"
+    assert "user_note" not in cm, "/session new left user context block"
+
+
+@pytest.mark.asyncio
+async def test_session_new_resets_shell(tmp_path):
+    """``/session new`` must reset the shell session."""
+    with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+        old_sm = _make_sm(tmp_path)
+        agent = _make_mock_agent(old_sm._storage)
+        agent.shell = MagicMock()
+        agent.shell.reset = AsyncMock()
+
+        registry = CommandRegistry(
+            frontend=AsyncMock(),
+            config=MagicMock(default_model="test"),
+            agent=agent,
+            session_manager=old_sm,
+            skills_dirs=None,
+            mcp_file=None,
+        )
+        handler = CommandHandler(registry=registry, frontend=AsyncMock())
+
+        result = await handler.handle("/session new")
+        await _apply_post_session_swap(result)
+
+        if result.new_session_manager is not None:
+            result.new_session_manager.close()
+        old_sm.close()
+
+    agent.shell.reset.assert_awaited_once()

--- a/packages/nooa-cli/tests/tui/test_command_runner.py
+++ b/packages/nooa-cli/tests/tui/test_command_runner.py
@@ -1,0 +1,320 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the TUI-local command runner.
+
+Command lifecycle is separate from agent QueueManager jobs: slash and bang
+commands get UI feedback, but they are not agent background jobs.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from nooa_cli.tui.command_runner import CommandRunner
+from nooa_cli.tui.commands import CommandResult
+from nooa_cli.tui.output import BashOutput, CommandStatus
+from nooa_cli.tui.session import Session
+
+
+@pytest.mark.asyncio
+async def test_command_runner_serializes_commands_and_renders_lifecycle():
+    """Commands run one at a time while lifecycle and queue status update."""
+    rendered = []
+    dynamic_statuses = []
+    dynamic_queues = []
+
+    async def render(output):
+        rendered.append(output)
+
+    runner = CommandRunner(
+        render,
+        set_dynamic_status=dynamic_statuses.append,
+        set_dynamic_queue=dynamic_queues.append,
+    )
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    order = []
+
+    async def first():
+        order.append("first-start")
+        first_entered.set()
+        await release_first.wait()
+        order.append("first-end")
+
+    async def second():
+        order.append("second")
+
+    t1 = asyncio.create_task(runner.run(kind="slash", text="/slow", work=first))
+    await first_entered.wait()
+    t2 = asyncio.create_task(runner.run(kind="bang", text="!echo hi", work=second))
+    await asyncio.sleep(0)
+
+    assert order == ["first-start"]
+    assert [r.state for r in runner.records] == ["running", "queued"]
+
+    release_first.set()
+    await asyncio.gather(t1, t2)
+
+    assert order == ["first-start", "first-end", "second"]
+    statuses = [o for o in rendered if isinstance(o, CommandStatus)]
+    assert [(s.text, s.state) for s in statuses] == [("/slow", "done"), ("!echo hi", "done")]
+    assert dynamic_statuses[0] == "○ 1 queued"
+    assert "· /slow" in dynamic_statuses
+    assert ["!echo hi"] in dynamic_queues
+    assert "✓ /slow done" not in dynamic_statuses
+    assert "· !echo hi" in dynamic_statuses
+    assert "✓ !echo hi done" not in dynamic_statuses
+
+
+@pytest.mark.asyncio
+async def test_command_runner_surfaces_post_done_render_failures_without_hanging():
+    """Post-done render failures become failed statuses without blocking the queue."""
+    rendered = []
+
+    async def render(output):
+        rendered.append(output)
+
+    runner = CommandRunner(render)
+
+    async def work():
+        async def post_done():
+            raise RuntimeError("render boom")
+
+        return post_done
+
+    await runner.run(kind="slash", text="/boom", work=work)
+
+    statuses = [o for o in rendered if isinstance(o, CommandStatus)]
+    assert [(s.text, s.state) for s in statuses] == [("/boom", "done"), ("/boom", "failed")]
+    assert "post-completion render failed" in statuses[-1].error
+
+
+@pytest.mark.asyncio
+async def test_command_runner_animates_running_status():
+    """Running commands pulse slowly enough for both spinner frames to appear."""
+    dynamic_statuses = []
+
+    async def render(_output):
+        return None
+
+    runner = CommandRunner(render, set_dynamic_status=dynamic_statuses.append)
+
+    async def slow():
+        await asyncio.sleep(0.6)
+
+    await runner.run(kind="slash", text="/slow", work=slow)
+
+    running_statuses = [s for s in dynamic_statuses if s.endswith("/slow")]
+    assert any(s.startswith("·") for s in running_statuses)
+    assert any(s.startswith("•") for s in running_statuses)
+    assert "✓ /slow done" not in dynamic_statuses
+
+
+@pytest.mark.asyncio
+async def test_command_runner_renders_failed_without_converting_to_agent_job():
+    """Command failures render in the TUI lifecycle instead of agent job state."""
+    rendered = []
+    dynamic_statuses = []
+    dynamic_queues = []
+
+    async def render(output):
+        rendered.append(output)
+
+    runner = CommandRunner(
+        render,
+        set_dynamic_status=dynamic_statuses.append,
+        set_dynamic_queue=dynamic_queues.append,
+    )
+
+    async def boom():
+        raise RuntimeError("boom")
+
+    await runner.run(kind="slash", text="/boom", work=boom)
+
+    assert runner.records[-1].state == "failed"
+    assert runner.records[-1].error == "RuntimeError: boom"
+    statuses = [o for o in rendered if isinstance(o, CommandStatus)]
+    assert [(s.text, s.state) for s in statuses] == [("/boom", "failed")]
+    assert "boom" in statuses[-1].error
+    assert dynamic_statuses == ["○ 1 queued", "· /boom", ""]
+    assert dynamic_queues == [["/boom"], [], []]
+
+
+@pytest.mark.asyncio
+async def test_session_bang_routes_through_command_runner_and_renders_status():
+    """Bang commands use CommandRunner and render status before shell output."""
+    session = Session.__new__(Session)
+    session.agent = MagicMock()
+    session.agent.shell.cwd = "/tmp"
+    session.frontend = SimpleNamespace(render=AsyncMock())
+    session._bang_shell = MagicMock()
+    session._bang_shell.cwd = "/tmp"
+    session._bang_shell.run = AsyncMock(
+        return_value=SimpleNamespace(stdout="hello", stderr="", returncode=0)
+    )
+    app = MagicMock()
+    app.set_command_status = MagicMock()
+    app.set_command_queue = MagicMock()
+    session._app = app
+    session._command_runner = None
+
+    await session._on_bang("echo hello")
+
+    session._bang_shell.run.assert_awaited_once_with("echo hello")
+    rendered = [call.args[0] for call in session.frontend.render.await_args_list]
+    statuses = [o for o in rendered if isinstance(o, CommandStatus)]
+    assert [(s.text, s.state) for s in statuses] == [("!echo hello", "done")]
+    app.set_command_status.assert_any_call("○ 1 queued")
+    app.set_command_queue.assert_any_call(["!echo hello"])
+    app.set_command_status.assert_any_call("· !echo hello")
+    assert not any(
+        call.args == ("✓ !echo hello done",) for call in app.set_command_status.call_args_list
+    )
+    assert isinstance(rendered[0], CommandStatus)
+    assert isinstance(rendered[1], BashOutput)
+    assert rendered[1].stdout == "hello"
+
+
+@pytest.mark.asyncio
+async def test_session_slash_routes_through_command_runner_and_preserves_result_handling():
+    """Slash commands use CommandRunner without changing result routing."""
+    session = Session.__new__(Session)
+    session._first_message = None
+    session._session_manager = None
+    session.frontend = SimpleNamespace(render=AsyncMock())
+    session._command_runner = None
+    session._emit_text = MagicMock()
+    app = MagicMock()
+    app._agent_task = None
+    app.submit_message = MagicMock()
+    app.set_command_status = MagicMock()
+    app.set_command_queue = MagicMock()
+    session._app = app
+    session.agent = MagicMock()
+
+    handler = MagicMock()
+    handler.handle = AsyncMock(
+        return_value=CommandResult(success=True, agent_message="from command")
+    )
+    session._handler = handler
+
+    await session._on_command("/skill args")
+
+    handler.handle.assert_awaited_once_with("/skill args", render_outputs=False)
+    app.submit_message.assert_called_once_with("from command")
+    rendered = [call.args[0] for call in session.frontend.render.await_args_list]
+    statuses = [o for o in rendered if isinstance(o, CommandStatus)]
+    assert [(s.text, s.state) for s in statuses] == [("/skill args", "done")]
+    app.set_command_status.assert_any_call("○ 1 queued")
+    app.set_command_queue.assert_any_call(["/skill args"])
+    app.set_command_status.assert_any_call("· /skill args")
+    assert not any(
+        call.args == ("✓ /skill args done",) for call in app.set_command_status.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_slash_renders_done_before_user_visible_output():
+    """User-visible slash output appears after the durable done marker."""
+    session = Session.__new__(Session)
+    session._first_message = None
+    session._session_manager = None
+    session.frontend = SimpleNamespace(render=AsyncMock())
+    session._command_runner = None
+    session._emit_text = MagicMock()
+    app = MagicMock()
+    app._agent_task = None
+    app.set_command_status = MagicMock()
+    app.set_command_queue = MagicMock()
+    session._app = app
+    session.agent = SimpleNamespace()
+
+    class _SlashResult:
+        command = "mcp"
+        value = "output"
+        output_to_agent = False
+
+        def __str__(self):
+            return "command output"
+
+    handler = MagicMock()
+    handler.handle = AsyncMock(
+        return_value=CommandResult(success=True, slash_result=_SlashResult())
+    )
+    session._handler = handler
+
+    await session._on_command("/mcp list")
+
+    rendered = [call.args[0] for call in session.frontend.render.await_args_list]
+    assert isinstance(rendered[0], CommandStatus)
+    assert rendered[0].text == "/mcp list"
+    assert rendered[0].state == "done"
+    assert rendered[1].content == "command output"
+
+
+@pytest.mark.asyncio
+async def test_session_exit_renders_done_before_goodbye_then_exits():
+    """Exit commands render done, then goodbye output, then close the app."""
+    from nooa_cli.tui.output import TextOutput
+
+    session = Session.__new__(Session)
+    session._first_message = None
+    session._session_manager = None
+    session.frontend = SimpleNamespace(render=AsyncMock())
+    session._command_runner = None
+    session._emit_text = MagicMock()
+    app = MagicMock()
+    app._agent_task = None
+    app.set_command_status = MagicMock()
+    app.set_command_queue = MagicMock()
+    app.exit = MagicMock()
+    session._app = app
+    session.agent = SimpleNamespace()
+
+    handler = MagicMock()
+    handler.handle = AsyncMock(
+        return_value=CommandResult(
+            success=True,
+            outputs=[TextOutput("Goodbye! Stay vibing.", "status")],
+            exit=True,
+        )
+    )
+    session._handler = handler
+
+    await session._on_command("/exit")
+
+    rendered = [call.args[0] for call in session.frontend.render.await_args_list]
+    assert isinstance(rendered[0], CommandStatus)
+    assert rendered[0].text == "/exit"
+    assert rendered[0].state == "done"
+    assert rendered[1].content == "Goodbye! Stay vibing."
+    app.exit.assert_called_once()
+
+
+def test_terminal_frontend_renders_done_status_as_check_command_done():
+    """Done command statuses render as compact check-marked command text."""
+    from nooa_cli.tui.config import Config
+    from nooa_cli.tui.frontend import TerminalFrontend
+
+    frontend = TerminalFrontend(Config())
+    frontend._console.print_success = MagicMock()
+
+    frontend._render_command_status(CommandStatus(id=7, kind="slash", state="done", text="/models"))
+
+    frontend._console.print_success.assert_called_once_with("[command]/models[/command]")
+
+
+def test_terminal_frontend_escapes_done_status_command_markup():
+    """Done command text is escaped before insertion into Rich markup."""
+    from nooa_cli.tui.config import Config
+    from nooa_cli.tui.frontend import TerminalFrontend
+
+    frontend = TerminalFrontend(Config())
+    frontend._console.print_success = MagicMock()
+
+    frontend._render_command_status(
+        CommandStatus(id=8, kind="bang", state="done", text="!echo [/command]")
+    )
+
+    frontend._console.print_success.assert_called_once_with(r"[command]!echo \[/command][/command]")

--- a/packages/nooa-cli/tests/tui/test_compact_command.py
+++ b/packages/nooa-cli/tests/tui/test_compact_command.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for /compact command — event queue must survive summarization failure.
+
+Regression tests for GitLab issue #146: /compact was clearing the event queue
+when summarization failed, causing data loss.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from nooa_cli.tui.commands import CommandHandler, CommandRegistry
+from nooa_cli.tui.output import TextOutput
+
+
+@pytest.fixture
+def mock_frontend():
+    frontend = AsyncMock()
+    frontend.render = AsyncMock()
+    frontend.get_input = AsyncMock(return_value="")
+    frontend.start_thinking = AsyncMock()
+    frontend.stop_thinking = AsyncMock()
+    frontend.is_connected = True
+    return frontend
+
+
+@pytest.fixture
+def mock_config():
+    config = MagicMock()
+    config.default_model = "test-model"
+    return config
+
+
+@pytest.fixture
+def mock_agent(mock_config):
+    agent = MagicMock()
+    agent._llm = MagicMock()
+    agent.event_manager = MagicMock()
+    agent.event_manager.clear = MagicMock()
+    agent.event_manager.keys = MagicMock(return_value=["tag1", "tag2", "tag3"])
+    agent.event_manager.collapse = MagicMock()
+    agent.context_stats = MagicMock()
+    agent.context_stats.total_tokens = 5000
+    return agent
+
+
+@pytest.fixture
+def registry(mock_frontend, mock_config, mock_agent):
+    return CommandRegistry(
+        frontend=mock_frontend,
+        config=mock_config,
+        agent=mock_agent,
+        skills_dirs=[Path(".cursor/skills")],
+        mcp_file=Path(".mcp.json"),
+    )
+
+
+@pytest.fixture
+def handler(registry, mock_frontend):
+    return CommandHandler(registry=registry, frontend=mock_frontend)
+
+
+# ============================================================================
+# /compact — summarization failure must NOT clear the event queue (#146)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_compact_summarization_failure_preserves_events(handler, mock_agent):
+    """When summarization raises, /compact must NOT call event_manager.clear().
+
+    This is the core regression test for #146.
+    """
+    # Set up a summarizer that fails
+    summarizer = MagicMock()
+    summarizer._render_range_to_markdown = MagicMock(return_value="# History")
+    summarizer.summarize = AsyncMock(side_effect=RuntimeError("LLM unavailable"))
+    mock_agent._summarizers = [summarizer]
+
+    result = await handler.handle("/compact")
+
+    # Events must NOT be cleared
+    mock_agent.event_manager.clear.assert_not_called()
+    # The command should still succeed (it's a warning, not an error)
+    assert result.success is True
+    text_outputs = [o for o in result.outputs if isinstance(o, TextOutput)]
+    assert any(
+        "failed" in o.content.lower() or "Summarization failed" in o.content for o in text_outputs
+    )
+    # Should mention the error
+    assert any("LLM unavailable" in o.content for o in text_outputs)
+
+
+@pytest.mark.asyncio
+async def test_compact_summarization_failure_does_not_set_compact_done(handler, mock_agent):
+    """Failed summarization should not signal compact_done."""
+    summarizer = MagicMock()
+    summarizer._render_range_to_markdown = MagicMock(return_value="# History")
+    summarizer.summarize = AsyncMock(side_effect=RuntimeError("LLM unavailable"))
+    mock_agent._summarizers = [summarizer]
+
+    result = await handler.handle("/compact")
+
+    # compact_done should NOT be set on failure — renaming should not be triggered
+    assert result.compact_done is False
+
+
+@pytest.mark.asyncio
+async def test_compact_summarization_success(handler, mock_agent):
+    """Happy path: successful summarization collapses events."""
+    summarizer = MagicMock()
+    summarizer._render_range_to_markdown = MagicMock(return_value="# History")
+    summarizer.config = MagicMock()
+    summarizer.config.target_chars = 2000
+    summarizer.summarize = AsyncMock(return_value="Summary of conversation")
+    mock_agent._summarizers = [summarizer]
+    # After collapse, fewer keys
+    mock_agent.event_manager.keys = MagicMock(
+        side_effect=[["tag1", "tag2", "tag3"], ["summary_tag"]]
+    )
+
+    result = await handler.handle("/compact")
+
+    # Collapse should be called with the correct range
+    mock_agent.event_manager.collapse.assert_called_once_with(
+        "tag1", "tag3", "Summary of conversation"
+    )
+    mock_agent.event_manager.clear.assert_not_called()
+    assert result.success is True
+    assert result.compact_done is True
+    text_outputs = [o for o in result.outputs if isinstance(o, TextOutput)]
+    assert any("Compacted" in o.content for o in text_outputs)
+
+
+@pytest.mark.asyncio
+async def test_compact_no_summarizer_clears_events(handler, mock_agent):
+    """Without a summarizer, /compact falls back to clearing events (expected behavior)."""
+    mock_agent._summarizers = []
+
+    result = await handler.handle("/compact")
+
+    mock_agent.event_manager.clear.assert_called_once()
+    assert result.success is True
+    assert result.compact_done is True
+
+
+@pytest.mark.asyncio
+async def test_compact_empty_history(handler, mock_agent):
+    """With no events, /compact shows info message."""
+    mock_agent.event_manager.keys = MagicMock(return_value=[])
+
+    result = await handler.handle("/compact")
+
+    assert result.success is True
+    mock_agent.event_manager.clear.assert_not_called()
+    text_outputs = [o for o in result.outputs if isinstance(o, TextOutput)]
+    assert any("Nothing to compact" in o.content for o in text_outputs)
+
+
+@pytest.mark.asyncio
+async def test_compact_no_rich_live_spinner(handler, mock_agent, mock_frontend):
+    """No rich.live spinner during summarization — it flickers layered on the pt app.
+
+    Regression: /compact used frontend.start_thinking() (a rich.live.Live at ~10fps)
+    on top of prompt_toolkit's full-screen app, repainting through emit_block /
+    run_in_terminal and fighting pt's own status spinner = visible flicker. The
+    progress indicator is now a single static status block.
+    """
+    summarizer = MagicMock()
+    summarizer._render_range_to_markdown = MagicMock(return_value="# History")
+    summarizer.summarize = AsyncMock(side_effect=RuntimeError("boom"))
+    mock_agent._summarizers = [summarizer]
+
+    await handler.handle("/compact")
+
+    mock_frontend.start_thinking.assert_not_called()
+    mock_frontend.stop_thinking.assert_not_called()
+    # A single static "Summarizing history…" status line is rendered instead.
+    rendered = [c.args[0] for c in mock_frontend.render.call_args_list if c.args]
+    assert any(isinstance(o, TextOutput) and "Summarizing history" in o.content for o in rendered)

--- a/packages/nooa-cli/tests/tui/test_completer.py
+++ b/packages/nooa-cli/tests/tui/test_completer.py
@@ -582,12 +582,8 @@ def test_mcp_remove_offers_configured_servers():
 def test_mcp_approve_and_revoke_complete_configured_servers():
     reg = _mcp_registry(["maas-jira"])
     completer = Completer(registry=reg)
-    assert [item.text for item in completer.complete("/mcp approve ")] == [
-        "/mcp approve maas-jira"
-    ]
-    assert [item.text for item in completer.complete("/mcp revoke ")] == [
-        "/mcp revoke maas-jira"
-    ]
+    assert [item.text for item in completer.complete("/mcp approve ")] == ["/mcp approve maas-jira"]
+    assert [item.text for item in completer.complete("/mcp revoke ")] == ["/mcp revoke maas-jira"]
 
 
 def test_mcp_completion_marks_approved_server():

--- a/packages/nooa-cli/tests/tui/test_completer.py
+++ b/packages/nooa-cli/tests/tui/test_completer.py
@@ -1,0 +1,614 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the shared completion engine (completer.py).
+
+Verifies that both TUI and web get identical completion behavior.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from nooa_cli.tui.completer import Completer
+
+
+@pytest.fixture
+def mock_registry():
+    reg = MagicMock()
+    _completions = {
+        "/help": "Show all commands",
+        "/edit": "Edit a file",
+        "/session resume": "Resume a session",
+        "/session delete": "Delete a session",
+        "/session list": "List sessions",
+        "/python on": "Enable Python display",
+        "/python off": "Disable Python display",
+        "/exit": "Exit",
+    }
+    # The completer uses get_active_help() (keys may include argument hints).
+    # For built-in commands there are no hints, so this is the same dict.
+    reg.get_active_help.return_value = _completions
+    reg.get_completions.return_value = _completions
+    return reg
+
+
+@pytest.fixture
+def completer(mock_registry):
+    return Completer(registry=mock_registry)
+
+
+# ---------------------------------------------------------------------------
+# Slash command completion
+# ---------------------------------------------------------------------------
+
+
+def test_slash_prefix_returns_all_commands(completer):
+    items = completer.complete("/")
+    texts = [i.text for i in items]
+    assert "/help" in texts
+    assert "/edit" in texts
+    assert "/exit" in texts
+
+
+def test_slash_partial_filters(completer):
+    items = completer.complete("/he")
+    assert len(items) == 1
+    assert items[0].text == "/help"
+    assert items[0].description == "Show all commands"
+
+
+def test_slash_session_partial(completer):
+    items = completer.complete("/session ")
+    texts = [i.text for i in items]
+    assert "/session resume" in texts
+    assert "/session delete" in texts
+    assert "/session list" in texts
+
+
+def test_slash_case_insensitive(completer):
+    items = completer.complete("/HE")
+    assert len(items) == 1
+    assert items[0].text == "/help"
+
+
+# ---------------------------------------------------------------------------
+# Path completion (/edit)
+# ---------------------------------------------------------------------------
+
+
+def test_edit_path_completion(completer):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create some files
+        Path(tmpdir, "foo.py").touch()
+        Path(tmpdir, "bar.txt").touch()
+        Path(tmpdir, "subdir").mkdir()
+
+        items = completer.complete(f"/edit {tmpdir}/")
+        texts = [i.text for i in items]
+        displays = [i.display for i in items]
+
+        assert any("foo.py" in t for t in texts)
+        assert any("bar.txt" in t for t in texts)
+        assert any("subdir/" in d for d in displays)
+
+        # Every item.text must start with "/edit " so the web UI
+        # can use it as a full input replacement without losing the command.
+        for item in items:
+            assert item.text.startswith("/edit "), (
+                f"Path completion item should be a full replacement: {item.text!r}"
+            )
+
+
+def test_edit_path_partial_filter(completer):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "alpha.py").touch()
+        Path(tmpdir, "beta.py").touch()
+
+        items = completer.complete(f"/edit {tmpdir}/al")
+        texts = [i.text for i in items]
+        assert len(items) == 1
+        assert any("alpha.py" in t for t in texts)
+
+
+# ---------------------------------------------------------------------------
+# Bang commands
+# ---------------------------------------------------------------------------
+
+
+def test_bang_prefix_returns_no_builtins(completer):
+    items = completer.complete("!")
+    texts = [i.text for i in items]
+    # No bang builtins — !<cmd> just runs bash
+    assert texts == []
+
+
+# ---------------------------------------------------------------------------
+# No completions for regular text
+# ---------------------------------------------------------------------------
+
+
+def test_regular_text_no_completions(completer):
+    assert completer.complete("hello") == []
+    assert completer.complete("") == []
+    assert completer.complete("how are you") == []
+
+
+# ---------------------------------------------------------------------------
+# User-invocable skills in completer — real registry, not mock
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def user_skill_registry(tmp_path):
+    """A real CommandRegistry with one install-as:command skill."""
+    from unittest.mock import MagicMock
+
+    from nooa_cli.tui.commands import CommandRegistry
+
+    skill_dir = tmp_path / "myskill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: myskill\ndescription: My test skill\n"
+        "argument-hint: <action>\ninstall-as: command\n---\nDo the thing.\n"
+    )
+
+    agent = MagicMock()
+    agent.get_summarization_status = MagicMock(
+        return_value={
+            "active_events": 0,
+            "policy": "auto",
+            "has_summarizer": False,
+            "max_tokens": 100000,
+            "current_tokens": 0,
+            "preserve_recent": 5,
+            "summary_count": 0,
+            "summary_tags": [],
+        }
+    )
+    config = MagicMock()
+    config.default_model = "test-model"
+    frontend = MagicMock()
+
+    return CommandRegistry(
+        config=config,
+        agent=agent,
+        frontend=frontend,
+        skills_dirs=[tmp_path],
+        mcp_file=None,
+    )
+
+
+def test_user_skill_appears_in_completer_via_real_registry(user_skill_registry):
+    """User skill shows up in Completer.complete() with a REAL registry, not a mock.
+
+    This catches the gap where registry.get_completions() works but the skill
+    fails to reach the Tab-completion dropdown in practice.
+    """
+    completer = Completer(registry=user_skill_registry)
+    items = completer.complete("/")
+    texts = [i.text for i in items]
+    assert any("myskill" in t for t in texts), f"Expected '/myskill' in completions, got: {texts}"
+
+
+def test_user_skill_partial_completion(user_skill_registry):
+    """Partial typing '/mys' narrows to the user skill."""
+    completer = Completer(registry=user_skill_registry)
+    items = completer.complete("/mys")
+    texts = [i.text for i in items]
+    assert any("myskill" in t for t in texts)
+    # Built-in commands like /model don't start with /mys
+    assert not any("model" in t for t in texts)
+
+
+def test_opted_out_skill_not_in_completer(tmp_path):
+    """A skill with user-invocable: false does NOT appear in Tab completions.
+
+    CC default: user-invocable is true. Opt out with user-invocable: false.
+    """
+    from unittest.mock import MagicMock
+
+    from nooa_cli.tui.commands import CommandRegistry
+
+    skill_dir = tmp_path / "internal"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: internal\ndescription: Internal tool\nuser-invocable: false\n---\nBody.\n"
+    )
+
+    agent = MagicMock()
+    agent.get_summarization_status = MagicMock(
+        return_value={
+            "active_events": 0,
+            "policy": "auto",
+            "has_summarizer": False,
+            "max_tokens": 100000,
+            "current_tokens": 0,
+            "preserve_recent": 5,
+            "summary_count": 0,
+            "summary_tags": [],
+        }
+    )
+    config = MagicMock()
+    config.default_model = "test"
+    frontend = MagicMock()
+
+    registry = CommandRegistry(
+        config=config,
+        agent=agent,
+        frontend=frontend,
+        skills_dirs=[tmp_path],
+        mcp_file=None,
+    )
+    completer = Completer(registry=registry)
+    items = completer.complete("/")
+    texts = [i.text for i in items]
+    assert not any("internal" in t for t in texts), (
+        f"Opted-out skill should not appear in completions, but found in: {texts}"
+    )
+
+
+def _make_skill_registry(tmp_path, skill_name: str, skill_md_text: str):
+    """Helper: create a CommandRegistry with a single skill."""
+    from unittest.mock import MagicMock
+
+    from nooa_cli.tui.commands import CommandRegistry
+
+    skill_dir = tmp_path / skill_name
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(skill_md_text)
+
+    agent = MagicMock()
+    agent.get_summarization_status = MagicMock(
+        return_value={
+            "active_events": 0,
+            "policy": "auto",
+            "has_summarizer": False,
+            "max_tokens": 100000,
+            "current_tokens": 0,
+            "preserve_recent": 5,
+            "summary_count": 0,
+            "summary_tags": [],
+        }
+    )
+    config = MagicMock()
+    config.default_model = "test"
+    frontend = MagicMock()
+
+    return CommandRegistry(
+        config=config,
+        agent=agent,
+        frontend=frontend,
+        skills_dirs=[tmp_path],
+        mcp_file=None,
+    )
+
+
+def test_bracket_hint_not_inserted(tmp_path):
+    """[label] style argument hints must NOT be inserted when Tab-completing.
+
+    /wtf-status has argument-hint: [label].  Selecting the completion should
+    insert '/wtf-status' only — not '/wtf-status [label]'.
+    """
+    registry = _make_skill_registry(
+        tmp_path,
+        "wtf-status",
+        "---\nname: wtf-status\ndescription: Show project status\n"
+        "argument-hint: [label]\n---\nShow status.\n",
+    )
+    completer = Completer(registry=registry)
+    items = completer.complete("/wtf-status")
+
+    assert items, "Expected at least one completion for /wtf-status"
+    item = next((i for i in items if "wtf-status" in i.text), None)
+    assert item is not None, f"No wtf-status item found in: {[i.text for i in items]}"
+    assert item.text == "/wtf-status", f"Hint must not be inserted; got text={item.text!r}"
+
+
+def test_bracket_hint_shown_in_display(tmp_path):
+    """[label] style argument hints must appear in the display (menu) string."""
+    registry = _make_skill_registry(
+        tmp_path,
+        "wtf-status",
+        "---\nname: wtf-status\ndescription: Show project status\n"
+        "argument-hint: [label]\n---\nShow status.\n",
+    )
+    completer = Completer(registry=registry)
+    items = completer.complete("/wtf")
+
+    item = next((i for i in items if "wtf-status" in i.text), None)
+    assert item is not None, f"No wtf-status item found in: {[i.text for i in items]}"
+    assert "[label]" in item.display, (
+        f"Hint should be visible in the dropdown; got display={item.display!r}"
+    )
+
+
+def test_angle_hint_shown_in_display(tmp_path):
+    """<action> style argument hints must appear in the display (menu) string."""
+    registry = _make_skill_registry(
+        tmp_path,
+        "wtf",
+        "---\nname: wtf\ndescription: Manage issues\nargument-hint: <action>\n---\nManage.\n",
+    )
+    completer = Completer(registry=registry)
+    items = completer.complete("/wtf")
+
+    item = next((i for i in items if i.text == "/wtf"), None)
+    assert item is not None, f"No /wtf item found in: {[i.text for i in items]}"
+    assert "<action>" in item.display, (
+        f"Hint should be visible in the dropdown; got display={item.display!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inline @ file/dir mentions
+# ---------------------------------------------------------------------------
+
+
+def test_mention_completion_at_start(completer):
+    """An @ at the start of the buffer completes files/dirs under the typed path."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "notes.md").touch()
+        Path(tmpdir, "sub").mkdir()
+
+        items = completer.complete(f"@{tmpdir}/")
+        displays = [i.display for i in items]
+        assert any("notes.md" in d for d in displays)
+        assert any("sub/" in d for d in displays)
+
+        # Every replacement keeps everything up to and including the @.
+        for item in items:
+            assert item.text.startswith(f"@{tmpdir}/"), item.text
+
+
+def test_mention_completion_inline(completer):
+    """An @ typed mid-sentence completes against the path after it."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "alpha.py").touch()
+        Path(tmpdir, "beta.py").touch()
+
+        text = f"please read @{tmpdir}/al"
+        items = completer.complete(text)
+        assert len(items) == 1
+        # Replacement preserves the leading sentence and the @.
+        assert items[0].text == f"please read @{tmpdir}/alpha.py"
+
+
+def test_mention_only_last_token(completer):
+    """An earlier @ in the buffer must not hijack completion."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "x.py").touch()
+        # Cursor is right after the trailing space — no active mention.
+        items = completer.complete(f"@{tmpdir}/x.py ")
+        assert items == []
+
+
+def test_mention_requires_boundary(completer):
+    """An @ not at a word boundary (e.g. an email) is not a mention."""
+    assert completer.complete("user@example") == []
+
+
+# ---------------------------------------------------------------------------
+# Mention expansion (submit-time markdown substitution)
+# ---------------------------------------------------------------------------
+
+
+def test_expand_mentions_file():
+    """A submitted @file mention becomes a Markdown link to its absolute path."""
+    from nooa_cli.tui.completer import expand_mentions
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        f = Path(tmpdir, "blah.md")
+        f.touch()
+        rel = str(f)
+        out = expand_mentions(f"see @{rel} for details")
+        assert out == f"see [{rel}](<{f.resolve()}>) for details"
+
+
+def test_expand_mentions_directory_strips_trailing_slash():
+    """A directory mention drops its trailing slash in the link label."""
+    from nooa_cli.tui.completer import expand_mentions
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        d = Path(tmpdir, "docs")
+        d.mkdir()
+        out = expand_mentions(f"@{d}/")
+        assert out == f"[{d}](<{d.resolve()}>)"
+
+
+def test_expand_mentions_nonexistent_untouched():
+    """A mention that resolves to no file/dir is left verbatim."""
+    from nooa_cli.tui.completer import expand_mentions
+
+    text = "ping @nope/does/not/exist now"
+    assert expand_mentions(text) == text
+
+
+def test_expand_mentions_email_untouched():
+    """An email address (@ not at a word boundary) is not treated as a mention."""
+    from nooa_cli.tui.completer import expand_mentions
+
+    text = "contact user@example.com please"
+    assert expand_mentions(text) == text
+
+
+def test_expand_mentions_multiple():
+    """Every resolvable @ mention in a line is expanded independently."""
+    from nooa_cli.tui.completer import expand_mentions
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        a = Path(tmpdir, "a.txt")
+        b = Path(tmpdir, "b.txt")
+        a.touch()
+        b.touch()
+        out = expand_mentions(f"@{a} and @{b}")
+        assert f"[{a}](<{a.resolve()}>)" in out
+        assert f"[{b}](<{b.resolve()}>)" in out
+
+
+# ---------------------------------------------------------------------------
+# Bang command-name completion
+# ---------------------------------------------------------------------------
+
+
+def test_bang_command_completes_executables(completer, monkeypatch, tmp_path):
+    """The first token of !cmd completes $PATH executables, not files."""
+    import stat
+
+    exe = tmp_path / "mytool"
+    exe.write_text("#!/bin/sh\n")
+    exe.chmod(exe.stat().st_mode | stat.S_IXUSR)
+    # A non-executable file with the same prefix must be excluded.
+    (tmp_path / "mytool.txt").write_text("x")
+
+    monkeypatch.setenv("PATH", str(tmp_path))
+    items = completer.complete("!myto")
+    displays = [i.display for i in items]
+    assert "mytool" in displays
+    assert "mytool.txt" not in displays
+    # Selecting inserts the command plus a trailing space, ready for args.
+    item = next(i for i in items if i.display == "mytool")
+    assert item.text == "!mytool "
+
+
+def test_bang_argument_completes_paths(completer):
+    """After the command + a space, completion switches to filesystem paths."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "data.csv").touch()
+        items = completer.complete(f"!cat {tmpdir}/")
+        displays = [i.display for i in items]
+        assert any("data.csv" in d for d in displays)
+
+
+# ---------------------------------------------------------------------------
+# Regression: empty-arg bang completion + trailing-punctuation mentions
+# ---------------------------------------------------------------------------
+
+
+def test_bang_empty_arg_completes_cwd_paths(completer, tmp_path, monkeypatch):
+    """'!ls ' (command + trailing space, no arg yet) completes cwd paths.
+
+    Regression for the branch that sent any space-free command token to
+    $PATH completion: a trailing space ends the command token, so the next
+    Tab must offer filesystem paths, not nothing.
+    """
+    (tmp_path / "data.csv").touch()
+    monkeypatch.chdir(tmp_path)
+    items = completer.complete("!ls ")
+    displays = [i.display for i in items]
+    assert any("data.csv" in d for d in displays), displays
+
+
+def test_expand_mentions_trailing_punctuation():
+    """A mention followed by sentence punctuation still resolves."""
+    from nooa_cli.tui.completer import expand_mentions
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        f = Path(tmpdir, "file.md")
+        f.touch()
+        out = expand_mentions(f"see @{f}. thanks")
+        # The path resolves; the trailing '.' stays outside the link.
+        assert f"[{f}](<{f.resolve()}>)." in out, out
+
+
+def test_expand_mentions_angle_brackets_target():
+    """The link target is angle-bracketed so a ')' in a path can't break out."""
+    from nooa_cli.tui.completer import expand_mentions
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        f = Path(tmpdir, "weird(name).md")
+        f.touch()
+        out = expand_mentions(f"@{f}")
+        assert f"(<{f.resolve()}>)" in out, out
+
+
+# ---------------------------------------------------------------------------
+# MCP server-name completion (/mcp connect | /mcp disconnect)
+# ---------------------------------------------------------------------------
+
+
+def _mcp_registry(servers, connected=()):
+    """A registry whose agent.mcp is a stub MCPRegistry (discovered/connected)."""
+    from unittest.mock import MagicMock
+
+    reg = MagicMock()
+    mcp = MagicMock()
+    mcp.discovered.return_value = sorted(servers)
+    mcp.connected.return_value = sorted(connected)
+    mcp._is_approved.return_value = False
+    reg.agent.mcp = mcp
+    return reg
+
+
+def test_mcp_connect_lists_configured_servers():
+    reg = _mcp_registry(["maas-jira", "maas-confluence"])
+    completer = Completer(registry=reg)
+    items = completer.complete("/mcp connect ")
+    texts = [i.text for i in items]
+    assert "/mcp connect maas-jira" in texts
+    assert "/mcp connect maas-confluence" in texts
+
+
+def test_mcp_connect_partial_filters():
+    reg = _mcp_registry(["maas-jira", "maas-confluence", "langfuse"])
+    completer = Completer(registry=reg)
+    items = completer.complete("/mcp connect maas-c")
+    texts = [i.text for i in items]
+    assert texts == ["/mcp connect maas-confluence"]
+
+
+def test_mcp_connect_marks_connected_status():
+    reg = _mcp_registry(["maas-jira", "langfuse"], connected=["langfuse"])
+    completer = Completer(registry=reg)
+    by_text = {i.text: i.description for i in completer.complete("/mcp connect ")}
+    assert by_text["/mcp connect langfuse"] == "connected"
+    assert by_text["/mcp connect maas-jira"] == "approval required"
+
+
+def test_mcp_disconnect_only_offers_connected():
+    reg = _mcp_registry(["maas-jira", "langfuse"], connected=["langfuse"])
+    completer = Completer(registry=reg)
+    texts = [i.text for i in completer.complete("/mcp disconnect ")]
+    assert texts == ["/mcp disconnect langfuse"]
+
+
+def test_mcp_remove_offers_configured_servers():
+    reg = _mcp_registry(["maas-jira", "langfuse"], connected=["langfuse"])
+    completer = Completer(reg)
+    texts = [item.text for item in completer.complete("/mcp remove ")]
+    assert texts == ["/mcp remove langfuse", "/mcp remove maas-jira"]
+
+
+def test_mcp_approve_and_revoke_complete_configured_servers():
+    reg = _mcp_registry(["maas-jira"])
+    completer = Completer(registry=reg)
+    assert [item.text for item in completer.complete("/mcp approve ")] == [
+        "/mcp approve maas-jira"
+    ]
+    assert [item.text for item in completer.complete("/mcp revoke ")] == [
+        "/mcp revoke maas-jira"
+    ]
+
+
+def test_mcp_completion_marks_approved_server():
+    reg = _mcp_registry(["maas-jira"])
+    reg.agent.mcp._is_approved.return_value = True
+    item = Completer(registry=reg).complete("/mcp connect ")[0]
+    assert item.description == "approved"
+
+
+def test_mcp_completion_missing_command_is_safe():
+    from unittest.mock import MagicMock
+
+    reg = MagicMock()
+    reg.agent.mcp = None
+    completer = Completer(registry=reg)
+    assert completer.complete("/mcp connect ") == []
+
+
+def test_mcp_completion_omits_unsafe_untrusted_server_names():
+    reg = _mcp_registry(["safe-server", "evil\x1b[2J", "has spaces"])
+    items = Completer(registry=reg).complete("/mcp connect ")
+
+    assert [item.text for item in items] == ["/mcp connect safe-server"]
+    assert all("\x1b" not in item.display for item in items)

--- a/packages/nooa-cli/tests/tui/test_config_skills_dirs_ordering.py
+++ b/packages/nooa-cli/tests/tui/test_config_skills_dirs_ordering.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``Config.load`` skills_dirs ordering.
+
+The scan order matters: ``SkillManager.install()`` attaches a skill the
+first time it sees a given attribute name, then skips subsequent matches.
+So whichever directory appears first in ``cfg.tui.skills_dirs`` wins.
+
+Precedence:
+
+    1. user-explicit ``--skills-dir`` values
+    2. default locations (``~/.claude/commands``, ``.claude/skills``, …)
+
+Installed packages contribute skills through ``nooa.skills`` rather than a
+TUI-specific directory entry-point group.
+"""
+
+from pathlib import Path
+
+import pytest
+from nooa_cli.tui.config import Config
+
+
+@pytest.fixture(autouse=True)
+def _isolate_settings(tmp_path_factory, monkeypatch):
+    """Pin the layered settings.yaml dirs so Config.load() can't read a real
+    user/project settings.yaml (e.g. one written by `/config set` at the
+    repo root) and perturb skills_dirs assertions."""
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(tmp_path_factory.mktemp("settings-user")))
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(tmp_path_factory.mktemp("settings-proj")))
+    monkeypatch.delenv("NEMO_OO_SETTINGS", raising=False)
+
+
+def _skill_dir(base: Path, name: str) -> Path:
+    d = base / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "dummy-skill").mkdir(exist_ok=True)
+    (d / "dummy-skill" / "SKILL.md").write_text("---\nname: dummy\ndescription: x\n---\n\nbody")
+    return d
+
+
+def test_explicit_skills_dir_precedes_defaults(tmp_path, monkeypatch):
+    """--skills-dir comes before the default ~/.claude/commands etc."""
+    explicit = _skill_dir(tmp_path, "user-explicit")
+    default = _skill_dir(tmp_path, "fake-home/.claude/commands")
+
+    # Force cwd and $HOME defaults to point at existing dirs for the test
+    monkeypatch.chdir(tmp_path / "fake-home")
+    monkeypatch.setenv("HOME", str(tmp_path / "fake-home"))
+
+    cfg = Config.load(skills_dir=[explicit])
+    dirs = cfg.tui.skills_dirs
+    assert explicit in dirs
+    assert default in dirs
+    assert dirs.index(explicit) < dirs.index(default), (
+        "user --skills-dir must appear before default dirs"
+    )
+
+
+def test_string_skills_dir_not_iterated_as_characters(tmp_path, monkeypatch):
+    """A single string passed as ``skills_dir=`` is treated as one path,
+    not iterated character-by-character (``list("/path")`` → ['/', 'p',
+    'a', …] bug from the pre-fix code)."""
+    explicit = _skill_dir(tmp_path, "single-string")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # Pass a bare string (not a list) as skills_dir.
+    cfg = Config.load(skills_dir=str(explicit))
+
+    assert explicit in cfg.tui.skills_dirs
+    # No character-fragments should show up
+    assert not any(len(str(d)) == 1 for d in cfg.tui.skills_dirs)
+
+
+def test_same_explicit_dir_passed_twice_is_deduped(tmp_path, monkeypatch):
+    shared = _skill_dir(tmp_path, "shared")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    cfg = Config.load(skills_dir=[shared, shared])
+
+    assert cfg.tui.skills_dirs.count(shared) == 1

--- a/packages/nooa-cli/tests/tui/test_context_usage_display.py
+++ b/packages/nooa-cli/tests/tui/test_context_usage_display.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for context-window usage shown in the TUI.
+
+Two surfaces:
+
+1. The status-bar rule between turns includes a compact ``"ctx N%"``
+   label whenever the agent has a bounded context and the runtime has
+   rendered at least one generation.
+2. The TUI agent registers a dynamic ``context_usage`` block in its
+   ``context_manager`` so the LLM sees the same stats every turn.
+"""
+
+from types import SimpleNamespace
+
+# ── _context_usage_label -----------------------------------------------------
+
+
+def _make_session_for_label(context_stats):
+    """Build a minimal Session whose ``_context_usage_label`` we can call."""
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session.agent = SimpleNamespace(context_stats=context_stats)
+    return session
+
+
+def _stats(*, total, model_context_window=None, reserved_output_tokens=None):
+    """Real ContextWindowStats for the label helper.
+
+    ``total`` is the provider-reported prompt-token count (None before the
+    first response). The percentage is against the usable window (model
+    window minus the output-token reserve).
+    """
+    from nooa.context_blocks.models import ContextWindowStats
+
+    return ContextWindowStats(
+        context_blocks_count=0,
+        events_count=0,
+        prompt_tokens=total,
+        model_context_window=model_context_window,
+        reserved_output_tokens=reserved_output_tokens,
+    )
+
+
+def test_context_usage_label_placeholder_when_no_stats():
+    # No generation context yet → placeholder, not blank.
+    session = _make_session_for_label(None)
+    assert session._context_usage_label() == "ctx —"
+
+
+def test_context_usage_label_placeholder_before_first_response():
+    # Stats exist (render ran) but the provider has not reported usage yet.
+    session = _make_session_for_label(_stats(total=None, model_context_window=200_000))
+    assert session._context_usage_label() == "ctx —"
+
+
+def test_context_usage_label_placeholder_when_no_window():
+    # Provider tokens known but the model window is unknown → can't compute %.
+    session = _make_session_for_label(_stats(total=1234, model_context_window=None))
+    assert session._context_usage_label() == "ctx —"
+
+
+def test_context_usage_label_shows_integer_percent():
+    # 16 000 / 80 000 = 20.0%
+    session = _make_session_for_label(_stats(total=16_000, model_context_window=80_000))
+    assert session._context_usage_label() == "ctx 20%"
+
+
+def test_context_usage_label_rounds():
+    # 13 000 / 80 000 = 16.25% → "ctx 16%"
+    session = _make_session_for_label(_stats(total=13_000, model_context_window=80_000))
+    assert session._context_usage_label() == "ctx 16%"
+
+
+def test_context_usage_label_accounts_for_output_reserve():
+    # 30 000 / (100 000 − 40 000 usable) = 50%, not 30% of the raw window.
+    session = _make_session_for_label(
+        _stats(total=30_000, model_context_window=100_000, reserved_output_tokens=40_000)
+    )
+    assert session._context_usage_label() == "ctx 50%"
+
+
+def test_context_usage_label_uses_model_context_window():
+    # 20 000 / 200 000 = 10%
+    session = _make_session_for_label(_stats(total=20_000, model_context_window=200_000))
+    assert session._context_usage_label() == "ctx 10%"
+
+
+# ── TUI agent registers the context_usage dynamic block -----------------------
+
+
+def test_tui_agent_installs_context_usage_dynamic_block():
+    """BaseTUIAgent.__init__ registers a dynamic context_usage block.
+
+    The expression depends only on ``self.context_stats`` so it stays
+    None-safe on the very first turn (when no generation has run).
+    """
+    import os
+
+    # Don't actually hit any LLM — pin to a FakeLLMClient and a
+    # minimum-viable config.
+    from pathlib import Path
+
+    from nooa_cli.tui.agent import TUIAgent
+    from nooa_cli.tui.config import AgentConfig, SummarizationConfig
+
+    from nooa.unifiedllm import FakeLLMClient
+
+    agent_cfg = AgentConfig(
+        working_dir=Path(os.getcwd()),
+        summarization=SummarizationConfig(policy="none"),
+    )
+    agent = TUIAgent(llm=FakeLLMClient(), config=agent_cfg)
+
+    # Dynamic context keys are stored on the context manager
+    cm = agent.context_manager
+    keys = list(cm.keys())
+    assert "context_usage" in keys, f"context_usage missing; have: {keys}"

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -70,7 +70,7 @@ def test_event_explorer_renders_shared_session_events() -> None:
                     "2",
                     _FakeEvent(
                         "SessionStarted",
-                        host="tui",
+                        origin="tui",
                         model="test-model",
                         agent="CodingAgent",
                         working_directory="/work/repo",

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -1,0 +1,1442 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the terminal event explorer."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from nooa_cli.tui.commands import EventsCommand
+from nooa_cli.tui.event_explorer import (
+    EventExplorerModel,
+    EventExplorerRow,
+    build_event_rows,
+    detail_match_occurrences,
+    highlighted_detail_lines,
+    render_event_explorer,
+    wrapped_detail_lines,
+)
+from nooa_cli.tui.output import TextOutput
+
+
+class _FakeEvent:
+    def __init__(self, event_type: str, **fields):
+        self.event_type = event_type
+        for key, value in fields.items():
+            setattr(self, key, value)
+
+    def model_dump(self):
+        return {"event_type": self.event_type, **self.__dict__}
+
+
+def test_event_explorer_builds_rows_and_full_text_searches() -> None:
+    events = [
+        ("1", _FakeEvent("TUIUserInput", text="please inspect frobnicator")),
+        (
+            "2",
+            _FakeEvent(
+                "ToolCallEvent",
+                name="execute_python",
+                arguments={"code": "# comment\nprint('needle')"},
+            ),
+        ),
+        ("3", _FakeEvent("PythonOutput", execution_status="complete", stdout="needle output")),
+    ]
+    em = SimpleNamespace(items=lambda: events)
+
+    rows = build_event_rows(em)
+    model = EventExplorerModel(rows)
+
+    assert [row.tag for row in rows] == ["1", "2", "3"]
+    assert "execute_python" in rows[1].summary
+
+    model.set_query("needle output")
+    assert [rows[i].tag for i in model.matches] == ["3"]
+
+    model.set_query("needle")
+    assert [rows[i].tag for i in model.matches] == ["2", "3"]
+
+
+def test_event_explorer_renders_shared_session_events() -> None:
+    rows = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                ("1", _FakeEvent("SessionUserMessage", content="inspect the failure")),
+                (
+                    "2",
+                    _FakeEvent(
+                        "SessionStarted",
+                        host="tui",
+                        model="test-model",
+                        agent="CodingAgent",
+                        working_directory="/work/repo",
+                    ),
+                ),
+            ]
+        )
+    )
+
+    assert rows[0].summary == "inspect the failure"
+    assert "## User input" in (rows[0].markdown or "")
+    assert "inspect the failure" in (rows[0].markdown or "")
+    assert "test-model" in (rows[1].markdown or "")
+
+
+def test_event_explorer_renders_generic_events_as_markdown_sections() -> None:
+    row = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                (
+                    "12",
+                    _FakeEvent(
+                        "ToolCallEvent",
+                        name="execute_python",
+                        arguments={"code": "print(42)"},
+                        result=None,
+                    ),
+                )
+            ]
+        )
+    )[0]
+
+    markdown = row.markdown or ""
+    assert "**[12]** *ToolCallEvent*" in markdown
+    assert "_metadata:" not in markdown
+    assert "## Tool" in markdown
+    assert "execute_python" in markdown
+    assert "## Python" in markdown
+    assert "```python\nprint(42)\n```" in markdown
+    assert "## Result" not in markdown
+    assert "## arguments" not in markdown
+
+    plain = "\n".join(wrapped_detail_lines(row, width=80))
+    assert "**[12]** *ToolCallEvent*" in plain
+    assert "## Python" in plain
+    assert "ToolCallEvent(" not in plain
+
+
+def test_event_explorer_renders_python_output_as_markdown_sections() -> None:
+    row = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                (
+                    "7",
+                    _FakeEvent(
+                        "PythonOutput",
+                        tool_call_id="tc_1",
+                        execution_status="complete",
+                        stdout="hello\nworld\n",
+                        stderr="",
+                        error="",
+                        value=None,
+                    ),
+                )
+            ]
+        )
+    )[0]
+
+    assert row.markdown is not None
+    assert "**[7]** *PythonOutput* · tool=tc_1" in row.markdown
+    assert "_metadata:" in row.markdown
+    assert "tool_call_id=tc_1" in row.markdown
+    assert "## Status" in row.markdown
+    assert "`complete`" in row.markdown
+    assert "## Stdout" in row.markdown
+    assert "```text\nhello\nworld\n```" in row.markdown
+    assert "## Stderr" not in row.markdown
+    assert "## Error" not in row.markdown
+    assert "## Value" not in row.markdown
+
+    plain = "\n".join(wrapped_detail_lines(row, width=80))
+    assert "**[7]** *PythonOutput* · tool=tc_1" in plain
+    assert "## Stdout" in plain
+    assert "PythonOutput(" not in plain
+
+
+def test_event_explorer_python_output_markdown_keeps_stderr_and_error_when_present() -> None:
+    row = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                (
+                    "8",
+                    _FakeEvent(
+                        "PythonOutput",
+                        execution_status="error",
+                        stdout="partial",
+                        stderr="warning",
+                        error="Traceback: boom",
+                        value={"answer": 42},
+                    ),
+                )
+            ]
+        )
+    )[0]
+
+    markdown = row.markdown or ""
+    assert "## Stdout" in markdown
+    assert "```text\npartial\n```" in markdown
+    assert "## Stderr" in markdown
+    assert "```text\nwarning\n```" in markdown
+    assert "## Error" in markdown
+    assert "```pytb\nTraceback: boom\n```" in markdown
+    assert "## Value" in markdown
+    assert '"answer": 42' in markdown
+
+
+def test_event_explorer_python_output_markdown_code_blocks_render_formatted() -> None:
+    row = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                (
+                    "9",
+                    _FakeEvent(
+                        "PythonOutput",
+                        execution_status="complete",
+                        stdout="for i in range(3):\n    print(i)\n",
+                    ),
+                )
+            ]
+        )
+    )[0]
+
+    rendered = "\n".join(highlighted_detail_lines(row, width=80))
+    stripped = __import__("re").sub(r"\x1b\[[0-9;]*m", "", rendered)
+
+    assert "```" not in stripped
+    assert "for i in range(3):" in stripped
+    assert "print(i)" in stripped
+    assert "\x1b[" in rendered
+
+
+def test_event_explorer_uses_compact_header_and_metadata_footer() -> None:
+    """Compact header shows tag/type/date/short-ids; noise fields go to a metadata footer."""
+    row = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                (
+                    "42",
+                    _FakeEvent(
+                        "Task",
+                        id="abc",
+                        timestamp="2026-01-02T03:04:05Z",
+                        metadata={"call_id": "c1", "model": "m"},
+                        images=[{"url": "file://large.png"}],
+                        prompt="Do the work",
+                    ),
+                )
+            ]
+        )
+    )[0]
+
+    markdown = row.markdown or ""
+    header = markdown.splitlines()[0]
+    footer = markdown.rsplit("\n", 1)[-1]
+
+    assert header.startswith("**[42]** *Task* · 2026-01-02 03:04:05 · id=abc")
+    assert "call=c1" in header
+    assert "## Prompt" in markdown
+    assert "Do the work" in markdown
+    assert "---" in markdown
+    assert footer.startswith("_metadata: id=abc · timestamp=")
+    assert "metadata=" in footer
+    assert "images=" in footer
+    assert "## metadata" not in markdown.lower()
+    assert "## images" not in markdown.lower()
+
+
+def test_event_explorer_python_output_markdown_escapes_terminal_controls() -> None:
+    row = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                (
+                    "11",
+                    _FakeEvent(
+                        "PythonOutput",
+                        execution_status="complete",
+                        stdout="safe\x1b]52;c;YWJj\x07after",
+                    ),
+                )
+            ]
+        )
+    )[0]
+
+    markdown = row.markdown or ""
+    rendered = "\n".join(highlighted_detail_lines(row, width=100))
+    stripped = __import__("re").sub(r"\x1b\[[0-9;]*m", "", rendered)
+
+    assert "\x1b]" not in markdown
+    assert "\x07" not in markdown
+    assert "\\x1b]52;c;YWJj\\x07" in markdown
+    assert "\x1b]" not in rendered
+    assert "\x07" not in rendered
+    assert "\\x1b]52;c;YWJj\\x07" in stripped
+
+
+def test_event_explorer_existing_markdown_fenced_code_still_renders_formatted() -> None:
+    row = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                (
+                    "10",
+                    _FakeEvent(
+                        "TUIAgentMessage",
+                        content="Before\n```python\nfor i in range(3):\n    print(i)\n```\nAfter",
+                    ),
+                )
+            ]
+        )
+    )[0]
+
+    rendered = "\n".join(highlighted_detail_lines(row, width=80))
+    stripped = __import__("re").sub(r"\x1b\[[0-9;]*m", "", rendered)
+
+    assert "```" not in stripped
+    assert "for i in range(3):" in stripped
+    assert "print(i)" in stripped
+    assert "\x1b[" in rendered
+
+
+def test_event_explorer_renders_llm_output_as_syntax_highlighted_code() -> None:
+    """LLMOutput events render their content as syntax-highlighted code blocks."""
+    row = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [("6", _FakeEvent("LLMOutput", content="def f():\n    return 1"))]
+        )
+    )[0]
+
+    markdown = row.markdown or ""
+    rendered = "\n".join(highlighted_detail_lines(row, width=70))
+    stripped = __import__("re").sub(r"\x1b\[[0-9;]*m", "", rendered)
+
+    assert "## LLM output" in markdown
+    assert "```python" in markdown
+    assert "def f():" in stripped
+    assert "\x1b[" in rendered
+
+
+def test_event_explorer_renders_summary_as_readable_markdown() -> None:
+    """Summary events show summary text inline and compact range/children metadata."""
+    row = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                (
+                    "1..5",
+                    _FakeEvent(
+                        "Summary",
+                        summary_tag="1..5",
+                        children_tags=["1", "2", "3", "4", "5"],
+                        summary_text="User asked for a renderer and the agent implemented it.",
+                    ),
+                )
+            ]
+        )
+    )[0]
+
+    markdown = row.markdown or ""
+    plain = "\n".join(wrapped_detail_lines(row, width=90))
+
+    assert "**[1..5]** *Summary*" in markdown
+    assert "children_tags=" in markdown.rsplit("\n", 1)[-1]
+    assert "User asked for a renderer" in plain
+    assert "Summary Tag" in plain
+    assert "Summary(" not in plain
+
+
+def test_event_explorer_navigation_and_rendering() -> None:
+    rows = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                ("1", _FakeEvent("TUIUserInput", text="first")),
+                ("2", _FakeEvent("TUIUserInput", text="second")),
+                ("3", _FakeEvent("TUIUserInput", text="third")),
+            ]
+        )
+    )
+    model = EventExplorerModel(rows)
+
+    model.move(-1)
+    assert model.current.tag == "2"
+    model.move(+1)
+    assert model.current.tag == "3"
+    model.jump_home()
+    assert model.current.tag == "1"
+
+    rendered = render_event_explorer(model, width=70, height=14)
+    assert "Event Explorer" in rendered
+    assert "1" in rendered
+    assert "↑/↓ matches/scroll" in rendered
+
+
+def test_event_explorer_search_mode_up_down_moves_between_match_occurrences() -> None:
+    row = build_event_rows(
+        SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="alpha " * 80))])
+    )[0]
+    model = EventExplorerModel([row])
+    model.edit_query("alpha")
+    model.focus = "list"
+    render_event_explorer(model, width=44, height=8)
+    first_offset = model.detail_offset
+
+    model.move_or_scroll(+1)
+    render_event_explorer(model, width=44, height=8)
+
+    assert model.current.tag == "1"
+    assert model.search_line_cursor == 1
+    assert model.detail_offset >= first_offset
+
+    model.move_or_scroll(-1)
+    render_event_explorer(model, width=44, height=8)
+    assert model.current.tag == "1"
+    assert model.search_line_cursor == 0
+
+
+def test_event_explorer_fts_list_navigation_centers_current_match() -> None:
+    row = build_event_rows(
+        SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="alpha " * 120))])
+    )[0]
+    model = EventExplorerModel([row])
+    model.edit_query("alpha")
+    model.focus = "list"
+    render_event_explorer(model, width=44, height=8)
+
+    for _ in range(18):
+        model.move_or_scroll(+1)
+        render_event_explorer(model, width=44, height=8)
+
+    target = model.current_search_line()
+    assert target is not None
+    assert model._last_detail_visible_lines > 0
+    middle = model.detail_offset + model._last_detail_visible_lines // 2
+    assert abs(target - middle) <= 1
+
+
+def test_event_explorer_fts_detail_focus_up_down_scrolls_text() -> None:
+    row = build_event_rows(
+        SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="alpha " * 120))])
+    )[0]
+    model = EventExplorerModel([row])
+    model.edit_query("alpha")
+    model.focus = "detail"
+    render_event_explorer(model, width=44, height=8)
+
+    model.move_or_scroll(+1)
+    rendered = render_event_explorer(model, width=90, height=8)
+
+    assert model.search_active is True
+    assert model.search_line_cursor == 0
+    assert model.detail_offset == 1
+    assert "↑/↓ scroll text" in rendered
+
+
+def test_event_explorer_fts_current_match_uses_distinct_highlight() -> None:
+    row = build_event_rows(
+        SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="alpha beta alpha"))])
+    )[0]
+    line_no, occurrence_no = detail_match_occurrences(row, width=80, query="alpha")[0]
+    lines = highlighted_detail_lines(
+        row,
+        width=80,
+        query="alpha",
+        current_match_line=line_no,
+        current_match_occurrence=occurrence_no,
+    )
+    joined = "\n".join(lines)
+
+    assert "\x1b[30;106malpha\x1b[0m" in joined
+    assert "\x1b[30;43malpha\x1b[0m" in joined
+
+
+def test_event_explorer_current_match_highlights_second_match_on_same_line() -> None:
+    row = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [("1", _FakeEvent("TUIUserInput", text="alpha beta alpha gamma"))]
+        )
+    )[0]
+    occurrences = detail_match_occurrences(row, width=120, query="alpha")
+    same_line = [(line, occurrence) for line, occurrence in occurrences if occurrence == 1]
+    assert same_line
+    line_no, occurrence_no = same_line[0]
+
+    lines = highlighted_detail_lines(
+        row,
+        width=120,
+        query="alpha",
+        current_match_line=line_no,
+        current_match_occurrence=occurrence_no,
+    )
+    selected_line = lines[line_no]
+
+    assert selected_line.count("\x1b[30;106malpha\x1b[0m") == 1
+    assert selected_line.count("\x1b[30;43malpha\x1b[0m") >= 1
+    assert selected_line.index("\x1b[30;43malpha\x1b[0m") < selected_line.index(
+        "\x1b[30;106malpha\x1b[0m"
+    )
+
+
+def test_event_explorer_ansi_styles_header_footer_and_mode_label() -> None:
+    model = EventExplorerModel(
+        build_event_rows(
+            SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="alpha"))])
+        )
+    )
+    model.edit_query("alpha")
+
+    rendered = render_event_explorer(model, width=90, height=10, ansi=True)
+    lines = rendered.splitlines()
+
+    assert lines[0].startswith("\x1b[48;5;236;38;5;252m")
+    assert lines[-1].startswith("\x1b[48;5;236;38;5;252m")
+    assert "\x1b[1;30;45mFTS MODE\x1b[0m" in lines[-1]
+    assert "\x1b[48;5;236;38;5;252m" in lines[-1].split("\x1b[1;30;45mFTS MODE\x1b[0m", 1)[1]
+
+    model.search_active = False
+    rendered = render_event_explorer(model, width=90, height=10, ansi=True)
+    assert "\x1b[1;30;46mBROWSE MODE\x1b[0m" in rendered.splitlines()[-1]
+
+
+def test_event_explorer_fts_divider_prompt_matches_session_explorer_style() -> None:
+    model = EventExplorerModel(
+        build_event_rows(
+            SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="alpha"))])
+        )
+    )
+    model.search_active = True
+    model.set_query("alpha")
+
+    rendered = render_event_explorer(model, width=90, height=12, ansi=True)
+
+    assert "\x1b[1;30;45m[FTS: alpha] \x1b[0m" in rendered
+
+
+def test_event_explorer_fts_mode_survives_tab_focus_changes() -> None:
+    rows = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                ("1", _FakeEvent("TUIUserInput", text="alpha one")),
+                ("2", _FakeEvent("TUIUserInput", text="alpha two")),
+            ]
+        )
+    )
+    model = EventExplorerModel(rows)
+    model.edit_query("alpha")
+    model.toggle_focus()
+    assert model.search_active is True
+    assert model.focus == "detail"
+
+    rendered = render_event_explorer(model, width=90, height=12)
+    assert "FTS MODE" in rendered
+    assert "pane=event text" in rendered
+    assert "↑/↓ scroll text" in rendered
+
+    model.move_or_scroll(+1)
+    assert model.search_active is True
+    assert model.focus == "detail"
+    assert model.current.tag == "1"
+
+    model.toggle_focus()
+    assert model.search_active is True
+    assert model.focus == "list"
+    rendered = render_event_explorer(model, width=90, height=12)
+    assert "↑/↓ next match" in rendered
+    model.move_or_scroll(+1)
+    assert model.current.tag == "2"
+
+
+def test_event_explorer_footer_does_not_advertise_noop_enter_in_browse_mode() -> None:
+    model = EventExplorerModel([EventExplorerRow("1", "T", "summary", "summary", "detail")])
+
+    browse = render_event_explorer(model, width=120, height=10)
+    assert "enter browse" not in browse
+    assert "enter exit FTS" not in browse
+
+    model.search_active = True
+    fts = render_event_explorer(model, width=120, height=10)
+    assert "enter exit FTS" in fts
+
+
+def test_event_explorer_advertises_q_close() -> None:
+    model = EventExplorerModel(
+        build_event_rows(
+            SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="hello"))])
+        )
+    )
+
+    rendered = render_event_explorer(model, width=120, height=10)
+    source = Path("packages/nooa-cli/src/nooa_cli/tui/event_explorer.py").read_text()
+
+    assert "q quit" not in rendered
+    assert "esc clear" in rendered
+    assert "q close" in rendered
+    assert '@kb.add("q")' not in source
+
+
+def test_event_explorer_browse_mode_label_is_explicit() -> None:
+    model = EventExplorerModel(
+        build_event_rows(
+            SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="hello"))])
+        )
+    )
+
+    rendered = render_event_explorer(model, width=90, height=10)
+
+    assert "BROWSE MODE" in rendered
+    assert "pane=events" in rendered
+
+
+def test_event_explorer_search_mode_moves_to_next_event_after_last_occurrence() -> None:
+    rows = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                ("1", _FakeEvent("TUIUserInput", text="alpha one")),
+                ("2", _FakeEvent("TUIUserInput", text="alpha two")),
+            ]
+        )
+    )
+    model = EventExplorerModel(rows)
+    model.edit_query("alpha")
+    render_event_explorer(model, width=60, height=10)
+
+    model.move_or_scroll(+1)
+    render_event_explorer(model, width=60, height=10)
+
+    assert model.current.tag == "2"
+    assert model.search_line_cursor == 0
+
+
+def test_event_explorer_search_no_matches() -> None:
+    model = EventExplorerModel(
+        build_event_rows(
+            SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="hello"))])
+        )
+    )
+    model.set_query("missing")
+    rendered = render_event_explorer(model, width=60, height=10)
+    assert "No matches" in rendered
+
+
+def test_event_explorer_search_shows_match_position_and_highlights_matches() -> None:
+    rows = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                ("1", _FakeEvent("TUIUserInput", text="alpha one")),
+                ("2", _FakeEvent("TUIUserInput", text="beta two")),
+                ("3", _FakeEvent("TUIUserInput", text="alpha three")),
+            ]
+        )
+    )
+    model = EventExplorerModel(rows)
+    model.set_query("alpha")
+
+    rendered = render_event_explorer(model, width=80, height=14, ansi=True)
+    assert "match 1/2" in rendered
+    assert "\x1b[30;43malpha\x1b[0m" in rendered
+
+    model.move(+1)
+    rendered = render_event_explorer(model, width=80, height=14, ansi=True)
+    assert "match 2/2" in rendered
+    assert model.current.tag == "3"
+
+
+def test_event_explorer_search_highlights_matches_inside_detail_text() -> None:
+    row = build_event_rows(
+        SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="find alpha here"))])
+    )[0]
+    joined = "\n".join(highlighted_detail_lines(row, width=80, query="alpha"))
+
+    assert "\x1b[30;43malpha\x1b[0m" in joined
+
+
+def test_event_explorer_wraps_long_event_details_and_scrolls_within_event() -> None:
+    long_text = "alpha " * 40
+    row = build_event_rows(
+        SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text=long_text))])
+    )[0]
+    lines = wrapped_detail_lines(row, width=32)
+
+    assert len(lines) > len(row.detail.splitlines())
+    assert all(len(line) <= 32 for line in lines)
+
+    model = EventExplorerModel([row])
+    render_event_explorer(model, width=44, height=10)
+    before = model.detail_offset
+    model.page_detail(+4)
+    assert model.detail_offset > before
+    rendered = render_event_explorer(model, width=44, height=10)
+    assert "event lines" in rendered
+
+
+def test_event_explorer_renders_execute_python_event_as_formatted_markdown() -> None:
+    row = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                (
+                    "2",
+                    _FakeEvent(
+                        "ToolCallEvent",
+                        name="execute_python",
+                        arguments={"code": "for i in range(3):\n    print(i)"},
+                    ),
+                )
+            ]
+        )
+    )[0]
+
+    lines = highlighted_detail_lines(row, width=50)
+    joined = "\n".join(lines)
+    stripped = __import__("re").sub(r"\x1b\[[0-9;]*m", "", joined)
+    assert "ToolCallEvent" in stripped
+    assert "[2]" in stripped
+    assert "Tool" in stripped
+    assert "execute_python" in stripped
+    assert "Python" in stripped
+    assert "print" in stripped
+    assert "event:" not in stripped
+    assert "ToolCallEvent(" not in stripped
+    assert "\x1b[" in joined
+
+
+def test_event_explorer_renders_fenced_code_fields_as_formatted_markdown() -> None:
+    row = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                (
+                    "4",
+                    _FakeEvent(
+                        "AgentMessage",
+                        content="before\n```python\nvalue = 42\nprint(value)\n```\nafter",
+                    ),
+                )
+            ]
+        )
+    )[0]
+
+    assert row.code == "value = 42\nprint(value)"
+    lines = highlighted_detail_lines(row, width=50)
+    joined = "\n".join(lines)
+    stripped = __import__("re").sub(r"\x1b\[[0-9;]*m", "", joined)
+    assert "AgentMessage" in stripped
+    assert "before" in stripped
+    assert "```" not in stripped
+    assert "value = 42" in stripped
+    assert "print(value)" in stripped
+    assert "event:" not in stripped
+    assert "\x1b[" in joined
+
+
+def test_event_explorer_tab_focus_changes_up_down_semantics() -> None:
+    long_text = "alpha " * 80
+    rows = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                ("1", _FakeEvent("TUIUserInput", text="first")),
+                ("2", _FakeEvent("TUIUserInput", text=long_text)),
+            ]
+        )
+    )
+    model = EventExplorerModel(rows)
+    assert model.focus == "list"
+    assert model.current.tag == "2"
+
+    model.toggle_focus()
+    assert model.focus == "detail"
+    render_event_explorer(model, width=44, height=10)
+    model.scroll_detail(+3)
+    assert model.current.tag == "2"
+    assert model.detail_offset > 0
+    rendered = render_event_explorer(model, width=44, height=10)
+    assert "BROWSE MODE" in rendered
+    assert "pane=event text" in rendered
+    assert "❯ event lines" in rendered
+
+    model.toggle_focus()
+    model.move(-1)
+    assert model.current.tag == "1"
+
+
+def test_event_explorer_highlights_markdown_event_detail() -> None:
+    row = build_event_rows(
+        SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="hello"))])
+    )[0]
+    joined = "\n".join(highlighted_detail_lines(row, width=70))
+    plain = __import__("re").sub(r"\x1b\[[0-9;]*m", "", joined)
+
+    assert "event:" not in joined
+    assert "\x1b[1;38;5;230;48;5;238m" in joined
+    assert "\x1b[" in joined
+    assert "[1] TUIUserInput" in plain
+    assert "TUIUserInput" in plain
+    assert "User input" in plain
+    assert "text=" not in plain
+    assert "TUIUserInput(" not in plain
+    assert "hello" in plain
+
+
+def test_event_explorer_renders_tui_agent_message_as_event_markdown() -> None:
+    row = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                (
+                    "5",
+                    _FakeEvent(
+                        "TUIAgentMessage",
+                        content="# Answer\n\nThis is **markdown**, not repr.\n\n```python\nprint(1)\n```",
+                    ),
+                )
+            ]
+        )
+    )[0]
+
+    assert row.markdown is not None
+    assert row.code is not None
+
+    plain = "\n".join(wrapped_detail_lines(row, width=50))
+    assert "**[5]** *TUIAgentMessage*" in plain
+    assert "_metadata:" not in plain
+    assert "# Answer" in plain
+    assert "## content" not in plain
+    assert "TUIAgentMessage(" not in plain
+    assert "event:" not in plain
+
+    highlighted = "\n".join(highlighted_detail_lines(row, width=50))
+    stripped = __import__("re").sub(r"\x1b\[[0-9;]*m", "", highlighted)
+    assert "TUIAgentMessage" in stripped
+    assert "[5]" in stripped
+    assert "Answer" in stripped
+    assert "content=" not in stripped
+    assert "TUIAgentMessage(" not in stripped
+    assert "event:" not in stripped
+
+
+def test_event_explorer_handles_tiny_resize_heights_without_overflowing_body() -> None:
+    model = EventExplorerModel(
+        build_event_rows(
+            SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="hello"))])
+        )
+    )
+
+    rendered = render_event_explorer(model, width=40, height=3)
+
+    assert len(rendered.splitlines()) == 3
+    assert "Event Explorer" in rendered
+
+
+@pytest.mark.asyncio
+async def test_events_command_opens_in_app_explorer() -> None:
+    agent = MagicMock()
+    agent.event_manager = MagicMock()
+    frontend = MagicMock()
+    frontend.open_event_explorer = AsyncMock()
+    config = MagicMock()
+
+    cmd = EventsCommand(frontend, config, agent)
+    result = await cmd.execute([])
+
+    assert result.success is True
+    assert isinstance(result.outputs[0], TextOutput)
+    assert "closed" in result.outputs[0].content
+    frontend.open_event_explorer.assert_awaited_once_with(agent.event_manager)
+
+
+def test_events_command_rejects_args() -> None:
+    cmd = EventsCommand(MagicMock(), MagicMock(), MagicMock())
+
+    ok, error = cmd.validate_args(["1"])
+
+    assert ok is False
+    assert error == "Usage: /events"
+
+
+@pytest.mark.asyncio
+async def test_events_command_reports_failures() -> None:
+    agent = MagicMock()
+    agent.event_manager = MagicMock()
+    frontend = MagicMock()
+    frontend.open_event_explorer = AsyncMock(side_effect=RuntimeError("boom"))
+    config = MagicMock()
+
+    cmd = EventsCommand(frontend, config, agent)
+    result = await cmd.execute([])
+
+    assert result.success is False
+    assert "boom" in result.outputs[0].content
+
+
+@pytest.mark.asyncio
+async def test_tui_app_opens_and_closes_event_explorer_in_app() -> None:
+    from .tui_app_harness import FakeAgent, TUIHarness
+
+    agent = FakeAgent()
+    agent.event_manager = SimpleNamespace(
+        items=lambda: [("1", _FakeEvent("TUIUserInput", text="alpha event"))]
+    )
+    async with TUIHarness(agent=agent) as h:
+        task = asyncio.create_task(h.app.open_event_explorer(agent.event_manager))
+        await h.wait_for(lambda: h.app._event_explorer_model is not None)
+
+        assert h.app._event_explorer_model.current.tag == "1"
+        await h.press("q")
+        await asyncio.wait_for(task, timeout=1)
+        assert h.app._event_explorer_model is None
+
+
+@pytest.mark.asyncio
+async def test_tui_app_event_explorer_keys_do_not_edit_prompt() -> None:
+    from .tui_app_harness import FakeAgent, TUIHarness
+
+    agent = FakeAgent()
+    agent.event_manager = SimpleNamespace(
+        items=lambda: [
+            ("1", _FakeEvent("TUIUserInput", text="alpha one")),
+            ("2", _FakeEvent("TUIUserInput", text="alpha two")),
+        ]
+    )
+    async with TUIHarness(agent=agent) as h:
+        task = asyncio.create_task(h.app.open_event_explorer(agent.event_manager))
+        await h.wait_for(lambda: h.app._event_explorer_model is not None)
+
+        await h.type_keys("/")
+        await h.type_keys("alpha")
+        await h.press("down")
+
+        assert h.capture_input() == ""
+        assert h.app._event_explorer_model.query == "alpha"
+        assert h.app._event_explorer_model.search_active is True
+        await h.press("escape")
+        await h.wait_for(lambda: h.app._event_explorer_model.search_active is False)
+        await h.press("escape")
+        await h.wait_for(lambda: h.app._event_explorer_model.query == "")
+        await h.press("q")
+        await asyncio.wait_for(task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_tui_app_event_explorer_fts_can_search_printable_navigation_and_quit_keys() -> None:
+    from .tui_app_harness import FakeAgent, TUIHarness
+
+    agent = FakeAgent()
+    agent.event_manager = SimpleNamespace(
+        items=lambda: [("1", _FakeEvent("TUIUserInput", text="jqkr event"))]
+    )
+    async with TUIHarness(agent=agent) as h:
+        task = asyncio.create_task(h.app.open_event_explorer(agent.event_manager))
+        await h.wait_for(lambda: h.app._event_explorer_model is not None)
+
+        await h.type_keys("/")
+        await h.type_keys("jqkr")
+
+        await h.wait_for(lambda: h.app._event_explorer_model.query == "jqkr")
+        assert h.capture_input() == ""
+        assert h.app.active_subview is not None
+
+        await h.press("escape")
+        await h.wait_for(lambda: h.app._event_explorer_model.search_active is False)
+        await h.press("q")
+        await asyncio.wait_for(task, timeout=1)
+
+
+def test_event_explorer_has_in_app_mouse_scroll_bindings() -> None:
+    source = Path("packages/nooa-cli/src/nooa_cli/tui/tui_application.py").read_text()
+
+    assert "open_event_explorer" in source
+    assert "Keys.ScrollDown" in source
+    assert "Keys.ScrollUp" in source
+    assert "mouse_support=Condition(lambda: self._active_subview is not None)" in source
+    assert "_SuspendedPromptToolkitResize" not in source
+
+
+# ============================================================================
+# Session explorer tests
+# ============================================================================
+
+
+def _session_row(id: str, name: str, turns: list[tuple[str, str]]):
+    from nooa_cli.tui.session_explorer import SessionExplorerRow
+    from nooa_cli.tui.session_manager import Turn
+
+    turn_objs = [
+        Turn(role=role, content=content, ts=1000.0 + i) for i, (role, content) in enumerate(turns)
+    ]
+    search_text = "\n".join([id, name, "test-model", *[t.content for t in turn_objs]])
+    return SessionExplorerRow(
+        id=id,
+        name=name,
+        model="test/model",
+        agent="TUIAgent",
+        working_dir="/tmp/project",
+        started_at=1000.0,
+        last_active=2000.0,
+        turn_count=len(turn_objs),
+        turns=turn_objs,
+        search_text=search_text,
+    )
+
+
+def test_session_explorer_model_searches_across_sessions_and_dialog() -> None:
+    from nooa_cli.tui.session_explorer import SessionExplorerModel
+
+    rows = [
+        _session_row("aaaa0000-0000-0000-0000-000000000001", "alpha", [("user", "hello world")]),
+        _session_row(
+            "bbbb0000-0000-0000-0000-000000000002", "beta", [("agent", "contains frobnicator")]
+        ),
+    ]
+    model = SessionExplorerModel(rows)
+
+    model.set_query("frobnicator")
+
+    assert model.matches == [1]
+    assert model.current is rows[1]
+
+
+def test_session_explorer_navigation_tab_and_rendering() -> None:
+    from nooa_cli.tui.session_explorer import (
+        SessionExplorerModel,
+        render_session_explorer,
+    )
+
+    rows = [
+        _session_row("aaaa0000-0000-0000-0000-000000000001", "alpha", [("user", "first")]),
+        _session_row("bbbb0000-0000-0000-0000-000000000002", "beta", [("agent", "second")]),
+    ]
+    model = SessionExplorerModel(rows)
+
+    model.move(+1)
+    model.toggle_focus()
+    rendered = render_session_explorer(model, width=90, height=20)
+
+    assert model.current is rows[1]
+    assert model.focus == "dialog"
+    assert "Session Explorer" in rendered
+    assert "session dialog" in rendered
+    assert "beta" in rendered
+    assert "OO:" in rendered
+    assert "second" in rendered
+
+
+def test_session_explorer_opens_detail_at_end_of_long_session() -> None:
+    from nooa_cli.tui.session_explorer import (
+        SessionExplorerModel,
+        render_session_explorer,
+    )
+
+    turns = [("user", f"early line {i}") for i in range(20)] + [("agent", "final answer")]
+    model = SessionExplorerModel(
+        [_session_row("aaaa0000-0000-0000-0000-000000000001", "long", turns)]
+    )
+    model.toggle_focus()
+
+    rendered = render_session_explorer(model, width=90, height=12)
+
+    assert "final answer" in rendered
+    assert "early line 0" not in rendered
+
+
+def test_session_explorer_visible_tail_renders_markdown() -> None:
+    from nooa_cli.tui.session_explorer import (
+        SessionExplorerModel,
+        render_session_explorer,
+    )
+
+    model = SessionExplorerModel(
+        [
+            _session_row(
+                "aaaa0000-0000-0000-0000-000000000001",
+                "markdown",
+                [("agent", "**bold final**\n\n- one\n- two")],
+            )
+        ]
+    )
+    model.focus = "dialog"
+
+    rendered = render_session_explorer(model, width=80, height=16, ansi=True)
+
+    assert "\x1b[1mbold final\x1b[0m" in rendered
+    assert "\x1b[1m • \x1b[0mone" in rendered
+
+
+def test_session_explorer_highlight_does_not_bleed_into_blank_lines() -> None:
+    from nooa_cli.tui.session_explorer import (
+        SessionExplorerModel,
+        render_session_explorer,
+    )
+
+    row = _session_row(
+        "aaaa0000-0000-0000-0000-000000000001",
+        "hi",
+        [("agent", "a line ending with hi")],
+    )
+    model = SessionExplorerModel([row])
+    model.set_query("hi")
+
+    rendered = render_session_explorer(model, width=60, height=18, ansi=True)
+    lines = rendered.splitlines()
+    highlighted = [line for line in lines if "\x1b[30;43m" in line]
+
+    assert highlighted
+    assert all(line.strip(" \x1b[0m") for line in highlighted)
+    assert not any(line.endswith("\x1b[30;43m") for line in lines)
+
+
+def test_session_explorer_has_separate_session_and_dialog_fts_modes() -> None:
+    from nooa_cli.tui.session_explorer import (
+        SessionExplorerModel,
+        render_session_explorer,
+    )
+
+    rows = [
+        _session_row("aaaa0000-0000-0000-0000-000000000001", "alpha", [("agent", "shared needle")]),
+        _session_row("bbbb0000-0000-0000-0000-000000000002", "beta", [("agent", "other text")]),
+    ]
+    model = SessionExplorerModel(rows)
+
+    model.set_query("alpha", scope="sessions")
+    assert model.matches == [0]
+
+    model.focus = "dialog"
+    model.search_active = True
+    model.search_scope = "dialog"
+    model.edit_query("needle")
+    rendered = render_session_explorer(model, width=90, height=16, ansi=True)
+
+    assert model.matches == [0]
+    assert model.session_query == "alpha"
+    assert model.detail_query == "needle"
+    assert "[FTS dialog: needle]" in rendered
+    assert "\x1b[30;106mneedle\x1b[0m" in rendered
+
+
+def test_session_explorer_tab_switches_fts_scope_with_pane() -> None:
+    from nooa_cli.tui.session_explorer import SessionExplorerModel, SessionExplorerView
+
+    view = SessionExplorerView.__new__(SessionExplorerView)
+    view.model = SessionExplorerModel(
+        [_session_row("aaaa0000-0000-0000-0000-000000000001", "alpha", [("agent", "needle")])]
+    )
+
+    assert view.handle_key("slash") == "handled"
+    assert view.model.search_scope == "sessions"
+    assert view.handle_key("tab") == "handled"
+    assert view.model.focus == "dialog"
+    assert view.model.search_scope == "dialog"
+
+
+def test_session_explorer_dialog_fts_up_down_moves_between_matches() -> None:
+    from nooa_cli.tui.session_explorer import (
+        SessionExplorerModel,
+        render_session_explorer,
+    )
+
+    row = _session_row(
+        "aaaa0000-0000-0000-0000-000000000001",
+        "alpha",
+        [("agent", "needle one\n" + "filler\n" * 8 + "needle two")],
+    )
+    model = SessionExplorerModel([row])
+    model.focus = "dialog"
+    model.search_active = True
+    model.set_query("needle", scope="dialog")
+
+    render_session_explorer(model, width=80, height=10)
+    first_offset = model.detail_offset
+    model.move_or_scroll(+1)
+    render_session_explorer(model, width=80, height=10)
+
+    assert model.detail_search_cursor == 1
+    assert model.detail_offset > first_offset
+
+
+def test_session_explorer_tab_to_dialog_fts_then_down_moves_to_next_match() -> None:
+    from nooa_cli.tui.session_explorer import (
+        SessionExplorerModel,
+        SessionExplorerView,
+        render_session_explorer,
+    )
+
+    view = SessionExplorerView.__new__(SessionExplorerView)
+    view.model = SessionExplorerModel(
+        [
+            _session_row(
+                "aaaa0000-0000-0000-0000-000000000001",
+                "alpha",
+                [("agent", "needle one\n" + "filler\n" * 10 + "needle two")],
+            )
+        ]
+    )
+    view.pending_input = None
+
+    render_session_explorer(view.model, width=80, height=12)
+    assert view.handle_key("slash") == "handled"
+    for ch in "needle":
+        assert view.handle_key("text", ch) == "handled"
+    assert view.handle_key("tab") == "handled"
+
+    # The user can press Down immediately after Tab, before the redraw that
+    # discovers dialog match line numbers.
+    assert view.handle_key("down") == "handled"
+    rendered = render_session_explorer(view.model, width=80, height=12)
+
+    assert view.model.search_scope == "dialog"
+    assert view.model.focus == "dialog"
+    assert view.model.detail_search_cursor == 1
+    assert "needle two" in rendered
+    assert "needle one" not in rendered
+
+
+def test_session_explorer_list_fts_navigation_scrolls_detail_to_match() -> None:
+    from nooa_cli.tui.session_explorer import (
+        SessionExplorerModel,
+        render_session_explorer,
+    )
+
+    first = _session_row(
+        "aaaa0000-0000-0000-0000-000000000001",
+        "alpha one",
+        [("agent", "alpha near top")],
+    )
+    second = _session_row(
+        "bbbb0000-0000-0000-0000-000000000002",
+        "alpha two",
+        [("agent", "filler\n" * 12 + "alpha near bottom")],
+    )
+    model = SessionExplorerModel([first, second])
+    model.search_active = True
+    model.set_query("alpha", scope="sessions")
+
+    rendered = render_session_explorer(model, width=80, height=10)
+    assert "alpha near top" in rendered
+
+    model.move_or_scroll(+1)
+    rendered = render_session_explorer(model, width=80, height=10)
+
+    assert model.cursor == 1
+    assert "alpha near bottom" in rendered
+
+
+def test_session_explorer_fts_divider_prompt_is_highlighted_when_active() -> None:
+    from nooa_cli.tui.session_explorer import (
+        SessionExplorerModel,
+        render_session_explorer,
+    )
+
+    model = SessionExplorerModel(
+        [_session_row("aaaa0000-0000-0000-0000-000000000001", "alpha", [("agent", "needle")])]
+    )
+    model.search_active = True
+    model.set_query("alpha", scope="sessions")
+
+    rendered = render_session_explorer(model, width=90, height=12, ansi=True)
+
+    assert "\x1b[1;30;45m[FTS sessions: alpha] \x1b[0m" in rendered
+
+
+def test_session_explorer_selected_dialog_match_uses_distinct_highlight() -> None:
+    from nooa_cli.tui.session_explorer import (
+        SessionExplorerModel,
+        render_session_explorer,
+    )
+
+    row = _session_row(
+        "aaaa0000-0000-0000-0000-000000000001",
+        "alpha",
+        [("agent", "needle one\n" + "filler\n" * 8 + "needle two")],
+    )
+    model = SessionExplorerModel([row])
+    model.focus = "dialog"
+    model.search_active = True
+    model.set_query("needle", scope="dialog")
+    render_session_explorer(model, width=80, height=10, ansi=True)
+    model.move_or_scroll(+1)
+
+    rendered = render_session_explorer(model, width=80, height=10, ansi=True)
+
+    assert "\x1b[30;106mneedle\x1b[0m two" in rendered
+    assert "\x1b[30;43mneedle\x1b[0m one" not in rendered
+
+
+def test_session_explorer_mouse_scroll_actions_target_dialog() -> None:
+    from nooa_cli.tui.session_explorer import SessionExplorerModel, SessionExplorerView
+
+    view = SessionExplorerView.__new__(SessionExplorerView)
+    view.model = SessionExplorerModel(
+        [
+            _session_row(
+                "aaaa0000-0000-0000-0000-000000000001",
+                "long",
+                [("user", f"line {i}") for i in range(20)],
+            )
+        ]
+    )
+
+    view.handle_key("scroll_up")
+
+    assert view.model.focus == "dialog"
+
+
+def test_session_explorer_view_fts_accepts_navigation_and_quit_chars() -> None:
+    from nooa_cli.tui.session_explorer import SessionExplorerView
+
+    view = SessionExplorerView.__new__(SessionExplorerView)
+    from nooa_cli.tui.session_explorer import SessionExplorerModel
+
+    view.model = SessionExplorerModel(
+        [_session_row("aaaa0000-0000-0000-0000-000000000001", "jqk", [("user", "jqk query")])]
+    )
+
+    assert view.handle_key("slash") == "handled"
+    assert view.handle_key("j") == "handled"
+    assert view.handle_key("quit") == "handled"
+    assert view.handle_key("k") == "handled"
+
+    assert view.model.query == "jqk"
+    assert view.handle_key("escape") == "handled"
+    assert view.model.search_active is False
+    assert view.handle_key("quit") == "close"
+
+
+def test_session_explorer_resume_key_closes_with_resume_prefill() -> None:
+    from nooa_cli.tui.session_explorer import SessionExplorerModel, SessionExplorerView
+
+    view = SessionExplorerView.__new__(SessionExplorerView)
+    view.model = SessionExplorerModel(
+        [_session_row("aaaa0000-0000-0000-0000-000000000001", "alpha", [("user", "hello")])]
+    )
+    view.pending_input = None
+
+    assert view.handle_key("resume") == "close"
+    assert view.pending_input == "/session resume aaaa0000"
+
+
+def test_session_explorer_resume_key_types_r_in_fts_mode() -> None:
+    from nooa_cli.tui.session_explorer import SessionExplorerModel, SessionExplorerView
+
+    view = SessionExplorerView.__new__(SessionExplorerView)
+    view.model = SessionExplorerModel(
+        [_session_row("aaaa0000-0000-0000-0000-000000000001", "alpha", [("user", "hello")])]
+    )
+    view.pending_input = None
+    view.model.search_active = True
+
+    assert view.handle_key("resume") == "handled"
+    assert view.model.query == "r"
+    assert view.pending_input is None
+
+
+def test_session_explorer_slash_key_types_slash_in_fts_mode() -> None:
+    from nooa_cli.tui.session_explorer import SessionExplorerModel, SessionExplorerView
+
+    view = SessionExplorerView.__new__(SessionExplorerView)
+    view.model = SessionExplorerModel(
+        [_session_row("aaaa0000-0000-0000-0000-000000000001", "alpha", [("user", "path /tmp")])]
+    )
+    view.pending_input = None
+
+    assert view.handle_key("slash") == "handled"
+    assert view.handle_key("text", "t") == "handled"
+    assert view.handle_key("slash") == "handled"
+    assert view.handle_key("text", "m") == "handled"
+
+    assert view.model.search_active is True
+    assert view.model.query == "t/m"
+
+
+@pytest.mark.asyncio
+async def test_session_list_opens_in_app_explorer_when_available() -> None:
+    from nooa_cli.tui.commands import SessionCommand
+
+    frontend = MagicMock()
+    frontend.open_session_explorer = AsyncMock()
+    cmd = SessionCommand(frontend, MagicMock(), MagicMock())
+
+    result = await cmd.execute(["list"])
+
+    assert result.success is True
+    assert "closed" in result.outputs[0].content
+    frontend.open_session_explorer.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_tui_app_opens_and_closes_session_explorer_in_app(monkeypatch) -> None:
+    from nooa_cli.tui.session_explorer import SessionExplorerRow
+    from nooa_cli.tui.session_manager import Turn
+
+    from .tui_app_harness import TUIHarness
+
+    rows = [
+        SessionExplorerRow(
+            id="aaaa0000-0000-0000-0000-000000000001",
+            name="alpha session",
+            model="test/model",
+            agent="TUIAgent",
+            working_dir="/tmp/project",
+            started_at=1000.0,
+            last_active=2000.0,
+            turn_count=1,
+            turns=[Turn(role="user", content="find alpha", ts=1000.0)],
+            search_text="alpha session find alpha",
+        )
+    ]
+    monkeypatch.setattr(
+        "nooa_cli.tui.session_explorer.build_session_rows",
+        lambda *, limit=100: rows,
+    )
+
+    async with TUIHarness() as h:
+        task = asyncio.create_task(h.app.open_session_explorer())
+        await h.wait_for(lambda: h.app.active_subview is not None)
+
+        view = h.app.active_subview
+        assert view is not None
+        model = view.model
+        assert model.current.id.startswith("aaaa0000")
+        await h.type_keys("/")
+        await h.type_keys("alpha")
+        await h.wait_for(lambda: model.query == "alpha")
+        await h.press("tab")
+        await h.wait_for(lambda: model.focus == "dialog")
+
+        assert h.capture_input() == ""
+        await h.press("escape")
+        await h.press("q")
+        await asyncio.wait_for(task, timeout=1)
+        assert h.app.active_subview is None
+
+
+@pytest.mark.asyncio
+async def test_tui_app_session_explorer_resume_prefills_input(monkeypatch) -> None:
+    from nooa_cli.tui.session_explorer import SessionExplorerRow
+    from nooa_cli.tui.session_manager import Turn
+
+    from .tui_app_harness import TUIHarness
+
+    rows = [
+        SessionExplorerRow(
+            id="aaaa0000-0000-0000-0000-000000000001",
+            name="alpha session",
+            model="test/model",
+            agent="TUIAgent",
+            working_dir="/tmp/project",
+            started_at=1000.0,
+            last_active=2000.0,
+            turn_count=1,
+            turns=[Turn(role="user", content="find alpha", ts=1000.0)],
+            search_text="alpha session find alpha",
+        )
+    ]
+    monkeypatch.setattr(
+        "nooa_cli.tui.session_explorer.build_session_rows",
+        lambda *, limit=100: rows,
+    )
+
+    async with TUIHarness() as h:
+        task = asyncio.create_task(h.app.open_session_explorer())
+        await h.wait_for(lambda: h.app.active_subview is not None)
+
+        await h.type_keys("r")
+        await asyncio.wait_for(task, timeout=1)
+
+        assert h.app.active_subview is None
+        assert h.capture_input() == "/session resume aaaa0000"

--- a/packages/nooa-cli/tests/tui/test_explorer_shared.py
+++ b/packages/nooa-cli/tests/tui/test_explorer_shared.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for job and todo explorer views."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from nooa_cli.tui.event_explorer import (
+    highlight_terms_with_current,
+)
+from nooa_cli.tui.explorer_base import (
+    ExplorerConfig,
+    ExplorerModel,
+    ExplorerView,
+    display_line,
+    highlight_terms,
+    search_terms,
+    style_bar,
+    wrap_plain_line,
+)
+from nooa_cli.tui.job_explorer import (
+    JobExplorerView,
+    build_job_rows,
+)
+from nooa_cli.tui.todo_explorer import (
+    TodoExplorerView,
+    build_todo_rows,
+)
+
+# ─── explorer_base tests ─────────────────────────────────────────────────────
+
+
+class TestExplorerBaseUtils:
+    """Test shared utility functions."""
+
+    def test_wrap_plain_line_empty(self):
+        assert wrap_plain_line("", 80) == [""]
+
+    def test_wrap_plain_line_short(self):
+        assert wrap_plain_line("hello", 80) == ["hello"]
+
+    def test_wrap_plain_line_long(self):
+        result = wrap_plain_line("x" * 100, 50)
+        assert len(result) >= 2
+        assert all(len(line) <= 50 for line in result)
+
+    def test_search_terms_empty(self):
+        assert search_terms("") == []
+        assert search_terms("   ") == []
+
+    def test_search_terms_split(self):
+        assert search_terms("foo bar") == ["foo", "bar"]
+
+    def test_highlight_terms_no_terms(self):
+        assert highlight_terms("hello world", []) == "hello world"
+
+    def test_highlight_terms_with_match(self):
+        result = highlight_terms("hello world", ["world"])
+        assert "world" in result
+        assert "\x1b[" in result
+
+    def test_highlight_terms_with_current_occurrence(self):
+        result = highlight_terms_with_current("foo bar foo", ["foo"], 1)
+        assert "\x1b[30;106m" in result  # second occurrence highlighted differently
+
+    def test_display_line_pads(self):
+        result = display_line("hi", 10, [], ansi=False)
+        assert len(result) == 10
+
+    def test_style_bar_no_ansi(self):
+        assert style_bar("test", ansi=False) == "test"
+
+    def test_style_bar_ansi(self):
+        result = style_bar("test", ansi=True)
+        assert "\x1b[" in result
+
+
+class TestExplorerModel:
+    """Test ExplorerModel navigation and search."""
+
+    @staticmethod
+    def _make_model(n=5):
+        rows = [MagicMock(search_text=f"item {i}") for i in range(n)]
+        return ExplorerModel(rows)
+
+    def test_init(self):
+        model = self._make_model()
+        assert len(model.rows) == 5
+        assert model.cursor == 0
+        assert len(model.matches) == 5
+
+    def test_move(self):
+        model = self._make_model()
+        model.move(2)
+        assert model.cursor == 2
+        model.move(-1)
+        assert model.cursor == 1
+
+    def test_move_clamps(self):
+        model = self._make_model()
+        model.move(-10)
+        assert model.cursor == 0
+        model.move(100)
+        assert model.cursor == 4
+
+    def test_set_query_filters(self):
+        model = self._make_model()
+        model.set_query("item 3")
+        assert len(model.matches) == 1
+        assert model.matches[0] == 3
+
+    def test_set_query_empty_resets(self):
+        model = self._make_model()
+        model.set_query("item 3")
+        model.set_query("")
+        assert len(model.matches) == 5
+
+    def test_toggle_focus(self):
+        model = self._make_model()
+        assert model.focus == "list"
+        model.toggle_focus()
+        assert model.focus == "detail"
+        model.toggle_focus()
+        assert model.focus == "list"
+
+    def test_jump_home_end(self):
+        model = self._make_model()
+        model.move(3)
+        model.jump_home()
+        assert model.cursor == 0
+        model.jump_end()
+        assert model.cursor == 4
+
+
+class TestExplorerView:
+    """Test ExplorerView rendering and key handling."""
+
+    @staticmethod
+    def _make_view(n=5):
+        rows = [MagicMock(search_text=f"item {i}") for i in range(n)]
+        model = ExplorerModel(rows)
+        config = ExplorerConfig(title="Test Explorer")
+        return ExplorerView(model, config)
+
+    def test_render_produces_string(self):
+        view = self._make_view()
+        output = view.render(80, 24)
+        assert isinstance(output, str)
+        assert "Test Explorer" in output
+
+    def test_handle_key_quit_closes(self):
+        view = self._make_view()
+        assert view.handle_key("quit") == "close"
+
+    def test_handle_key_slash_activates_search(self):
+        view = self._make_view()
+        view.handle_key("slash")
+        assert view.model.search_active is True
+
+    def test_handle_key_escape_deactivates_search(self):
+        view = self._make_view()
+        view.handle_key("slash")
+        view.handle_key("escape")
+        assert view.model.search_active is False
+
+    def test_handle_key_down_moves(self):
+        view = self._make_view()
+        view.handle_key("down")
+        assert view.model.cursor == 1
+
+    def test_handle_key_tab_toggles_focus(self):
+        view = self._make_view()
+        view.handle_key("tab")
+        assert view.model.focus == "detail"
+
+    def test_render_empty(self):
+        rows = []
+        model = ExplorerModel(rows)
+        config = ExplorerConfig(title="Empty", empty_message="Nothing here.")
+        view = ExplorerView(model, config)
+        output = view.render(80, 24)
+        assert "Nothing here." in output
+
+
+# ─── Job explorer tests ──────────────────────────────────────────────────────
+
+
+class TestJobExplorer:
+    """Test job explorer view."""
+
+    def test_build_job_rows_none(self):
+        assert build_job_rows(None) == []
+
+    def test_build_job_rows_with_handles(self):
+        qm = MagicMock()
+        handle1 = MagicMock()
+        handle1.name = "ci"
+        handle1.label = "ci-pipeline"
+        handle1.state = "running"
+        handle1.values = ["line1", "line2"]
+        qm.jobs.return_value = {"ci": "running"}
+        qm.job.return_value = handle1
+        ch = MagicMock()
+        ch.qsize.return_value = 3
+        qm.channels.return_value = {"ci": ch}
+
+        rows = build_job_rows(qm)
+        assert len(rows) == 1
+        assert rows[0].channel == "ci"
+        assert rows[0].state == "running"
+        assert rows[0].delivered == 2
+        assert rows[0].queued == 3
+
+    def test_job_explorer_view_renders(self):
+        qm = MagicMock()
+        handle = MagicMock()
+        handle.name = "monitor"
+        handle.label = "health-check"
+        handle.state = "done"
+        handle.values = ["ok"]
+        qm.jobs.return_value = {"monitor": "done"}
+        qm.job.return_value = handle
+        qm.channels.return_value = {}
+
+        view = JobExplorerView(qm)
+        output = view.render(80, 24)
+        assert "Job Explorer" in output
+
+    def test_job_explorer_ignores_unknown_actions(self):
+        qm = MagicMock()
+        handle = MagicMock()
+        handle.name = "test-job"
+        handle.label = "test"
+        handle.state = "running"
+        handle.values = []
+        qm.jobs.return_value = {"test-job": "running"}
+        qm.job.return_value = handle
+        qm.channels.return_value = {}
+
+        view = JobExplorerView(qm)
+        result = view.handle_key("text", "x")
+        assert result == "ignored"
+
+
+# ─── Todo explorer tests ─────────────────────────────────────────────────────
+
+
+class TestTodoExplorer:
+    """Test todo explorer view."""
+
+    def test_build_todo_rows_none(self):
+        assert build_todo_rows(None) == []
+
+    def test_build_todo_rows_with_items(self):
+        todo_mgr = MagicMock()
+        todo1 = MagicMock()
+        todo1.id = "abc12345"
+        todo1.title = "Fix the bug"
+        todo1.status = "open"
+        todo1.deps = []
+        todo1.created_at = "2025-01-01 12:00"
+        todo1.notes = "Important fix"
+        todo1.comments = []
+        todo_mgr.list_todos.return_value = [todo1]
+
+        rows = build_todo_rows(todo_mgr)
+        assert len(rows) == 1
+        assert rows[0].id == "abc12345"
+        assert rows[0].title == "Fix the bug"
+        assert rows[0].status == "open"
+
+    def test_todo_explorer_view_renders(self):
+        todo_mgr = MagicMock()
+        todo1 = MagicMock()
+        todo1.id = "def67890"
+        todo1.title = "Write tests"
+        todo1.status = "done"
+        todo1.deps = []
+        todo1.created_at = "2025-01-01 12:00"
+        todo1.notes = ""
+        todo1.comments = []
+        todo_mgr.list_todos.return_value = [todo1]
+
+        view = TodoExplorerView(todo_mgr)
+        output = view.render(80, 24)
+        assert "Todo Explorer" in output
+
+    def test_todo_explorer_ignores_unknown_actions(self):
+        todo_mgr = MagicMock()
+        todo1 = MagicMock()
+        todo1.id = "xyz99999"
+        todo1.title = "Some task"
+        todo1.status = "open"
+        todo1.deps = []
+        todo1.created_at = "2025-01-01 12:00"
+        todo1.notes = ""
+        todo1.comments = []
+        todo_mgr.list_todos.return_value = [todo1]
+
+        view = TodoExplorerView(todo_mgr)
+        result = view.handle_key("text", "x")
+        assert result == "ignored"
+
+    def test_todo_explorer_empty(self):
+        todo_mgr = MagicMock()
+        todo_mgr.list_todos.return_value = []
+
+        view = TodoExplorerView(todo_mgr)
+        output = view.render(80, 24)
+        assert "No todos." in output

--- a/packages/nooa-cli/tests/tui/test_health_check.py
+++ b/packages/nooa-cli/tests/tui/test_health_check.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the LLM health check module."""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from nooa_cli.tui.health_check import (
+    _PROBE_MAX_TOKENS,
+    _classify_error,
+    _detect_provider,
+    _get_expected_env_var,
+    _has_llm_config_yaml,
+    probe_llm,
+)
+
+
+def _make_llm(model="test-model", registry_config=None):
+    """Create a mock LLM with the right attributes."""
+    llm = MagicMock()
+    llm.model = model
+    llm._registry_config = registry_config
+    llm.config = {}
+    return llm
+
+
+class TestDetectProvider:
+    """Test provider detection."""
+
+    def test_anthropic(self):
+        assert _detect_provider("claude-sonnet-4-5") == "anthropic"
+
+    def test_openai(self):
+        assert _detect_provider("gpt-4o") == "openai"
+
+    def test_unknown_returns_none_on_error(self):
+        # If litellm can't figure it out, we get None or a provider string
+        result = _detect_provider("totally-fake-xyz-model-999")
+        # Either None or a string is fine
+        assert result is None or isinstance(result, str)
+
+
+class TestGetExpectedEnvVar:
+    """Test env var detection for LLM providers."""
+
+    def test_from_registry_config(self):
+        llm = _make_llm(registry_config={"api_key_env": "MY_CUSTOM_KEY"})
+        assert _get_expected_env_var(llm) == "MY_CUSTOM_KEY"
+
+    def test_from_provider_detection(self):
+        llm = _make_llm(model="claude-sonnet-4-5")
+        llm._registry_config = None
+        result = _get_expected_env_var(llm)
+        assert result == "ANTHROPIC_API_KEY"
+
+    def test_openai_model(self):
+        llm = _make_llm(model="gpt-4o")
+        llm._registry_config = None
+        result = _get_expected_env_var(llm)
+        assert result == "OPENAI_API_KEY"
+
+
+class TestClassifyError:
+    """Test error classification into user-friendly messages."""
+
+    def test_auth_401_env_not_set(self):
+        llm = _make_llm(model="claude-sonnet-4-5")
+        llm._registry_config = None
+        exc = Exception("Error code: 401 - Unauthorized")
+        with (
+            patch(
+                "nooa_cli.tui.health_check._get_expected_env_var",
+                return_value="ANTHROPIC_API_KEY",
+            ),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            os.environ.pop("ANTHROPIC_API_KEY", None)
+            result = _classify_error(exc, llm)
+        assert not result.ok
+        assert "Authentication failed" in result.error_message
+        assert "ANTHROPIC_API_KEY" in result.fix_hint
+        assert "NOT set" in result.fix_hint
+
+    def test_auth_401_env_set_but_invalid(self):
+        llm = _make_llm(model="claude-sonnet-4-5")
+        llm._registry_config = None
+        exc = Exception("Error code: 401 - Unauthorized")
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-bad-key"}):
+            result = _classify_error(exc, llm)
+        assert not result.ok
+        assert "Authentication failed" in result.error_message
+        assert "invalid" in result.fix_hint
+
+    def test_model_not_found_404(self):
+        llm = _make_llm(model="gpt-99")
+        exc = Exception("Error code: 404 - Model not found")
+        result = _classify_error(exc, llm)
+        assert not result.ok
+        assert "not found" in result.error_message
+        assert "gpt-99" in result.error_message
+
+    def test_model_not_found_suggests_config_creation(self):
+        llm = _make_llm(model="fake-model")
+        exc = Exception("The model `fake-model` does not exist")
+        with patch("nooa_cli.tui.health_check._has_project_config", return_value=False):
+            result = _classify_error(exc, llm)
+        assert "/config set model" in result.fix_hint
+
+    def test_model_not_found_suggests_edit_config(self):
+        llm = _make_llm(model="fake-model")
+        exc = Exception("The model `fake-model` does not exist")
+        with patch("nooa_cli.tui.health_check._has_project_config", return_value=True):
+            result = _classify_error(exc, llm)
+        assert "edit" in result.fix_hint.lower() or "Or edit" in result.fix_hint
+
+    def test_permission_403(self):
+        llm = _make_llm(model="gpt-4o")
+        exc = Exception("Error code: 403 - Forbidden")
+        result = _classify_error(exc, llm)
+        assert not result.ok
+        assert "Access denied" in result.error_message
+
+    def test_connection_refused(self):
+        llm = _make_llm(model="my-model")
+        exc = ConnectionError("Connection refused")
+        result = _classify_error(exc, llm)
+        assert not result.ok
+        assert "Cannot connect" in result.error_message
+
+    def test_connection_with_yaml_mentions_api_base(self):
+        llm = _make_llm(model="my-model")
+        exc = ConnectionError("Connection refused")
+        with patch("nooa_cli.tui.health_check._has_llm_config_yaml", return_value=True):
+            result = _classify_error(exc, llm)
+        assert "api_base" in result.fix_hint
+
+    def test_connection_without_yaml_mentions_provider_down(self):
+        llm = _make_llm(model="my-model")
+        exc = ConnectionError("Connection refused")
+        with patch("nooa_cli.tui.health_check._has_llm_config_yaml", return_value=False):
+            result = _classify_error(exc, llm)
+        assert "temporarily down" in result.fix_hint
+
+    def test_timeout(self):
+        llm = _make_llm(model="slow-model")
+        exc = Exception("Request timed out")
+        result = _classify_error(exc, llm)
+        assert not result.ok
+        assert "timed out" in result.error_message
+
+    def test_output_limit_reached(self):
+        llm = _make_llm(model="openai/azure/openai/gpt-5.5")
+        exc = Exception(
+            "Could not finish the message because max_tokens or model output limit "
+            "was reached. Please try again with higher max_tokens."
+        )
+        result = _classify_error(exc, llm)
+        assert not result.ok
+        assert "output limit" in result.error_message
+        assert "--model <name>" in result.fix_hint
+        assert "file a bug" in result.fix_hint
+
+    def test_rate_limit_429(self):
+        llm = _make_llm(model="gpt-4o")
+        exc = Exception("Error code: 429 - Too Many Requests")
+        result = _classify_error(exc, llm)
+        assert not result.ok
+        assert "Rate limited" in result.error_message
+
+    def test_unknown_error_shows_env_status(self):
+        llm = _make_llm(model="claude-sonnet-4-5")
+        llm._registry_config = None
+        exc = ValueError("Something unexpected")
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-real"}):
+            result = _classify_error(exc, llm)
+        assert "ANTHROPIC_API_KEY" in result.fix_hint
+        assert "set" in result.fix_hint
+
+
+class TestHasLlmConfigYaml:
+    """Test llm_config.yaml detection.
+
+    Mirrors :func:`nooa.llm_config.llm_config_chain` — see
+    that helper's tests for full chain coverage.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_paths(self, tmp_path, monkeypatch):
+        """Redirect user/project dirs so the host's real config is invisible.
+
+        Bundled-default entry-points are stubbed empty so the chain
+        check sees only what the test sets up.
+        """
+        user = tmp_path / "user"
+        project = tmp_path / "project"
+        user.mkdir()
+        project.mkdir()
+        monkeypatch.setenv("NEMO_OO_USER_DIR", str(user))
+        monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project))
+        monkeypatch.setattr("nooa.llm_config.bundled_config_paths", lambda: [])
+        monkeypatch.delenv("NEMO_OO_LLM_CONFIG", raising=False)
+        monkeypatch.chdir(tmp_path)
+        return user, project
+
+    def test_returns_false_when_no_file(self):
+        assert _has_llm_config_yaml() is False
+
+    def test_returns_true_when_project_has_file(self, _isolate_paths):
+        _, project = _isolate_paths
+        (project / "llm_config.yaml").write_text("models: {}")
+        assert _has_llm_config_yaml() is True
+
+    def test_returns_true_when_user_has_file(self, _isolate_paths):
+        user, _ = _isolate_paths
+        (user / "llm_config.yaml").write_text("models: {}")
+        assert _has_llm_config_yaml() is True
+
+    def test_returns_true_when_env_var_set(self, tmp_path, monkeypatch):
+        extra = tmp_path / "extra.yaml"
+        extra.write_text("models: {}")
+        monkeypatch.setenv("NEMO_OO_LLM_CONFIG", str(extra))
+        assert _has_llm_config_yaml() is True
+
+    def test_bundled_only_returns_false(self, tmp_path, monkeypatch):
+        """Bundled defaults alone must not register as a user-supplied config.
+
+        Otherwise every install would steer ``_classify_error`` toward
+        "check your llm_config.yaml" hints even for users who haven't
+        created one.
+        """
+        # Stub the entry-point lookup with a synthetic bundled YAML.
+        synthetic = tmp_path / "synthetic_bundled.yaml"
+        synthetic.write_text("models: {}")
+        monkeypatch.setattr(
+            "nooa.llm_config.bundled_config_paths",
+            lambda: [synthetic],
+        )
+        assert _has_llm_config_yaml() is False
+
+    def test_bundled_plus_user_returns_true(self, _isolate_paths, tmp_path, monkeypatch):
+        """Bundled + a user-supplied file → True (it's the *user* file that matters)."""
+        synthetic = tmp_path / "synthetic_bundled.yaml"
+        synthetic.write_text("models: {}")
+        monkeypatch.setattr(
+            "nooa.llm_config.bundled_config_paths",
+            lambda: [synthetic],
+        )
+        user, _ = _isolate_paths
+        (user / "llm_config.yaml").write_text("models: {}")
+        assert _has_llm_config_yaml() is True
+
+
+class TestProbeLLM:
+    """Test the probe_llm async function."""
+
+    @pytest.mark.asyncio
+    async def test_successful_probe(self):
+        """A successful LLM call returns ok=True."""
+        llm = _make_llm()
+        llm.acall = AsyncMock(return_value=MagicMock())
+
+        result = await probe_llm(llm)
+        assert result.ok
+        assert result.error_message is None
+
+        # Verify the probe used a small, non-pathological token cap
+        llm.acall.assert_called_once()
+        call_kwargs = llm.acall.call_args
+        assert call_kwargs.kwargs["max_tokens"] == _PROBE_MAX_TOKENS
+
+    @pytest.mark.asyncio
+    async def test_auth_error_probe(self):
+        """Auth errors are caught and classified."""
+        llm = _make_llm(model="claude-sonnet-4-5")
+        llm._registry_config = None
+        llm.acall = AsyncMock(side_effect=Exception("Error code: 401 - Unauthorized"))
+
+        result = await probe_llm(llm)
+        assert not result.ok
+        assert "Authentication failed" in result.error_message
+        assert "claude-sonnet-4-5" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_timeout_probe(self):
+        """Timeout is caught when the endpoint is unresponsive."""
+        llm = _make_llm(model="slow-model")
+
+        async def slow_call(**kwargs):
+            await asyncio.sleep(100)
+
+        llm.acall = slow_call
+
+        with patch("nooa_cli.tui.health_check._PROBE_TIMEOUT_SECONDS", 0.1):
+            result = await probe_llm(llm)
+
+        assert not result.ok
+        assert "timed out" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_connection_error_probe(self):
+        """Connection errors are caught and classified."""
+        llm = _make_llm(model="unreachable-model")
+        llm.acall = AsyncMock(side_effect=ConnectionError("Connection refused"))
+
+        result = await probe_llm(llm)
+        assert not result.ok
+        assert "Cannot connect" in result.error_message
+        assert "unreachable-model" in result.error_message

--- a/packages/nooa-cli/tests/tui/test_input_handler.py
+++ b/packages/nooa-cli/tests/tui/test_input_handler.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for TUIInputHandler — prompt_continuation, key bindings."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from nooa_cli.tui.input_handler import TUIInputHandler, create_key_bindings
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_registry():
+    registry = MagicMock()
+    registry.get_completions.return_value = {"/help": "Show help", "/exit": "Exit"}
+    return registry
+
+
+@pytest.fixture
+def handler(mock_registry):
+    return TUIInputHandler(mock_registry)
+
+
+# ---------------------------------------------------------------------------
+# Indentation: prompt_continuation must be "" so wrapped lines don't indent
+# ---------------------------------------------------------------------------
+
+
+class TestPromptContinuation:
+    @pytest.mark.asyncio
+    async def test_get_input_passes_empty_prompt_continuation(self, handler):
+        """get_input() must pass prompt_continuation='' to suppress wrap indent.
+
+        Without this, prompt_toolkit indents continuation lines to match the
+        prompt width (e.g. '/Volumes/dev/dev/tui006 (sonnet-4-5) ❯ ' = 44 chars),
+        making wrapped text appear indented on the second line.
+        """
+        with patch.object(handler.session, "prompt_async", new_callable=AsyncMock) as mock_prompt:
+            mock_prompt.return_value = "hello"
+            await handler.get_input("❯ ")
+
+        _, kwargs = mock_prompt.call_args
+        assert "prompt_continuation" in kwargs, (
+            "prompt_async was not called with prompt_continuation kwarg"
+        )
+        assert kwargs["prompt_continuation"] == "", (
+            f"Expected prompt_continuation='', got {kwargs['prompt_continuation']!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_input_returns_stripped_result(self, handler):
+        """get_input() strips leading/trailing whitespace from the result."""
+        with patch.object(handler.session, "prompt_async", new_callable=AsyncMock) as mock_prompt:
+            mock_prompt.return_value = "  hello world  "
+            result = await handler.get_input("❯ ")
+
+        assert result == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# Key bindings: Enter submits, c-j (Shift+Enter on iTerm2) inserts newline
+# ---------------------------------------------------------------------------
+
+
+class TestKeyBindings:
+    def test_enter_binding_exists(self):
+        """The 'enter' key (ControlM) must be bound (to submit)."""
+        from prompt_toolkit.keys import Keys
+
+        bindings = create_key_bindings()
+        bound_keys = [b.keys for b in bindings.bindings]
+        assert any(keys == (Keys.ControlM,) for keys in bound_keys), (
+            "enter/ControlM is not bound — submitting won't work"
+        )
+
+    def test_escape_enter_binding_exists(self):
+        """Alt/Option+Enter must be bound as newline fallback."""
+        from prompt_toolkit.keys import Keys
+
+        bindings = create_key_bindings()
+        bound_key_tuples = [b.keys for b in bindings.bindings]
+        assert any(keys == (Keys.Escape, Keys.ControlM) for keys in bound_key_tuples), (
+            "Alt/Option+Enter (Escape+ControlM) is not bound"
+        )
+
+    def test_c_j_binding_exists(self):
+        """ControlJ (\\n) must be bound to insert newline.
+
+        iTerm2 sends \\n (0x0a, ControlJ) for Shift+Enter.
+        """
+        from prompt_toolkit.keys import Keys
+
+        bindings = create_key_bindings()
+        bound_keys = [b.keys for b in bindings.bindings]
+        assert any(keys == (Keys.ControlJ,) for keys in bound_keys), (
+            "c-j (ControlJ) is not bound — Shift+Enter on iTerm2 will submit"
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: Shift+Enter inserts newline
+# ---------------------------------------------------------------------------
+
+
+class TestShiftEnter:
+    @pytest.mark.asyncio
+    async def test_iterm2_shift_enter_inserts_newline(self, mock_registry):
+        """Full pipeline: iTerm2 Shift+Enter (\\n / ControlJ) → newline, not submit."""
+        import io
+
+        from nooa_cli.tui.input_handler import create_key_bindings
+        from prompt_toolkit import PromptSession
+        from prompt_toolkit.input import create_pipe_input
+        from prompt_toolkit.output import create_output
+
+        with create_pipe_input() as inp:
+            out = create_output(stdout=io.StringIO())
+            session = PromptSession(
+                input=inp,
+                output=out,
+                key_bindings=create_key_bindings(),
+                multiline=True,
+            )
+            # "hi" + ControlJ (iTerm2 Shift+Enter) + "there" + regular Enter
+            inp.send_text("hi\nthere\r")
+            result = await session.prompt_async("> ", prompt_continuation="")
+
+        assert result == "hi\nthere", (
+            f"Expected 'hi\\nthere', got {result!r} — "
+            "iTerm2 Shift+Enter (ControlJ) submitted instead of inserting newline"
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: @ inline mention triggers completion and substitutes on submit
+# ---------------------------------------------------------------------------
+
+
+class TestMentionKeyBindings:
+    def test_at_binding_exists(self):
+        """The '@' key must be bound so typing it can trigger completion."""
+        bindings = create_key_bindings()
+        bound = [b.keys for b in bindings.bindings]
+        assert any(keys == ("@",) for keys in bound), "'@' is not bound"
+
+    @pytest.mark.asyncio
+    async def test_at_completion_fires_on_mention(self, tmp_path):
+        """Typing '@<dir>/' populates the completion menu from the filesystem.
+
+        Drives the real prompt_toolkit Buffer through the same
+        ``_set_completions_sync`` path the '@' keybinding uses, so this proves
+        the keybinding's logic wires into the shared Completer — without
+        racing prompt_toolkit's async render loop (which clears completion
+        state on submit).
+        """
+        from nooa_cli.tui.input_handler import (
+            _MENTION_RE,
+            SlashCommandCompleter,
+            _set_completions_sync,
+        )
+        from prompt_toolkit.buffer import Buffer
+        from prompt_toolkit.document import Document
+
+        (tmp_path / "alpha.md").touch()
+        (tmp_path / "beta.md").touch()
+
+        registry = MagicMock()
+        registry.get_active_help.return_value = {}
+
+        text = f"see @{tmp_path}/"
+        # The '@' keybinding gates on this regex before triggering completion.
+        assert _MENTION_RE.search(text) is not None
+
+        buf = Buffer(completer=SlashCommandCompleter(registry))
+        buf.set_document(Document(text, len(text)), bypass_readonly=True)
+        _set_completions_sync(buf)
+
+        assert buf.complete_state is not None, "@ mention did not open a completion menu"
+        displays = [c.display_text for c in buf.complete_state.completions]
+        assert any("alpha.md" in d for d in displays), displays
+        assert any("beta.md" in d for d in displays), displays

--- a/packages/nooa-cli/tests/tui/test_keep_going.py
+++ b/packages/nooa-cli/tests/tui/test_keep_going.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the retained opt-in keep-going mode."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from nooa_cli.tui.commands import KeepGoingCommand
+from nooa_cli.tui.config import TUIConfig
+from nooa_cli.tui.keep_going import KeepGoingDecision
+from nooa_cli.tui.output import TextOutput
+from nooa_cli.tui.tui_application import DispatcherExit, TUIApplication
+
+from nooa.runtime.channels import QueueManager
+
+
+class _Agent:
+    def __init__(self) -> None:
+        self.vars: dict[str, object] = {}
+        self.queue_manager = QueueManager()
+        self._user_messages_in = self.queue_manager.queue("user_messages")
+        self.user_messages = self._user_messages_in.reader
+        self._system_messages_in = self.queue_manager.queue("system_messages")
+        self.system_messages = self._system_messages_in.reader
+
+
+class _ReflectionRunner:
+    def __init__(self) -> None:
+        self.scheduled = 0
+        self.invalidate = None
+
+    async def interrupt(self) -> None:
+        return None
+
+    def on_response_done(self) -> None:
+        self.scheduled += 1
+
+    def indicator_frame(self) -> str:
+        return ""
+
+
+def _config(*, enabled: bool, model: str | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        tui=SimpleNamespace(
+            keep_going=enabled,
+            keep_going_model=model,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_keep_going_command_configures_and_persists(monkeypatch, tmp_path):
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(tmp_path))
+    config = TUIConfig()
+    agent = SimpleNamespace(vars={})
+    command = KeepGoingCommand(AsyncMock(), config, agent)
+
+    result = await command.execute(["model", "audit-model"])
+    assert result.success
+    assert config.keep_going_model == "audit-model"
+    assert agent.vars["tui_keep_going_model"] == "audit-model"
+
+    result = await command.execute(["on"])
+    assert result.success
+    assert config.keep_going is True
+    assert agent.vars["tui_keep_going"] is True
+
+    import yaml
+
+    settings = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+    assert settings["tui"]["keep_going_model"] == "audit-model"
+    assert settings["tui"]["keep_going"] is True
+
+
+@pytest.mark.asyncio
+async def test_keep_going_command_requires_a_judge_model():
+    config = TUIConfig()
+    command = KeepGoingCommand(AsyncMock(), config, SimpleNamespace(vars={}))
+
+    result = await command.execute(["on"])
+
+    assert not result.success
+    assert any(
+        "model is not configured" in output.content
+        for output in result.outputs
+        if isinstance(output, TextOutput)
+    )
+
+
+def test_keep_going_model_completion_uses_model_registry(monkeypatch):
+    from nooa_cli.tui.completer import Completer
+
+    import nooa.unifiedllm as unifiedllm
+
+    monkeypatch.setattr(
+        unifiedllm,
+        "MODELS",
+        {"audit-alpha": object(), "audit-beta": object(), "other": object()},
+    )
+    registry = SimpleNamespace(_user_skills={}, get_active_help=lambda: {})
+
+    items = Completer(registry).complete("/keep-going model audit-")
+
+    assert [item.text for item in items] == [
+        "/keep-going model audit-alpha",
+        "/keep-going model audit-beta",
+    ]
+
+    assert [item.text for item in Completer(registry).complete("/keep-going ")] == [
+        "/keep-going on",
+        "/keep-going off",
+        "/keep-going model",
+    ]
+
+
+def test_keep_going_judge_output_type_is_minimal():
+    assert set(KeepGoingDecision.model_fields) == {"should_reprompt", "reason", "next_action"}
+
+
+@pytest.mark.asyncio
+async def test_build_keep_going_prompt_shapes_internal_continuation(monkeypatch):
+    from nooa_cli.tui import keep_going
+
+    async def fake_judge(**kwargs):
+        assert kwargs["model"] == "audit-model"
+        return KeepGoingDecision(
+            should_reprompt=True,
+            reason="open todos remain",
+            next_action="Finish the open todos.",
+        )
+
+    monkeypatch.setattr(keep_going, "judge_keep_going", fake_judge)
+
+    prompt = await keep_going.build_keep_going_prompt(
+        _Agent(),
+        SimpleNamespace(kind="DONE"),
+        model="audit-model",
+    )
+
+    assert prompt is not None
+    assert prompt.display_reason == "open todos remain"
+    assert "Reason: open todos remain" in prompt.prompt
+    assert "Next action: Finish the open todos." in prompt.prompt
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_queues_keep_going_as_system_message(monkeypatch):
+    from nooa_cli.tui import keep_going
+
+    agent = _Agent()
+    calls: list[dict] = []
+
+    async def fake_build(agent_arg, result, *, model):
+        assert agent_arg is agent
+        assert result.kind == "DONE"
+        assert model == "audit-model"
+        return SimpleNamespace(
+            prompt="[keep-going] continue",
+            display_reason="open todo remains",
+        )
+
+    async def handle(notification):
+        calls.append(notification)
+        if len(calls) == 1:
+            return SimpleNamespace(kind="DONE", explanation="")
+        raise DispatcherExit()
+
+    monkeypatch.setattr(keep_going, "build_keep_going_prompt", fake_build)
+    agent.handle = handle
+    app = TUIApplication(agent=agent, config=_config(enabled=True, model="audit-model"))
+
+    app.submit_message("first")
+    await asyncio.wait_for(app._agent_task, timeout=1)
+
+    assert calls == [
+        {"user_messages": ["first"]},
+        {"system_messages": ["[keep-going] continue"]},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_new_user_input_cancels_stale_keep_going_audit(monkeypatch):
+    from nooa_cli.tui import keep_going
+
+    agent = _Agent()
+    calls: list[dict] = []
+    audit_started = asyncio.Event()
+    release_audit = asyncio.Event()
+
+    async def fake_build(agent_arg, result, *, model):
+        audit_started.set()
+        await release_audit.wait()
+        return SimpleNamespace(prompt="[keep-going] stale", display_reason="stale audit")
+
+    async def handle(notification):
+        calls.append(notification)
+        if len(calls) == 1:
+            return SimpleNamespace(kind="DONE", explanation="")
+        if len(calls) == 2:
+            return SimpleNamespace(kind="WAIT", explanation="")
+        raise DispatcherExit()
+
+    monkeypatch.setattr(keep_going, "build_keep_going_prompt", fake_build)
+    agent.handle = handle
+    app = TUIApplication(agent=agent, config=_config(enabled=True, model="audit-model"))
+
+    app.submit_message("first")
+    await asyncio.wait_for(audit_started.wait(), timeout=1)
+    app.submit_message("second")
+    for _ in range(100):
+        if len(calls) == 2:
+            break
+        await asyncio.sleep(0)
+    release_audit.set()
+    await asyncio.sleep(0.01)
+
+    assert calls == [
+        {"user_messages": ["first"]},
+        {"user_messages": ["second"]},
+    ]
+    app._agent_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await app._agent_task
+
+
+@pytest.mark.asyncio
+async def test_reflection_waits_for_keep_going_audit_then_runs_when_no_continuation(monkeypatch):
+    from nooa_cli.tui import keep_going
+
+    agent = _Agent()
+    runner = _ReflectionRunner()
+    agent._tui_reflection_runner = runner
+    audit_finished = asyncio.Event()
+
+    async def fake_build(agent_arg, result, *, model):
+        audit_finished.set()
+        return None
+
+    async def handle(notification):
+        return SimpleNamespace(kind="DONE", explanation="")
+
+    monkeypatch.setattr(keep_going, "build_keep_going_prompt", fake_build)
+    agent.handle = handle
+    app = TUIApplication(agent=agent, config=_config(enabled=True, model="audit-model"))
+
+    app.submit_message("first")
+    await asyncio.wait_for(audit_finished.wait(), timeout=1)
+    for _ in range(100):
+        if runner.scheduled:
+            break
+        await asyncio.sleep(0)
+
+    assert runner.scheduled == 1
+    app._agent_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await app._agent_task

--- a/packages/nooa-cli/tests/tui/test_litellm_task_destroyed.py
+++ b/packages/nooa-cli/tests/tui/test_litellm_task_destroyed.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: litellm LoggingWorker task-destroyed warnings suppressed.
+
+The litellm GLOBAL_LOGGING_WORKER singleton creates infinite-loop tasks on
+whatever event loop is current. When the agent loop is torn down, those
+tasks would emit "Task was destroyed but it is pending!" — which pollutes
+the TUI scrollback. These tests verify our suppression layers work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+
+class FakeLoggingWorkerTask:
+    """Simulates a litellm LoggingWorker._worker_loop pending task."""
+
+    def __repr__(self):
+        return "<Task pending name='Task-99' coro=<LoggingWorker._worker_loop() running at logging_worker.py:121>>"
+
+
+# ─── Test 1: agent loop exception handler suppresses LoggingWorker ────
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_exception_handler_suppresses_logging_worker():
+    """The custom exception handler on the agent loop drops 'Task was destroyed'
+    for LoggingWorker tasks and passes other messages through."""
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    app = TUIApplication(agent=None)
+
+    # Create the agent loop (starts the thread)
+    loop = app._ensure_agent_loop()
+    assert loop.is_running()
+
+    # Collect messages that go through the exception handler
+    forwarded: list[str] = []
+
+    def _capture_default(ctx):
+        forwarded.append(ctx.get("message", ""))
+
+    loop.default_exception_handler = _capture_default
+
+    # Simulate a "Task was destroyed" for LoggingWorker — should be suppressed
+    loop.call_soon_threadsafe(
+        loop.call_exception_handler,
+        {
+            "message": "Task was destroyed but it is pending!",
+            "task": FakeLoggingWorkerTask(),
+        },
+    )
+
+    # Simulate a different warning — should NOT be suppressed
+    loop.call_soon_threadsafe(
+        loop.call_exception_handler,
+        {
+            "message": "Something else went wrong",
+        },
+    )
+
+    # Give the loop time to process both
+    await asyncio.sleep(0.1)
+
+    # Stop the agent loop
+    await app._stop_agent_loop()
+
+    # Only the non-LoggingWorker message should have been forwarded
+    assert "Something else went wrong" in forwarded
+    assert not any("Task was destroyed" in m for m in forwarded)
+
+
+# ─── Test 2: _loud_handler on UI loop suppresses LoggingWorker ────────
+
+
+@pytest.mark.asyncio
+async def test_loud_handler_suppresses_logging_worker_task_destroyed():
+    """Session._loud_handler drops 'Task was destroyed' for LoggingWorker."""
+    from nooa_cli.tui.session import Session
+
+    # We need a minimal Session — mock enough to call _loud_handler
+    # _loud_handler is a method that takes (self, loop, context)
+    # Let's call it directly with the right context
+    emitted: list[str] = []
+
+    class FakeApp:
+        def emit_block(self, text):
+            emitted.append(text)
+
+    class FakeSession:
+        _loud_handler = Session._loud_handler
+        _app = FakeApp()
+        _in_loud_handler = False
+        _loud_handler_reentrant = False
+
+    session = FakeSession()
+
+    loop = asyncio.get_running_loop()
+
+    # Should be suppressed
+    session._loud_handler(
+        loop,
+        {
+            "message": "Task was destroyed but it is pending!",
+            "task": FakeLoggingWorkerTask(),
+        },
+    )
+
+    # Should NOT be suppressed
+    session._loud_handler(
+        loop,
+        {
+            "message": "Some real error occurred",
+        },
+    )
+
+    # Only the non-suppressed message should produce output
+    assert not any("Task was destroyed" in e for e in emitted)
+    assert any("Some real error" in e for e in emitted)
+
+
+# ─── Test 3: _stop_agent_loop calls litellm stop ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stop_agent_loop_stops_litellm_worker():
+    """_stop_agent_loop gracefully stops litellm's GLOBAL_LOGGING_WORKER."""
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    app = TUIApplication(agent=None)
+    app._ensure_agent_loop()
+
+    stop_called = []
+
+    async def fake_stop():
+        stop_called.append(True)
+
+    with patch(
+        "nooa_cli.tui.tui_application._stop_litellm_worker",
+        new=fake_stop,
+    ):
+        await app._stop_agent_loop()
+
+    assert stop_called, "_stop_litellm_worker was not called during _stop_agent_loop"

--- a/packages/nooa-cli/tests/tui/test_loud_handler_diagnostics.py
+++ b/packages/nooa-cli/tests/tui/test_loud_handler_diagnostics.py
@@ -1,0 +1,520 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for gl-212 asyncio.Lock loop-mismatch diagnostic instrumentation.
+
+Covers the diagnostic code path in ``Session._loud_handler`` that fires
+when an exception contains "bound to a different event loop".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+from nooa_cli.tui.session import Session
+
+
+def _make_session_stub(*, emit_block_side_effect=None):
+    """Build a minimal Session stub with only the fields _loud_handler touches."""
+    session = Session.__new__(Session)
+    session._loud_handler_reentrant = False
+    session._app = MagicMock()
+    if emit_block_side_effect:
+        session._app.emit_block.side_effect = emit_block_side_effect
+    # Use a MagicMock as _startup_loop to avoid leaking real event loops.
+    # The diagnostic code only calls id() and `is` on it.
+    session._startup_loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    session.agent = MagicMock()
+    # Default: agent has no shell or _actor
+    session.agent.shell = None
+    session.agent._actor = None
+    return session
+
+
+class TestDiagnosticTrigger:
+    """Diagnostics fire only for loop-mismatch exceptions."""
+
+    def test_triggers_on_bound_to_different_loop(self):
+        """Diagnostic dump emits when exception message matches."""
+        session = _make_session_stub()
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("Task <foo> cb=[...] bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        # emit_block should have been called at least once (diag + normal)
+        calls = session._app.emit_block.call_args_list
+        assert len(calls) >= 1
+        diag_text = calls[0][0][0]
+        assert "[gl-212]" in diag_text
+        assert "diagnostic dump" in diag_text
+
+    def test_does_not_trigger_on_unrelated_exception(self):
+        """No diagnostic dump for exceptions without the loop-mismatch message."""
+        session = _make_session_stub()
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = ValueError("something else entirely")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        # emit_block called once for normal handler, NOT for diagnostics
+        calls = session._app.emit_block.call_args_list
+        assert len(calls) == 1
+        text = calls[0][0][0]
+        assert "[gl-212]" not in text
+
+    def test_does_not_trigger_without_exception(self):
+        """No diagnostic dump when context has no exception."""
+        session = _make_session_stub()
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        context = {"message": "Task was destroyed but it is pending!"}
+
+        session._loud_handler(loop, context)
+
+        calls = session._app.emit_block.call_args_list
+        # May be 0 or 1 depending on message filtering, but never has [gl-212]
+        for call in calls:
+            assert "[gl-212]" not in call[0][0]
+
+
+class TestDiagnosticContent:
+    """The diagnostic dump contains expected loop/lock information."""
+
+    def test_includes_handler_loop_id(self):
+        """Dump shows the handler loop's id."""
+        session = _make_session_stub()
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        diag_text = session._app.emit_block.call_args_list[0][0][0]
+        assert f"id={id(loop):#x}" in diag_text
+
+    def test_includes_startup_loop_id(self):
+        """Dump shows the startup loop's id."""
+        session = _make_session_stub()
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        diag_text = session._app.emit_block.call_args_list[0][0][0]
+        assert f"id={id(session._startup_loop):#x}" in diag_text
+
+    def test_includes_same_flag_when_loops_match(self):
+        """When handler loop IS the startup loop, same=True."""
+        session = _make_session_stub()
+        loop = session._startup_loop  # same loop
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        diag_text = session._app.emit_block.call_args_list[0][0][0]
+        assert "same=True" in diag_text
+
+    def test_includes_same_flag_when_loops_differ(self):
+        """When handler loop is NOT the startup loop, same=False."""
+        session = _make_session_stub()
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        diag_text = session._app.emit_block.call_args_list[0][0][0]
+        assert "same=False" in diag_text
+
+    def test_includes_exception_repr(self):
+        """Dump shows the repr of the exception."""
+        session = _make_session_stub()
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        diag_text = session._app.emit_block.call_args_list[0][0][0]
+        assert "RuntimeError" in diag_text
+        assert "bound to a different event loop" in diag_text
+
+    def test_includes_restart_suggestion(self):
+        """Dump includes the user-facing suggestion to restart."""
+        session = _make_session_stub()
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        diag_text = session._app.emit_block.call_args_list[0][0][0]
+        assert "restart the TUI" in diag_text
+        assert "gl#212" in diag_text
+
+
+class TestLockInspection:
+    """Lock inspection paths in the diagnostic dump."""
+
+    def test_bash_session_lock_reported(self):
+        """When BashSession._lock exists, it is included in the dump."""
+        session = _make_session_stub()
+        mock_lock = asyncio.Lock()
+        session.agent.shell = MagicMock()
+        session.agent.shell._session = MagicMock()
+        session.agent.shell._session._lock = mock_lock
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        diag_text = session._app.emit_block.call_args_list[0][0][0]
+        assert "BashSession._lock:" in diag_text
+
+    def test_bash_session_lock_with_loop_attr(self):
+        """When lock has _loop attribute (pre-3.10 or custom lock), its id is reported.
+
+        Note: real asyncio.Lock on Python >=3.12 has no _loop attribute. This test
+        simulates a non-standard/legacy lock that does have _loop to exercise the
+        hasattr(lock, "_loop") code path.
+        """
+        session = _make_session_stub()
+        mock_lock = MagicMock()
+        mock_lock._loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        # hasattr check must pass
+        session.agent.shell = MagicMock()
+        session.agent.shell._session = MagicMock()
+        session.agent.shell._session._lock = mock_lock
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        diag_text = session._app.emit_block.call_args_list[0][0][0]
+        assert "lock._loop: id=" in diag_text
+
+    def test_bash_session_lock_without_loop_attr(self):
+        """On Python 3.12+, Lock has no _loop attr — no crash, no lock._loop line."""
+        session = _make_session_stub()
+        # Real asyncio.Lock on 3.12+ has no _loop attribute
+        real_lock = asyncio.Lock()
+        session.agent.shell = MagicMock()
+        session.agent.shell._session = MagicMock()
+        session.agent.shell._session._lock = real_lock
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        diag_text = session._app.emit_block.call_args_list[0][0][0]
+        assert "BashSession._lock:" in diag_text
+        # On Python 3.12+, _loop doesn't exist so this line should NOT appear
+        if not hasattr(real_lock, "_loop"):
+            assert "lock._loop: id=" not in diag_text
+
+    def test_actor_generation_lock_reported(self):
+        """When Actor._generation_lock exists, it is included in the dump."""
+        session = _make_session_stub()
+        mock_lock = asyncio.Lock()
+        session.agent._actor = MagicMock()
+        session.agent._actor._generation_lock = mock_lock
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        diag_text = session._app.emit_block.call_args_list[0][0][0]
+        assert "Actor._generation_lock:" in diag_text
+
+    def test_bash_inspection_failure_handled(self):
+        """If shell inspection raises, it's caught and noted."""
+        session = _make_session_stub()
+
+        # Use a dedicated class to avoid leaking property descriptors onto MagicMock
+        class _Agent:
+            @property
+            def shell(self):
+                raise RuntimeError("boom")
+
+            _actor = None
+
+        session.agent = _Agent()
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        diag_text = session._app.emit_block.call_args_list[0][0][0]
+        assert "BashSession inspection failed" in diag_text
+
+    def test_actor_inspection_failure_handled(self):
+        """If actor inspection raises, it's caught and noted."""
+        session = _make_session_stub()
+
+        # Use a dedicated class to avoid leaking property descriptors onto MagicMock
+        class _Agent:
+            shell = None
+
+            @property
+            def _actor(self):
+                raise RuntimeError("kaboom")
+
+        session.agent = _Agent()
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        diag_text = session._app.emit_block.call_args_list[0][0][0]
+        assert "Actor inspection failed" in diag_text
+
+    def test_no_shell_no_crash(self):
+        """When agent has no shell attribute, no crash."""
+        session = _make_session_stub()
+        session.agent.shell = None
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        # Should not raise
+        session._loud_handler(loop, context)
+
+    def test_no_actor_no_crash(self):
+        """When agent has no _actor attribute, no crash."""
+        session = _make_session_stub()
+        session.agent._actor = None
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        # Should not raise
+        session._loud_handler(loop, context)
+
+
+class TestReentrancyGuard:
+    """Diagnostic emit uses reentrancy guard correctly."""
+
+    def test_reentrant_falls_back_to_stderr(self):
+        """When _loud_handler_reentrant is True, diag goes to stderr."""
+        session = _make_session_stub()
+        session._loud_handler_reentrant = True
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        fake_stderr = StringIO()
+        with patch.object(sys, "__stderr__", fake_stderr):
+            session._loud_handler(loop, context)
+
+        output = fake_stderr.getvalue()
+        assert "[gl-212]" in output
+
+    def test_non_reentrant_uses_emit_block(self):
+        """When not reentrant, diagnostic goes through emit_block."""
+        session = _make_session_stub()
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        calls = session._app.emit_block.call_args_list
+        assert any("[gl-212]" in call[0][0] for call in calls)
+
+    def test_emit_block_failure_in_diag_falls_back_to_stderr(self):
+        """If emit_block raises during diagnostic emit, fall back to stderr.
+
+        The diagnostic try/except catches the failure and writes to stderr
+        instead, then continues to the normal handler path so the original
+        traceback is not lost.
+        """
+        session = _make_session_stub()
+        call_count = [0]
+
+        def emit_block_side_effect(text):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("emit_block failed")
+
+        session._app.emit_block.side_effect = emit_block_side_effect
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        fake_stderr = StringIO()
+        with patch.object(sys, "__stderr__", fake_stderr):
+            session._loud_handler(loop, context)
+
+        # Diagnostic was written to stderr as fallback
+        assert "[gl-212]" in fake_stderr.getvalue()
+        # Normal handler still ran (second emit_block call)
+        assert call_count[0] >= 2
+
+    def test_reentrant_flag_reset_after_emit(self):
+        """_loud_handler_reentrant is reset to False after emit_block."""
+        session = _make_session_stub()
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        assert session._loud_handler_reentrant is False
+
+
+class TestFallThrough:
+    """After diagnostics, the normal handler path still executes."""
+
+    def test_normal_handler_formats_exception_after_diag(self):
+        """The full traceback is still emitted via normal handler path."""
+        session = _make_session_stub()
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "error in task", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        # emit_block called at least twice: once for diag, once for normal
+        calls = session._app.emit_block.call_args_list
+        assert len(calls) >= 2
+        # Second call is the normal handler output
+        normal_text = calls[1][0][0]
+        assert "RuntimeError" in normal_text
+
+    def test_unclosed_session_still_filtered_after_diag_path(self):
+        """'Unclosed client session' messages are still dropped even if diag
+        section was not triggered."""
+        session = _make_session_stub()
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        context = {"message": "Unclosed client session"}
+
+        session._loud_handler(loop, context)
+
+        # Should not have emitted anything
+        session._app.emit_block.assert_not_called()
+
+    def test_unclosed_connector_still_filtered(self):
+        """'Unclosed connector' messages are still dropped."""
+        session = _make_session_stub()
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        context = {"message": "Unclosed connector"}
+
+        session._loud_handler(loop, context)
+
+        session._app.emit_block.assert_not_called()
+
+
+class TestStartupLoop:
+    """_startup_loop is captured and used correctly."""
+
+    def test_startup_loop_is_none_when_not_set(self):
+        """If _startup_loop was never set, diagnostic still works (shows None)."""
+        session = _make_session_stub()
+        del session._startup_loop  # simulate never having run()
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        exc = RuntimeError("bound to a different event loop")
+        context = {"message": "", "exception": exc}
+
+        session._loud_handler(loop, context)
+
+        diag_text = session._app.emit_block.call_args_list[0][0][0]
+        # getattr with default None should produce id(None)
+        assert "startup loop:" in diag_text
+
+
+class TestBangShell:
+    """Tests for the TUI-owned shell used by bang (!) commands."""
+
+    async def test_get_bang_shell_creates_shell_tools(self):
+        """_get_bang_shell lazily creates a ShellTools instance."""
+        from nooa.tools.shell_tools import ShellTools
+
+        session = Session.__new__(Session)
+        session._bang_shell = None
+        session.agent = MagicMock()
+        session.agent.shell = MagicMock()
+        session.agent.shell.cwd = tempfile.gettempdir()
+
+        shell = await session._get_bang_shell()
+        assert isinstance(shell, ShellTools)
+        assert session._bang_shell is shell
+
+    async def test_get_bang_shell_returns_same_instance(self):
+        """Repeated calls return the same ShellTools instance."""
+        session = Session.__new__(Session)
+        session._bang_shell = None
+        session.agent = MagicMock()
+        session.agent.shell = MagicMock()
+        session.agent.shell.cwd = tempfile.gettempdir()
+
+        shell1 = await session._get_bang_shell()
+        shell2 = await session._get_bang_shell()
+        assert shell1 is shell2
+
+    async def test_get_bang_shell_is_not_agent_shell(self):
+        """The bang shell is a distinct instance from the agent's shell."""
+        from nooa.tools.shell_tools import ShellTools
+
+        session = Session.__new__(Session)
+        session._bang_shell = None
+        session.agent = MagicMock()
+        session.agent.shell = ShellTools(cwd=tempfile.gettempdir())
+
+        bang_shell = await session._get_bang_shell()
+        assert bang_shell is not session.agent.shell
+
+    async def test_get_bang_shell_uses_agent_cwd(self):
+        """The bang shell inherits cwd from the agent's shell."""
+        from pathlib import Path
+
+        session = Session.__new__(Session)
+        session._bang_shell = None
+        session.agent = MagicMock()
+        session.agent.shell = MagicMock()
+        session.agent.shell.cwd = Path("/some/dir")
+
+        shell = await session._get_bang_shell()
+        assert str(shell.cwd) == "/some/dir"
+
+    async def test_get_bang_shell_syncs_cwd(self):
+        """When agent shell cwd changes, bang shell syncs on next call."""
+        from pathlib import Path
+
+        session = Session.__new__(Session)
+        session._bang_shell = None
+        session.agent = MagicMock()
+        session.agent.shell = MagicMock()
+        session.agent.shell.cwd = Path(tempfile.gettempdir())
+
+        shell = await session._get_bang_shell()
+        assert str(shell.cwd) == tempfile.gettempdir()
+
+        # Simulate agent changing directory to a real path
+        session.agent.shell.cwd = Path("/")
+        await session._get_bang_shell()
+        # The bang shell should have cd'd to /
+        assert str(shell.cwd) == "/"

--- a/packages/nooa-cli/tests/tui/test_loud_handler_diagnostics.py
+++ b/packages/nooa-cli/tests/tui/test_loud_handler_diagnostics.py
@@ -511,7 +511,9 @@ class TestBangShell:
         session.agent.shell.cwd = Path(tempfile.gettempdir())
 
         shell = await session._get_bang_shell()
-        assert str(shell.cwd) == tempfile.gettempdir()
+        # Resolve both sides: on macOS the temp dir is reached through the
+        # /var -> /private/var symlink, and the shell reports the real path.
+        assert Path(shell.cwd).resolve() == Path(tempfile.gettempdir()).resolve()
 
         # Simulate agent changing directory to a real path
         session.agent.shell.cwd = Path("/")

--- a/packages/nooa-cli/tests/tui/test_mcp_approval.py
+++ b/packages/nooa-cli/tests/tui/test_mcp_approval.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Security tests for exact-config MCP approvals and environment resolution."""
+
+from __future__ import annotations
+
+import json
+import stat
+
+import pytest
+from nooa_cli.tui.mcp_approval import (
+    MCPApprovalStore,
+    build_approval_request,
+    redact_approved_environment,
+    resolve_approved_environment,
+)
+
+
+def _request(config, *, name="server", mcp_file=None):
+    return build_approval_request(name, mcp_file=mcp_file, servers={name: config})
+
+
+def test_fingerprint_is_stable_across_mapping_order():
+    first = _request(
+        {
+            "transport": "streamable-http",
+            "url": "https://example.test/mcp",
+            "headers": {"X-B": "2", "X-A": "1"},
+        }
+    )
+    second = _request(
+        {
+            "headers": {"X-A": "1", "X-B": "2"},
+            "url": "https://example.test/mcp",
+            "transport": "streamable-http",
+        }
+    )
+    assert first.fingerprint == second.fingerprint
+
+
+@pytest.mark.parametrize(
+    ("field", "changed"),
+    [
+        ("url", "https://attacker.test/mcp"),
+        ("command", "attacker-command"),
+        ("args", ["--changed"]),
+        ("headers", {"Authorization": "Bearer ${OTHER_TOKEN}"}),
+        ("env", {"TOKEN": "${OTHER_TOKEN}"}),
+        ("oauth_scope", "admin"),
+    ],
+)
+def test_any_effective_config_change_invalidates_fingerprint(field, changed):
+    base = {
+        "transport": "streamable-http",
+        "url": "https://trusted.test/mcp",
+        "command": "python",
+        "args": ["server.py"],
+        "headers": {"Authorization": "Bearer ${TOKEN}"},
+        "env": {"TOKEN": "${TOKEN}"},
+        "oauth_scope": "read",
+    }
+    original = _request(base)
+    modified = _request({**base, field: changed})
+    assert original.fingerprint != modified.fingerprint
+
+
+def test_inline_server_wholly_overrides_same_named_file_entry(tmp_path):
+    mcp_file = tmp_path / ".mcp.json"
+    mcp_file.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "server": {
+                        "url": "https://file-attacker.test/${HOST_SECRET}",
+                        "transport": "streamable-http",
+                    }
+                }
+            }
+        )
+    )
+    request = build_approval_request(
+        "server",
+        mcp_file=mcp_file,
+        servers={"server": {"url": "https://inline.test/mcp"}},
+    )
+    assert request.target == "https://inline.test/mcp"
+    assert request.variables == ()
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"transport": "stdio"},
+        {"transport": "streamable-http"},
+        {"transport": "websocket", "url": "https://example.test"},
+        {"command": "python", "args": "server.py"},
+        {"url": "https://example.test", "headers": {"X-Test": 1}},
+        {"command": "python", "env": {"TOKEN": 1}},
+        {"command": ""},
+        {"url": ""},
+        {"url": "https://example.test", "oauth_manual": "false"},
+        {"url": "https://example.test", "oauth_scope": ["read"]},
+        {"url": "https://example.test", "expand_env_vars": True},
+    ],
+)
+def test_invalid_config_is_rejected_before_approval(config):
+    with pytest.raises(ValueError):
+        _request(config)
+
+
+def test_request_finds_nested_bindings_without_reading_secret(monkeypatch):
+    secret = "must-not-appear-in-review"
+    monkeypatch.setenv("HOST_SECRET", secret)
+    request = _request(
+        {
+            "command": "python",
+            "args": ["server.py", "${HOST_SECRET}"],
+            "env": {"TOKEN": "prefix-${HOST_SECRET}"},
+        }
+    )
+    assert request.bindings == (
+        ("HOST_SECRET", "args[1]"),
+        ("HOST_SECRET", "env.TOKEN"),
+    )
+    assert secret not in request.review_text()
+
+
+def test_approved_resolution_handles_http_and_stdio_sinks(monkeypatch):
+    monkeypatch.setenv("HOST_SECRET", "canary")
+    request = _request(
+        {
+            "url": "https://example.test/${HOST_SECRET}",
+            "transport": "streamable-http",
+            "headers": {"Authorization": "Bearer ${HOST_SECRET}"},
+            "args": ["--token", "${HOST_SECRET}"],
+            "env": {"TOKEN": "${HOST_SECRET}"},
+        }
+    )
+    resolved = resolve_approved_environment(request)
+    assert resolved["url"] == "https://example.test/canary"
+    assert resolved["headers"]["Authorization"] == "Bearer canary"
+    assert resolved["args"] == ["--token", "canary"]
+    assert resolved["env"] == {"TOKEN": "canary"}
+    assert request.config["env"] == {"TOKEN": "${HOST_SECRET}"}
+
+
+def test_resolution_fails_before_partial_output_when_variable_is_missing(monkeypatch):
+    monkeypatch.setenv("PRESENT", "value")
+    monkeypatch.delenv("MISSING", raising=False)
+    request = _request(
+        {
+            "url": "https://example.test/${PRESENT}",
+            "headers": {"Authorization": "Bearer ${MISSING}"},
+        }
+    )
+    with pytest.raises(ValueError, match="MISSING"):
+        resolve_approved_environment(request)
+    assert request.config["url"].endswith("${PRESENT}")
+
+
+def test_error_redaction_covers_literal_and_url_encoded_environment_values(monkeypatch):
+    monkeypatch.setenv("HOST_SECRET", "canary / value")
+    request = _request({"url": "https://example.test/${HOST_SECRET}"})
+
+    redacted = redact_approved_environment(
+        request,
+        "literal canary / value; encoded canary%20%2F%20value; plus canary+%2F+value",
+    )
+
+    assert "canary" not in redacted
+    assert redacted.count("${HOST_SECRET}") == 3
+
+
+def test_store_contains_no_secret_and_is_user_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOST_SECRET", "canary-secret")
+    request = _request(
+        {
+            "url": "https://example.test/mcp",
+            "headers": {"Authorization": "Bearer ${HOST_SECRET}"},
+        }
+    )
+    path = tmp_path / "mcp_approvals.json"
+    store = MCPApprovalStore(path)
+    store.approve(request)
+
+    content = path.read_text()
+    assert store.is_approved(request) is True
+    assert "canary-secret" not in content
+    assert "HOST_SECRET" in content
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_corrupt_or_unknown_store_version_fails_closed(tmp_path):
+    request = _request({"url": "https://example.test/mcp"})
+    path = tmp_path / "mcp_approvals.json"
+    path.write_text("not json")
+    assert MCPApprovalStore(path).is_approved(request) is False
+    path.write_text('{"version": 999, "approvals": {}}')
+    assert MCPApprovalStore(path).is_approved(request) is False
+
+
+def test_revoke_removes_all_historical_approvals_for_server(tmp_path):
+    store = MCPApprovalStore(tmp_path / "mcp_approvals.json")
+    first = _request({"url": "https://one.test/mcp"})
+    second = _request({"url": "https://two.test/mcp"})
+    other = _request({"url": "https://other.test/mcp"}, name="other")
+    for request in (first, second, other):
+        store.approve(request)
+
+    assert store.revoke_server("server") is True
+    assert store.is_approved(first) is False
+    assert store.is_approved(second) is False
+    assert store.is_approved(other) is True
+
+
+def test_review_redacts_url_userinfo_query_and_fragment():
+    request = _request(
+        {
+            "url": "https://user:password@example.test/mcp?token=secret#fragment",
+            "transport": "streamable-http",
+        }
+    )
+    review = request.review_text()
+    assert "example.test/mcp?<redacted>" in review
+    assert "password" not in review
+    assert "token=secret" not in review
+    assert "fragment" not in review
+
+
+def test_review_lists_security_metadata_without_header_secret():
+    request = _request(
+        {
+            "url": "https://example.test/mcp",
+            "headers": {
+                "Authorization": "hardcoded-secret",
+                "Host": "virtual.example.test",
+            },
+            "oauth_redirect_uri": "https://callback.example.test/return?code=secret",
+            "oauth_scope": "read admin",
+            "oauth_client_id": "approved-client",
+        }
+    )
+
+    review = request.review_text()
+
+    assert "Header names: Authorization, Host" in review
+    assert "hardcoded-secret" not in review
+    assert "OAuth redirect: https://callback.example.test/return?<redacted>" in review
+    assert "OAuth scope: read admin" in review
+    assert "OAuth client ID: approved-client" in review
+
+
+def test_review_escapes_terminal_control_characters():
+    request = _request(
+        {
+            "command": "python\x1b[2J\u202espoof",
+            "env": {"BAD\x07KEY": "${HOST_SECRET}"},
+        }
+    )
+    review = request.review_text()
+    assert "\x1b" not in review
+    assert "\x07" not in review
+    assert "\u202e" not in review
+    assert r"\x1b" in review
+    assert r"\x07" in review
+    assert r"\u202e" in review
+
+
+def test_stdio_review_shows_bounded_literal_invocation():
+    request = _request(
+        {
+            "command": "sh",
+            "args": ["-c", "touch /tmp/review-this-command", "x" * 300],
+        }
+    )
+
+    review = request.review_text()
+
+    assert "sh -c 'touch /tmp/review-this-command'" in review
+    assert "more characters" in review
+    assert len(request.target) < 300

--- a/packages/nooa-cli/tests/tui/test_mcp_real_transports.py
+++ b/packages/nooa-cli/tests/tui/test_mcp_real_transports.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""TUI-registry integration tests against real local MCP transports."""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from nooa_cli.tui.mcp_approval import MCPApprovalRequired
+from nooa_cli.tui.mcp_registry import MCPRegistry
+
+from nooa.runtime.context_manager import ContextManager
+
+pytest.importorskip("mcp")
+
+SERVER_SOURCE = '''
+import os
+import sys
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("tui-approval-integration")
+last_authorization = "missing"
+last_path = "missing"
+
+@mcp.tool()
+def probe(value: str) -> str:
+    """Echo a value and the fake test token visible to this server."""
+    return f"{value}:{os.environ.get('MCP_INTEGRATION_TOKEN', 'missing')}"
+
+@mcp.tool()
+def http_probe(value: str) -> str:
+    """Echo the latest HTTP authorization header and original request path."""
+    return f"{value}:{last_authorization}:{last_path}"
+
+if len(sys.argv) > 1:
+    import uvicorn
+
+    inner = mcp.streamable_http_app()
+
+    class CaptureAndRewritePath:
+        def __init__(self, app):
+            self.app = app
+
+        async def __call__(self, scope, receive, send):
+            global last_authorization, last_path
+            if scope["type"] == "http":
+                last_path = scope["path"]
+                headers = {
+                    key.decode("latin-1").lower(): value.decode("latin-1")
+                    for key, value in scope.get("headers", [])
+                }
+                last_authorization = headers.get("authorization", "missing")
+                scope = dict(scope)
+                scope["path"] = "/mcp"
+                scope["raw_path"] = b"/mcp"
+            await self.app(scope, receive, send)
+
+    uvicorn.run(CaptureAndRewritePath(inner), host="127.0.0.1", port=int(sys.argv[1]))
+else:
+    mcp.run(transport="stdio")
+'''
+
+
+class _Agent:
+    def __init__(self) -> None:
+        self.context_manager = ContextManager()
+
+
+def _registry(tmp_path: Path, servers: dict) -> tuple[MCPRegistry, _Agent]:
+    registry = MCPRegistry(
+        mcp_file=tmp_path / "absent.mcp.json",
+        servers=servers,
+        approval_path=tmp_path / "approvals.json",
+    )
+    agent = _Agent()
+    registry.attach(agent)
+    agent.mcp = registry
+    return registry, agent
+
+
+def _approve(registry: MCPRegistry, name: str) -> None:
+    request = registry._approval_request(name)
+    registry._approve(name, request.confirmation)
+
+
+def _wait_for_server(process: subprocess.Popen[str], port: int) -> None:
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            output = process.communicate()[0]
+            pytest.fail(f"MCP HTTP server exited during startup:\n{output}")
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                return
+        except OSError:
+            time.sleep(0.05)
+    pytest.fail("MCP HTTP server did not start within 10 seconds")
+
+
+@pytest.fixture
+def mcp_server_script(tmp_path: Path) -> Path:
+    script = tmp_path / "server.py"
+    script.write_text(SERVER_SOURCE)
+    return script
+
+
+@pytest.fixture
+def mcp_http_url(mcp_server_script: Path, unused_tcp_port: int) -> Iterator[str]:
+    process = subprocess.Popen(
+        [sys.executable, str(mcp_server_script), str(unused_tcp_port)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        _wait_for_server(process, unused_tcp_port)
+        yield f"http://127.0.0.1:{unused_tcp_port}/mcp"
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+        if process.stdout is not None:
+            process.stdout.close()
+
+
+@pytest.mark.asyncio
+async def test_approved_stdio_config_discovers_and_invokes_real_server(
+    tmp_path: Path, mcp_server_script: Path, monkeypatch
+) -> None:
+    canary = "stdio-canary"
+    monkeypatch.setenv("MCP_INTEGRATION_TOKEN", canary)
+    registry, agent = _registry(
+        tmp_path,
+        {
+            "local": {
+                "command": sys.executable,
+                "args": [str(mcp_server_script)],
+                "env": {"MCP_INTEGRATION_TOKEN": "${MCP_INTEGRATION_TOKEN}"},
+            }
+        },
+    )
+
+    with pytest.raises(MCPApprovalRequired):
+        await registry.connect(["local"])
+    _approve(registry, "local")
+    assert await registry.connect(["local"]) == ["local"]
+
+    assert await agent.local.probe(value="stdio-ok") == f"stdio-ok:{canary}"
+
+
+@pytest.mark.asyncio
+async def test_approved_http_config_discovers_and_invokes_real_server(
+    tmp_path: Path, mcp_http_url: str, monkeypatch
+) -> None:
+    canary = "http-canary"
+    monkeypatch.setenv("MCP_HTTP_TOKEN", canary)
+    registry, agent = _registry(
+        tmp_path,
+        {
+            "loopback": {
+                "url": f"{mcp_http_url}/${{MCP_HTTP_TOKEN}}",
+                "transport": "streamable-http",
+                "headers": {"Authorization": "Bearer ${MCP_HTTP_TOKEN}"},
+            }
+        },
+    )
+
+    with pytest.raises(MCPApprovalRequired):
+        await registry.connect(["loopback"])
+    _approve(registry, "loopback")
+    assert await registry.connect(["loopback"]) == ["loopback"]
+
+    assert await agent.loopback.http_probe(value="http-ok") == (
+        f"http-ok:Bearer {canary}:/mcp/{canary}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_approved_value_is_not_reexpanded_by_installed_core(
+    tmp_path: Path, mcp_server_script: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("OUTER_VALUE", "${NESTED_SECRET}")
+    monkeypatch.setenv("NESTED_SECRET", "must-not-reach-child")
+    registry, agent = _registry(
+        tmp_path,
+        {
+            "local": {
+                "command": sys.executable,
+                "args": [str(mcp_server_script)],
+                "env": {"MCP_INTEGRATION_TOKEN": "${OUTER_VALUE}"},
+            }
+        },
+    )
+
+    _approve(registry, "local")
+    assert await registry.connect(["local"]) == ["local"]
+
+    assert await agent.local.probe(value="nested") == "nested:${NESTED_SECRET}"

--- a/packages/nooa-cli/tests/tui/test_mcp_registry.py
+++ b/packages/nooa-cli/tests/tui/test_mcp_registry.py
@@ -1,0 +1,675 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for MCPRegistry — agent-facing MCP server management."""
+
+import asyncio
+import threading
+
+import pytest
+from nooa_cli.tui.mcp_registry import MCPRegistry
+
+from nooa.agentdoc._visibility import is_hidden_field
+from nooa.runtime.context_manager import ContextManager
+
+
+class _FakeTool:
+    """Stand-in for a dynamically generated MCPTool subclass."""
+
+    _tool_method_names = frozenset({"search", "get_page"})
+
+    async def search(self, query: str) -> object:
+        """Search the knowledge base."""
+
+    async def get_page(self, page_id: str) -> object:
+        """Fetch a page by id."""
+
+    async def _call_tool(self, *a, **k): ...
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.context_manager = ContextManager()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_approval_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(tmp_path / "user"))
+
+
+def _approve(reg, *names):
+    selected = names or tuple(reg.discovered())
+    for name in selected:
+        request = reg._approval_request(name)
+        reg._approval_store.approve(request)
+
+
+def _make(servers=None, mcp_file=None, attach=True, approve=True):
+    reg = MCPRegistry(mcp_file=mcp_file, servers=servers)
+    if approve:
+        _approve(reg)
+    agent = _FakeAgent()
+    if attach:
+        reg.attach(agent)
+    return reg, agent
+
+
+def _fake_create(monkeypatch, tool_factory=_FakeTool):
+    """Patch MCPManager.create_from_server to return a fresh fake tool."""
+    calls = []
+
+    def _create(name, **kwargs):
+        calls.append((name, kwargs))
+        return tool_factory()
+
+    import nooa.mcp as mcp_mod
+
+    monkeypatch.setattr(mcp_mod.MCPManager, "create_from_server", staticmethod(_create))
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Discovery / register
+# ---------------------------------------------------------------------------
+
+
+def test_discovered_unions_inline_and_file(tmp_path):
+    mcp_file = tmp_path / ".mcp.json"
+    mcp_file.write_text('{"mcpServers": {"fileserver": {"url": "https://f/mcp"}}}')
+    reg, _ = _make(servers={"inline": {"url": "https://i/mcp"}}, mcp_file=mcp_file)
+    assert reg.discovered() == ["fileserver", "inline"]
+
+
+def test_discovered_dedups_name_collision(tmp_path):
+    mcp_file = tmp_path / ".mcp.json"
+    mcp_file.write_text('{"mcpServers": {"maas": {"url": "https://file/mcp"}}}')
+    reg, _ = _make(servers={"maas": {"url": "https://inline/mcp"}}, mcp_file=mcp_file)
+    assert reg.discovered() == ["maas"]
+
+
+def test_register_adds_in_memory_entry():
+    reg, _ = _make()
+    assert reg.discovered() == []
+    reg.register("foo", url="https://foo/mcp", transport="streamable-http")
+    assert reg.discovered() == ["foo"]
+
+
+def test_register_copies_mutable_inputs():
+    args = ["server.py"]
+    env = {"TOKEN": "literal"}
+    reg, _ = _make()
+
+    reg.register("foo", command="python", args=args, env=env)
+    args.append("--changed")
+    env["TOKEN"] = "changed"
+
+    assert reg._servers["foo"]["args"] == ["server.py"]
+    assert reg._servers["foo"]["env"] == {"TOKEN": "literal"}
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_change_while_connected(monkeypatch):
+    _fake_create(monkeypatch)
+    reg, _ = _make(servers={"foo": {"url": "https://foo/mcp"}})
+    await reg.connect(["foo"])
+
+    with pytest.raises(RuntimeError, match="Disconnect"):
+        reg.register("foo", url="https://changed/mcp")
+
+
+# ---------------------------------------------------------------------------
+# Connect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connect_attaches_and_activates(monkeypatch):
+    calls = _fake_create(monkeypatch)
+    reg, agent = _make(servers={"maas": {"url": "https://x/mcp"}})
+    newly = await reg.connect(["maas"])
+    assert newly == ["maas"]
+    assert reg.connected() == ["maas"]
+    assert reg.activated() == ["maas"]
+    assert hasattr(agent, "maas")
+    assert calls[0][0] == "maas"
+
+
+@pytest.mark.asyncio
+async def test_connect_without_activate(monkeypatch):
+    _fake_create(monkeypatch)
+    reg, _ = _make(servers={"maas": {"url": "https://x/mcp"}})
+    await reg.connect(["maas"], activate=False)
+    assert reg.connected() == ["maas"]
+    assert reg.activated() == []
+
+
+@pytest.mark.asyncio
+async def test_connect_is_idempotent(monkeypatch):
+    calls = _fake_create(monkeypatch)
+    reg, _ = _make(servers={"maas": {"url": "https://x/mcp"}})
+    await reg.connect(["maas"])
+    again = await reg.connect(["maas"])
+    assert again == []
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_connect_glob(monkeypatch):
+    _fake_create(monkeypatch)
+    reg, _ = _make(servers={"conf-a": {"url": "a"}, "conf-b": {"url": "b"}, "other": {"url": "c"}})
+    newly = await reg.connect(["conf-*"])
+    assert newly == ["conf-a", "conf-b"]
+
+
+@pytest.mark.asyncio
+async def test_connect_uses_approved_oauth_config_and_bound_prompt(monkeypatch):
+    calls = _fake_create(monkeypatch)
+    reg, _ = _make(
+        servers={
+            "maas": {
+                "url": "https://x/mcp",
+                "oauth_manual": True,
+                "oauth_scope": "read",
+            }
+        }
+    )
+
+    async def prompt(url):
+        return "code"
+
+    reg._bind_oauth_code_prompt(prompt)
+    await reg.connect(["maas"])
+    _, kwargs = calls[0]
+    assert kwargs["oauth_code_prompt"] is prompt
+    assert kwargs["oauth_manual"] is True
+    assert kwargs["oauth_scope"] == "read"
+    assert kwargs["url"] == "https://x/mcp"
+    assert kwargs["transport"] == "streamable-http"
+    assert kwargs["servers"] == {"maas": {}}
+
+
+@pytest.mark.asyncio
+async def test_connect_requires_approval_before_factory(monkeypatch):
+    from nooa_cli.tui.mcp_approval import MCPApprovalRequired
+
+    calls = _fake_create(monkeypatch)
+    reg, _ = _make(
+        servers={"maas": {"url": "https://x/mcp", "transport": "streamable-http"}},
+        approve=False,
+    )
+
+    with pytest.raises(MCPApprovalRequired, match="/mcp approve maas"):
+        await reg.connect(["maas"])
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_approved_config_expands_only_in_exact_factory_override(monkeypatch):
+    canary = "sk-host-secret-canary"
+    monkeypatch.setenv("OPENAI_API_KEY", canary)
+    calls = _fake_create(monkeypatch)
+    config = {
+        "url": "https://trusted.example/mcp/${OPENAI_API_KEY}",
+        "transport": "streamable-http",
+        "headers": {"Authorization": "Bearer ${OPENAI_API_KEY}"},
+    }
+    reg, _ = _make(servers={"maas": config}, approve=False)
+    request = reg._approval_request("maas")
+    reg._approve("maas", request.confirmation)
+
+    await reg.connect(["maas"])
+
+    factory_kwargs = calls[0][1]
+    assert factory_kwargs["url"] == f"https://trusted.example/mcp/{canary}"
+    assert factory_kwargs["headers"]["Authorization"] == f"Bearer {canary}"
+    assert factory_kwargs["servers"] == {"maas": {}}
+    assert config["url"].endswith("${OPENAI_API_KEY}")
+
+
+@pytest.mark.asyncio
+async def test_resolved_value_is_not_reexpanded_by_older_core(monkeypatch):
+    monkeypatch.setenv("OUTER", "${OPENAI_API_KEY}")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-be-read")
+    calls = _fake_create(monkeypatch)
+    reg, _ = _make(
+        servers={
+            "maas": {
+                "url": "https://trusted.example/${OUTER}",
+                "transport": "streamable-http",
+            }
+        },
+        approve=False,
+    )
+    request = reg._approval_request("maas")
+    reg._approve("maas", request.confirmation)
+
+    await reg.connect(["maas"])
+
+    assert calls[0][1]["url"] == "https://trusted.example/${OPENAI_API_KEY}"
+    assert calls[0][1]["servers"] == {"maas": {}}
+
+
+@pytest.mark.asyncio
+async def test_connection_error_redacts_approved_secret(monkeypatch):
+    secret = "sk-secret-in-failed-url"
+    monkeypatch.setenv("MCP_SECRET", secret)
+    reg, _ = _make(
+        servers={"maas": {"url": "https://example.test/${MCP_SECRET}"}},
+        approve=False,
+    )
+    _approve(reg, "maas")
+
+    import nooa.mcp as mcp_mod
+
+    def _fail(*args, **kwargs):
+        raise RuntimeError(f"Could not connect to https://example.test/{secret}")
+
+    monkeypatch.setattr(mcp_mod.MCPManager, "create_from_server", staticmethod(_fail))
+
+    with pytest.raises(RuntimeError) as caught:
+        await reg.connect(["maas"])
+
+    assert secret not in str(caught.value)
+    assert "${MCP_SECRET}" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_connect_stays_pending_until_worker_finishes(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    import nooa.mcp as mcp_mod
+
+    def _blocking_create(*args, **kwargs):
+        started.set()
+        assert release.wait(timeout=5)
+        return _FakeTool()
+
+    monkeypatch.setattr(mcp_mod.MCPManager, "create_from_server", staticmethod(_blocking_create))
+    reg, _ = _make(servers={"maas": {"url": "https://x/mcp"}})
+    connect_task = asyncio.create_task(reg.connect(["maas"]))
+    assert await asyncio.to_thread(started.wait, 1)
+
+    connect_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await connect_task
+
+    assert "maas" in reg._pending
+    with pytest.raises(RuntimeError, match="already in progress"):
+        await reg.connect(["maas"])
+
+    release.set()
+    for _ in range(100):
+        if "maas" not in reg._pending:
+            break
+        await asyncio.sleep(0.01)
+    assert "maas" not in reg._pending
+
+
+@pytest.mark.asyncio
+async def test_config_change_invalidates_approval_before_secret_expansion(monkeypatch):
+    from nooa_cli.tui.mcp_approval import MCPApprovalRequired
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-host-secret-canary")
+    calls = _fake_create(monkeypatch)
+    reg, _ = _make(
+        servers={
+            "maas": {
+                "url": "https://trusted.example/mcp",
+                "transport": "streamable-http",
+                "headers": {"Authorization": "Bearer ${OPENAI_API_KEY}"},
+            }
+        },
+        approve=False,
+    )
+    request = reg._approval_request("maas")
+    reg._approve("maas", request.confirmation)
+    reg._servers["maas"]["url"] = "https://attacker.example/mcp"
+
+    with pytest.raises(MCPApprovalRequired):
+        await reg.connect(["maas"])
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_removed_expand_env_vars_field_is_rejected(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-host-secret-canary")
+    calls = _fake_create(monkeypatch)
+    reg, _ = _make(
+        servers={
+            "attacker": {
+                "url": "https://attacker.example/${OPENAI_API_KEY}",
+                "transport": "streamable-http",
+                "expand_env_vars": True,
+            }
+        },
+        approve=False,
+    )
+
+    with pytest.raises(ValueError, match="unsupported field.*expand_env_vars"):
+        await reg.connect(["attacker"])
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_unapproved_stdio_command_never_reaches_factory(monkeypatch):
+    from nooa_cli.tui.mcp_approval import MCPApprovalRequired
+
+    calls = _fake_create(monkeypatch)
+    reg, _ = _make(
+        servers={"local": {"command": "sh", "args": ["-c", "touch /tmp/pwned"]}},
+        approve=False,
+    )
+
+    with pytest.raises(MCPApprovalRequired, match="execute a local process"):
+        await reg.connect(["local"])
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_agent_attribute_collision_is_rejected_before_factory(monkeypatch):
+    calls = _fake_create(monkeypatch)
+    reg, _ = _make(servers={"mcp": {"url": "https://x/mcp", "transport": "streamable-http"}})
+    reg._agent.mcp = reg
+
+    with pytest.raises(ValueError, match="overwrite existing agent attribute"):
+        await reg.connect(["mcp"])
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_normalized_server_name_collision_is_rejected(monkeypatch):
+    calls = _fake_create(monkeypatch)
+    reg, _ = _make(
+        servers={
+            "foo-bar": {"url": "https://one/mcp", "transport": "streamable-http"},
+            "foo_bar": {"url": "https://two/mcp", "transport": "streamable-http"},
+        }
+    )
+    await reg.connect(["foo-bar"])
+
+    with pytest.raises(ValueError, match="conflicts with connected server"):
+        await reg.connect(["foo_bar"])
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_connection_time_endpoint_override_is_rejected(monkeypatch):
+    calls = _fake_create(monkeypatch)
+    reg, _ = _make(servers={"maas": {"url": "https://trusted/mcp", "transport": "streamable-http"}})
+
+    with pytest.raises(TypeError, match="endpoint/config overrides"):
+        await reg.connect(["maas"], url="https://attacker/mcp")
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_connection_time_oauth_override_is_rejected(monkeypatch):
+    calls = _fake_create(monkeypatch)
+    reg, _ = _make(servers={"maas": {"url": "https://trusted/mcp"}})
+
+    with pytest.raises(TypeError, match="endpoint/config overrides"):
+        await reg.connect(["maas"], oauth_redirect_uri="https://attacker/callback")
+
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Activate / deactivate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_activate_deactivate_membership(monkeypatch):
+    _fake_create(monkeypatch)
+    reg, _ = _make(servers={"maas": {"url": "x"}})
+    await reg.connect(["maas"], activate=False)
+    assert reg.activated() == []
+    reg.activate(["maas"])
+    assert reg.activated() == ["maas"]
+    reg.deactivate(["maas"])
+    assert reg.activated() == []
+
+
+@pytest.mark.asyncio
+async def test_deactivate_does_not_close_session(monkeypatch):
+    _fake_create(monkeypatch)
+    reg, _ = _make(servers={"maas": {"url": "x"}})
+    await reg.connect(["maas"])
+    tool = reg["maas"]
+    reg.deactivate(["maas"])
+    reg.activate(["maas"])
+    assert reg["maas"] is tool
+    assert reg.connected() == ["maas"]
+
+
+@pytest.mark.asyncio
+async def test_activate_glob(monkeypatch):
+    _fake_create(monkeypatch)
+    reg, _ = _make(servers={"a": {"url": "x"}, "b": {"url": "y"}})
+    await reg.connect(["*"], activate=False)
+    reg.activate(["*"])
+    assert reg.activated() == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Visibility — self.<server> stays hidden from doc(self) either way
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connected_attr_is_hidden_from_doc(monkeypatch):
+    _fake_create(monkeypatch)
+    reg, agent = _make(servers={"maas": {"url": "x"}})
+    await reg.connect(["maas"])  # activated by default
+    assert is_hidden_field(agent, "maas") is True
+    reg.deactivate(["maas"])
+    assert is_hidden_field(agent, "maas") is True
+
+
+# ---------------------------------------------------------------------------
+# Status / <mcp> block
+# ---------------------------------------------------------------------------
+
+
+def test_status_empty():
+    reg, _ = _make()
+    assert reg.status() == "No MCP servers configured."
+
+
+def test_status_configured_only():
+    reg, _ = _make(servers={"maas": {"url": "x"}})
+    out = reg.status()
+    assert "Configured MCP servers" in out
+    assert "self.mcp.connect(['name'])" in out
+    assert "  maas" in out
+
+
+def test_status_marks_unapproved_server():
+    reg, _ = _make(
+        servers={"maas": {"url": "https://x/mcp", "transport": "streamable-http"}},
+        approve=False,
+    )
+    assert "approval required" in reg.status()
+
+
+def test_status_escapes_control_characters_in_untrusted_server_name():
+    reg, _ = _make(
+        servers={"evil\x1b[2J": {"url": "https://x/mcp", "transport": "streamable-http"}},
+        approve=False,
+    )
+
+    status = reg.status()
+
+    assert "\x1b" not in status
+    assert "evil\\x1b[2J" in status
+
+
+@pytest.mark.asyncio
+async def test_status_connected_inactive(monkeypatch):
+    _fake_create(monkeypatch)
+    reg, _ = _make(servers={"maas": {"url": "x"}})
+    await reg.connect(["maas"], activate=False)
+    out = reg.status()
+    assert "Connected but inactive" in out
+    assert "self.maas" in out
+    assert "search" in out  # tool names summarized
+    assert "search(" not in out  # but no full signatures
+
+
+@pytest.mark.asyncio
+async def test_status_active_lists_tools_as_free_functions(monkeypatch):
+    _fake_create(monkeypatch)
+    reg, _ = _make(servers={"maas": {"url": "x"}})
+    await reg.connect(["maas"])
+    out = reg.status()
+    assert "Active MCP servers" in out
+    assert "self.maas" in out
+    # tool names are summarized on the server row (docs via doc(self.maas))
+    assert "search" in out
+    assert "get_page" in out
+    assert "(2 tools)" in out
+
+
+@pytest.mark.asyncio
+async def test_status_precedence_active_over_connected(monkeypatch):
+    _fake_create(monkeypatch)
+    reg, _ = _make(servers={"maas": {"url": "x"}})
+    await reg.connect(["maas"])
+    out = reg.status()
+    # an active server appears once, in the Active section (not Configured/inactive)
+    assert "Active MCP servers" in out
+    assert "self.maas" in out
+    assert "Configured MCP servers" not in out
+    assert "Connected but inactive" not in out
+
+
+@pytest.mark.asyncio
+async def test_status_truncates_many_tools(monkeypatch):
+    many = {f"tool_{i}" for i in range(50)}
+
+    class _BigTool:
+        _tool_method_names = frozenset(many)
+
+    def _make_methods():
+        pass
+
+    _fake_create(monkeypatch, tool_factory=_BigTool)
+    reg, _ = _make(servers={"big": {"url": "x"}})
+    await reg.connect(["big"])
+    out = reg.status()
+    assert "more" in out
+    assert "(50 tools)" in out
+
+
+# ---------------------------------------------------------------------------
+# Disconnect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disconnect_removes_attr_and_state(monkeypatch):
+    _fake_create(monkeypatch)
+    reg, agent = _make(servers={"maas": {"url": "x"}})
+    await reg.connect(["maas"])
+    out = await reg.disconnect(["maas"])
+    assert out == ["maas"]
+    assert reg.connected() == []
+    assert reg.activated() == []
+    assert not hasattr(agent, "maas")
+
+
+# ---------------------------------------------------------------------------
+# attach / detach + context block
+# ---------------------------------------------------------------------------
+
+
+def test_attach_registers_context_block():
+    reg, agent = _make(servers={"maas": {"url": "x"}})
+    assert "mcp" in agent.context_manager
+
+
+@pytest.mark.asyncio
+async def test_detach_disconnects_and_removes_block(monkeypatch):
+    _fake_create(monkeypatch)
+    reg, agent = _make(servers={"maas": {"url": "x"}})
+    await reg.connect(["maas"])
+    reg.detach()
+    assert "mcp" not in agent.context_manager
+    assert reg.connected() == []
+
+
+def test_getitem_raises_when_not_connected():
+    reg, _ = _make(servers={"maas": {"url": "x"}})
+    with pytest.raises(KeyError):
+        reg["maas"]
+
+
+@pytest.mark.asyncio
+async def test_status_three_state_inactive_section(monkeypatch):
+    """A deactivated-but-connected server stays visible in its own section."""
+    _fake_create(monkeypatch)
+    reg, _ = _make(servers={"maas": {"url": "x"}, "jira": {"url": "y"}})
+    await reg.connect(["maas"])  # active
+    await reg.connect(["jira"], activate=False)  # connected, inactive
+    out = reg.status()
+    assert "Active MCP servers" in out
+    assert "Connected but inactive" in out
+    assert "self.maas" in out
+    assert "self.jira" in out
+
+
+@pytest.mark.asyncio
+async def test_deactivate_moves_to_inactive_section(monkeypatch):
+    _fake_create(monkeypatch)
+    reg, _ = _make(servers={"maas": {"url": "x"}})
+    await reg.connect(["maas"])
+    assert "Active MCP servers" in reg.status()
+    reg.deactivate(["maas"])
+    out = reg.status()
+    assert "Connected but inactive" in out
+    assert "Active MCP servers" not in out
+
+
+def test_mcp_lifecycle_command_is_not_agent_exposed():
+    """Approval/lifecycle stays in the native TUI command, outside the agent skill."""
+    from nooa.skill import get_slash_commands
+
+    reg, _ = _make(servers={"maas": {"url": "x"}})
+    assert [meta.name for meta, _method in get_slash_commands(reg)] == ["mcp-add"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_add_slash_command_returns_agent_task(monkeypatch, tmp_path):
+    """/mcp-add hands the server details to the agent (output_to_agent=True)."""
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(tmp_path))
+    reg, _ = _make(servers={"maas": {"url": "x"}})
+    out = await reg.mcp_add_command(
+        "maas-gdrive https://maas.prd.astra.nvidia.com/maas/gdrive/mcp streamable-http"
+    )
+    assert "maas-gdrive" in out
+    assert "tui.mcp_servers" in out
+    assert "settings.yaml" in out
+    # Includes the currently-configured servers for context.
+    assert "maas" in out
+
+
+@pytest.mark.asyncio
+async def test_mcp_add_slash_command_empty_shows_usage():
+    reg, _ = _make(servers={})
+    out = await reg.mcp_add_command("")
+    assert "Usage: /mcp-add" in out
+
+
+def test_mcp_add_slash_command_outputs_to_agent():
+    from nooa.skill import get_slash_commands
+
+    reg, _ = _make(servers={})
+    meta = next(m for m, _ in get_slash_commands(reg) if m.name == "mcp-add")
+    assert meta.output_to_agent is True

--- a/packages/nooa-cli/tests/tui/test_memory_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_memory_explorer.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the terminal memory explorer."""
+
+from __future__ import annotations
+
+from nooa_cli.tui.memory_explorer import (
+    MemoryExplorerView,
+    build_memory_rows,
+    relative_age,
+)
+from nooa_memory import MemoryConfig, MemoryManager, MemoryType
+from nooa_memory.config import ReflectionPolicy, SpontaneousConfig, WritePolicy
+
+from nooa import Agent
+from nooa.unifiedllm import FakeLLMClient
+
+
+def _seeded_manager():
+    """A real MemoryManager on a bare agent with an in-memory store."""
+    llm = FakeLLMClient()
+
+    class MemAgent(Agent, llm=llm):
+        pass
+
+    agent = MemAgent()
+    cfg = MemoryConfig(
+        enabled=True,
+        path=":memory:",
+        owner="tester",
+        instruct=False,
+        spontaneous=SpontaneousConfig(enabled=False),
+        write=WritePolicy(on_events=(), write_episodic=False),
+        reflection=ReflectionPolicy(enabled=False),
+    )
+    mgr = MemoryManager.install(agent, config=cfg)
+    skill_id = mgr.remember(
+        "Deploys go through `make ship`.",
+        type=MemoryType.SKILL,
+        title="Deploy procedure",
+        tags=["deploy", "ship"],
+    )
+    todo_id = mgr.remember("Ship the 1.4 release notes", type=MemoryType.TODO)
+    ref_id = mgr.remember(
+        "The deploy skill is documented in another memory.",
+        references=[f"memory:{skill_id}"],
+    )
+    mgr.associate(ref_id, skill_id, "derived_from")
+    return agent, mgr, {"skill": skill_id, "todo": todo_id, "ref": ref_id}
+
+
+def _view(agent, mgr):
+    rows = build_memory_rows(agent, mgr)
+    calls: dict[str, list[str]] = {"forgot": [], "done": []}
+
+    def _forget(memory_id: str) -> None:
+        calls["forgot"].append(memory_id)
+        mgr.forget(memory_id)
+
+    def _mark_done(memory_id: str) -> None:
+        calls["done"].append(memory_id)
+        mgr.update(memory_id, status="done")
+
+    return MemoryExplorerView(rows, forget=_forget, mark_done=_mark_done), calls
+
+
+def test_build_rows_snapshots_store_usage_references_and_edges() -> None:
+    agent, mgr, ids = _seeded_manager()
+
+    rows = build_memory_rows(agent, mgr)
+
+    assert {r.id for r in rows} == set(ids.values())
+    todo = next(r for r in rows if r.id == ids["todo"])
+    assert todo.type_tag == "todo:open"
+    assert todo.importance == "MEDIUM"
+    for expected in ("todo:open", "Ship the 1.4 release notes", "tester"):
+        assert expected in todo.search_text
+
+    skill = next(r for r in rows if r.id == ids["skill"])
+    assert "deploy" in skill.search_text and "Deploy procedure" in skill.search_text
+    assert skill.usage["fetches"] == 0
+
+    ref = next(r for r in rows if r.id == ids["ref"])
+    assert len(ref.reference_lines) == 1
+    assert "(LIVE)" in ref.reference_lines[0]
+    assert ref.edges == [(ids["skill"], "derived_from", 1.0)]
+
+
+def test_view_renders_rows_and_detail() -> None:
+    agent, mgr, ids = _seeded_manager()
+    view, _calls = _view(agent, mgr)
+
+    todo = next(r for r in view.model.rows if r.id == ids["todo"])
+    line = view.format_row(todo, 120)
+    assert "todo:open" in line
+    assert "MEDIUM" in line
+    assert "Ship the 1.4 release notes" in line
+    assert "never" in line  # never fetched
+
+    ref = next(r for r in view.model.rows if r.id == ids["ref"])
+    detail = view.detail_lines(ref, 100)
+    assert f"Id: {ids['ref']}" in detail
+    assert any(line.startswith("Usage:") for line in detail)
+    assert any("fetches=0" in line for line in detail)
+    assert any("(LIVE)" in line for line in detail)
+    assert any(ids["skill"][:8] in line and "derived_from" in line for line in detail)
+    assert any("The deploy skill is documented" in line for line in detail)
+
+    frame = view.render(140, 30)
+    assert "Memory Explorer" in frame
+    assert "f forget" in frame and "d todo done" in frame
+
+
+def test_search_filters_on_type_tags_owner_and_content() -> None:
+    agent, mgr, ids = _seeded_manager()
+    view, _calls = _view(agent, mgr)
+
+    view.model.set_query("todo:open")
+    assert [view.model.rows[i].id for i in view.model.matches] == [ids["todo"]]
+    view.model.set_query("deploy")
+    assert {view.model.rows[i].id for i in view.model.matches} == {ids["skill"], ids["ref"]}
+    view.model.set_query("tester")
+    assert len(view.model.matches) == 3
+
+
+def test_action_d_marks_todo_done_round_trip() -> None:
+    agent, mgr, ids = _seeded_manager()
+    view, calls = _view(agent, mgr)
+
+    todo = next(r for r in view.model.rows if r.id == ids["todo"])
+    # Route through the real key path: "d" arrives as a text key.
+    view.model.cursor = view.model.matches.index(view.model.rows.index(todo))
+    assert view.handle_key("text", "d") == "handled"
+
+    assert calls["done"] == [ids["todo"]]
+    assert mgr.store.get(ids["todo"]).status == "done"
+    assert todo.status == "done"
+    assert "todo:done" in view.format_row(todo, 120)
+    assert "todo:done" in todo.search_text
+
+    # d again (already done) and d on a non-todo row are ignored.
+    assert view.handle_action("text:d", todo) == "ignored"
+    skill = next(r for r in view.model.rows if r.id == ids["skill"])
+    assert view.handle_action("text:d", skill) == "ignored"
+    assert calls["done"] == [ids["todo"]]
+
+
+def test_action_f_forgets_memory_round_trip() -> None:
+    agent, mgr, ids = _seeded_manager()
+    view, calls = _view(agent, mgr)
+
+    skill = next(r for r in view.model.rows if r.id == ids["skill"])
+    view.model.cursor = view.model.matches.index(view.model.rows.index(skill))
+    assert view.handle_key("text", "f") == "handled"
+
+    assert calls["forgot"] == [ids["skill"]]
+    assert len(view.model.rows) == 2
+    assert all(r.id != ids["skill"] for r in view.model.rows)
+    assert len(view.model.matches) == 2
+    # Archived in the store: gone from the active listing.
+    assert {m.id for m in mgr.store.all_memories()} == {ids["todo"], ids["ref"]}
+
+
+def test_relative_age_bands() -> None:
+    now = 1_000_000.0
+    assert relative_age(None) == "never"
+    assert relative_age(now - 5, now) == "5s"
+    assert relative_age(now - 300, now) == "5m"
+    assert relative_age(now - 7200, now) == "2h"
+    assert relative_age(now - 3 * 86400, now) == "3d"
+
+
+def test_last_reflection_summary_lines():
+    """Header line renders completed and interrupted maintenance rows."""
+    from nooa_cli.tui.memory_explorer import last_reflection_summary
+
+    _agent, mgr, _ids = _seeded_manager()
+    assert last_reflection_summary(mgr) is None  # nothing yet
+
+    mgr.store.log_maintenance(
+        "reflect",
+        {
+            "trigger": "idle",
+            "interrupted": False,
+            "duration_ms": 1400.0,
+            "merged": 3,
+            "edges_added": 5,
+            "pruned": 1,
+        },
+    )
+    line = last_reflection_summary(mgr)
+    assert "merged 3" in line and "+5 edges" in line and "pruned 1" in line
+    assert "(idle, 1.4s)" in line
+
+    mgr.store.log_maintenance(
+        "reflect",
+        {
+            "trigger": "idle",
+            "interrupted": True,
+            "stopped_in": "form_edges",
+            "duration_ms": 300.0,
+            "merged": 0,
+            "edges_added": 0,
+            "pruned": 0,
+        },
+    )
+    line = last_reflection_summary(mgr)
+    assert "interrupted @ form_edges" in line
+
+
+def test_view_title_carries_reflection_line():
+    agent, mgr, _ids = _seeded_manager()
+    rows = build_memory_rows(agent, mgr)
+    view = MemoryExplorerView(
+        rows,
+        forget=lambda _id: None,
+        mark_done=lambda _id: None,
+        last_reflection="last reflection: 2m ago — merged 3, +5 edges, pruned 1 (idle, 1.4s)",
+    )
+    assert "last reflection: 2m ago" in view.config.title
+
+
+def test_action_d_on_dropped_todo_keeps_search_text_consistent() -> None:
+    agent, mgr, ids = _seeded_manager()
+    mgr.update(ids["todo"], status="dropped")
+    view, calls = _view(agent, mgr)
+
+    todo = next(r for r in view.model.rows if r.id == ids["todo"])
+    assert "todo:dropped" in todo.search_text  # row built from the dropped state
+    assert view.handle_action("text:d", todo) == "handled"
+
+    assert calls["done"] == [ids["todo"]]
+    assert mgr.store.get(ids["todo"]).status == "done"
+    assert todo.status == "done"
+    # The search tag follows the transition: a "done" filter finds the row,
+    # and the stale dropped tag is gone.
+    assert "todo:done" in todo.search_text
+    assert "todo:dropped" not in todo.search_text

--- a/packages/nooa-cli/tests/tui/test_name_session_thread_safety.py
+++ b/packages/nooa-cli/tests/tui/test_name_session_thread_safety.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Reproduce cross-thread sqlite segfault from concurrent name_session + handle.
+
+The TUI schedules name_session (PredictStrategy) on the main thread while
+handle (CodeActStrategy) runs on the agent thread. Both call build_context ->
+event_manager.values() -> SQLiteEventBackend.active_tags() + get() concurrently,
+racing on the same sqlite3.Connection. With check_same_thread=False this isn't
+caught by Python — it segfaults in the sqlite C code or pydantic-core.
+
+This test verifies the fix: _name_session_on_agent_loop dispatches the coroutine
+to the agent loop so all sqlite access is serialized on one thread.
+"""
+
+import asyncio
+import threading
+import uuid
+
+from nooa.context_blocks import Metadata
+from nooa.storage import SQLiteStorageManager
+
+
+def _populate_backend(backend, n=50):
+    """Store N events so values() has work to do."""
+    for i in range(n):
+        backend.store(
+            f"evt-{i}",
+            Metadata(content=f"event payload {i}" * 20),
+        )
+
+
+def _reader_loop(backend, iterations=200):
+    """Simulate build_context -> event_manager.values() from a thread."""
+    for _ in range(iterations):
+        tags = backend.active_tags()
+        for tag in tags[:10]:
+            backend.get(tag)
+
+
+class TestCrossThreadSqliteRace:
+    """Demonstrate that concurrent reads from two threads on one connection crash."""
+
+    def test_concurrent_reads_are_safe_with_lock(self, tmp_path):
+        """Concurrent reads from two threads are safe thanks to the RLock.
+
+        Previously this test asserted concurrent access would FAIL (proving
+        the need for the fix). Now the RLock on SQLiteEventBackend serializes
+        access, so concurrent reads from multiple threads succeed without error.
+        """
+        db_path = tmp_path / f"{uuid.uuid4()}.db"
+        storage = SQLiteStorageManager(db_path, check_same_thread=False)
+        backend = storage.event_backend
+
+        _populate_backend(backend, n=50)
+
+        errors = []
+
+        def worker():
+            try:
+                _reader_loop(backend, iterations=500)
+            except Exception as e:
+                errors.append(e)
+
+        # Launch two threads both reading from the same backend
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        storage.close()
+
+        # With the RLock, concurrent access is safe — no errors.
+        assert len(errors) == 0, (
+            f"Concurrent reads should be safe with the RLock, but got: {errors}"
+        )
+
+    def test_name_session_dispatched_to_agent_loop(self):
+        """Verify _name_session_on_agent_loop uses run_coroutine_threadsafe."""
+        from nooa_cli.tui.session import Session
+
+        # Check the method exists and dispatches to agent loop
+        assert hasattr(Session, "_name_session_on_agent_loop"), (
+            "_name_session_on_agent_loop method missing — "
+            "name_session will race with handle on different threads"
+        )
+
+    def test_name_session_uses_agent_loop_when_available(self):
+        """When agent loop is available, coroutine is scheduled there."""
+        from unittest.mock import MagicMock, patch
+
+        from nooa_cli.tui.session import Session
+
+        # Create a mock session with the minimum required attributes
+        session = object.__new__(Session)
+        session._naming_futures = set()
+
+        # Mock the app with an agent loop
+        mock_loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        mock_loop.is_running.return_value = True
+
+        mock_app = MagicMock()
+        mock_app._agent_loop = mock_loop
+        session._app = mock_app
+        session._session_manager = MagicMock()
+        session._session_manager.user_named = False
+        session.agent = MagicMock()
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_dispatch:
+            session._name_session_on_agent_loop("hello world")
+            mock_dispatch.assert_called_once()
+            # Verify it targeted the agent loop
+            args = mock_dispatch.call_args
+            assert args[0][1] is mock_loop

--- a/packages/nooa-cli/tests/tui/test_reflection_runner.py
+++ b/packages/nooa-cli/tests/tui/test_reflection_runner.py
@@ -1,0 +1,662 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Idle-reflection runner + /reflection command
+(design: docs/design/memory-system/design-idle-reflection.md §3/§9 "Runner")."""
+
+import asyncio
+import time
+
+import pytest
+from nooa_cli.tui.config import Config
+from nooa_memory.reflection import ReflectionReport
+
+
+def _configure_project(monkeypatch, tmp_path):
+    project_dir = tmp_path / ".nooa"
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project_dir))
+    import nooa_cli.tui.session_manager as session_manager
+
+    monkeypatch.setattr(session_manager, "SESSIONS_DIR", project_dir / "sessions")
+    return project_dir
+
+
+async def _bootstrap_memory_agent(
+    tmp_path, monkeypatch, *, reflection=True, debounce_s=0.05, grace_s=0.2
+):
+    """A bootstrapped TUIAgent with session memory + short reflection knobs.
+
+    Generative hooks are pinned OFF: mechanics tests must never construct
+    real LLM-backed callables — the episode-phase tests below inject scripted
+    ones explicitly.
+    """
+    from nooa_cli.tui.bootstrap import bootstrap
+
+    project_dir = _configure_project(monkeypatch, tmp_path)
+    cfg = Config()
+    cfg.tui.default_model = "test-model"
+    cfg.agent.summarization.policy = "none"
+    cfg.tui.memory = "session"
+    cfg.tui.reflection = reflection
+    cfg.tui.reflection_generative = False
+    cfg.tui.reflection_debounce_s = debounce_s
+    cfg.tui.reflection_grace_s = grace_s
+    result = await bootstrap(cfg)
+    return cfg, result, project_dir
+
+
+async def _wait_for(predicate, timeout=3.0, interval=0.01):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(interval)
+    raise AssertionError("condition not met within timeout")
+
+
+def _slow_reflect(item_sleep_s: float, items: int):
+    """A reflect_interruptible stand-in: per-item sleeps honoring should_stop."""
+
+    def reflect(should_stop, *, trigger="idle"):
+        t0 = time.monotonic()
+        for _ in range(items):
+            if should_stop():
+                return ReflectionReport(
+                    interrupted=True,
+                    stopped_in="merge_duplicates",
+                    duration_ms=(time.monotonic() - t0) * 1000,
+                )
+            time.sleep(item_sleep_s)
+        return ReflectionReport(merged=1, duration_ms=(time.monotonic() - t0) * 1000)
+
+    return reflect
+
+
+# ---------------------------------------------------------------------------
+# config + bootstrap
+# ---------------------------------------------------------------------------
+
+
+def test_reflection_config_defaults():
+    cfg = Config.load()
+    assert cfg.tui.reflection is False
+    assert cfg.tui.reflection_agents == {}
+    assert cfg.tui.reflection_debounce_s == 10.0
+    assert cfg.tui.reflection_grace_s == 0.5
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_reflection_off_keeps_post_task_policy(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch, reflection=False)
+    try:
+        runner = result.agent._tui_reflection_runner
+        assert runner.enabled is False
+        assert result.agent.memory._mgr.config.reflection.trigger == "post_task"
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_reflection_on_remaps_trigger_to_manual(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch, reflection=True)
+    try:
+        runner = result.agent._tui_reflection_runner
+        assert runner.enabled is True
+        assert result.agent.memory._mgr.config.reflection.trigger == "manual"
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_memory_written_feeds_dirty_and_run_resets_it(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch)
+    try:
+        runner = result.agent._tui_reflection_runner
+        mgr = result.agent.memory._mgr
+        assert runner.dirty == 0
+        mgr.remember("the deploy command is make ship")
+        mgr.remember("rollback runbook: run make undeploy twice")
+        assert runner.dirty == 2
+
+        runner.on_response_done()
+        await _wait_for(lambda: runner.last_report is not None)
+        # ReflectionCompleted is not dirt: a run never re-triggers itself.
+        assert runner.dirty == 0
+        assert runner.state == "idle"
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+# ---------------------------------------------------------------------------
+# start gate truth table: {enabled, dirty, agent-idle}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("enabled", "dirty", "idle", "should_run"),
+    [
+        (False, True, True, False),
+        (True, False, True, False),
+        (True, True, False, False),
+        (True, True, True, True),
+    ],
+)
+async def test_start_gate_truth_table(tmp_path, monkeypatch, enabled, dirty, idle, should_run):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch)
+    try:
+        agent = result.agent
+        runner = agent._tui_reflection_runner
+        mgr = agent.memory._mgr
+        calls: list[str] = []
+
+        def fake_reflect(should_stop, *, trigger="idle"):
+            calls.append(trigger)
+            return ReflectionReport()
+
+        monkeypatch.setattr(mgr, "reflect_interruptible", fake_reflect)
+
+        runner.enabled = enabled
+        runner.dirty = 3 if dirty else 0
+        if not idle:
+            agent._user_messages_in.put("queued follow-up")
+
+        runner.on_response_done()
+        await asyncio.sleep(cfg.tui.reflection_debounce_s * 4)
+
+        assert (len(calls) > 0) is should_run
+        if should_run:
+            assert calls == ["idle"]
+        else:
+            assert runner.state == "idle"
+        if not idle:
+            agent._user_messages_in.flush()
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_pending_non_user_queue_work_counts_as_not_idle(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch)
+    try:
+        agent = result.agent
+        runner = agent._tui_reflection_runner
+        runner.dirty = 1
+        agent._system_messages_in.put("pending system work")
+
+        runner.on_response_done()
+        assert runner.state == "idle"  # gate refused before any task was made
+        await asyncio.sleep(cfg.tui.reflection_debounce_s * 4)
+        assert runner.last_report is None
+        agent._system_messages_in.flush()
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+# ---------------------------------------------------------------------------
+# debounce + interrupt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_debounce_cancellation_never_shows_indicator(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch, debounce_s=1.0)
+    try:
+        runner = result.agent._tui_reflection_runner
+        mgr = result.agent.memory._mgr
+        called = []
+        monkeypatch.setattr(
+            mgr, "reflect_interruptible", lambda s, *, trigger="idle": called.append(1)
+        )
+
+        runner.dirty = 1
+        runner.on_response_done()
+        assert runner.state == "debounce"
+        assert runner.indicator_frame() == ""  # never shown during DEBOUNCE
+
+        await runner.interrupt()  # input arrived during debounce
+        assert runner.state == "idle"
+        assert runner.indicator_frame() == ""  # silent: no 'interrupted' flash
+        await asyncio.sleep(0.05)
+        assert called == []
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_stops_slow_run_within_grace(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch, grace_s=0.5)
+    try:
+        runner = result.agent._tui_reflection_runner
+        mgr = result.agent.memory._mgr
+        # 100 items x 20 ms: a full pass takes 2 s, one item stops in 20 ms.
+        monkeypatch.setattr(mgr, "reflect_interruptible", _slow_reflect(0.02, 100))
+
+        runner.dirty = 1
+        runner.on_response_done()
+        await _wait_for(lambda: runner.state == "running")
+
+        t0 = time.monotonic()
+        await runner.interrupt()
+        elapsed = time.monotonic() - t0
+        assert elapsed < 0.5  # within grace, not the 2 s full pass
+
+        await _wait_for(lambda: runner.last_report is not None)
+        assert runner.last_report.interrupted is True
+        assert runner.last_report.stopped_in == "merge_duplicates"
+        assert runner.state == "idle"
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_prompt_never_blocked_by_stuck_run(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch, grace_s=0.1)
+    try:
+        runner = result.agent._tui_reflection_runner
+        mgr = result.agent.memory._mgr
+
+        def stuck_reflect(should_stop, *, trigger="idle"):
+            time.sleep(0.8)  # one stuck item that refuses to observe the stop
+            return ReflectionReport(interrupted=True, stopped_in="merge_duplicates")
+
+        monkeypatch.setattr(mgr, "reflect_interruptible", stuck_reflect)
+
+        runner.dirty = 1
+        runner.on_response_done()
+        await _wait_for(lambda: runner.state == "running")
+
+        t0 = time.monotonic()
+        await runner.interrupt()
+        elapsed = time.monotonic() - t0
+        # Timestamp-asserted: interrupt() returned after grace, long before
+        # the stuck item finished — the prompt would dispatch here.
+        assert elapsed < 0.5
+        assert runner.state == "running"  # executor still winding down
+
+        await _wait_for(lambda: runner.state == "idle", timeout=2.0)
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+# ---------------------------------------------------------------------------
+# indicator frames
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_indicator_frame_states(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch, grace_s=0.5)
+    try:
+        runner = result.agent._tui_reflection_runner
+        mgr = result.agent.memory._mgr
+        monkeypatch.setattr(mgr, "reflect_interruptible", _slow_reflect(0.02, 100))
+
+        assert runner.indicator_frame() == ""  # IDLE -> zero width
+
+        runner.dirty = 1
+        runner.on_response_done()
+        await _wait_for(lambda: runner.state == "running")
+
+        frames = set()
+        deadline = time.monotonic() + 0.6
+        while time.monotonic() < deadline and runner.state == "running":
+            frames.add(runner.indicator_frame())
+            await asyncio.sleep(0.05)
+        assert all(f.startswith("✦ reflecting ") for f in frames)
+        assert len(frames) >= 2  # the wave glides between repaint ticks
+
+        await runner.interrupt()
+        assert runner.indicator_frame() == "✦ reflection interrupted"  # one flash
+        await asyncio.sleep(0.4)
+        assert runner.indicator_frame() == ""  # flash does not linger
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+# ---------------------------------------------------------------------------
+# /reflection command
+# ---------------------------------------------------------------------------
+
+
+def _registry_for(cfg, result):
+    from nooa_cli.tui.commands import CommandRegistry
+
+    return CommandRegistry(
+        config=cfg.tui,
+        agent=result.agent,
+        frontend=object(),
+        skills_dirs=[],
+        session_manager=result.session_manager,
+        root_config=cfg,
+    )
+
+
+@pytest.mark.asyncio
+async def test_reflection_command_round_trip(tmp_path, monkeypatch):
+    cfg, result, project_dir = await _bootstrap_memory_agent(
+        tmp_path, monkeypatch, reflection=False
+    )
+    try:
+        registry = _registry_for(cfg, result)
+        cmd = registry._commands["reflection"]
+        agent_key = "nooa_cli.tui.agent:TUIAgent"
+
+        status = await cmd.execute([])
+        assert status.success
+        assert "Idle reflection: off" in status.outputs[0].content
+
+        on_result = await cmd.execute(["on"])
+        assert on_result.success
+        assert cfg.tui.reflection_agents[agent_key] is True
+        mgr = result.agent.memory._mgr
+        assert mgr.config.reflection.trigger == "manual"
+        runner = result.agent._tui_reflection_runner  # rebuilt by the command
+        assert runner.enabled is True
+        # Persisted as a real bool in settings.yaml — the file Config.load reads.
+        reloaded = Config.load()
+        assert reloaded.tui.reflection_agents.get(agent_key) is True
+
+        runner.dirty = 2
+        runner.last_report = ReflectionReport(merged=3, edges_added=5, pruned=1, duration_ms=1400.0)
+        status = await cmd.execute(["status"])
+        assert status.success
+        text = status.outputs[0].content
+        assert "Idle reflection: on" in text
+        assert "dirty: 2" in text
+        assert "merged 3, +5 edges" in text
+        assert "1.4s" in text
+
+        off_result = await cmd.execute(["off"])
+        assert off_result.success
+        assert cfg.tui.reflection_agents[agent_key] is False
+        assert result.agent.memory._mgr.config.reflection.trigger == "post_task"
+        assert result.agent._tui_reflection_runner.enabled is False
+        reloaded = Config.load()
+        assert reloaded.tui.reflection_agents.get(agent_key) is False
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_reflection_status_reports_interrupted_run(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch)
+    try:
+        registry = _registry_for(cfg, result)
+        cmd = registry._commands["reflection"]
+        runner = result.agent._tui_reflection_runner
+        runner.last_report = ReflectionReport(
+            interrupted=True, stopped_in="form_edges", duration_ms=300.0
+        )
+        status = await cmd.execute([])
+        assert "interrupted @ form_edges" in status.outputs[0].content
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_reflection_off_mid_run_cancels_and_rewires(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch)
+    try:
+        registry = _registry_for(cfg, result)
+        cmd = registry._commands["reflection"]
+        old_runner = result.agent._tui_reflection_runner
+        mgr = result.agent.memory._mgr
+        monkeypatch.setattr(mgr, "reflect_interruptible", _slow_reflect(0.02, 100))
+
+        old_runner.dirty = 1
+        old_runner.on_response_done()
+        await _wait_for(lambda: old_runner.state == "running")
+
+        off_result = await cmd.execute(["off"])
+        assert off_result.success
+        # The mid-run pass was stopped (within one item) and the old runner
+        # torn down: unsubscribed and replaced by a fresh, disabled one.
+        await _wait_for(lambda: old_runner.state == "idle", timeout=2.0)
+        assert old_runner._unsubscribe is None
+        new_runner = result.agent._tui_reflection_runner
+        assert new_runner is not old_runner
+        assert new_runner.enabled is False
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_memory_off_tears_down_runner(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch)
+    try:
+        registry = _registry_for(cfg, result)
+        memory_cmd = registry._commands["memory"]
+        runner = result.agent._tui_reflection_runner
+
+        off_result = await memory_cmd.execute(["off"])
+        assert off_result.success
+        assert not hasattr(result.agent, "_tui_reflection_runner")
+        assert runner._unsubscribe is None  # MemoryWritten handler removed
+        assert not hasattr(result.agent, "memory")
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+# ---------------------------------------------------------------------------
+# generative episode phase: LLM writes the episode, then consolidation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idle_run_writes_episode_then_reasoner_consumes(tmp_path, monkeypatch):
+    """The user-specified pipeline: phase 1 writes an episode about the recent
+    session window; consolidation runs next, so the reasoner abstracts that
+    fresh episode IN THE SAME PASS — and the runner's own write is not dirt."""
+    from nooa_memory import Memory, MemoryType
+
+    from nooa.events import Task
+
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch)
+    agent = result.agent
+    runner = agent._tui_reflection_runner
+    mgr = agent.memory._mgr
+    try:
+        writer_calls: list[str] = []
+
+        def scripted_writer(events_text: str) -> str:
+            writer_calls.append(events_text)
+            return "Episode: worked through the reflection harness tests end to end."
+
+        def scripted_reasoner(episodes):
+            assert any("reflection harness tests" in e.content for e in episodes)
+            return [
+                Memory(
+                    content="Insight: idle reflection needs episode records to abstract from.",
+                    type=MemoryType.REFLECTION,
+                )
+            ]
+
+        runner._episode_writer = scripted_writer
+        mgr._reasoner = scripted_reasoner
+
+        agent.event_manager.add(Task(prompt="please run the reflection harness tests"))
+        mgr.remember("some fact to make the store dirty")  # dirt -> run eligible
+        runner.on_response_done()
+        await _wait_for(lambda: runner.last_report is not None and runner.state == "idle")
+
+        assert len(writer_calls) == 1
+        assert "reflection harness tests" in writer_calls[0]  # transcript reached the LLM
+
+        episodes = [m for m in mgr.store.all_memories() if m.type is MemoryType.EPISODE]
+        assert len(episodes) == 1
+        assert episodes[0].title == "session episode"
+        assert episodes[0].source_task_ref == "idle_reflection"
+
+        insights = [m for m in mgr.store.all_memories() if m.type is MemoryType.REFLECTION]
+        assert len(insights) == 1  # reasoner consumed the fresh episode, same pass
+        derived = {e.target_id for e in insights[0].edges}
+        assert episodes[0].id in derived
+
+        assert runner.last_report.created == 1
+        assert runner.dirty == 0  # the runner's own episode write is not dirt
+    finally:
+        runner.teardown()
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_unnoteworthy_episode_writes_nothing(tmp_path, monkeypatch):
+    from nooa_memory import MemoryType
+
+    from nooa.events import Task
+
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch)
+    agent = result.agent
+    runner = agent._tui_reflection_runner
+    mgr = agent.memory._mgr
+    try:
+        runner._episode_writer = lambda events_text: None  # "not noteworthy"
+        agent.event_manager.add(Task(prompt="small talk"))
+        mgr.remember("dirt")
+        runner.on_response_done()
+        await _wait_for(lambda: runner.last_report is not None and runner.state == "idle")
+
+        assert [m for m in mgr.store.all_memories() if m.type is MemoryType.EPISODE] == []
+    finally:
+        runner.teardown()
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_during_debounce_never_calls_episode_writer(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch, debounce_s=5.0)
+    agent = result.agent
+    runner = agent._tui_reflection_runner
+    mgr = agent.memory._mgr
+    try:
+        calls: list[str] = []
+        runner._episode_writer = lambda events_text: calls.append(events_text) or None
+        mgr.remember("dirt")
+        runner.on_response_done()
+        assert runner.state == "debounce"
+        await runner.interrupt()
+        assert calls == []  # stopped before phase 1 ever started
+        assert runner.state == "idle"
+    finally:
+        runner.teardown()
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+# ---------------------------------------------------------------------------
+# /reflection now — eager runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_now_skips_debounce_and_dirty_gate(tmp_path, monkeypatch):
+    """Eager runs need neither dirt nor a debounce — and work even while the
+    idle toggle is OFF (an explicit request runs whatever is configured)."""
+    cfg, result, _ = await _bootstrap_memory_agent(
+        tmp_path, monkeypatch, reflection=False, debounce_s=5.0
+    )
+    runner = result.agent._tui_reflection_runner
+    try:
+        assert runner.enabled is False and runner.dirty == 0
+        assert runner.run_now() is True
+        await _wait_for(lambda: runner.last_report is not None and runner.state == "idle")
+        assert runner.last_report.interrupted is False  # a full deterministic pass
+    finally:
+        runner.teardown()
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_run_now_refuses_while_a_run_is_pending(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch)
+    runner = result.agent._tui_reflection_runner
+    mgr = result.agent.memory._mgr
+    try:
+        monkeypatch.setattr(mgr, "reflect_interruptible", _slow_reflect(0.05, 100))
+        assert runner.run_now() is True
+        await _wait_for(lambda: runner.state == "running")
+        assert runner.run_now() is False  # one run at a time
+        await runner.interrupt()
+    finally:
+        runner.teardown()
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_reflection_now_command(tmp_path, monkeypatch):
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch, reflection=False)
+    runner = result.agent._tui_reflection_runner
+    try:
+        registry = _registry_for(cfg, result)
+        cmd = registry._commands["reflection"]
+
+        assert cmd.validate_args(["now"])[0] is True
+        assert cmd.validate_args(["eagerly"])[0] is False
+
+        out = await cmd.execute(["now"])
+        assert out.success
+        assert "Reflection started" in out.outputs[0].content
+        await _wait_for(lambda: runner.last_report is not None and runner.state == "idle")
+
+        # while a (slow) run is active, a second `now` reports the pending run
+        mgr = result.agent.memory._mgr
+        monkeypatch.setattr(mgr, "reflect_interruptible", _slow_reflect(0.05, 100))
+        assert runner.run_now() is True
+        await _wait_for(lambda: runner.state == "running")
+        out = await cmd.execute(["now"])
+        assert out.success
+        assert "already pending" in out.outputs[0].content
+        await runner.interrupt()
+    finally:
+        runner.teardown()
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_rebuilt_runner_inherits_preexisting_dirt(tmp_path, monkeypatch):
+    """The user-reported bug: memories written BEFORE /reflection on must
+    still count as dirt after the toggle rebuilds the runner — otherwise the
+    idle gate never opens for exactly the memories the user wants consolidated."""
+    from nooa_cli.tui.reflection_runner import ReflectionRunner
+
+    cfg, result, _ = await _bootstrap_memory_agent(tmp_path, monkeypatch, reflection=False)
+    agent = result.agent
+    mgr = agent.memory._mgr
+    old_runner = agent._tui_reflection_runner
+    try:
+        mgr.remember("written before the reflection toggle, take one")
+        mgr.remember("another pre-toggle memory, quite different content")
+
+        # what `/reflection on` does: tear down + rebuild the runner
+        old_runner.teardown()
+        rebuilt = ReflectionRunner(agent, mgr, cfg.tui, enabled=True)
+        assert rebuilt.dirty >= 2  # pre-toggle writes still count
+        rebuilt.teardown()
+
+        # after a consolidation pass, a rebuilt runner starts clean
+        mgr.reflect_interruptible(lambda: False, trigger="idle")
+        fresh = ReflectionRunner(agent, mgr, cfg.tui, enabled=True)
+        assert fresh.dirty == 0
+        fresh.teardown()
+    finally:
+        old_runner.teardown()
+        if result.session_manager is not None:
+            result.session_manager.close()

--- a/packages/nooa-cli/tests/tui/test_restore_terminal.py
+++ b/packages/nooa-cli/tests/tui/test_restore_terminal.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for Session._restore_terminal — three code paths."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _make_session():
+    """Build a minimal Session-like object with just the restore method."""
+    from nooa_cli.tui.session import Session
+
+    # Session.__init__ requires several args; we bypass it and attach
+    # the method + required state directly.
+    obj = object.__new__(Session)
+    obj._saved_termios = None
+    return obj
+
+
+class TestRestoreTerminalTermiosSuccess:
+    """Path 1: termios available, saved attrs present, stdin is a tty."""
+
+    def test_restores_saved_attrs(self):
+        session = _make_session()
+        fake_attrs = [1, 2, 3, 4, 5, 6, []]
+        session._saved_termios = fake_attrs
+        mock_termios = MagicMock()
+
+        with patch("sys.stdin") as mock_stdin, patch.dict("sys.modules", {"termios": mock_termios}):
+            mock_stdin.isatty.return_value = True
+            mock_stdin.fileno.return_value = 0
+            session._restore_terminal()
+
+        mock_termios.tcsetattr.assert_called_once_with(0, mock_termios.TCSANOW, fake_attrs)
+
+    def test_noop_when_no_saved_attrs(self):
+        session = _make_session()
+        session._saved_termios = None
+
+        mock_termios = MagicMock()
+        with patch("sys.stdin") as mock_stdin, patch.dict("sys.modules", {"termios": mock_termios}):
+            mock_stdin.isatty.return_value = True
+            session._restore_terminal()
+
+        mock_termios.tcsetattr.assert_not_called()
+
+    def test_noop_when_not_a_tty(self):
+        session = _make_session()
+        session._saved_termios = [1, 2, 3]
+
+        mock_termios = MagicMock()
+        with patch("sys.stdin") as mock_stdin, patch.dict("sys.modules", {"termios": mock_termios}):
+            mock_stdin.isatty.return_value = False
+            session._restore_terminal()
+
+        mock_termios.tcsetattr.assert_not_called()
+
+
+class TestRestoreTerminalTermiosOSError:
+    """Path 2: termios raises OSError → falls back to stty."""
+
+    def test_falls_back_to_stty_on_oserror(self):
+        session = _make_session()
+        session._saved_termios = [1, 2, 3]
+
+        mock_termios = MagicMock()
+        mock_termios.tcsetattr.side_effect = OSError("device not configured")
+
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch.dict("sys.modules", {"termios": mock_termios}),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_stdin.isatty.return_value = True
+            mock_stdin.fileno.return_value = 0
+            session._restore_terminal()
+
+        mock_run.assert_called_once_with(["stty", "sane"], stdin=mock_stdin, check=False)
+
+
+class TestRestoreTerminalNoTermios:
+    """Path 3: termios not available (ImportError) → falls back to stty."""
+
+    def test_falls_back_to_stty_when_no_termios(self):
+        session = _make_session()
+        session._saved_termios = None  # Would be None if termios wasn't available at save time
+
+        def _raise_import(name, *args, **kwargs):
+            if name == "termios":
+                raise ImportError("No module named 'termios'")
+            return original_import(name, *args, **kwargs)
+
+        import builtins
+
+        original_import = builtins.__import__
+
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("subprocess.run") as mock_run,
+            patch("builtins.__import__", side_effect=_raise_import),
+        ):
+            mock_stdin.isatty.return_value = True
+            session._restore_terminal()
+
+        mock_run.assert_called_once_with(["stty", "sane"], stdin=mock_stdin, check=False)

--- a/packages/nooa-cli/tests/tui/test_resume_emit_order.py
+++ b/packages/nooa-cli/tests/tui/test_resume_emit_order.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""SessionResumed must be emitted AFTER skills attach, so subscribers receive it.
+
+Regression: bootstrap() emitted SessionResumed before library skills (e.g.
+agent_mesh) were attached in build_registry(). The event fired into the void —
+no subscriber existed yet — so a skill's resume handler never ran. Moving the
+emit into build_registry() (after skill activation) fixes the ordering.
+"""
+
+import pytest
+
+from nooa.sessions import SessionResumed
+
+
+@pytest.mark.asyncio
+async def test_emit_happens_after_skill_can_subscribe(tmp_path, monkeypatch):
+    """A handler subscribed during build_registry() receives the resume event."""
+    from nooa_cli.tui import session_manager as session_manager_module
+    from nooa_cli.tui.bootstrap import bootstrap, build_registry
+    from nooa_cli.tui.config import Config
+
+    monkeypatch.setattr(session_manager_module, "SESSIONS_DIR", tmp_path)
+
+    result = await bootstrap(Config())
+
+    # Subscribe BEFORE build_registry runs the emit — emulating a skill that
+    # attaches during build_registry's library-skill activation.
+    seen = []
+    result.agent.event_manager.register_event_type(SessionResumed)
+    result.agent.event_manager.on("SessionResumed", lambda e: seen.append(e))
+
+    # build_registry needs a frontend; a minimal stub is enough for the emit path.
+    from unittest.mock import MagicMock
+
+    build_registry(result, MagicMock())
+
+    assert len(seen) == 1
+    assert seen[0].session_id == result.session_id
+    await result.agent.close()
+    result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_does_not_emit_on_its_own(tmp_path, monkeypatch):
+    """bootstrap() must NOT emit — otherwise it fires before skills attach."""
+    from nooa_cli.tui import session_manager as session_manager_module
+    from nooa_cli.tui.bootstrap import bootstrap
+    from nooa_cli.tui.config import Config
+
+    monkeypatch.setattr(session_manager_module, "SESSIONS_DIR", tmp_path)
+
+    from nooa.runtime.event_manager import EventManager
+
+    captured = []
+    real_add = EventManager.add
+
+    def _tee(self, event, **kw):
+        if isinstance(event, SessionResumed):
+            captured.append(event)
+        return real_add(self, event, **kw)
+
+    import pytest as _pytest  # noqa: F401
+
+    EventManager.add = _tee
+    try:
+        result = await bootstrap(Config())
+    finally:
+        EventManager.add = real_add
+
+    assert captured == []  # bootstrap itself emits nothing now
+    await result.agent.close()
+    result.session_manager.close()
+
+
+def test_bootstrap_result_carries_restored_flag():
+    from nooa_cli.tui.bootstrap import BootstrapResult
+
+    assert "restored" in BootstrapResult.__dataclass_fields__

--- a/packages/nooa-cli/tests/tui/test_resume_emit_order.py
+++ b/packages/nooa-cli/tests/tui/test_resume_emit_order.py
@@ -9,8 +9,7 @@ emit into build_registry() (after skill activation) fixes the ordering.
 """
 
 import pytest
-
-from nooa.sessions import SessionResumed
+from nooa_cli.sessions import SessionResumed
 
 
 @pytest.mark.asyncio

--- a/packages/nooa-cli/tests/tui/test_resume_replay.py
+++ b/packages/nooa-cli/tests/tui/test_resume_replay.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for session resume replay truncation and batch rendering."""
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from nooa_cli.tui.output import HistoryReplay, HistoryTurn
+from nooa_cli.tui.session_manager import (
+    RESUME_MAX_TURNS,
+    build_resume_outputs,
+)
+
+
+def _make_session_db(turns: list[tuple[str, str]], rich_events: list[dict] | None = None) -> Path:
+    """Create a temp session DB with the given turns and optional rich events."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    db_path = Path(tmp.name)
+    tmp.close()
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE events (event_type TEXT, data TEXT, insertion_order INTEGER)")
+    order = 0
+    for role, content in turns:
+        if role == "user":
+            conn.execute(
+                "INSERT INTO events VALUES (?, ?, ?)",
+                ("TUIUserInput", json.dumps({"text": content}), order),
+            )
+        elif role == "agent":
+            conn.execute(
+                "INSERT INTO events VALUES (?, ?, ?)",
+                ("TUIAgentMessage", json.dumps({"content": content}), order),
+            )
+        elif role == "rich":
+            conn.execute(
+                "INSERT INTO events VALUES (?, ?, ?)",
+                ("RichOutput", json.dumps({"payload": {"kind": "plot", "data": content}}), order),
+            )
+        order += 1
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+class TestTruncation:
+    """Tests for turn truncation in build_resume_outputs."""
+
+    def test_no_truncation_when_under_limit(self):
+        """Sessions with fewer turns than max_turns are not truncated."""
+        turns = [("user", f"msg {i}") for i in range(5)]
+        db = _make_session_db(turns)
+        outputs = build_resume_outputs(db, "abc12345", max_turns=10)
+        replays = [o for o in outputs if isinstance(o, HistoryReplay)]
+        total = sum(len(r.turns) for r in replays)
+        assert total == 5
+        assert replays[0].omitted_count == 0
+
+    def test_truncation_keeps_last_n_turns(self):
+        """Only the last max_turns turns are kept."""
+        turns = [("user", f"msg {i}") for i in range(50)]
+        db = _make_session_db(turns)
+        outputs = build_resume_outputs(db, "abc12345", max_turns=10)
+        replays = [o for o in outputs if isinstance(o, HistoryReplay)]
+        total = sum(len(r.turns) for r in replays)
+        assert total == 10
+        # Should show last 10 messages
+        all_turns = [t for r in replays for t in r.turns]
+        assert all_turns[0].content == "msg 40"
+        assert all_turns[-1].content == "msg 49"
+
+    def test_omitted_count_in_header(self):
+        """The first HistoryReplay reports how many turns were omitted."""
+        turns = [("user", f"msg {i}") for i in range(30)]
+        db = _make_session_db(turns)
+        outputs = build_resume_outputs(db, "abc12345", max_turns=10)
+        replays = [o for o in outputs if isinstance(o, HistoryReplay)]
+        assert replays[0].omitted_count == 20
+
+    def test_truncation_disabled_with_zero(self):
+        """max_turns=0 disables truncation."""
+        turns = [("user", f"msg {i}") for i in range(50)]
+        db = _make_session_db(turns)
+        outputs = build_resume_outputs(db, "abc12345", max_turns=0)
+        replays = [o for o in outputs if isinstance(o, HistoryReplay)]
+        total = sum(len(r.turns) for r in replays)
+        assert total == 50
+
+    def test_default_max_turns(self):
+        """Default truncation uses RESUME_MAX_TURNS."""
+        turns = [("user", f"msg {i}") for i in range(50)]
+        db = _make_session_db(turns)
+        outputs = build_resume_outputs(db, "abc12345")
+        replays = [o for o in outputs if isinstance(o, HistoryReplay)]
+        total = sum(len(r.turns) for r in replays)
+        assert total == RESUME_MAX_TURNS
+
+    def test_rich_items_after_truncated_turns_are_dropped(self):
+        """Rich items interleaved with truncated turns are not kept."""
+        # Create: 10 user turns, then a rich event, then 5 more user turns
+        turns = (
+            [("user", f"early {i}") for i in range(10)]
+            + [("rich", "plot_data")]
+            + [("user", f"late {i}") for i in range(5)]
+        )
+        db = _make_session_db(turns)
+        # Keep only 5 turns — all "early" turns + the rich event should be dropped
+        outputs = build_resume_outputs(db, "abc12345", max_turns=5, in_nemo_term=True)
+        replays = [o for o in outputs if isinstance(o, HistoryReplay)]
+        total = sum(len(r.turns) for r in replays)
+        assert total == 5
+        # No rich events should survive since they precede kept turns
+        from nooa_cli.tui.output import _RichReplayPayload
+
+        rich_items = [o for o in outputs if isinstance(o, _RichReplayPayload)]
+        assert len(rich_items) == 0
+
+    def test_rich_items_after_kept_turns_are_preserved(self):
+        """Rich items interleaved with kept turns survive truncation."""
+        # Create: 5 user turns, then 5 more + a rich event at the end
+        turns = (
+            [("user", f"early {i}") for i in range(5)]
+            + [("user", f"late {i}") for i in range(4)]
+            + [("rich", "kept_plot")]
+            + [("user", "final")]
+        )
+        db = _make_session_db(turns)
+        # Keep 5 turns — last 5 turns include "late 3", "late 4" area + rich + final
+        outputs = build_resume_outputs(db, "abc12345", max_turns=5, in_nemo_term=True)
+        from nooa_cli.tui.output import _RichReplayPayload
+
+        rich_items = [o for o in outputs if isinstance(o, _RichReplayPayload)]
+        assert len(rich_items) == 1
+
+
+class TestBatchRendering:
+    """Tests for batch rendering in TerminalFrontend._render_history_replay."""
+
+    def test_single_write_to_terminal(self):
+        """History replay writes to terminal file in one call, not per-turn."""
+        from nooa_cli.tui.frontend import TerminalFrontend
+
+        # Create a mock console
+        mock_file = MagicMock()
+        mock_console = MagicMock()
+        mock_console.console.width = 80
+        mock_console.console.file = mock_file
+
+        frontend = TerminalFrontend.__new__(TerminalFrontend)
+        frontend._console = mock_console
+
+        replay = HistoryReplay(
+            turns=[
+                HistoryTurn(role="user", content="hello"),
+                HistoryTurn(role="agent", content="world"),
+                HistoryTurn(role="user", content="bye"),
+            ],
+            session_id="abc123",
+            show_header=True,
+            show_footer=True,
+        )
+
+        frontend._render_history_replay(replay)
+
+        # Should write once (batch) + flush once
+        assert mock_file.write.call_count == 1
+        assert mock_file.flush.call_count == 1
+        # The single write should contain content from all turns
+        written = mock_file.write.call_args[0][0]
+        assert "hello" in written
+        assert "world" in written
+        assert "bye" in written
+
+    def test_history_replay_on_emit_stream_keeps_semantic_replay_callback(self):
+        """Live TUI rendering stores resumed HistoryReplay as a reflowable block."""
+        from nooa_cli.tui.frontend import TerminalFrontend
+        from nooa_cli.tui.session import _EmitStream
+
+        emitted = []
+        current_width = 80
+
+        def emit(text: str, replay=None):
+            emitted.append((text, replay))
+
+        stream = _EmitStream(emit, replay_width=lambda: current_width)
+        mock_console = MagicMock()
+        mock_console.console.width = 120
+        mock_console.console.file = stream
+
+        frontend = TerminalFrontend.__new__(TerminalFrontend)
+        frontend._console = mock_console
+
+        replay = HistoryReplay(
+            turns=[
+                HistoryTurn(
+                    role="agent",
+                    content="This is a resumed markdown paragraph that should wrap differently.",
+                )
+            ],
+            session_id="abc123",
+            show_header=True,
+            show_footer=True,
+        )
+
+        frontend._render_history_replay(replay)
+
+        assert len(emitted) == 1
+        rendered, replay_callback = emitted[0]
+        assert "abc123" in rendered
+        assert callable(replay_callback)
+        current_width = 24
+        rerendered = replay_callback()
+        assert rerendered != rendered
+        assert "abc123" in rerendered
+        assert len(rerendered.splitlines()[0]) < len(rendered.splitlines()[0])
+
+    def test_emit_stream_preserves_order_when_semantic_block_appears_inside_hold(self):
+        """A semantic HistoryReplay inside batch_render must not jump ahead of buffered text."""
+        from nooa_cli.tui.session import _EmitStream
+
+        emitted = []
+
+        def emit(text: str, replay=None):
+            emitted.append((text, replay))
+
+        stream = _EmitStream(emit)
+        with stream.hold():
+            stream.write("before")
+            stream.emit_with_replay("history", lambda: "history-reflowed")
+            stream.write("after")
+
+        assert [text for text, _ in emitted] == ["before", "history", "after"]
+        assert emitted[1][1]() == "history-reflowed"

--- a/packages/nooa-cli/tests/tui/test_sensitive_prompt.py
+++ b/packages/nooa-cli/tests/tui/test_sensitive_prompt.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the in-app masked prompt used by manual MCP OAuth."""
+
+from nooa_cli.tui.subapp import SensitiveTextPromptView
+
+
+def test_sensitive_prompt_masks_value_and_submits():
+    view = SensitiveTextPromptView("OAuth", "Paste the authorization code")
+    for character in "code-123":
+        view.handle_key("text", character)
+
+    rendered = view.render(80, 10)
+    assert "code-123" not in rendered
+    assert "•" * len("code-123") in rendered
+    assert view.handle_key("enter") == "close"
+    assert view.value == "code-123"
+
+
+def test_sensitive_prompt_accepts_keys_reserved_by_explorer_views():
+    view = SensitiveTextPromptView("OAuth", "Paste")
+    for action in ("quit", "resume", "j", "k", "slash"):
+        assert view.handle_key(action) == "handled"
+    assert view.handle_key("backspace") == "handled"
+    assert view.handle_key("enter") == "close"
+    assert view.value == "qrjk"
+
+
+def test_sensitive_prompt_escape_cancels_without_value():
+    view = SensitiveTextPromptView("OAuth", "Paste")
+    view.handle_key("text", "secret")
+    assert view.handle_key("escape") == "close"
+    assert view.value is None
+
+
+def test_sensitive_prompt_strips_terminal_controls_from_server_url():
+    view = SensitiveTextPromptView("OAuth", "https://example.test/\x1b[2J\u202eauthorize")
+    rendered = view.render(80, 10)
+    assert "\x1b" not in rendered
+    assert "\u202e" not in rendered
+
+
+def test_sensitive_prompt_scrolls_long_authorization_url():
+    message = "Authorize: https://example.test/" + "a" * 500 + "\nTAIL_VISIBLE"
+    view = SensitiveTextPromptView("OAuth", message)
+
+    first = view.render(40, 8)
+    assert "TAIL_VISIBLE" not in first
+    view.handle_key("end")
+    last = view.render(40, 8)
+
+    assert "TAIL_VISIBLE" in last

--- a/packages/nooa-cli/tests/tui/test_session_cleared_event.py
+++ b/packages/nooa-cli/tests/tui/test_session_cleared_event.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""SessionCleared is emitted after /clear resets the agent's working state."""
+
+import pytest
+
+from nooa.sessions import SessionCleared
+
+
+def test_event_is_runtime_role_and_fields():
+    from nooa.context_blocks.models import Role
+
+    e = SessionCleared(session_id="abc")
+    assert e.session_id == "abc"
+    assert type(e)._role is Role.RUNTIME_EVENT
+    # session_id is optional (may be unknown at clear time).
+    assert SessionCleared().session_id is None
+
+
+def test_event_keeps_legacy_handler_alias_during_migration():
+    assert SessionCleared.handler_aliases == ("TuiSessionCleared",)
+
+
+@pytest.mark.asyncio
+async def test_reset_emits_cleared_event_to_subscribers():
+    """_reset_agent_working_state emits SessionCleared; a subscriber receives it."""
+    from nooa_cli.tui.commands import _reset_agent_working_state
+
+    from nooa import Agent
+    from nooa.unifiedllm import FakeLLMClient
+
+    class _A(Agent, llm=FakeLLMClient()):
+        pass
+
+    agent = _A()
+    agent.event_manager.register_event_type(SessionCleared)
+    seen = []
+    agent.event_manager.on("SessionCleared", lambda e: seen.append(e))
+
+    await _reset_agent_working_state(agent)
+
+    assert len(seen) == 1
+    assert isinstance(seen[0], SessionCleared)

--- a/packages/nooa-cli/tests/tui/test_session_cleared_event.py
+++ b/packages/nooa-cli/tests/tui/test_session_cleared_event.py
@@ -3,8 +3,7 @@
 """SessionCleared is emitted after /clear resets the agent's working state."""
 
 import pytest
-
-from nooa.sessions import SessionCleared
+from nooa_cli.sessions import SessionCleared
 
 
 def test_event_is_runtime_role_and_fields():

--- a/packages/nooa-cli/tests/tui/test_session_manager.py
+++ b/packages/nooa-cli/tests/tui/test_session_manager.py
@@ -106,8 +106,13 @@ class TestListSessions:
         ids = [s.id for s in sessions]
         assert ids.index(sm_new.session_id) < ids.index(sm_old.session_id)
 
-    def test_turn_count_reflects_all_turns(self, tmp_path):
-        """list_sessions includes turn_count = number of user + agent turns."""
+    def test_turn_count_counts_user_turns(self, tmp_path):
+        """list_sessions includes turn_count = number of user turns.
+
+        Agent replies are not counted. The live path increments once per
+        ``record_user`` and the summary query matches it; ``turns()`` still
+        returns both roles, so it stays the longer of the two.
+        """
         from nooa.interactive import AgentMessage
 
         with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
@@ -121,7 +126,7 @@ class TestListSessions:
             metas = SessionManager.list_sessions()
 
         meta = next(m for m in metas if m.id == sid)
-        assert meta.turn_count == 3  # 2 user + 1 agent
+        assert meta.turn_count == 2  # 2 user; the agent reply is not a turn
 
     def test_limit_is_respected(self, tmp_path):
         """list_sessions(limit=N) returns at most N results."""

--- a/packages/nooa-cli/tests/tui/test_session_manager.py
+++ b/packages/nooa-cli/tests/tui/test_session_manager.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for SessionManager and related session persistence logic."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from nooa_cli.tui.session_manager import SessionManager
+
+
+def _make_sm(tmp_path, *, model="m", agent_cls="A", working_dir="", session_id=None):
+    """Create a SessionManager backed by a SQLite DB in tmp_path."""
+    return SessionManager.create(
+        session_id=session_id,
+        model=model,
+        agent_cls=agent_cls,
+        working_dir=working_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestSessionManagerBasic:
+    def test_creates_session_in_sessions_dir(self, tmp_path):
+        """A new SessionManager creates a DB file in SESSIONS_DIR."""
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm = _make_sm(tmp_path, model="openai/gpt-4o", agent_cls="TUIAgent", working_dir="/tmp")
+            sid = sm.session_id
+            sm.close()
+
+            metas = SessionManager.list_sessions()
+
+        assert any(m.id == sid for m in metas)
+
+    def test_record_user_persisted(self, tmp_path):
+        """record_user() inserts a user turn retrievable via load_turns."""
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm = _make_sm(tmp_path)
+            sm.record_user("hello")
+            sid = sm.session_id
+            sm.close()
+
+            turns = SessionManager.load_turns(sid)
+
+        assert len(turns) == 1
+        assert turns[0].role == "user"
+        assert turns[0].content == "hello"
+
+    def test_turns_returned_in_insertion_order(self, tmp_path):
+        """load_turns returns turns in insertion order."""
+        from nooa.interactive import AgentMessage
+
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm = _make_sm(tmp_path)
+            sm.record_user("first")
+            sm._handle.events.add(AgentMessage(content="reply"))
+            sm.record_user("second")
+            sid = sm.session_id
+            sm.close()
+
+            turns = SessionManager.load_turns(sid)
+
+        assert [t.content for t in turns] == ["first", "reply", "second"]
+
+    def test_load_turns_empty_for_missing_session(self, tmp_path):
+        """load_turns returns [] for a session_id that doesn't exist."""
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            turns = SessionManager.load_turns("nonexistent-id")
+        assert turns == []
+
+
+# ---------------------------------------------------------------------------
+# list_sessions
+# ---------------------------------------------------------------------------
+
+
+class TestListSessions:
+    def test_returns_empty_list_when_no_sessions(self, tmp_path):
+        """list_sessions returns [] when SESSIONS_DIR is empty."""
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            result = SessionManager.list_sessions()
+        assert result == []
+
+    def test_returns_sessions_sorted_newest_first(self, tmp_path):
+        """Sessions are returned sorted by last_active (file mtime) descending."""
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm_old = _make_sm(tmp_path)
+            sm_old.record_user("old")
+            sm_old.close()
+
+            # Ensure different mtime by bumping the new file's mtime
+            time.sleep(0.01)
+
+            sm_new = _make_sm(tmp_path)
+            sm_new.record_user("new")
+            sm_new.close()
+
+            sessions = SessionManager.list_sessions()
+
+        # newest (sm_new) should be first
+        ids = [s.id for s in sessions]
+        assert ids.index(sm_new.session_id) < ids.index(sm_old.session_id)
+
+    def test_turn_count_reflects_all_turns(self, tmp_path):
+        """list_sessions includes turn_count = number of user + agent turns."""
+        from nooa.interactive import AgentMessage
+
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm = _make_sm(tmp_path)
+            sm.record_user("one")
+            sm.record_user("two")
+            sm._handle.events.add(AgentMessage(content="reply"))
+            sid = sm.session_id
+            sm.close()
+
+            metas = SessionManager.list_sessions()
+
+        meta = next(m for m in metas if m.id == sid)
+        assert meta.turn_count == 3  # 2 user + 1 agent
+
+    def test_limit_is_respected(self, tmp_path):
+        """list_sessions(limit=N) returns at most N results."""
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            for _ in range(5):
+                sm = _make_sm(tmp_path)
+                sm.record_user("hi")
+                sm.close()
+
+            sessions = SessionManager.list_sessions(limit=2)
+
+        assert len(sessions) == 2
+
+
+# ---------------------------------------------------------------------------
+# rename / naming
+# ---------------------------------------------------------------------------
+
+
+class TestSessionManagerRename:
+    def test_rename_persists_name(self, tmp_path):
+        """rename() stores the name so it survives list_sessions()."""
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm = _make_sm(tmp_path)
+            sm.rename("My Session", user_named=True)
+            sid = sm.session_id
+            sm.close()
+
+            metas = SessionManager.list_sessions()
+
+        meta = next(m for m in metas if m.id == sid)
+        assert meta.name == "My Session"
+        assert meta.user_named is True
+
+    def test_rename_auto_does_not_set_user_named(self, tmp_path):
+        """rename(..., user_named=False) leaves user_named=False."""
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm = _make_sm(tmp_path)
+            sm.rename("auto name", user_named=False)
+            sid = sm.session_id
+            sm.close()
+
+            metas = SessionManager.list_sessions()
+
+        meta = next(m for m in metas if m.id == sid)
+        assert meta.name == "auto name"
+        assert meta.user_named is False
+
+
+# ---------------------------------------------------------------------------
+# close() idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestSessionManagerClose:
+    def test_close_is_idempotent(self, tmp_path):
+        """Calling close() twice must not raise and session should still be listable."""
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm = _make_sm(tmp_path, model="m", agent_cls="TUIAgent", working_dir="/tmp")
+            sid = sm.session_id
+            sm.close()
+            sm.close()  # second call must be a no-op
+
+            metas = SessionManager.list_sessions()
+        assert any(m.id == sid for m in metas)
+
+    def test_close_session_still_accessible(self, tmp_path):
+        """After close(), load_turns still works."""
+        before = time.time()
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm = _make_sm(tmp_path)
+            sm.record_user("test")
+            sid = sm.session_id
+            sm.close()
+
+            turns = SessionManager.load_turns(sid)
+        after = time.time()
+
+        assert turns[0].ts >= before
+        assert turns[0].ts <= after
+
+
+# ---------------------------------------------------------------------------
+# find_by_prefix
+# ---------------------------------------------------------------------------
+
+
+class TestFindByPrefix:
+    def test_finds_session_by_short_prefix(self, tmp_path):
+        """find_by_prefix returns the full ID matching a short prefix."""
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm = _make_sm(tmp_path)
+            sid = sm.session_id
+            sm.close()
+
+            matches = SessionManager.find_by_prefix(sid[:8])
+
+        assert matches == [sid]
+
+    def test_returns_empty_for_no_match(self, tmp_path):
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            matches = SessionManager.find_by_prefix("xxxxxxxx")
+        assert matches == []
+
+    def test_returns_multiple_for_ambiguous_prefix(self, tmp_path):
+        """When multiple sessions share a prefix, all are returned."""
+        sid1 = "prefix00-aaaa-0000-0000-000000000001"
+        sid2 = "prefix00-bbbb-0000-0000-000000000002"
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm1 = _make_sm(tmp_path, session_id=sid1)
+            sm1.close()
+            sm2 = _make_sm(tmp_path, session_id=sid2)
+            sm2.close()
+
+            matches = SessionManager.find_by_prefix("prefix00")
+
+        assert len(matches) == 2
+        assert sid1 in matches
+        assert sid2 in matches
+
+
+# ---------------------------------------------------------------------------
+# delete_session
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteSession:
+    def test_delete_removes_session_and_turns(self, tmp_path):
+        """delete_session() removes the DB file so the session disappears."""
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm = _make_sm(tmp_path)
+            sm.record_user("hi")
+            sid = sm.session_id
+            sm.close()
+
+            SessionManager.delete_session(sid)
+
+            metas = SessionManager.list_sessions()
+            turns = SessionManager.load_turns(sid)
+
+        assert not any(m.id == sid for m in metas)
+        assert turns == []
+
+    def test_delete_nonexistent_returns_false(self, tmp_path):
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            result = SessionManager.delete_session("does-not-exist")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# list_sessions sort stability
+# ---------------------------------------------------------------------------
+
+
+class TestListSessionsSortStability:
+    def test_sessions_sorted_newest_first(self, tmp_path):
+        """list_sessions returns sessions newest-first by file mtime."""
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm_a = _make_sm(tmp_path)
+            sm_a.record_user("a")
+            sid_a = sm_a.session_id
+            sm_a.close()
+
+            time.sleep(0.01)
+
+            sm_b = _make_sm(tmp_path)
+            sm_b.record_user("b")
+            sid_b = sm_b.session_id
+            sm_b.close()
+
+            time.sleep(0.01)
+
+            sm_c = _make_sm(tmp_path)
+            sm_c.record_user("c")
+            sid_c = sm_c.session_id
+            sm_c.close()
+
+            metas = SessionManager.list_sessions()
+
+        ids = [m.id for m in metas]
+        # c is newest, a is oldest
+        assert ids.index(sid_c) < ids.index(sid_b) < ids.index(sid_a)
+
+    def test_all_sessions_returned(self, tmp_path):
+        """list_sessions returns all sessions created in SESSIONS_DIR."""
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm1 = _make_sm(tmp_path)
+            sm1.close()
+            sm2 = _make_sm(tmp_path)
+            sm2.close()
+
+            metas = SessionManager.list_sessions()
+
+        # Both sessions should be present
+        assert len(metas) == 2

--- a/packages/nooa-cli/tests/tui/test_session_plumbing.py
+++ b/packages/nooa-cli/tests/tui/test_session_plumbing.py
@@ -1,0 +1,658 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for plumbing inside ``Session`` and ``TUIConsole``.
+
+These cover seams the post-landing test-coverage review flagged:
+
+- G4: ``_EmitStream`` must coalesce one ``Console.print`` into one
+  ``emit_block`` call (not one per chunk).
+- G5: ``TUIConsole.replace_console`` swaps the underlying Rich console.
+- G6: ``Session._cancel_background_tasks`` cancels and awaits every
+  tracked task and leaves the set empty.
+
+The style is direct construction with no prompt_toolkit / no harness —
+these components don't need an ``Application`` to be testable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from nooa_cli.tui.console import TUIConsole
+from nooa_cli.tui.session import _EmitStream
+from rich.console import Console
+from rich.table import Table
+
+
+def test_emit_stream_coalesces_one_print_into_one_emit_call() -> None:
+    """Rich writes many small chunks per ``Console.print``. ``_EmitStream``
+    must buffer until the trailing ``flush()`` and call ``emit`` exactly
+    once — otherwise each styled span pays a ``run_in_terminal`` hop."""
+    calls: list[str] = []
+    stream = _EmitStream(calls.append)
+
+    table = Table(title="test")
+    table.add_column("a")
+    table.add_column("b")
+    table.add_row("1", "2")
+    table.add_row("3", "4")
+
+    # Emulate what the redirected Rich console does: file=stream, print, flush.
+    Console(file=stream, force_terminal=True, color_system="256", width=80).print(table)
+
+    assert len(calls) == 1, f"expected 1 emit call, got {len(calls)}"
+    # And the coalesced block has the full table content.
+    assert "test" in calls[0]
+    assert "a" in calls[0] and "b" in calls[0]
+
+
+def test_emit_stream_empty_flush_is_noop() -> None:
+    """Flushing an empty buffer doesn't emit a stray empty block."""
+    calls: list[str] = []
+    stream = _EmitStream(calls.append)
+    stream.flush()
+    assert calls == []
+
+
+def test_emit_stream_multiple_prints_produce_multiple_emits() -> None:
+    """Each ``Console.print`` flushes at the end → one emit per print."""
+    calls: list[str] = []
+    stream = _EmitStream(calls.append)
+    c = Console(file=stream, force_terminal=True, color_system="256", width=80)
+    c.print("first")
+    c.print("second")
+    assert len(calls) == 2
+
+
+def test_tui_console_replace_console_swaps_underlying_console() -> None:
+    """``replace_console`` is the public seam Session uses to redirect
+    frontend output. A replaced console is what ``print_agent`` /
+    ``print_table`` / etc. end up writing to."""
+    tui = TUIConsole()
+    original = tui.console
+
+    # A StringIO-backed console so we can inspect what was written.
+    import io as _io
+
+    captured_file = _io.StringIO()
+    replacement = Console(file=captured_file, force_terminal=True, color_system="256", width=80)
+    tui.replace_console(replacement)
+
+    assert tui.console is replacement
+    assert tui.console is not original
+
+    # A call that routes through ``tui.console`` should land in our file.
+    tui.console.print("hello-from-replacement")
+    assert "hello-from-replacement" in captured_file.getvalue()
+
+
+async def test_session_cancel_background_tasks_cancels_and_clears() -> None:
+    """``_cancel_background_tasks`` cancels every tracked task, awaits
+    their cancellation, and empties the set."""
+    from nooa_cli.tui.session import Session
+
+    # Minimal Session stub — we only touch ``_background_tasks`` and
+    # ``_cancel_background_tasks``. Avoids the real Session's config/agent
+    # construction dance.
+    session = Session.__new__(Session)
+    session._background_tasks = set()
+
+    async def _long_running() -> None:
+        await asyncio.sleep(60)
+
+    t1 = asyncio.create_task(_long_running())
+    t2 = asyncio.create_task(_long_running())
+    session._background_tasks.update({t1, t2})
+
+    await session._cancel_background_tasks()
+
+    assert session._background_tasks == set()
+    assert t1.cancelled() and t2.cancelled()
+
+
+async def test_session_cancel_background_tasks_is_safe_when_empty() -> None:
+    """No tracked tasks → the helper returns immediately; no errors."""
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session._background_tasks = set()
+
+    await session._cancel_background_tasks()
+    assert session._background_tasks == set()
+
+
+def test_print_exit_message_includes_name_and_short_hash(capsys) -> None:
+    """When the session has a name and id, the exit message tags both
+    in the form ``name [first8charsofhash]`` — same shape as the
+    session-label rendered above the input bar."""
+    from unittest.mock import Mock
+
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session._session_manager = Mock()
+    session._session_manager.session_id = "abc1234567890def"
+    session._session_manager.name = "my-debug-run"
+
+    session._print_exit_message()
+    err = capsys.readouterr().err
+    assert "Goodbye! Stay vibing." in err
+    assert "my-debug-run [abc12345]" in err
+
+
+def test_print_exit_message_short_hash_only_when_name_missing(capsys) -> None:
+    """Unnamed sessions still get the bracketed short-hash tag."""
+    from unittest.mock import Mock
+
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session._session_manager = Mock()
+    session._session_manager.session_id = "deadbeefcafebabe"
+    session._session_manager.name = None
+
+    session._print_exit_message()
+    err = capsys.readouterr().err
+    assert "Goodbye! Stay vibing. — [deadbeef]" in err
+
+
+def test_print_exit_message_no_session_manager(capsys) -> None:
+    """Sessions without a session_manager still get the goodbye line,
+    just without a tag."""
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session._session_manager = None
+
+    session._print_exit_message()
+    err = capsys.readouterr().err
+    assert "Goodbye! Stay vibing." in err
+    # Strip ANSI before checking for absence of a bracketed session tag.
+    import re
+
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", err)
+    assert "[" not in plain  # no bracketed tag
+
+
+async def test_session_on_user_message_fires_when_dispatcher_dequeues() -> None:
+    """Regression guard for the original bug: the user-bar echo wiring
+    used to assign to ``self._app.on_user_message``, an attribute that
+    nothing reads. The fix installs a hook on
+    the channel's ``on_get`` hook, so the echo fires when the
+    dispatcher dequeues the message.
+    """
+    from unittest.mock import Mock, patch
+
+    from nooa_cli.tui.session import Session
+
+    from nooa.runtime.channels import Channel
+
+    session = Session.__new__(Session)
+    session._renderer = Mock()
+    session._app = Mock()
+    session._app.color_depth = 8
+    session._session_manager = Mock()
+    session._session_manager.user_named = True  # skip auto-name path
+    session._first_message = None
+    # _colors is a read-only property that reads the global theme; no setup needed.
+
+    queue: Channel[str] = Channel("user_messages", "queue")
+
+    # The real hook does record_user (DB) then routes to _on_user_message_ui (UI).
+    def _combined_hook(text: str) -> None:
+        session._session_manager.record_user(text)
+        session._on_user_message_ui(text)
+
+    queue.set_on_get(_combined_hook)
+
+    queue.put("hi from dispatcher")
+    with patch("nooa_cli.tui.session._build_user_bar", return_value="BAR"):
+        item = await queue.get()
+    assert item == "hi from dispatcher"
+
+    session._session_manager.record_user.assert_called_once_with("hi from dispatcher")
+    session._renderer.reset_turn.assert_called_once()
+    session._app.emit_block.assert_called_once_with("BAR")
+
+
+async def test_session_on_user_message_fires_for_mid_turn_dequeue() -> None:
+    """Symmetry: ``on_get`` lives on the queue (not the dispatcher loop)
+    precisely so the echo fires when the agent drains mid-turn via
+    ``await self.user_messages.get()`` — not just when the dispatcher
+    dequeues. If a future refactor moves the call into the dispatcher
+    loop, the mid-turn drain path silently drops user-bar / SessionUserMessage.
+    """
+    from unittest.mock import Mock, patch
+
+    from nooa_cli.tui.session import Session
+
+    from nooa.runtime.channels import Channel
+
+    session = Session.__new__(Session)
+    session._renderer = Mock()
+    session._app = Mock()
+    session._app.color_depth = 8
+    session._session_manager = Mock()
+    session._session_manager.user_named = True
+    session._first_message = None
+    # _colors is a read-only property that reads the global theme; no setup needed.
+
+    inq: Channel[str] = Channel("user_messages", "queue")
+
+    # The real hook does record_user (DB) then routes to _on_user_message_ui (UI).
+    def _combined_hook(text: str) -> None:
+        session._session_manager.record_user(text)
+        session._on_user_message_ui(text)
+
+    inq.set_on_get(_combined_hook)
+    # Mid-turn drain goes through the read facade, the same surface
+    # the LLM uses.
+    reader = inq.reader
+
+    inq.put("clarification")
+    with patch("nooa_cli.tui.session._build_user_bar", return_value="BAR"):
+        item = await reader.get()
+    assert item == "clarification"
+
+    # Must fire exactly once — symmetric with the dispatcher path.
+    session._session_manager.record_user.assert_called_once_with("clarification")
+    session._renderer.reset_turn.assert_called_once()
+    session._app.emit_block.assert_called_once_with("BAR")
+
+
+async def test_session_cancel_background_tasks_skips_done_tasks() -> None:
+    """Tasks that already finished aren't cancelled (a no-op), but the
+    set is still cleared."""
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session._background_tasks = set()
+
+    async def _noop() -> None:
+        return
+
+    t = asyncio.create_task(_noop())
+    await t  # task completes before cancel_background_tasks runs
+    session._background_tasks.add(t)
+
+    await session._cancel_background_tasks()
+    assert session._background_tasks == set()
+    assert not t.cancelled()  # done tasks aren't flipped to cancelled
+
+
+async def test_on_command_clear_cancels_agent_task() -> None:
+    """``/clear`` while the agent is mid-turn must cancel ``_agent_task``
+    so the old turn doesn't keep running in the stale session."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nooa_cli.tui.commands import CommandResult
+    from nooa_cli.tui.output import ClearScreen
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session._first_message = "hello"
+    session._background_tasks = set()
+    session._emit_console = None
+
+    agent = MagicMock()
+    agent._storage = MagicMock()
+    agent.event_manager = MagicMock()
+    agent.event_manager.set_backend = MagicMock()
+    agent.queue_manager = MagicMock()
+    agent.queue_manager.shutdown = AsyncMock()
+    agent.queue_manager._channels = {}
+    agent.queue_manager.names = MagicMock(return_value=[])
+    session.agent = agent
+
+    registry = MagicMock()
+    registry.commands = MagicMock(return_value=[])
+    session.registry = registry
+    session._session_manager = MagicMock()
+    session._session_manager.close = MagicMock()
+
+    # Simulate a running agent task
+    async def _fake_agent_work():
+        await asyncio.sleep(999)
+
+    fake_task = asyncio.ensure_future(_fake_agent_work())
+
+    app = MagicMock()
+    app._agent_task = fake_task
+
+    async def _cancel_agent_turn(*, source: str = "session") -> bool:
+        assert source == "session"
+        fake_task.cancel()
+        try:
+            await fake_task
+        except asyncio.CancelledError:
+            pass
+        return True
+
+    app.cancel_agent_turn = AsyncMock(side_effect=_cancel_agent_turn)
+    session._app = app
+    session._emit_text = MagicMock()
+
+    # Make _handler.handle return a result with new_session_manager
+    new_sm = MagicMock()
+    new_sm.session_id = "new-session-id"
+    new_sm._storage = MagicMock()
+
+    fake_result = CommandResult(success=True, outputs=[ClearScreen()])
+    fake_result.new_session_manager = new_sm
+
+    handler = MagicMock()
+    handler.handle = AsyncMock(return_value=fake_result)
+    session._handler = handler
+
+    # Mock _swap_session_manager so it doesn't try real session operations
+    session._swap_session_manager = AsyncMock()
+
+    await session._on_command("/clear")
+
+    app.cancel_agent_turn.assert_awaited_once_with(source="session")
+    assert fake_task.cancelled(), (
+        f"_agent_task not cancelled; done={fake_task.done()}, cancelled={fake_task.cancelled()}"
+    )
+    assert session._first_message is None, "_first_message not reset after /clear"
+    session._swap_session_manager.assert_awaited_once_with(new_sm)
+
+
+async def test_on_command_clear_without_running_task() -> None:
+    """``/clear`` when no agent task is running must not crash."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nooa_cli.tui.commands import CommandResult
+    from nooa_cli.tui.output import ClearScreen
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session._first_message = "hello"
+    session._background_tasks = set()
+
+    agent = MagicMock()
+    agent._storage = MagicMock()
+    agent.event_manager = MagicMock()
+    agent.event_manager.set_backend = MagicMock()
+    agent.queue_manager = MagicMock()
+    agent.queue_manager.shutdown = AsyncMock()
+    agent.queue_manager._channels = {}
+    agent.queue_manager.names = MagicMock(return_value=[])
+    session.agent = agent
+
+    registry = MagicMock()
+    registry.commands = MagicMock(return_value=[])
+    session.registry = registry
+    session._session_manager = MagicMock()
+    session._session_manager.close = MagicMock()
+
+    app = MagicMock()
+    app._agent_task = None  # no running task
+    app.cancel_agent_turn = AsyncMock(return_value=False)
+    session._app = app
+    session._emit_text = MagicMock()
+
+    new_sm = MagicMock()
+    new_sm.session_id = "new-session-id"
+    new_sm._storage = MagicMock()
+
+    fake_result = CommandResult(success=True, outputs=[ClearScreen()])
+    fake_result.new_session_manager = new_sm
+
+    handler = MagicMock()
+    handler.handle = AsyncMock(return_value=fake_result)
+    session._handler = handler
+
+    # Mock _swap_session_manager so it doesn't try real session operations
+    session._swap_session_manager = AsyncMock()
+
+    # Must not raise
+    await session._on_command("/clear")
+    app.cancel_agent_turn.assert_awaited_once_with(source="session")
+    assert session._first_message is None
+
+
+async def test_run_command_runs_post_session_swap_on_agent_loop() -> None:
+    """Session-owned post-swap mutations must go through agent_run_async."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nooa_cli.tui.commands import CommandResult
+    from nooa_cli.tui.output import ClearScreen, TextOutput
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session._first_message = "hello"
+    session.agent = MagicMock()
+    session.registry = MagicMock()
+    session.registry.commands = MagicMock(return_value=[])
+    session._session_manager = MagicMock()
+    session._emit_text = MagicMock()
+
+    calls: list[str] = []
+
+    async def _agent_run_async(fn):
+        calls.append("agent_run_async")
+        value = fn()
+        if hasattr(value, "__await__"):
+            value = await value
+        return value
+
+    app = MagicMock()
+    app.cancel_agent_turn = AsyncMock(return_value=True)
+    app.agent_run_async = AsyncMock(side_effect=_agent_run_async)
+    session._app = app
+
+    new_sm = MagicMock()
+    fake_result = CommandResult(success=True, outputs=[ClearScreen()])
+    fake_result.new_session_manager = new_sm
+
+    async def _post_swap():
+        calls.append("post_swap")
+        return [TextOutput("post swap done", "status")]
+
+    fake_result.post_session_swap = _post_swap
+    handler = MagicMock()
+    handler.handle = AsyncMock(return_value=fake_result)
+    session._handler = handler
+    session._swap_session_manager = AsyncMock()
+
+    render_callback = await session._run_command("/clear")
+
+    app.cancel_agent_turn.assert_awaited_once_with(source="session")
+    session._swap_session_manager.assert_awaited_once_with(new_sm)
+    app.agent_run_async.assert_awaited_once()
+    assert calls == ["agent_run_async", "post_swap"]
+    assert any(getattr(o, "content", None) == "post swap done" for o in fake_result.outputs)
+    assert render_callback is not None
+
+
+async def test_run_command_marks_session_transition_while_cancelling() -> None:
+    """Session commands suppress cancelled-turn UX until the swap completes."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nooa_cli.tui.commands import CommandResult
+    from nooa_cli.tui.output import ClearScreen
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session._first_message = "hello"
+    session.agent = MagicMock()
+    session.registry = MagicMock()
+    session.registry.commands = MagicMock(return_value=[])
+    session._session_manager = MagicMock()
+    session._emit_text = MagicMock()
+
+    app = MagicMock()
+    app._session_transitioning = False
+
+    async def _cancel_agent_turn(*, source: str) -> bool:
+        assert source == "session"
+        assert app._session_transitioning is True
+        return True
+
+    async def _swap_session_manager(_new_sm) -> None:
+        assert app._session_transitioning is True
+
+    app.cancel_agent_turn = AsyncMock(side_effect=_cancel_agent_turn)
+    app.agent_run_async = AsyncMock()
+    session._app = app
+
+    new_sm = MagicMock()
+    fake_result = CommandResult(success=True, outputs=[ClearScreen()])
+    fake_result.new_session_manager = new_sm
+
+    handler = MagicMock()
+    handler.handle = AsyncMock(return_value=fake_result)
+    session._handler = handler
+    session._swap_session_manager = AsyncMock(side_effect=_swap_session_manager)
+
+    await session._run_command("/clear")
+
+    assert app._session_transitioning is False
+    app.cancel_agent_turn.assert_awaited_once_with(source="session")
+    session._swap_session_manager.assert_awaited_once_with(new_sm)
+
+
+async def test_on_command_slash_result_posts_to_queue_without_double_submit() -> None:
+    """A slash command returning a result must be delivered to the agent
+    exactly once. ``_on_command`` posts the ``SlashCommandResult`` to the
+    ``slash_commands`` queue, which already wakes the dispatcher — it must
+    NOT also re-submit the same text as a user message (that delivered the
+    command twice: once on each queue)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nooa_cli.tui.commands import CommandResult
+    from nooa_cli.tui.session import Session
+
+    from nooa.slash_dispatch import SlashCommandResult
+
+    session = Session.__new__(Session)
+    session._first_message = None
+    session._session_manager = None
+
+    slash_ch = MagicMock()
+    agent = MagicMock()
+    agent._slash_commands_in = slash_ch
+    session.agent = agent
+
+    app = MagicMock()
+    app._agent_task = None
+    session._app = app
+    session._emit_text = MagicMock()
+    frontend = MagicMock()
+    frontend.render = AsyncMock()
+    session.frontend = frontend
+
+    sr = SlashCommandResult(command="status", args="", value={"ok": True}, text="status: ok")
+    fake_result = CommandResult(success=True, outputs=[])
+    fake_result.slash_result = sr
+
+    handler = MagicMock()
+    handler.handle = AsyncMock(return_value=fake_result)
+    session._handler = handler
+
+    await session._on_command("/status")
+
+    slash_ch.put.assert_called_once_with(sr)
+    app.submit_message.assert_not_called()
+
+
+async def test_on_command_slash_result_renders_via_frontend_markdown() -> None:
+    """Slash results should render through the frontend, not raw emit_block text.
+
+    This lets Markdown tables from commands like /mesh-list render properly.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nooa_cli.tui.commands import CommandResult
+    from nooa_cli.tui.output import AgentMessage
+    from nooa_cli.tui.session import Session
+
+    from nooa.slash_dispatch import SlashCommandResult
+
+    session = Session.__new__(Session)
+    session._first_message = None
+    session._session_manager = None
+
+    slash_ch = MagicMock()
+    agent = MagicMock()
+    agent._slash_commands_in = slash_ch
+    session.agent = agent
+
+    app = MagicMock()
+    app._agent_task = None
+    session._app = app
+    session._emit_text = MagicMock()
+
+    frontend = MagicMock()
+    frontend.render = AsyncMock()
+    session.frontend = frontend
+
+    text = "| handle | status |\n|---|---|\n| `alice` | online |"
+    sr = SlashCommandResult(command="mesh-list", args="", value=text, text=text)
+    fake_result = CommandResult(success=True, outputs=[])
+    fake_result.slash_result = sr
+
+    handler = MagicMock()
+    handler.handle = AsyncMock(return_value=fake_result)
+    session._handler = handler
+
+    await session._on_command("/mesh-list")
+
+    rendered_agent_messages = [
+        call.args[0]
+        for call in frontend.render.await_args_list
+        if isinstance(call.args[0], AgentMessage)
+    ]
+    assert len(rendered_agent_messages) == 1
+    rendered = rendered_agent_messages[0]
+    assert rendered.content == text
+    assert rendered.show_rule is False
+    app.emit_block.assert_not_called()
+    slash_ch.put.assert_called_once_with(sr)
+
+
+async def test_on_command_slash_result_warns_and_drops_when_no_slash_channel() -> None:
+    """Strict routing: a slash result travels ONLY the slash_commands
+    channel. If ``self.agent`` has no ``_slash_commands_in`` (a non-TUI
+    agent, a partially-initialized object, a test double), there is no
+    slash-capable destination — the result must be dropped with a loud
+    scrollback warning, NEVER funneled through ``submit_message`` /
+    ``user_messages`` where it would masquerade as a typed user message.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nooa_cli.tui.commands import CommandResult
+    from nooa_cli.tui.session import Session
+
+    from nooa.slash_dispatch import SlashCommandResult
+
+    session = Session.__new__(Session)
+    session._first_message = None
+    session._session_manager = None
+
+    agent = MagicMock(spec=[])  # no _slash_commands_in attribute
+    session.agent = agent
+
+    app = MagicMock()
+    app._agent_task = None
+    session._app = app
+    session._emit_text = MagicMock()
+    frontend = MagicMock()
+    frontend.render = AsyncMock()
+    session.frontend = frontend
+
+    sr = SlashCommandResult(command="status", args="", value=None, text="status: ok")
+    fake_result = CommandResult(success=True, outputs=[])
+    fake_result.slash_result = sr
+
+    handler = MagicMock()
+    handler.handle = AsyncMock(return_value=fake_result)
+    session._handler = handler
+
+    await session._on_command("/status")
+
+    # NEVER routed through the user-message path.
+    app.submit_message.assert_not_called()
+    # A loud warning is emitted to scrollback naming the dropped command.
+    warned = " ".join(str(c.args[0]) for c in session._emit_text.call_args_list if c.args)
+    assert "slash_commands" in warned and "status" in warned

--- a/packages/nooa-cli/tests/tui/test_session_resumed_event.py
+++ b/packages/nooa-cli/tests/tui/test_session_resumed_event.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""SessionResumed is emitted after agent reconstitution."""
+
+import pytest
+from nooa_cli.tui.bootstrap import bootstrap
+from nooa_cli.tui.config import Config
+
+from nooa.sessions import SessionResumed
+
+
+def test_event_is_runtime_role_and_fields():
+    e = SessionResumed(session_id="abc", restored=True)
+    assert e.session_id == "abc"
+    assert e.restored is True
+    # Runtime events never enter conversation/LLM context.
+    from nooa.context_blocks.models import Role
+
+    assert type(e)._role is Role.RUNTIME_EVENT
+
+
+def test_event_keeps_legacy_handler_alias():
+    assert SessionResumed.handler_aliases == ("TuiSessionResumed",)
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_emits_event_to_subscribers_on_fresh_session(tmp_path, monkeypatch):
+    """SessionResumed is a runtime event (emit-only) — observe it via on().
+
+    Runtime events are never recorded/queryable, so a skill must subscribe with
+    event_manager.on("SessionResumed", handler) — which is exactly how
+    agent_mesh will auto-reconnect. We assert the handler fires once with the
+    right payload.
+
+    Because bootstrap() emits during construction (before we can subscribe), we
+    re-emit through the same manager to exercise the subscriber path the skills
+    use, and separately assert bootstrap reached the emit (no exception, agent
+    built with a session_id).
+    """
+    from nooa_cli.tui import session_manager as session_manager_module
+
+    monkeypatch.setattr(session_manager_module, "SESSIONS_DIR", tmp_path)
+
+    result = await bootstrap(Config())
+    agent = result.agent
+    assert result.session_id is not None
+
+    seen = []
+    agent.event_manager.register_event_type(SessionResumed)
+    agent.event_manager.on("SessionResumed", lambda e: seen.append(e))
+
+    agent.event_manager.add(SessionResumed(session_id=result.session_id, restored=False))
+
+    assert len(seen) == 1
+    assert seen[0].restored is False
+    assert seen[0].session_id == result.session_id
+    await agent.close()
+    result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_on_handler_receives_event():
+    """A subscriber registered before emit receives the event (the skill path)."""
+    from nooa import Agent
+    from nooa.unifiedllm import FakeLLMClient
+
+    class _A(Agent, llm=FakeLLMClient()):
+        pass
+
+    agent = _A()
+    agent.event_manager.register_event_type(SessionResumed)
+    got = []
+    agent.event_manager.on("SessionResumed", lambda e: got.append((e.session_id, e.restored)))
+    agent.event_manager.add(SessionResumed(session_id="sess-1", restored=True))
+    assert got == [("sess-1", True)]
+
+
+@pytest.mark.asyncio
+async def test_resume_without_snapshot_emits_restored_false(tmp_path, monkeypatch):
+    """-c on a session with no snapshot must emit restored=False, not True.
+
+    The emit now happens in build_registry() (after skills attach), so we drive
+    that path and capture the event it emits via a real subscriber.
+    """
+    from unittest.mock import MagicMock
+
+    from nooa_cli.tui import session_manager as session_manager_module
+    from nooa_cli.tui.bootstrap import build_registry
+
+    monkeypatch.setattr(session_manager_module, "SESSIONS_DIR", tmp_path)
+
+    # Fresh session first (resumable id, zero snapshots), then resume it:
+    # bootstrap restores nothing -> build_registry must emit restored=False.
+    first = await bootstrap(Config())
+    sid = first.session_id
+    await first.agent.close()
+    first.session_manager.close()
+
+    resumed = await bootstrap(Config(), resume_session_id=sid)
+    assert resumed.restored is False  # no snapshot was applied
+
+    captured: list = []
+    resumed.agent.event_manager.register_event_type(SessionResumed)
+    resumed.agent.event_manager.on("SessionResumed", lambda e: captured.append(e))
+
+    build_registry(resumed, MagicMock())
+
+    assert len(captured) == 1, f"expected one resume emit, got {captured!r}"
+    assert captured[0].restored is False
+    await resumed.agent.close()
+    resumed.session_manager.close()

--- a/packages/nooa-cli/tests/tui/test_session_resumed_event.py
+++ b/packages/nooa-cli/tests/tui/test_session_resumed_event.py
@@ -3,10 +3,9 @@
 """SessionResumed is emitted after agent reconstitution."""
 
 import pytest
+from nooa_cli.sessions import SessionResumed
 from nooa_cli.tui.bootstrap import bootstrap
 from nooa_cli.tui.config import Config
-
-from nooa.sessions import SessionResumed
 
 
 def test_event_is_runtime_role_and_fields():

--- a/packages/nooa-cli/tests/tui/test_session_rule_width.py
+++ b/packages/nooa-cli/tests/tui/test_session_rule_width.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: the session rule must never occupy the terminal's final column.
+
+A full-bleed rule wraps the cursor to the next row; when run_in_terminal
+(emit_block) repaints this non-full-screen app after a SIGWINCH resize,
+prompt_toolkit's erase is sized to the pre-resize frame and leaves a stale
+rule (of the old width) plus a blank gap line in the scrollback. Repeated
+resizes stack these into the "resize clutter" the status bar showed.
+
+See ``format_session_rule`` in ``tui_application``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from nooa_cli.tui.tui_application import format_session_rule
+
+
+def _rendered_width(fragments: list[tuple[str, str]]) -> int:
+    return sum(len(text) for _style, text in fragments)
+
+
+@pytest.mark.parametrize("cols", [20, 21, 40, 80, 81, 120, 200])
+def test_rule_never_occupies_final_column_no_label(cols: int) -> None:
+    """Without a label the rule must be strictly narrower than the terminal."""
+    width = _rendered_width(format_session_rule(cols, ""))
+    assert width == cols - 1, f"cols={cols}: rule width {width} != {cols - 1}"
+    assert width < cols, f"cols={cols}: rule must not span the final column"
+
+
+@pytest.mark.parametrize("cols", [20, 40, 80, 120, 200])
+@pytest.mark.parametrize("label", ["", "12:00 · opus · ctx 31% · Session [abc123]", "x"])
+def test_rule_never_occupies_final_column_with_label(cols: int, label: str) -> None:
+    """With any label the rendered fragments must still fit in cols-1."""
+    width = _rendered_width(format_session_rule(cols, label))
+    assert width <= cols - 1, (
+        f"cols={cols} label={label!r}: rendered width {width} exceeds cols-1={cols - 1}"
+    )
+
+
+def test_rule_degenerate_narrow_terminal() -> None:
+    """A pathologically narrow terminal never produces a negative/zero width."""
+    for cols in (1, 2, 3):
+        frags = format_session_rule(cols, "")
+        assert _rendered_width(frags) >= 1
+        # And with a label longer than the terminal, it still renders something.
+        frags = format_session_rule(cols, "a-very-long-label")
+        assert _rendered_width(frags) >= 1
+
+
+@pytest.mark.parametrize("cols", range(20, 130))
+def test_rule_never_full_bleed_for_any_label_length(cols: int) -> None:
+    """Brute-force the never-full-bleed invariant across every label length.
+
+    Regression for the off-by-one where ``len(label) == cols - 2`` made the
+    dash fill round back up to 1 and the line re-occupied the final column.
+    """
+    for length in range(0, cols + 3):
+        width = _rendered_width(format_session_rule(cols, "x" * length))
+        assert width < cols, (
+            f"cols={cols} label_len={length}: width {width} occupies the final column"
+        )
+
+
+def test_rule_label_is_preserved() -> None:
+    """The label text is rendered verbatim (only the dash fill is clamped)."""
+    label = "ctx 50% · Sess [deadbeef]"
+    frags = format_session_rule(120, label)
+    rendered = "".join(text for _style, text in frags)
+    assert label in rendered

--- a/packages/nooa-cli/tests/tui/test_settings.py
+++ b/packages/nooa-cli/tests/tui/test_settings.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :mod:`nooa_cli.tui.settings`.
+
+Settings live in layered ``settings.yaml`` files (user → project →
+``NEMO_OO_SETTINGS``), discovered through the shared
+:func:`nooa.layered_config.load_layered_yaml` helper, and
+round-trip with :func:`dump_settings`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from nooa_cli.tui.config import Config
+from nooa_cli.tui.settings import (
+    dump_settings,
+    load_settings,
+    settings_present,
+    settings_to_dict,
+)
+
+
+@pytest.fixture
+def user_dir(tmp_path, monkeypatch):
+    d = tmp_path / "user"
+    d.mkdir()
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(d))
+    return d
+
+
+@pytest.fixture
+def project_dir(tmp_path, monkeypatch):
+    d = tmp_path / "project"
+    d.mkdir()
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(d))
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("NEMO_OO_SETTINGS", raising=False)
+
+
+class TestRoundTrip:
+    def test_defaults_round_trip(self, user_dir, project_dir):
+        """dump → load yields the same persistable fields as the defaults."""
+        original = Config()
+        (user_dir / "settings.yaml").write_text(dump_settings(original))
+        loaded = load_settings(Config())
+        assert settings_to_dict(loaded) == settings_to_dict(original)
+
+    def test_modified_round_trip(self, user_dir, project_dir):
+        original = Config()
+        original.tui.default_model = "my-model"
+        original.tui.vi_mode = True
+        original.tui.toolbar_items = ["model", "cwd", "session"]
+        original.agent.working_dir = "/tmp"
+        original.agent.summarization.preserve_recent = 123
+        (user_dir / "settings.yaml").write_text(dump_settings(original))
+        loaded = load_settings(Config())
+        assert loaded.tui.default_model == "my-model"
+        assert loaded.tui.vi_mode is True
+        assert loaded.tui.toolbar_items == ["model", "cwd", "session"]
+        assert loaded.agent.working_dir == "/tmp"
+        assert loaded.agent.summarization.preserve_recent == 123
+
+    def test_dump_omits_computed_skills_dirs(self):
+        data = settings_to_dict(Config())
+        assert "skills_dirs" not in data["tui"]
+        assert "no_splash" not in data
+        assert "no_trace" not in data
+
+
+class TestLayering:
+    def test_project_overrides_user(self, user_dir, project_dir):
+        (user_dir / "settings.yaml").write_text("tui:\n  default_model: user-model\n")
+        (project_dir / "settings.yaml").write_text("tui:\n  default_model: project-model\n")
+        loaded = load_settings(Config())
+        assert loaded.tui.default_model == "project-model"
+
+    def test_env_overrides_all(self, user_dir, project_dir, tmp_path, monkeypatch):
+        (user_dir / "settings.yaml").write_text("tui:\n  default_model: user-model\n")
+        (project_dir / "settings.yaml").write_text("tui:\n  default_model: project-model\n")
+        env_file = tmp_path / "env.yaml"
+        env_file.write_text("tui:\n  default_model: env-model\n")
+        monkeypatch.setenv("NEMO_OO_SETTINGS", str(env_file))
+        loaded = load_settings(Config())
+        assert loaded.tui.default_model == "env-model"
+
+    def test_null_deletes_lower_layer_key(self, user_dir, project_dir):
+        (user_dir / "settings.yaml").write_text("tui:\n  agent_spec: foo\n")
+        (project_dir / "settings.yaml").write_text("tui:\n  agent_spec: null\n")
+        loaded = load_settings(Config())
+        # null removed the key from the merged dict → field keeps its default.
+        assert loaded.tui.agent_spec is None
+
+    def test_path_coercion(self, user_dir, project_dir):
+        (user_dir / "settings.yaml").write_text("tui:\n  mcp_file: custom.mcp.json\n")
+        loaded = load_settings(Config())
+        assert loaded.tui.mcp_file == Path("custom.mcp.json")
+
+
+class TestPresence:
+    def test_absent(self, user_dir, project_dir):
+        assert settings_present() is False
+
+    def test_present_when_user_file_exists(self, user_dir, project_dir):
+        (user_dir / "settings.yaml").write_text("tui:\n  vi_mode: true\n")
+        assert settings_present() is True
+
+    def test_dump_is_valid_yaml(self):
+        text = dump_settings(Config())
+        parsed = yaml.safe_load(text)
+        assert "tui" in parsed and "agent" in parsed
+
+    def test_toolbar_items_round_trip(self, user_dir, project_dir):
+        original = Config()
+        original.tui.toolbar_items = ["cwd", "model"]
+        (user_dir / "settings.yaml").write_text(dump_settings(original))
+        loaded = load_settings(Config())
+        assert loaded.tui.toolbar_items == ["cwd", "model"]
+
+    def test_keep_going_round_trip(self, user_dir, project_dir):
+        original = Config()
+        original.tui.keep_going = True
+        original.tui.keep_going_model = "audit-model"
+        (user_dir / "settings.yaml").write_text(dump_settings(original))
+        loaded = load_settings(Config())
+        assert loaded.tui.keep_going is True
+        assert loaded.tui.keep_going_model == "audit-model"

--- a/packages/nooa-cli/tests/tui/test_slash_command_hot_reload.py
+++ b/packages/nooa-cli/tests/tui/test_slash_command_hot_reload.py
@@ -1,0 +1,130 @@
+"""Test that slash command hot-reload picks up new code after SkillRegistry.reload()."""
+
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+
+from nooa.skill import Skill, slash_command
+from nooa.skill_registry import SkillRegistry
+
+
+def _make_skill_class(version: str):
+    """Create a Skill subclass dynamically with a slash command."""
+    ns = {"Skill": Skill, "slash_command": slash_command}
+    exec(
+        f"""
+class TestSkill(Skill):
+    @slash_command("greet", argument_hint="<name>")
+    def greet(self, args: str) -> str:
+        return "{version}: " + args
+""",
+        ns,
+    )
+    cls = ns["TestSkill"]
+    cls.__module__ = "test_hot_skill"
+    return cls
+
+
+def test_stale_slash_command_without_refresh():
+    """Prove the bug: after replacing a skill, CommandRegistry holds stale method refs.
+
+    Without calling refresh_skill_commands(), the _user_skills dict still
+    references the old bound method from the previous skill instance.
+    """
+    from nooa_cli.tui.commands import CommandRegistry
+
+    class FakeAgent:
+        pass
+
+    agent = FakeAgent()
+
+    # Create v1 skill
+    SkillV1 = _make_skill_class("v1")
+    skill_v1 = SkillV1()
+    agent.test_hot_skill = skill_v1
+
+    # Create command registry and discover initial commands
+    cmd_registry = CommandRegistry.__new__(CommandRegistry)
+    cmd_registry.agent = agent
+    cmd_registry._commands = {}
+    cmd_registry._user_skills = {}
+    cmd_registry.skills_dirs = []
+
+    fresh = cmd_registry._discover_skill_commands()
+    cmd_registry._user_skills.update(fresh)
+
+    assert "greet" in cmd_registry._user_skills
+    assert cmd_registry._user_skills["greet"]._method("world") == "v1: world"
+
+    # Replace skill with v2 (as _reload_one does via setattr)
+    SkillV2 = _make_skill_class("v2")
+    skill_v2 = SkillV2()
+    agent.test_hot_skill = skill_v2
+
+    # BUG: Without refresh, the command still uses v1's method
+    stale = cmd_registry._user_skills["greet"]._method("world")
+    assert stale == "v1: world", "Sanity check: without refresh, method is stale"
+
+    # After refresh, it should use v2
+    cmd_registry.refresh_skill_commands()
+    fresh_result = cmd_registry._user_skills["greet"]._method("world")
+    assert fresh_result == "v2: world"
+
+
+@pytest.mark.asyncio
+async def test_skill_registry_reload_one_calls_refresh():
+    """_reload_one should trigger refresh_skill_commands on the CommandRegistry.
+
+    This test verifies the fix: after _reload_one replaces the skill instance,
+    it should call agent._command_registry.refresh_skill_commands().
+    """
+
+    class FakeAgent:
+        pass
+
+    agent = FakeAgent()
+    registry = SkillRegistry(agent)
+
+    # Create initial skill
+    SkillV1 = _make_skill_class("v1")
+    skill_v1 = SkillV1()
+    agent.test_hot_skill = skill_v1
+    registry._attr_map["local.test_hot_skill"] = "test_hot_skill"
+    registry._loaded.add("local.test_hot_skill")
+
+    # Track whether refresh_skill_commands was called
+    refresh_called = []
+
+    class FakeCommandRegistry:
+        def refresh_skill_commands(self):
+            refresh_called.append(True)
+
+    agent._command_registry = FakeCommandRegistry()
+
+    # Patch importlib.import_module so _reload_one can "reimport" our fake module
+    SkillV2 = _make_skill_class("v2")
+    mod_v2 = types.ModuleType("test_hot_skill")
+    mod_v2.__file__ = "/fake/test_hot_skill/__init__.py"
+    mod_v2.TestSkill = SkillV2
+
+    # Put v1 module in sys.modules first (so _reload_one can find module name)
+    mod_v1 = types.ModuleType("test_hot_skill")
+    mod_v1.TestSkill = SkillV1
+    sys.modules["test_hot_skill"] = mod_v1
+
+    def fake_import(name):
+        sys.modules[name] = mod_v2
+        return mod_v2
+
+    with patch("importlib.import_module", side_effect=fake_import):
+        result = await registry._reload_one("local.test_hot_skill")
+
+    # Cleanup
+    sys.modules.pop("test_hot_skill", None)
+
+    assert "Reloaded" in result, f"Reload failed: {result}"
+    assert refresh_called, (
+        "refresh_skill_commands was NOT called after _reload_one — this is the bug"
+    )

--- a/packages/nooa-cli/tests/tui/test_stream_forwarder.py
+++ b/packages/nooa-cli/tests/tui/test_stream_forwarder.py
@@ -1,0 +1,320 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``_StrayStreamForwarder`` and ``install_stray_stream_capture``.
+
+The forwarder has to do three things reliably:
+
+1. Emit each complete line through ``emit_block``, styled so stdout and
+   stderr are visually distinct in the transcript.
+2. Buffer partial lines and hold them until the next ``\\n`` or an
+   explicit ``flush()`` so progress-bar / streaming-log writes don't
+   splatter mid-line into the queue.
+3. Install and uninstall symmetrically so nothing leaks into subsequent
+   tests or into the terminal after the TUI exits.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+from nooa_cli.tui.stream_forwarder import (
+    _StrayStreamForwarder,
+    install_stray_stream_capture,
+)
+
+
+def _mk(prefix: str = "· ", color: str = "2") -> tuple[_StrayStreamForwarder, list[str]]:
+    emitted: list[str] = []
+    original = io.StringIO()
+    fw = _StrayStreamForwarder(
+        original,
+        emitted.append,
+        prefix=prefix,
+        ansi_color=color,
+    )
+    return fw, emitted
+
+
+class TestLineBuffering:
+    def test_complete_line_is_emitted(self):
+        fw, emitted = _mk()
+        fw.write("hello\n")
+        assert emitted == ["\x1b[2m· hello\x1b[0m\n"]
+
+    def test_partial_line_is_buffered_until_newline(self):
+        fw, emitted = _mk()
+        fw.write("par")
+        fw.write("tial ")
+        assert emitted == []  # nothing flushed yet
+        fw.write("line\n")
+        assert emitted == ["\x1b[2m· partial line\x1b[0m\n"]
+
+    def test_multiple_newlines_in_one_write_emit_multiple_lines(self):
+        fw, emitted = _mk()
+        fw.write("one\ntwo\nthree\n")
+        assert emitted == [
+            "\x1b[2m· one\x1b[0m\n",
+            "\x1b[2m· two\x1b[0m\n",
+            "\x1b[2m· three\x1b[0m\n",
+        ]
+
+    def test_mixed_terminated_and_unterminated_in_one_write(self):
+        fw, emitted = _mk()
+        fw.write("first\nsecond")  # second has no trailing \n
+        assert emitted == ["\x1b[2m· first\x1b[0m\n"]
+        fw.flush()
+        assert emitted == [
+            "\x1b[2m· first\x1b[0m\n",
+            "\x1b[2m· second\x1b[0m\n",
+        ]
+
+    def test_flush_without_pending_is_noop(self):
+        fw, emitted = _mk()
+        fw.flush()
+        assert emitted == []
+
+    def test_empty_write_does_nothing(self):
+        fw, emitted = _mk()
+        fw.write("")
+        assert emitted == []
+
+    def test_write_returns_character_count(self):
+        fw, _ = _mk()
+        assert fw.write("hello\n") == 6
+        assert fw.write("") == 0
+
+
+class TestStyling:
+    def test_stdout_prefix_and_dim_color(self):
+        """The stdout marker defaults to ``· `` with ANSI dim (2)."""
+        fw, emitted = _mk(prefix="· ", color="2")
+        fw.write("plain\n")
+        assert emitted == ["\x1b[2m· plain\x1b[0m\n"]
+
+    def test_stderr_prefix_and_red_color(self):
+        """Stderr uses ``! `` with ANSI red (31)."""
+        fw, emitted = _mk(prefix="! ", color="31")
+        fw.write("boom\n")
+        assert emitted == ["\x1b[31m! boom\x1b[0m\n"]
+
+
+class TestDuckTyping:
+    def test_isatty_reports_false(self):
+        """Libraries that check isatty() must see False so they don't
+        emit raw ANSI sequences that we'd then capture as literal
+        characters inside our styled line."""
+        fw, _ = _mk()
+        assert fw.isatty() is False
+
+    def test_forwards_attribute_access_to_original(self):
+        """Non-write attributes (``encoding`` etc.) fall through."""
+        original = io.StringIO()
+        original.mode = "w"  # type: ignore[attr-defined]
+        fw = _StrayStreamForwarder(original, lambda _: None, prefix="· ", ansi_color="2")
+        assert fw.mode == "w"
+
+    def test_writelines_emits_each_entry(self):
+        fw, emitted = _mk()
+        fw.writelines(["a\n", "b\n"])
+        assert emitted == [
+            "\x1b[2m· a\x1b[0m\n",
+            "\x1b[2m· b\x1b[0m\n",
+        ]
+
+
+class TestEmitBlockFailureSafety:
+    def test_emit_block_exception_falls_through_to_original_stream(self):
+        """If the TUI's emit_block is broken for any reason, we must
+        still see the write somewhere — otherwise crashes are silent."""
+        original = io.StringIO()
+
+        def broken_emit(_: str) -> None:
+            raise RuntimeError("block queue exploded")
+
+        fw = _StrayStreamForwarder(original, broken_emit, prefix="! ", ansi_color="31")
+        fw.write("critical\n")
+        assert "critical" in original.getvalue()
+
+
+class TestInstallUninstall:
+    def test_install_replaces_both_streams_uninstall_restores(self):
+        original_out = sys.stdout
+        original_err = sys.stderr
+        try:
+            uninstall = install_stray_stream_capture(lambda _: None)
+            assert isinstance(sys.stdout, _StrayStreamForwarder)
+            assert isinstance(sys.stderr, _StrayStreamForwarder)
+            assert sys.stdout is not original_out
+            assert sys.stderr is not original_err
+            uninstall()
+            assert sys.stdout is original_out
+            assert sys.stderr is original_err
+        finally:
+            # Defensive: if something above raised, make sure we don't
+            # leak the forwarder into subsequent tests.
+            if isinstance(sys.stdout, _StrayStreamForwarder):
+                sys.stdout = original_out
+            if isinstance(sys.stderr, _StrayStreamForwarder):
+                sys.stderr = original_err
+
+    def test_installed_stdout_stderr_emit_through_callback(self):
+        emitted: list[str] = []
+        original_out = sys.stdout
+        original_err = sys.stderr
+        try:
+            uninstall = install_stray_stream_capture(emitted.append)
+            # Write via the installed wrappers — simulating any library.
+            sys.stdout.write("hello\n")
+            sys.stderr.write("boom\n")
+            assert emitted == [
+                "\x1b[2m· hello\x1b[0m\n",
+                "\x1b[31m! boom\x1b[0m\n",
+            ]
+        finally:
+            uninstall()
+            if sys.stdout is not original_out:
+                sys.stdout = original_out
+            if sys.stderr is not original_err:
+                sys.stderr = original_err
+
+    def test_uninstall_flushes_partial_lines(self):
+        """A partial line sitting in the buffer at shutdown must not be
+        lost — flush on uninstall so it lands in the transcript."""
+        emitted: list[str] = []
+        original_out = sys.stdout
+        try:
+            uninstall = install_stray_stream_capture(emitted.append)
+            sys.stdout.write("half-line-no-newline")
+            assert emitted == []  # buffered
+            uninstall()
+            assert any("half-line-no-newline" in chunk for chunk in emitted)
+        finally:
+            if sys.stdout is not original_out:
+                sys.stdout = original_out
+
+
+class TestDeduplication:
+    """Tests for consecutive line deduplication."""
+
+    def test_repeated_lines_collapsed(self):
+        """Repeated identical lines produce one emit + a dedup summary."""
+        emitted: list[str] = []
+        from nooa_cli.tui.stream_forwarder import _StrayStreamForwarder
+
+        fwd = _StrayStreamForwarder(sys.stdout, emitted.append, prefix="· ", ansi_color="2")
+        fwd.write("rate limit\n")
+        fwd.write("rate limit\n")
+        fwd.write("rate limit\n")
+        fwd.write("different line\n")
+
+        # First "rate limit" emitted immediately, then summary "(×2 more)",
+        # then "different line" emitted.
+        assert len(emitted) == 3
+        assert "rate limit" in emitted[0]
+        assert "×2 more" in emitted[1]
+        assert "different line" in emitted[2]
+
+    def test_single_line_no_dedup_suffix(self):
+        """A single line (no repeats) emits normally without dedup suffix."""
+        emitted: list[str] = []
+        from nooa_cli.tui.stream_forwarder import _StrayStreamForwarder
+
+        fwd = _StrayStreamForwarder(sys.stdout, emitted.append, prefix="· ", ansi_color="2")
+        fwd.write("hello\n")
+        fwd.write("world\n")
+        assert len(emitted) == 2
+        assert "×" not in emitted[0]
+        assert "×" not in emitted[1]
+
+    def test_flush_emits_dedup_summary(self):
+        """Calling flush() emits pending dedup summary."""
+        emitted: list[str] = []
+        from nooa_cli.tui.stream_forwarder import _StrayStreamForwarder
+
+        fwd = _StrayStreamForwarder(sys.stdout, emitted.append, prefix="· ", ansi_color="2")
+        fwd.write("retry\n")
+        fwd.write("retry\n")
+        fwd.write("retry\n")
+        fwd.flush()
+        # First emit + summary
+        assert len(emitted) == 2
+        assert "×2 more" in emitted[1]
+
+
+class TestBlankLineSuppression:
+    """Tests for blank/whitespace-only line suppression."""
+
+    def test_blank_lines_suppressed(self):
+        """Empty lines are not emitted."""
+        emitted: list[str] = []
+        from nooa_cli.tui.stream_forwarder import _StrayStreamForwarder
+
+        fwd = _StrayStreamForwarder(sys.stdout, emitted.append, prefix="· ", ansi_color="2")
+        fwd.write("\n")
+        fwd.write("   \n")
+        fwd.write("\n")
+        assert emitted == []
+
+    def test_whitespace_only_suppressed(self):
+        """Whitespace-only lines are suppressed."""
+        emitted: list[str] = []
+        from nooa_cli.tui.stream_forwarder import _StrayStreamForwarder
+
+        fwd = _StrayStreamForwarder(sys.stdout, emitted.append, prefix="· ", ansi_color="2")
+        fwd.write("  \t  \n")
+        assert emitted == []
+
+
+class TestOnStrayCallback:
+    """Tests for the on_stray callback mechanism."""
+
+    def test_on_stray_called_for_emitted_lines(self):
+        """on_stray receives (content, 'emitted') for lines that are displayed."""
+        emitted: list[str] = []
+        stray_calls: list[tuple[str, str]] = []
+        from nooa_cli.tui.stream_forwarder import _StrayStreamForwarder
+
+        fwd = _StrayStreamForwarder(
+            sys.stdout,
+            emitted.append,
+            prefix="· ",
+            ansi_color="2",
+            on_stray=lambda c, d: stray_calls.append((c, d)),
+        )
+        fwd.write("visible line\n")
+        assert len(stray_calls) == 1
+        assert stray_calls[0] == ("visible line", "emitted")
+
+    def test_on_stray_called_for_repeated_lines(self):
+        """on_stray receives (content, 'repeated') for deduplicated lines."""
+        stray_calls: list[tuple[str, str]] = []
+        from nooa_cli.tui.stream_forwarder import _StrayStreamForwarder
+
+        fwd = _StrayStreamForwarder(
+            sys.stdout,
+            lambda _: None,
+            prefix="· ",
+            ansi_color="2",
+            on_stray=lambda c, d: stray_calls.append((c, d)),
+        )
+        fwd.write("same\n")
+        fwd.write("same\n")
+        assert ("same", "emitted") in stray_calls
+        assert ("same", "repeated") in stray_calls
+
+    def test_on_stray_called_for_suppressed_noise(self):
+        """on_stray receives (content, 'suppressed') for noise-pattern lines."""
+        stray_calls: list[tuple[str, str]] = []
+        from nooa_cli.tui.stream_forwarder import _StrayStreamForwarder
+
+        fwd = _StrayStreamForwarder(
+            sys.stdout,
+            lambda _: None,
+            prefix="· ",
+            ansi_color="2",
+            on_stray=lambda c, d: stray_calls.append((c, d)),
+        )
+        fwd.write("Give Feedback / Get Help: something\n")
+        assert len(stray_calls) == 1
+        assert stray_calls[0][1] == "suppressed"

--- a/packages/nooa-cli/tests/tui/test_trace_session_naming.py
+++ b/packages/nooa-cli/tests/tui/test_trace_session_naming.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for trace session name generation and assignment.
+
+Covers:
+- ``_make_trace_session_name`` format
+- ``bootstrap()`` calls ``set_session`` with the right name after ``_session_id`` is resolved
+- ``Session._swap_session_manager`` calls ``set_session`` with the right name
+- Both are silent when the tracing package is not installed
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from nooa_cli.tui.session_manager import _make_trace_session_name
+
+# ---------------------------------------------------------------------------
+# _make_trace_session_name
+# ---------------------------------------------------------------------------
+
+TRACE_NAME_RE = re.compile(r"^tui-\d{8}-\d{6}-[0-9a-f]{8}$")
+
+
+class TestMakeTraceSessionName:
+    def test_format(self):
+        """Name must match tui-YYYYMMDD-HHMMSS-<8hex>."""
+        name = _make_trace_session_name("abcdef12-0000-0000-0000-000000000000")
+        assert TRACE_NAME_RE.match(name), f"Unexpected format: {name!r}"
+
+    def test_uses_session_id_prefix(self):
+        """Last 8 chars must be the first 8 chars of the session UUID."""
+        sid = "12345678-aaaa-bbbb-cccc-dddddddddddd"
+        name = _make_trace_session_name(sid)
+        assert name.endswith("-12345678")
+
+    def test_empty_session_id(self):
+        """Should not raise on empty string — produces tui-YYYYMMDD-HHMMSS-."""
+        name = _make_trace_session_name("")
+        assert name.startswith("tui-")
+
+
+# ---------------------------------------------------------------------------
+# Session._swap_session_manager calls set_session
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_session(tmp_path, monkeypatch):
+    """Build a minimal Session object with mocked dependencies."""
+    from nooa_cli.tui import session_manager as session_manager_module
+    from nooa_cli.tui.session import Session
+    from nooa_cli.tui.session_manager import SessionManager
+
+    sid = str(uuid.uuid4())
+    monkeypatch.setattr(session_manager_module, "SESSIONS_DIR", tmp_path)
+    sm = SessionManager.create(session_id=sid, model="m", agent_cls="A")
+    storage = sm._storage
+
+    agent = MagicMock()
+    agent._storage = storage
+    agent.event_manager = MagicMock()
+    agent.event_manager.on = MagicMock(return_value=lambda: None)
+    agent.event_manager.keys = MagicMock(return_value=[])
+    agent.handle = AsyncMock()
+    # queue_manager mock with async shutdown and empty channels
+    agent.queue_manager = MagicMock()
+    agent.queue_manager.shutdown = AsyncMock()
+    agent.queue_manager._channels = {}
+
+    frontend = AsyncMock()
+    frontend.render = AsyncMock()
+    frontend.get_input = AsyncMock(return_value="")
+    frontend.show_python = True
+    frontend.clear_streaming_state = MagicMock()
+
+    config = MagicMock()
+    config.tui.default_model = "test-model"
+    config.tui.vi_mode = False
+
+    registry = MagicMock()
+    registry.session_manager = sm
+    registry._commands = {}
+
+    session = Session.__new__(Session)
+    session.frontend = frontend
+    session.agent = agent
+    session.config = config
+    session.registry = registry
+    session._session_manager = sm
+    session._background_tasks = set()
+
+    return session, sm, storage
+
+
+class TestSwapSessionManagerCallsSetSession:
+    async def test_calls_set_session_with_correct_format(self, tmp_path, monkeypatch):
+        """_swap_session_manager must call set_session with tui-YYYYMMDD-HHMMSS-<sid8>."""
+        import sys
+
+        session, old_sm, _ = _make_mock_session(tmp_path, monkeypatch)
+
+        new_sid = str(uuid.uuid4())
+        new_sm = MagicMock()
+        new_sm.session_id = new_sid
+        new_sm._storage = MagicMock()
+
+        captured: list[str] = []
+        mock_set_session = MagicMock(side_effect=captured.append)
+        fake_tracing = MagicMock()
+        fake_tracing.set_session = mock_set_session
+
+        with patch.dict(sys.modules, {"nooa.tracing": fake_tracing}):
+            await session._swap_session_manager(new_sm)
+
+        assert len(captured) == 1, f"set_session not called; got {captured}"
+        assert TRACE_NAME_RE.match(captured[0]), f"Bad format: {captured[0]!r}"
+        assert captured[0].endswith(f"-{new_sid[:8]}")
+
+        old_sm.close()
+
+    async def test_silent_when_import_fails(self, tmp_path, monkeypatch):
+        """_swap_session_manager must not raise when tracing is not installed."""
+        session, old_sm, _ = _make_mock_session(tmp_path, monkeypatch)
+
+        new_sm = MagicMock()
+        new_sm.session_id = str(uuid.uuid4())
+        new_sm._storage = MagicMock()
+
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _raise_on_tracing(name, *args, **kwargs):
+            if "openinference_instrumentation" in name:
+                raise ImportError("not installed")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=_raise_on_tracing):
+            # Should not raise
+            await session._swap_session_manager(new_sm)
+
+        old_sm.close()
+
+    async def test_silent_when_set_session_raises(self, tmp_path, monkeypatch):
+        """_swap_session_manager must not crash if set_session raises a runtime error."""
+        import sys
+
+        session, old_sm, _ = _make_mock_session(tmp_path, monkeypatch)
+
+        new_sm = MagicMock()
+        new_sm.session_id = str(uuid.uuid4())
+        new_sm._storage = MagicMock()
+
+        fake_tracing = MagicMock()
+        fake_tracing.set_session = MagicMock(side_effect=RuntimeError("tracing broken"))
+
+        with patch.dict(sys.modules, {"nooa.tracing": fake_tracing}):
+            # Should not raise
+            await session._swap_session_manager(new_sm)
+
+        old_sm.close()
+
+
+# ---------------------------------------------------------------------------
+# _swap_session_manager flushes queues
+# ---------------------------------------------------------------------------
+
+
+class TestSwapSessionManagerClearsQueues:
+    async def test_flushes_queue_channels(self, tmp_path, monkeypatch):
+        """_swap_session_manager must flush all queue-mode channels."""
+        session, old_sm, _ = _make_mock_session(tmp_path, monkeypatch)
+
+        # Put a stale item in a queue channel
+        from nooa.runtime.channels import Channel
+
+        ch = Channel("user_messages", "queue")
+        ch.put("stale message from old session")
+        session.agent.queue_manager._channels = {"user_messages": ch}
+        session.agent.queue_manager.names = MagicMock(return_value=["user_messages"])
+        session.agent.queue_manager.get_channel = MagicMock(side_effect=lambda name: ch)
+
+        new_sm = MagicMock()
+        new_sm.session_id = str(uuid.uuid4())
+        new_sm._storage = MagicMock()
+
+        await session._swap_session_manager(new_sm)
+
+        assert ch.is_empty(), "queue channel should be flushed after session swap"
+
+    async def test_calls_shutdown_on_queue_manager(self, tmp_path, monkeypatch):
+        """_swap_session_manager must call shutdown() to cancel spawned jobs."""
+        session, old_sm, _ = _make_mock_session(tmp_path, monkeypatch)
+
+        new_sm = MagicMock()
+        new_sm.session_id = str(uuid.uuid4())
+        new_sm._storage = MagicMock()
+
+        await session._swap_session_manager(new_sm)
+
+        session.agent.queue_manager.shutdown.assert_awaited_once()
+
+    async def test_no_crash_without_queue_manager(self, tmp_path, monkeypatch):
+        """_swap_session_manager must not crash if agent has no queue_manager."""
+        session, old_sm, _ = _make_mock_session(tmp_path, monkeypatch)
+        del session.agent.queue_manager
+
+        new_sm = MagicMock()
+        new_sm.session_id = str(uuid.uuid4())
+        new_sm._storage = MagicMock()
+
+        # Should not raise
+        await session._swap_session_manager(new_sm)
+
+        old_sm.close()

--- a/packages/nooa-cli/tests/tui/test_trace_url_command.py
+++ b/packages/nooa-cli/tests/tui/test_trace_url_command.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for /trace-url slash command."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from nooa_cli.tui.commands import TraceUrlCommand
+
+
+@pytest.fixture
+def cmd():
+    """Create a TraceUrlCommand with minimal mocks."""
+    frontend = MagicMock()
+    config = MagicMock()
+    agent = MagicMock()
+    return TraceUrlCommand(frontend, config, agent)
+
+
+@pytest.mark.asyncio
+async def test_trace_url_no_tracing_package(cmd):
+    """Returns error when tracing package is not installed."""
+    with patch.dict("sys.modules", {"nooa.tracing": None}):
+        with patch("builtins.__import__", side_effect=ImportError):
+            result = await cmd.execute([])
+    assert not result.success
+
+
+@pytest.mark.asyncio
+async def test_trace_url_no_active_session(cmd):
+    """Returns error when no trace session is active."""
+    with patch("nooa.tracing.get_session", return_value=None):
+        result = await cmd.execute([])
+    assert not result.success
+    assert "No active trace session" in result.outputs[0].content
+
+
+@pytest.mark.asyncio
+async def test_trace_url_default_endpoint(cmd):
+    """Constructs URL with default localhost:5001 endpoint."""
+    with patch("nooa.tracing.get_session", return_value="tui-20250508-120000-abcdef12"):
+        with patch.dict(os.environ, {}, clear=False):
+            # Remove OTLP_ENDPOINT if set
+            env = os.environ.copy()
+            env.pop("OTLP_ENDPOINT", None)
+            with patch.dict(os.environ, env, clear=True):
+                result = await cmd.execute([])
+    assert result.success
+    assert (
+        "http://localhost:5001/traces/view?session_id=tui-20250508-120000-abcdef12"
+        in result.outputs[0].content
+    )
+
+
+@pytest.mark.asyncio
+async def test_trace_url_custom_endpoint(cmd):
+    """Constructs URL stripping /v1/traces from OTLP_ENDPOINT."""
+    with patch("nooa.tracing.get_session", return_value="tui-20250508-120000-abcdef12"):
+        with patch.dict(os.environ, {"OTLP_ENDPOINT": "http://myviewer:8080/v1/traces"}):
+            result = await cmd.execute([])
+    assert result.success
+    assert (
+        "http://myviewer:8080/traces/view?session_id=tui-20250508-120000-abcdef12"
+        in result.outputs[0].content
+    )
+
+
+@pytest.mark.asyncio
+async def test_trace_url_endpoint_with_v1_only(cmd):
+    """Strips /v1 suffix from endpoint."""
+    with patch("nooa.tracing.get_session", return_value="my-session"):
+        with patch.dict(os.environ, {"OTLP_ENDPOINT": "http://host:9000/v1"}):
+            result = await cmd.execute([])
+    assert result.success
+    assert "http://host:9000/traces/view?session_id=my-session" in result.outputs[0].content
+
+
+@pytest.mark.asyncio
+async def test_trace_url_endpoint_no_suffix(cmd):
+    """Endpoint without /v1/traces suffix is used as-is."""
+    with patch("nooa.tracing.get_session", return_value="my-session"):
+        with patch.dict(os.environ, {"OTLP_ENDPOINT": "http://host:9000"}):
+            result = await cmd.execute([])
+    assert result.success
+    assert "http://host:9000/traces/view?session_id=my-session" in result.outputs[0].content

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -1,0 +1,1036 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Behaviour spec for ``TUIApplication`` (Plan-C, single long-lived app).
+
+Each test pins a behaviour the TUI must preserve. Tests are grouped
+by tier of concern:
+
+* Tier 1 — baseline REPL (prompt, enter → agent, buffer clears, exit)
+* Tier 2 — input mechanics (Shift+Enter, backspace, history, cursor)
+* Tier 3 — commands (/slash dispatch, Tab completion, !bang)
+* Tier 4 — type-ahead queue (queued lines, delivery order, cancel)
+* Tier 5 — hard cases (Ctrl+C, errors, Rich ANSI, spinner, THE BUG)
+
+Tests read logical state (``app.input_buffer.text``,
+``app.status_text()``) via the harness's ``capture_*`` helpers rather
+than parsing terminal output — same discipline as the harness canaries.
+
+The ``XFAIL`` mark is still defined below for any future test that
+wants to pin an unimplemented behaviour; it's not applied anywhere
+right now because every listed behaviour is implemented.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+
+import pytest
+
+from .tui_app_harness import FakeAgent, ThreadGate, TUIHarness
+
+XFAIL = pytest.mark.xfail(strict=True, reason="not yet implemented in Plan-C TUIApplication")
+
+pytestmark = pytest.mark.asyncio
+
+
+# ╔══════════════════════════════════════════════════════════════════════╗
+# ║ Tier 1 — baseline REPL                                                ║
+# ╚══════════════════════════════════════════════════════════════════════╝
+
+
+async def test_baseline_prompt_visible_at_startup():
+    """The app renders the prompt marker and the cursor lives on the input line."""
+    async with TUIHarness() as h:
+        await h.wait_for(lambda: h.app.prompt_char_visible())  # new API
+
+
+async def test_baseline_enter_submits_to_agent():
+    async with TUIHarness() as h:
+        await h.type_keys("hello world")
+        await h.press("enter")
+        await h.wait_for(lambda: h.agent.messages_received == ["hello world"])
+
+
+async def test_baseline_agent_message_renders_to_output():
+    agent = FakeAgent()
+
+    async def step(self: FakeAgent, msg: str):
+        self.emit_message("Hi there!")
+
+    agent.queue(step)
+    async with TUIHarness(agent=agent) as h:
+        await h.type_keys("ping")
+        await h.press("enter")
+        await h.wait_output_contains("Hi there!")
+
+
+async def test_baseline_input_buffer_cleared_after_submit():
+    async with TUIHarness() as h:
+        await h.type_keys("something")
+        await h.press("enter")
+        await h.wait_input_equals("")
+
+
+async def test_baseline_ctrl_d_exits():
+    # Already pinned by the stub's Ctrl+D binding; keep un-xfailed so a
+    # regression flips the test red instead of silently green-to-green.
+    async with TUIHarness() as h:
+        await h.press("c-d")
+        await h.wait_for(lambda: not h.app.is_running)
+
+
+async def test_baseline_command_status_is_dynamic_not_scrollback():
+    """Queued/running command state lives in the status area, not transcript."""
+    async with TUIHarness() as h:
+        h.app.set_command_status("· /mesh-list")
+        await h.wait_for(lambda: "/mesh-list" in h.capture_status())
+        assert "/mesh-list" not in h.capture_output()
+        h.app.set_command_status("")
+        await h.wait_for(lambda: "/mesh-list" not in h.capture_status())
+
+
+async def test_mouse_support_only_enabled_for_subviews():
+    """Normal transcript mode must leave native terminal text selection/copy alone."""
+    async with TUIHarness() as h:
+        assert bool(h.app._app.mouse_support()) is False
+        h.app._active_subview = object()
+        assert bool(h.app._app.mouse_support()) is True
+        h.app._active_subview = None
+        assert bool(h.app._app.mouse_support()) is False
+
+
+async def test_status_text_separates_thinking_and_command_status():
+    """Thinking and command statuses render as separated status rows."""
+    async with TUIHarness() as h:
+        h.app._in_respond = True
+        h.app._agent_task = asyncio.Future()
+        h.app.set_command_status("· !find ~/dev/* | grep unified")
+        status = h.app.status_text()
+        assert "thinking...\n\n· !find" in status
+        assert "thinking...\n· !find" not in status
+        assert "thinking...   · !find" not in status
+        h.app._agent_task.cancel()
+
+
+async def test_baseline_command_queue_is_dynamic_not_scrollback():
+    """Queued commands live in dynamic UI state, not transcript scrollback."""
+    async with TUIHarness() as h:
+        h.app.set_command_queue(["/models", "!echo hi"])
+        await h.wait_for(lambda: h.app._command_queue_texts == ["/models", "!echo hi"])
+        assert "/models" not in h.capture_output()
+        assert "!echo hi" not in h.capture_output()
+        h.app.set_command_queue([])
+        await h.wait_for(lambda: h.app._command_queue_texts == [])
+
+
+async def test_command_queue_formatted_has_no_trailing_newline():
+    """The queue formatter does not append a blank row before the session rule."""
+    from prompt_toolkit.formatted_text import fragment_list_to_text
+
+    async with TUIHarness() as h:
+        h.app.set_command_queue(["!ls"])
+        root = h.app._app.layout.container.get_container()
+        queue_container = root.children[1].content
+        queue_control = queue_container.content
+        assert fragment_list_to_text(queue_control.text()) == "│ 1 command queued\n└─ !ls"
+
+
+async def test_baseline_command_queue_renders_below_status():
+    """The dynamic status row stays directly above the queued-command tree."""
+    from prompt_toolkit.formatted_text import fragment_list_to_text
+
+    async with TUIHarness() as h:
+        h.app.set_command_status("· !find ~/dev/* | grep unified")
+        h.app.set_command_queue(["!ls"])
+        root = h.app._app.layout.container.get_container()
+        status_control = root.children[0].content
+        queue_container = root.children[1].content
+        queue_control = queue_container.content
+        assert fragment_list_to_text(status_control.text()) == "· !find ~/dev/* | grep unified"
+        assert fragment_list_to_text(queue_control.text()).startswith("│ 1 command queued")
+
+
+# ╔══════════════════════════════════════════════════════════════════════╗
+# ║ Tier 2 — input mechanics                                              ║
+# ╚══════════════════════════════════════════════════════════════════════╝
+
+
+async def test_input_shift_enter_inserts_newline():
+    async with TUIHarness() as h:
+        await h.type_keys("line1")
+        await h.press("s-enter")
+        await h.type_keys("line2")
+        await h.press("enter")
+        await h.wait_for(lambda: h.agent.messages_received == ["line1\nline2"])
+
+
+async def test_input_backspace_deletes_char():
+    # Already provable in the stub; keep as a non-xfail regression to
+    # guarantee it never breaks as we grow the implementation.
+    async with TUIHarness() as h:
+        await h.type_keys("abc")
+        await h.press("backspace")
+        await h.wait_input_equals("ab")
+
+
+async def test_input_history_up_on_empty_buffer():
+    """With no queue, Up on an empty buffer recalls the previous submission."""
+    async with TUIHarness() as h:
+        await h.type_keys("first")
+        await h.press("enter")
+        await h.wait_input_equals("")
+        await h.press("up")
+        await h.wait_input_equals("first")
+
+
+async def test_input_cursor_home_and_end():
+    async with TUIHarness() as h:
+        await h.type_keys("abc")
+        await h.press("home")
+        await h.wait_for(lambda: h.app.input_cursor_position() == 0)
+        await h.press("end")
+        await h.wait_for(lambda: h.app.input_cursor_position() == 3)
+
+
+# ╔══════════════════════════════════════════════════════════════════════╗
+# ║ Tier 3 — commands                                                     ║
+# ╚══════════════════════════════════════════════════════════════════════╝
+
+
+async def test_commands_slash_dispatches_without_calling_agent():
+    """``/help`` routes to the command registry, not ``agent.handle()``."""
+    async with TUIHarness() as h:
+        await h.type_keys("/help")
+        await h.press("enter")
+        await h.wait_for(lambda: "/help" in h.app.commands_dispatched())
+        assert h.agent.messages_received == []
+
+
+async def test_commands_slash_fires_on_command_callback():
+    """Session wires ``on_command`` to route slash submissions into its
+    CommandRegistry; this test pins the hook contract."""
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    received: list[str] = []
+    from prompt_toolkit.application import create_app_session
+    from prompt_toolkit.input import create_pipe_input
+    from prompt_toolkit.output import DummyOutput
+
+    from .tui_app_harness import FakeAgent
+
+    agent = FakeAgent()
+    with create_pipe_input() as pipe, create_app_session(input=pipe, output=DummyOutput()):
+        app = TUIApplication(agent=agent, on_command=received.append)
+        import asyncio as _a
+
+        run_task = _a.create_task(app.run_async())
+        # wait for ready
+        for _ in range(200):
+            if app.is_running:
+                break
+            await _a.sleep(0.01)
+        pipe.send_text("/help\r")
+        for _ in range(200):
+            if received:
+                break
+            await _a.sleep(0.01)
+        assert received == ["/help"]
+        app.exit()
+        try:
+            await _a.wait_for(run_task, 2.0)
+        except (TimeoutError, _a.CancelledError):
+            run_task.cancel()
+
+
+async def test_commands_bang_fires_on_bang_callback_with_stripped_body():
+    """``on_bang`` receives the body without the leading ``!``."""
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    received: list[str] = []
+    from prompt_toolkit.application import create_app_session
+    from prompt_toolkit.input import create_pipe_input
+    from prompt_toolkit.output import DummyOutput
+
+    from .tui_app_harness import FakeAgent
+
+    agent = FakeAgent()
+    with create_pipe_input() as pipe, create_app_session(input=pipe, output=DummyOutput()):
+        app = TUIApplication(agent=agent, on_bang=received.append)
+        import asyncio as _a
+
+        run_task = _a.create_task(app.run_async())
+        for _ in range(200):
+            if app.is_running:
+                break
+            await _a.sleep(0.01)
+        pipe.send_text("!echo hi\r")
+        for _ in range(200):
+            if received:
+                break
+            await _a.sleep(0.01)
+        assert received == ["echo hi"]
+        app.exit()
+        try:
+            await _a.wait_for(run_task, 2.0)
+        except (TimeoutError, _a.CancelledError):
+            run_task.cancel()
+
+
+async def test_commands_tab_completion_for_slash():
+    async with TUIHarness() as h:
+        await h.type_keys("/he")
+        await h.press("tab")
+        # Completion menu should list /help; input buffer either expanded
+        # to "/help" or showed the menu — we accept either.
+        await h.wait_for(
+            lambda: h.capture_input() == "/help" or "/help" in h.app.completion_candidates()
+        )
+
+
+async def test_commands_bang_suspends_app_and_runs_shell():
+    """``!echo hi`` uses ``run_in_terminal`` so stdout goes to the real tty."""
+    async with TUIHarness() as h:
+        await h.type_keys("!echo hi")
+        await h.press("enter")
+        # Implementation should record that it asked the terminal to
+        # suspend + run a shell command. In production that's
+        # prompt_toolkit's ``run_in_terminal``; we assert the hook was
+        # called with the right command string.
+        await h.wait_for(lambda: h.app.last_bang_command() == "echo hi")
+
+
+# ╔══════════════════════════════════════════════════════════════════════╗
+# ║ Tier 4 — type-ahead queue                                             ║
+# ╚══════════════════════════════════════════════════════════════════════╝
+
+
+def _blocking_agent() -> FakeAgent:
+    """Agent whose ``handle()`` blocks until we manually set ``block``."""
+    agent = FakeAgent()
+    agent.block.clear()  # unset → handle() blocks on wait()
+    return agent
+
+
+async def test_queue_displays_above_prompt_while_agent_working():
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.type_keys("trigger")
+        await h.press("enter")
+        # Agent is now blocked. User type-aheads a message.
+        await h.wait_for(lambda: h.app.is_thinking())
+        await h.type_keys("queued-msg")
+        await h.press("enter")
+        await h.wait_for(lambda: h.capture_queued() == ["queued-msg"])
+
+
+async def test_queue_multiple_enters_merge_into_one_item():
+    """Successive Enters typed while the agent is working compose one
+    queued message joined with newlines so the agent isn't asked to
+    handle each line of a half-finished thought as its own turn."""
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("trigger")
+        await h.wait_for(lambda: h.app.is_thinking())
+        await h.type_keys("one")
+        await h.press("enter")
+        await h.type_keys("two")
+        await h.press("enter")
+        # One queue item, two lines.
+        await h.wait_for(lambda: h.capture_queued() == ["one\ntwo"])
+        # Three lines if the user keeps going.
+        await h.type_keys("three")
+        await h.press("enter")
+        await h.wait_for(lambda: h.capture_queued() == ["one\ntwo\nthree"])
+
+
+async def test_slash_command_while_agent_working_dispatches_immediately():
+    """Forever-loop model: slash commands no longer queue — they fire right away.
+
+    Contrast with the old contract where /exit typed mid-turn waited
+    for the agent to finish. Now the agent's handle() runs for the
+    whole session, so there's no "next turn" to flush commands into.
+    """
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("trigger")
+        await h.wait_for(lambda: h.app.is_thinking())
+        await h.type_keys("/exit")
+        await h.press("enter")
+        await h.wait_for(lambda: h.app.commands_dispatched() == ["/exit"])
+
+
+async def test_queue_up_arrow_pops_last_queued_item_when_buffer_empty():
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("trigger")
+        await h.wait_for(lambda: h.app.is_thinking())
+        await h.type_keys("foo")
+        await h.press("enter")
+        await h.wait_for(lambda: h.capture_queued() == ["foo"])
+        await h.press("up")
+        await h.wait_input_equals("foo")
+        assert h.capture_queued() == []
+
+
+async def test_queue_delivered_as_next_turn_when_agent_finishes():
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        await h.type_keys("queued")
+        await h.press("enter")
+        # Let the agent finish → queued message becomes the next handle()
+        agent.block.set()
+        await h.wait_for(lambda: agent.messages_received == ["first", "queued"])
+
+
+async def test_interleaved_cmd_msg_msg_commands_fire_immediately():
+    """Per-turn dispatcher model: commands dispatch immediately; only
+    messages queue (and consecutive ones merge).
+
+    Contrast with the old contract: messages and commands queued
+    together, flushed in order after handle() returned. Now
+    commands sidestep the agent's input queue and fire as soon as
+    typed; consecutive queued messages compose a single multi-line
+    item via the dispatcher's submit-merge.
+    """
+    agent = _blocking_agent()
+    commands_seen: list[str] = []
+    async with TUIHarness(agent=agent) as h:
+        h.app._on_command = commands_seen.append
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        # Interleave: message → command → message.
+        await h.submit_async("queued-text-1")
+        await h.submit_async("/my-cmd")
+        await h.submit_async("queued-text-2")
+        # Two queued messages around a slash command merge into one
+        # multi-line queue item — the slash didn't break the chain
+        # because slash commands never touch the user_messages queue.
+        await h.wait_for(lambda: h.capture_queued() == ["queued-text-1\nqueued-text-2"])
+        # The command fired immediately, without waiting for the agent.
+        assert commands_seen == ["/my-cmd"]
+        # Let the agent pump the rest.
+        agent.block.set()
+        await h.wait_for(
+            lambda: (
+                agent.messages_received
+                == [
+                    "first",
+                    "queued-text-1\nqueued-text-2",
+                ]
+            )
+        )
+
+
+async def test_queue_esc_soft_cancels_and_delivers_queue():
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        await h.type_keys("queued")
+        await h.press("enter")
+        await h.press("escape")
+        await h.wait_for(lambda: agent.messages_received == ["first", "queued"])
+
+
+# ╔══════════════════════════════════════════════════════════════════════╗
+# ║ Tier 5 — hard cases                                                   ║
+# ╚══════════════════════════════════════════════════════════════════════╝
+
+
+async def test_hard_ctrl_c_interrupts_and_preserves_buffer():
+    """C-c while the agent is working cancels the agent but keeps the buffer."""
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        await h.type_keys("in-progress")
+        await h.press("c-c")
+        # Agent gets cancelled; buffer contents survive.
+        await h.wait_for(lambda: not h.app.is_thinking())
+        assert h.capture_input() == "in-progress"
+
+
+async def test_hard_agent_error_shown_in_output():
+    agent = FakeAgent()
+
+    async def step(_self, _msg):
+        raise RuntimeError("boom")
+
+    agent.queue(step)
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("go")
+        await h.wait_output_contains("boom")
+
+
+async def test_hard_rich_ansi_preserved_in_output():
+    agent = FakeAgent()
+
+    async def step(self: FakeAgent, _msg):
+        self.emit_message("**bold**")  # Rich markdown renders bold ANSI
+
+    agent.queue(step)
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("go")
+        await h.wait_for(lambda: "\x1b[" in h.capture_output_ansi())
+
+
+async def test_hard_spinner_and_session_label_in_status():
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        h.app.set_session_label("session-abc")
+        await h.submit_async("go")
+        await h.wait_for(
+            lambda: "thinking" in h.capture_status() and "session-abc" in h.capture_status()
+        )
+
+
+async def test_hard_terminal_resize_does_not_crash():
+    async with TUIHarness() as h:
+        h.app.handle_resize(cols=40, rows=20)
+        await h.type_keys("still works")
+        await h.wait_input_equals("still works")
+
+
+async def test_hard_keystroke_during_agent_finish_not_lost():
+    """THE BUG — Plan-C's reason for being.
+
+    User presses a key in the tiny window while the agent is finishing
+    and the app would normally be restarting its prompt. In the one-App
+    architecture the input buffer is *always* reading, so the key lands.
+    """
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        # Simulate the exact race: release the agent and type in the
+        # same event-loop tick.
+        agent.block.set()
+        await h.type_keys("x")
+        # The character MUST have landed in the input buffer for the
+        # next turn — not dropped, not delivered to a dead typeahead.
+        await h.wait_input_equals("x")
+
+
+async def test_hard_synchronous_commands_dispatch_without_queueing():
+    """N synchronous /cmd items typed while agent is working fire immediately.
+
+    Forever-loop contract: commands don't queue behind the agent — the
+    agent loop doesn't own them. Each slash command goes straight
+    through ``on_command`` as typed; the queue only holds user messages.
+    """
+    agent = _blocking_agent()
+    commands_seen: list[str] = []
+    async with TUIHarness(agent=agent) as h:
+        h.app._on_command = commands_seen.append
+        await h.submit_async("first")  # starts agent; agent blocks
+        await h.wait_for(lambda: h.app.is_thinking())
+        for i in range(5):
+            await h.submit_async(f"/cmd-{i}")
+        # Commands all dispatched immediately — none queued.
+        assert h.capture_queued() == []
+        await h.wait_for(lambda: commands_seen == [f"/cmd-{i}" for i in range(5)])
+
+
+async def test_hard_sync_on_command_raising_surfaces_to_output():
+    """A synchronous ``on_command`` that raises must surface a
+    ``[callback error]`` line to scrollback.
+
+    Forever-loop contract: commands no longer queue behind the agent,
+    so each failing command reports independently as typed. There's no
+    "abort the queue" shortcut any more — there is no command queue.
+    """
+    agent = _blocking_agent()
+
+    def _raising(_text: str) -> None:
+        raise RuntimeError("boom-sync")
+
+    async with TUIHarness(agent=agent) as h:
+        h.app._on_command = _raising
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        await h.submit_async("/will-fail")
+        await h.wait_for(lambda: "[callback error] RuntimeError: boom-sync" in h.capture_output())
+
+
+async def test_hard_async_on_command_raising_surfaces_to_output() -> None:
+    """An async ``on_command`` coroutine that raises must surface the
+    error to scrollback via the task's done-callback (not vanish into
+    asyncio's default exception handler)."""
+    agent = _blocking_agent()
+
+    async def _raising_async(_text: str) -> None:
+        raise RuntimeError("boom-async")
+
+    async with TUIHarness(agent=agent) as h:
+        h.app._on_command = _raising_async
+        await h.submit_async("/go")
+        await h.wait_output_contains("[callback error] RuntimeError: boom-async")
+
+
+async def test_hard_ctrl_c_emits_interrupted_notice_to_scrollback() -> None:
+    """Ctrl-C during an agent turn must put a visible ``✗ Interrupted.``
+    marker into scrollback so the user knows the cancellation landed —
+    not just silently end the turn."""
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        await h.press("c-c")
+        await h.wait_output_contains("Interrupted")
+
+
+async def test_session_transition_cancel_suppresses_interrupted_and_restart() -> None:
+    """Session-command cancellations do not render Interrupted or restart old work."""
+    from unittest.mock import MagicMock
+
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    app = TUIApplication.__new__(TUIApplication)
+    task = MagicMock()
+    task.cancelled.return_value = True
+    q = MagicMock()
+    q.qsize.return_value = 1
+    agent = MagicMock()
+    agent._user_messages_in = q
+    app._agent_task = task
+    app._agent_cancel_requested = True
+    app._agent_loop_task = MagicMock()
+    app._session_transitioning = True
+    app._swapping = False
+    app._app = MagicMock()
+    app._app.is_running = True
+    app.agent = agent
+    app.emit_block = MagicMock()
+    app._ensure_dispatcher_task = MagicMock()
+    app._has_pending_or_running_non_user_work = MagicMock(return_value=True)
+
+    app._on_agent_done(task)
+
+    app.emit_block.assert_not_called()
+    app._ensure_dispatcher_task.assert_not_called()
+    assert app._agent_cancel_requested is False
+    assert app._agent_loop_task is None
+
+
+async def test_hard_sync_blocking_agent_keeps_input_responsive() -> None:
+    """A bad synchronous agent step must not starve prompt_toolkit.
+
+    Regression guard for the TUI freezing while the agent does sync work
+    on the UI event loop: typing during the blocking turn should still
+    update the live input buffer.
+    """
+    import time
+
+    agent = FakeAgent()
+
+    async def _sync_blocking_handle(notification):
+        for items in notification.values():
+            for item in items:
+                agent.messages_received.append(str(item))
+        time.sleep(0.35)
+        from nooa_cli.tui.tui_application import DispatcherExit
+
+        raise DispatcherExit()
+
+    agent.handle = _sync_blocking_handle  # type: ignore[method-assign]
+
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("start")
+        await h.wait_for(lambda: h.app.is_thinking())
+        await h.type_keys("still responsive")
+        await h.wait_input_equals("still responsive", timeout=1.0)
+
+
+async def test_hard_submit_message_re_entry_pushes_to_queue_not_stomps_task() -> None:
+    """Programmatic ``submit_message`` while the forever-loop agent is
+    running must push onto the agent's ``user_messages`` queue, not
+    replace ``_agent_task``.
+    """
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        assert h.app._agent_task is not None
+        first_task = h.app._agent_task
+
+        # Programmatic submission during the blocked turn — pushes onto
+        # the hidden InputQueue without replacing _agent_task. The
+        # exact tail item depends on whether the dispatcher already
+        # consumed "first" (race) — but "second" must be present in
+        # whatever the queue currently holds.
+        h.app.submit_message("second")
+        assert h.app._agent_task is first_task  # not replaced
+        snap = agent._user_messages_in.snapshot()
+        assert any("second" in item for item in snap), (
+            f"expected 'second' to be queued; snapshot={snap!r}"
+        )
+
+        # Pump: release the agent so it drains the queue.
+        agent.block.set()
+        # "second" must reach the agent — either as its own item (if
+        # the dispatcher already consumed "first" before the second
+        # submit_message ran) or merged into a "first\nsecond" item
+        # (if the merge race went the other way).
+        await h.wait_for(lambda: any("second" in m for m in agent.messages_received))
+
+
+class _DummySubview:
+    title = "dummy"
+
+    def __init__(self) -> None:
+        self.opened = False
+        self.closed = False
+        self.keys: list[tuple[str, str]] = []
+
+    def render(self, width: int, height: int) -> str:
+        return f"dummy {width}x{height}"
+
+    def handle_key(self, action: str, value: str = "") -> str:
+        self.keys.append((action, value))
+        if action == "quit":
+            return "close"
+        return "handled"
+
+    def on_open(self) -> None:
+        self.opened = True
+
+    def on_close(self) -> None:
+        self.closed = True
+
+
+async def test_in_app_subview_hosts_keys_without_editing_prompt() -> None:
+    view = _DummySubview()
+    async with TUIHarness() as h:
+        task = asyncio.create_task(h.app.open_subview(view))
+        await h.wait_for(lambda: h.app.active_subview is view)
+
+        await h.type_keys("abc")
+        await h.wait_for(lambda: ("text", "c") in view.keys)
+        assert h.capture_input() == ""
+        assert view.opened is True
+
+        await h.press("escape")
+        await h.wait_for(lambda: ("escape", "") in view.keys)
+        assert h.app.active_subview is view
+
+        await h.press("q")
+        await asyncio.wait_for(task, timeout=1)
+        assert h.app.active_subview is None
+        assert view.closed is True
+
+
+async def test_prompt_toolkit_resize_polling_disabled_to_avoid_delayed_double_redraw() -> None:
+    async with TUIHarness(full_screen=True) as h:
+        assert h.app._app.terminal_size_polling_interval is None
+
+
+async def test_resize_with_active_subview_redraws_once_without_transcript_replay() -> None:
+    view = _DummySubview()
+    async with TUIHarness(full_screen=True) as h:
+        h.app.emit_block("transcript behind subview\n")
+        await h.wait_output_contains("transcript behind subview")
+        task = asyncio.create_task(h.app.open_subview(view))
+        await h.wait_for(lambda: h.app.active_subview is view)
+
+        h.app.handle_resize(cols=40, rows=20)
+        assert h.app._fullscreen_invalidate_count == 0
+
+        await h.press("q")
+        await asyncio.wait_for(task, timeout=1)
+
+
+async def test_fullscreen_mode_rewrites_scrollback_on_resize() -> None:
+    """Fullscreen writes transcript once, then resize rewrites the whole scrollback."""
+    agent = FakeAgent()
+
+    async def step(self: FakeAgent, msg: str):
+        self.emit_message("A long traceback-ish line in native scrollback")
+
+    agent.queue(step)
+    async with TUIHarness(agent=agent, full_screen=True) as h:
+        assert h.app.full_screen is True
+        assert h.app._app.full_screen is False
+        assert h.app._output_window is None
+        await h.submit_async("trigger")
+        await h.wait_output_contains("traceback-ish line")
+        assert h.app._fullscreen_invalidate_count == 0
+        h.app.handle_resize(cols=40, rows=20)
+        assert h.app._fullscreen_invalidate_count == 1
+
+
+async def test_fullscreen_streaming_output_rewrites_scrollback_on_resize() -> None:
+    async with TUIHarness(full_screen=True) as h:
+        for i in range(25):
+            h.app.emit_block(f"chunk {i}\n")
+        await h.wait_output_contains("chunk 24")
+        assert h.app._fullscreen_invalidate_count == 0
+        h.app.handle_resize(cols=50, rows=20)
+        assert h.app._fullscreen_invalidate_count == 1
+
+
+async def test_fullscreen_resize_replays_semantic_callbacks_and_clears_scrollback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with TUIHarness(full_screen=True) as h:
+        calls = 0
+
+        def replay() -> str:
+            nonlocal calls
+            calls += 1
+            return f"reflowed width={h.app.output_columns()}\n"
+
+        h.app.emit_block("old width\n", replay=replay)
+        await h.wait_output_contains("old width")
+        capture = io.StringIO()
+        monkeypatch.setattr("sys.__stdout__", capture)
+
+        h.app.handle_resize(cols=50, rows=20)
+
+        rewritten = capture.getvalue()
+        assert calls == 1
+        assert rewritten.startswith("\x1b[H\x1b[2J\x1b[3J")
+        assert "reflowed width=50" in rewritten
+        assert "old width" not in rewritten
+        assert h.app._fullscreen_invalidate_count == 1
+
+
+async def test_clear_screen_resets_rewritten_scrollback_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with TUIHarness(full_screen=True) as h:
+        h.app.emit_block("before clear\n")
+        await h.wait_output_contains("before clear")
+        h.app.clear_transcript()
+        h.app.emit_block("after clear\n")
+        await h.wait_output_contains("after clear")
+        capture = io.StringIO()
+        monkeypatch.setattr("sys.__stdout__", capture)
+
+        h.app.handle_resize(cols=50, rows=20)
+
+        replayed = capture.getvalue()
+        assert replayed.startswith("\x1b[H\x1b[2J\x1b[3J")
+        assert "after clear" in replayed
+        assert "before clear" not in replayed
+        assert h.app._fullscreen_invalidate_count == 1
+
+
+async def test_non_fullscreen_keeps_native_scrollback_path() -> None:
+    async with TUIHarness() as h:
+        h.app.emit_block("plain scrollback\n")
+        await h.wait_output_contains("plain scrollback")
+        assert h.app._fullscreen_invalidate_count == 0
+
+
+async def test_cancel_status_stays_cancelling_until_agent_cleanup_ack() -> None:
+    """Esc keeps a visible cancelling state until the agent turn unwinds."""
+    agent = FakeAgent()
+    step_started = ThreadGate()
+    cleanup_started = ThreadGate()
+    release_cleanup = ThreadGate()
+    cleanup_done = ThreadGate()
+
+    async def step(_self: FakeAgent, _msg: str) -> None:
+        try:
+            step_started.set()
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            await release_cleanup.wait()
+            cleanup_done.set()
+            raise
+
+    agent.queue(step)
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        await asyncio.wait_for(step_started.wait(), timeout=1.0)
+        assert h.app.request_agent_cancel(source="escape") is True
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
+        assert "cancelling" in h.capture_status()
+        assert h.app.is_thinking() is True
+        assert cleanup_done.is_set() is False
+        release_cleanup.set()
+        await asyncio.wait_for(cleanup_done.wait(), timeout=1.0)
+        await h.wait_for(lambda: not h.app.is_thinking())
+        await h.wait_output_contains("Interrupted")
+
+
+async def test_cancel_does_not_deliver_queued_message_until_cleanup_ack() -> None:
+    """Queued input starts only after cancelled-turn cleanup completes."""
+    agent = FakeAgent()
+    step_started = ThreadGate()
+    cleanup_started = ThreadGate()
+    release_cleanup = ThreadGate()
+    cleanup_done = ThreadGate()
+
+    async def step(_self: FakeAgent, _msg: str) -> None:
+        try:
+            step_started.set()
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            await release_cleanup.wait()
+            cleanup_done.set()
+            raise
+
+    agent.queue(step)
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        await asyncio.wait_for(step_started.wait(), timeout=1.0)
+        await h.type_keys("queued")
+        await h.press("enter")
+        assert h.app.request_agent_cancel(source="escape") is True
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
+        assert agent.messages_received == ["first"]
+        assert "cancelling" in h.capture_status()
+        release_cleanup.set()
+        await asyncio.wait_for(cleanup_done.wait(), timeout=1.0)
+        await h.wait_for(lambda: agent.messages_received == ["first", "queued"])
+
+
+async def test_escape_cancels_agent_turn_but_not_spawned_jobs() -> None:
+    """Soft Esc cancels the turn only; QueueManager spawned jobs keep running."""
+    agent = FakeAgent()
+    job_started = ThreadGate()
+    handle_holder = {}
+
+    async def background_job():
+        job_started.set()
+        await asyncio.Future()
+
+    async def step(self: FakeAgent, _msg: str) -> None:
+        self.queue_manager.queue("job")
+        handle_holder["handle"] = self.queue_manager.spawn(background_job(), channel="job")
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            raise
+
+    agent.queue(step)
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await asyncio.wait_for(job_started.wait(), timeout=1.0)
+        await h.press("escape")
+        await h.wait_for(lambda: not h.app.is_thinking())
+        assert handle_holder["handle"].state == "running"
+        await agent.queue_manager.shutdown()
+
+
+async def test_repeated_ctrl_c_exits_while_cancel_is_pending() -> None:
+    """First Ctrl-C requests an acknowledged turn cancel; second Ctrl-C exits."""
+    agent = FakeAgent()
+    step_started = ThreadGate()
+    cleanup_started = ThreadGate()
+
+    async def step(_self: FakeAgent, _msg: str) -> None:
+        try:
+            step_started.set()
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            await asyncio.Future()
+
+    agent.queue(step)
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await asyncio.wait_for(step_started.wait(), timeout=1.0)
+        await h.press("c-c")
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
+        assert "cancelling" in h.capture_status()
+        await h.press("c-c")
+        await h.wait_for(lambda: not h.app.is_running)
+
+
+async def test_spawned_job_output_restarts_dispatcher_after_cancelled_turn() -> None:
+    """Spawned jobs survive Esc, and their later output still wakes the agent."""
+    agent = FakeAgent()
+    job_started = ThreadGate()
+    release_job = ThreadGate()
+    cleanup_started = ThreadGate()
+
+    async def background_job():
+        job_started.set()
+        await release_job.wait()
+        return "job-result"
+
+    async def step(self: FakeAgent, _msg: str) -> None:
+        self.queue_manager.queue("job")
+        self.queue_manager.spawn(background_job(), channel="job")
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            raise
+
+    agent.queue(step)
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await asyncio.wait_for(job_started.wait(), timeout=1.0)
+        assert h.app.request_agent_cancel(source="escape") is True
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
+        await h.wait_for(lambda: not h.app.is_thinking())
+        release_job.set()
+        await h.wait_for(lambda: agent.messages_received == ["first", "job-result"])
+
+
+async def test_session_cancel_agent_turn_is_safe_from_ui_loop() -> None:
+    """Session commands can cancel agent-loop dispatcher turns from the UI loop."""
+    agent = FakeAgent()
+    step_started = ThreadGate()
+    cleanup_started = ThreadGate()
+    cleanup_done = ThreadGate()
+
+    async def step(_self: FakeAgent, _msg: str) -> None:
+        try:
+            step_started.set()
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            cleanup_done.set()
+            raise
+
+    agent.queue(step)
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await asyncio.wait_for(step_started.wait(), timeout=1.0)
+        assert await h.app.cancel_agent_turn(source="session") is True
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
+        await asyncio.wait_for(cleanup_done.wait(), timeout=1.0)
+        await h.wait_for(lambda: not h.app.is_thinking())
+
+
+async def test_shutdown_agent_queue_manager_runs_spawn_cleanup_on_agent_loop() -> None:
+    """QueueManager.spawn cleanup runs when shutdown happens on the agent loop."""
+    agent = FakeAgent()
+    job_started = ThreadGate()
+    cleanup_started = ThreadGate()
+    cleanup_done = ThreadGate()
+
+    async def step(self: FakeAgent, _msg: str) -> None:
+        self.queue_manager.queue("job")
+
+        async def background_job():
+            try:
+                job_started.set()
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                cleanup_started.set()
+                await asyncio.sleep(0)
+                cleanup_done.set()
+                raise
+
+        self.queue_manager.spawn(background_job(), channel="job")
+
+    agent.queue(step)
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await asyncio.wait_for(job_started.wait(), timeout=1.0)
+        await h.app.shutdown_agent_queue_manager(agent=agent)
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
+        await asyncio.wait_for(cleanup_done.wait(), timeout=1.0)
+        assert agent.queue_manager._handles == []

--- a/packages/nooa-cli/tests/tui/test_tui_app_harness.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_harness.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Canary tests for ``TUIHarness`` itself.
+
+If these fail, nothing in ``test_tui_app_behavior.py`` can be trusted —
+the scaffolding is broken. Keep this file tiny and focused on the
+harness mechanics (start, type, press, teardown), not on TUI behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .tui_app_harness import FakeAgent, TUIHarness
+
+
+@pytest.mark.asyncio
+async def test_harness_starts_and_stops_cleanly():
+    async with TUIHarness() as h:
+        assert h.app is not None
+        assert h.app.is_running
+
+
+@pytest.mark.asyncio
+async def test_harness_types_into_input_buffer():
+    async with TUIHarness() as h:
+        await h.type_keys("hello")
+        await h.wait_input_equals("hello")
+
+
+@pytest.mark.asyncio
+async def test_harness_delivers_named_key():
+    async with TUIHarness() as h:
+        await h.type_keys("abc")
+        await h.press("backspace")
+        await h.wait_input_equals("ab")
+
+
+@pytest.mark.asyncio
+async def test_fake_agent_receives_notification_and_runs_script():
+    """FakeAgent ``respond(notification)`` records the message
+    and invokes any scripted step on the item."""
+    agent = FakeAgent()
+    received: list[str] = []
+    agent.queue(lambda _self, msg: received.append(msg))
+    result = await agent.handle({"user_messages": ["hi"]})
+    assert received == ["hi"]
+    assert agent.messages_received == ["hi"]
+    assert result.kind == "GET_USER_INPUT"

--- a/packages/nooa-cli/tests/tui/test_tui_memory.py
+++ b/packages/nooa-cli/tests/tui/test_tui_memory.py
@@ -1,0 +1,466 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+import pytest
+from nooa_cli.tui.config import Config
+
+
+def _configure_project(monkeypatch, tmp_path):
+    project_dir = tmp_path / ".nooa"
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project_dir))
+    import nooa_cli.tui.session_manager as session_manager
+
+    monkeypatch.setattr(session_manager, "SESSIONS_DIR", project_dir / "sessions")
+    return project_dir
+
+
+def test_tui_memory_config_defaults_to_off():
+    cfg = Config.load()
+    assert cfg.tui.memory == "off"
+    assert cfg.tui.memory_agents == {}
+    assert cfg.tui.memory_path is None
+
+
+def test_tui_memory_config_overrides_path(tmp_path):
+    db = tmp_path / "custom-memory.db"
+    cfg = Config.load(memory="session", memory_path=str(db))
+    assert cfg.tui.memory == "session"
+    assert cfg.tui.memory_path == db
+
+
+def test_tui_memory_config_loads_per_agent_preferences():
+    cfg = Config.load(memory_agents={"my.module:Agent": "session"})
+    assert cfg.tui.memory == "off"
+    assert cfg.tui.memory_agents == {"my.module:Agent": "session"}
+
+
+def test_tui_memory_config_accepts_project_scope():
+    cfg = Config.load(memory="project", memory_agents={"my.module:Agent": "project"})
+    assert cfg.tui.memory == "project"
+    assert cfg.tui.memory_agents == {"my.module:Agent": "project"}
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_default_memory_off_does_not_activate_memory(tmp_path, monkeypatch):
+    from nooa_cli.tui.bootstrap import bootstrap
+
+    _configure_project(monkeypatch, tmp_path)
+    cfg = Config()
+    cfg.tui.default_model = "test-model"
+    cfg.agent.summarization.policy = "none"
+    result = await bootstrap(cfg)
+    try:
+        assert not hasattr(result.agent, "memory")
+        assert "nemo.memory" not in result.agent.skills.activated()
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_per_agent_memory_is_session_scoped(tmp_path, monkeypatch):
+    from nooa_cli.tui.bootstrap import bootstrap
+    from nooa_memory.memory_skill import MemorySkill
+
+    project_dir = _configure_project(monkeypatch, tmp_path)
+    cfg = Config()
+    cfg.tui.default_model = "test-model"
+    cfg.tui.memory_agents["nooa_cli.tui.agent:TUIAgent"] = "session"
+    cfg.agent.summarization.policy = "none"
+    result = await bootstrap(cfg)
+    try:
+        assert isinstance(result.agent.memory, MemorySkill)
+        assert result.agent.memory._mgr is not None
+        assert result.session_id is not None
+        assert result.agent.memory._mgr.store.path == str(
+            project_dir / "sessions" / f"{result.session_id}-memory.db"
+        )
+        assert "nemo.memory" in result.agent.skills.activated()
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_session_memory_sets_owner_and_session_ref(tmp_path, monkeypatch):
+    from nooa_cli.tui.bootstrap import bootstrap
+
+    _configure_project(monkeypatch, tmp_path)
+    cfg = Config()
+    cfg.tui.default_model = "test-model"
+    cfg.tui.memory = "session"
+    cfg.agent.summarization.policy = "none"
+    result = await bootstrap(cfg)
+    try:
+        mgr = result.agent.memory._mgr
+        # hierarchical owner: role (class name) @ 8-hex session instance
+        assert mgr.owner == f"TUIAgent@{result.session_id[:8]}"
+        assert mgr.role == "TUIAgent"
+        assert mgr.session_ref == result.session_id
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_project_memory_uses_working_dir_store(tmp_path, monkeypatch):
+    from nooa_cli.tui.bootstrap import bootstrap
+
+    _configure_project(monkeypatch, tmp_path)
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    cfg = Config()
+    cfg.tui.default_model = "test-model"
+    cfg.tui.memory = "project"
+    cfg.agent.working_dir = str(work_dir)
+    cfg.agent.summarization.policy = "none"
+    result = await bootstrap(cfg)
+    try:
+        expected = (work_dir / ".nooa" / "memory" / "memory.sqlite").resolve()
+        mgr = result.agent.memory._mgr
+        assert mgr.store.path == str(expected)
+        assert expected.exists()
+        assert mgr.owner == f"TUIAgent@{result.session_id[:8]}"
+        assert mgr.session_ref == result.session_id
+        assert "nemo.memory" in result.agent.skills.activated()
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_configure_tui_memory_repoints_session_scope(tmp_path, monkeypatch):
+    from nooa_cli.tui.bootstrap import bootstrap, configure_tui_memory
+
+    project_dir = _configure_project(monkeypatch, tmp_path)
+    cfg = Config()
+    cfg.tui.default_model = "test-model"
+    cfg.tui.memory = "session"
+    cfg.agent.summarization.policy = "none"
+    result = await bootstrap(cfg)
+    try:
+        assert result.agent.memory._mgr.store.path == str(
+            project_dir / "sessions" / f"{result.session_id}-memory.db"
+        )
+        new_id = "22222222-2222-4222-8222-222222222222"
+        new_db = project_dir / "sessions" / f"{new_id}.db"
+        configure_tui_memory(result.agent, cfg, agent_db=new_db, session_id=new_id)
+        assert result.agent.memory._mgr.store.path == str(
+            project_dir / "sessions" / f"{new_id}-memory.db"
+        )
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+def test_session_manager_ignores_and_deletes_memory_sidecars(tmp_path, monkeypatch):
+    from nooa_cli.tui.session_manager import SessionManager
+
+    project_dir = _configure_project(monkeypatch, tmp_path)
+    sessions_dir = project_dir / "sessions"
+    sm = SessionManager.create(model="m", agent_cls="A", working_dir=str(tmp_path))
+    session_id = sm.session_id
+    sm.close()
+    sidecar = sessions_dir / f"{session_id}-memory.db"
+    sidecar.write_text("memory sidecar")
+
+    assert SessionManager.find_by_prefix(session_id[:8]) == [session_id]
+    assert [m.id for m in SessionManager.list_sessions()] == [session_id]
+
+    assert SessionManager.delete_session(session_id) is True
+    assert not (sessions_dir / f"{session_id}.db").exists()
+    assert not sidecar.exists()
+
+
+def test_delete_session_never_touches_project_memory_db(tmp_path, monkeypatch):
+    from nooa_cli.tui.session_manager import SessionManager
+
+    project_dir = _configure_project(monkeypatch, tmp_path)
+    sessions_dir = project_dir / "sessions"
+    sm = SessionManager.create(model="m", agent_cls="A", working_dir=str(tmp_path))
+    session_id = sm.session_id
+    sm.close()
+    sidecar = sessions_dir / f"{session_id}-memory.db"
+    sidecar.write_text("session sidecar")
+
+    project_db = tmp_path / "work" / ".nooa" / "memory" / "memory.sqlite"
+    project_db.parent.mkdir(parents=True, exist_ok=True)
+    project_db.write_text("project store")
+
+    assert SessionManager.delete_session(session_id) is True
+    # Only the session DB + its session-derived sidecars are unlinked.
+    assert not (sessions_dir / f"{session_id}.db").exists()
+    assert not sidecar.exists()
+    assert project_db.exists()
+    assert project_db.read_text() == "project store"
+
+
+@pytest.mark.asyncio
+async def test_memory_command_on_off_persists_to_settings_yaml_and_reloads(tmp_path, monkeypatch):
+    from nooa_cli.tui.bootstrap import bootstrap, resolve_tui_memory_scope
+    from nooa_cli.tui.commands import CommandRegistry
+    from nooa_cli.tui.settings import SETTINGS_FILENAME
+
+    project_dir = _configure_project(monkeypatch, tmp_path)
+    agent_key = "nooa_cli.tui.agent:TUIAgent"
+    cfg = Config()
+    cfg.tui.default_model = "test-model"
+    cfg.agent.summarization.policy = "none"
+    result = await bootstrap(cfg)
+    try:
+        registry = CommandRegistry(
+            config=cfg.tui,
+            agent=result.agent,
+            frontend=object(),
+            skills_dirs=[],
+            session_manager=result.session_manager,
+            root_config=cfg,
+        )
+        cmd = registry._commands["memory"]
+
+        on_result = await cmd.execute(["on"])
+        assert on_result.success
+        assert cfg.tui.memory == "project"  # on == the shared project store
+        assert cfg.tui.memory_agents[agent_key] == "project"
+        expected = (Path(cfg.agent.working_dir) / ".nooa" / "memory" / "memory.sqlite").resolve()
+        assert result.agent.memory._mgr.store.path == str(expected)
+
+        # Persistence lands in settings.yaml — the file the loader actually reads —
+        # NOT the phantom config.toml that no loader reads.
+        settings_file = project_dir / SETTINGS_FILENAME
+        assert settings_file.exists()
+        assert not (project_dir / "config.toml").exists()
+
+        # Round-trip: a fresh Config.load() (which applies settings.yaml) sees the
+        # preference, so it survives the restart the command prompts for.
+        reloaded = Config.load()
+        assert reloaded.tui.memory_agents.get(agent_key) == "project"
+        assert resolve_tui_memory_scope(result.agent, reloaded) == "project"
+
+        off_result = await cmd.execute(["off"])
+        assert off_result.success
+        assert cfg.tui.memory == "off"
+        assert cfg.tui.memory_agents[agent_key] == "off"
+        assert not hasattr(result.agent, "memory")
+
+        reloaded_off = Config.load()
+        assert reloaded_off.tui.memory_agents.get(agent_key) == "off"
+        assert resolve_tui_memory_scope(result.agent, reloaded_off) == "off"
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_memory_command_local_scope(tmp_path, monkeypatch):
+    from nooa_cli.tui.bootstrap import bootstrap
+    from nooa_cli.tui.commands import CommandRegistry
+
+    _configure_project(monkeypatch, tmp_path)
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    cfg = Config()
+    cfg.tui.default_model = "test-model"
+    cfg.agent.working_dir = str(work_dir)
+    cfg.agent.summarization.policy = "none"
+    result = await bootstrap(cfg)
+    try:
+        registry = CommandRegistry(
+            config=cfg.tui,
+            agent=result.agent,
+            frontend=object(),
+            skills_dirs=[],
+            session_manager=result.session_manager,
+            root_config=cfg,
+        )
+        cmd = registry._commands["memory"]
+
+        local_result = await cmd.execute(["local"])
+        assert local_result.success
+        assert cfg.tui.memory == "session"  # 'local' = per-session scope
+        assert cfg.tui.memory_agents["nooa_cli.tui.agent:TUIAgent"] == "session"
+        mgr = result.agent.memory._mgr
+        assert f"{result.session_id}-memory.db" in mgr.store.path
+        assert mgr.session_ref == result.session_id
+
+        status = await cmd.execute(["status"])
+        assert status.success
+        content = status.outputs[0].content
+        assert content.startswith("Memory: local (this session only)")
+        assert f"you are TUIAgent@{result.session_id[:8]}" in content
+        assert "store:" in content
+
+        # the old scope words are no longer part of the command vocabulary
+        assert cmd.validate_args(["project"])[0] is False
+        assert cmd.validate_args(["session"])[0] is False
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_rejects_memory_path_escape(tmp_path, monkeypatch):
+    from nooa_cli.tui.bootstrap import bootstrap
+
+    _configure_project(monkeypatch, tmp_path)
+    cfg = Config()
+    cfg.tui.default_model = "test-model"
+    cfg.tui.memory = "session"
+    cfg.tui.memory_path = tmp_path / "outside.db"
+    cfg.agent.summarization.policy = "none"
+
+    result = await bootstrap(cfg)
+    try:
+        assert not hasattr(result.agent, "memory")
+        assert any(
+            "tui.memory_path must be relative" in getattr(m, "content", "") for m in result.messages
+        )
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_rejects_memory_path_parent_escape(tmp_path, monkeypatch):
+    from nooa_cli.tui.bootstrap import bootstrap
+
+    _configure_project(monkeypatch, tmp_path)
+    cfg = Config()
+    cfg.tui.default_model = "test-model"
+    cfg.tui.memory = "session"
+    cfg.tui.memory_path = Path("../outside.db")
+    cfg.agent.summarization.policy = "none"
+
+    result = await bootstrap(cfg)
+    try:
+        assert not hasattr(result.agent, "memory")
+        assert any(
+            "tui.memory_path must stay under the project directory" in getattr(m, "content", "")
+            for m in result.messages
+        )
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_owner_resolution_override_chain(tmp_path, monkeypatch):
+    """per-agent override > global memory_owner > class-name default."""
+    from nooa_cli.tui.bootstrap import bootstrap
+
+    _configure_project(monkeypatch, tmp_path)
+    cfg = Config()
+    cfg.tui.default_model = "test-model"
+    cfg.tui.memory = "project"
+    cfg.tui.memory_owner = "team"
+    cfg.agent.working_dir = str(tmp_path / "work")
+    Path(cfg.agent.working_dir).mkdir()
+    cfg.agent.summarization.policy = "none"
+    result = await bootstrap(cfg)
+    try:
+        mgr = result.agent.memory._mgr
+        assert mgr.owner == f"team@{result.session_id[:8]}"  # global override wins
+        assert mgr.role == "team"
+
+        cfg.tui.memory_owner_agents["nooa_cli.tui.agent:TUIAgent"] = "planner"
+        from nooa_cli.tui.bootstrap import configure_tui_memory
+
+        configure_tui_memory(
+            result.agent,
+            cfg,
+            agent_db=result.session_manager.agent_db_path,
+            session_id=result.session_manager.session_id,
+        )
+        assert result.agent.memory._mgr.role == "planner"  # per-agent beats global
+        assert result.agent.memory._mgr.owner.startswith("planner@")
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_legacy_owner_rows_are_healed_on_configure(tmp_path, monkeypatch):
+    """Rows written under the module:qualname key fold into the class name."""
+    from nooa_cli.tui.bootstrap import bootstrap
+    from nooa_memory import Memory
+    from nooa_memory.embeddings import HashingEmbedder
+    from nooa_memory.store import MemoryStore
+
+    _configure_project(monkeypatch, tmp_path)
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    legacy_key = "nooa_cli.tui.agent:TUIAgent"
+    store_path = work_dir / ".nooa" / "memory" / "memory.sqlite"
+    seed_store = MemoryStore(store_path)
+    emb = HashingEmbedder(dim=256)
+    m = Memory(content="written by the legacy spelling", owner=legacy_key)
+    seed_store.add(m, emb.embed(m.embedding_text()))
+    seed_store.close()
+
+    cfg = Config()
+    cfg.tui.default_model = "test-model"
+    cfg.tui.memory = "project"
+    cfg.agent.working_dir = str(work_dir)
+    cfg.agent.summarization.policy = "none"
+    result = await bootstrap(cfg)
+    try:
+        mgr = result.agent.memory._mgr
+        healed = mgr.store.get(m.id)
+        assert healed.owner == "TUIAgent"  # folded into the canonical short name
+        history = mgr.store.maintenance_history(5)
+        rename_rows = [h for h in history if h["kind"] == "rename_owner"]
+        assert rename_rows and rename_rows[0]["report"] == {
+            "from": legacy_key,
+            "to": "TUIAgent",
+            "rows": 1,
+        }
+        # the healed row is now recallable in the agent's default own-scope
+        assert mgr.recall("legacy spelling")
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_generative_reflection_hooks_wiring(tmp_path, monkeypatch):
+    """/reflection on wires the LLM reconciler+reasoner by default; the
+    tui.reflection_generative knob and reflection-off both unwire them."""
+    from nooa_cli.tui.bootstrap import bootstrap, configure_tui_memory
+
+    _configure_project(monkeypatch, tmp_path)
+    cfg = Config()
+    cfg.tui.default_model = "test-model"
+    cfg.tui.memory = "project"
+    cfg.tui.reflection = True
+    cfg.agent.working_dir = str(tmp_path / "work")
+    Path(cfg.agent.working_dir).mkdir()
+    cfg.agent.summarization.policy = "none"
+    result = await bootstrap(cfg)
+    try:
+        mgr = result.agent.memory._mgr
+        assert mgr._reconciler is not None and mgr._reasoner is not None
+        assert mgr.config.reflection.trigger == "manual"  # idle runner owns it
+
+        cfg.tui.reflection_generative = False
+        configure_tui_memory(
+            result.agent,
+            cfg,
+            agent_db=result.session_manager.agent_db_path,
+            session_id=result.session_manager.session_id,
+        )
+        mgr = result.agent.memory._mgr
+        assert mgr._reconciler is None and mgr._reasoner is None
+
+        cfg.tui.reflection_generative = True
+        cfg.tui.reflection = False  # reflection off -> no generative hooks either
+        configure_tui_memory(
+            result.agent,
+            cfg,
+            agent_db=result.session_manager.agent_db_path,
+            session_id=result.session_manager.session_id,
+        )
+        assert result.agent.memory._mgr._reconciler is None
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()

--- a/packages/nooa-cli/tests/tui/tui_app_harness.py
+++ b/packages/nooa-cli/tests/tui/tui_app_harness.py
@@ -1,0 +1,379 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Test harness for driving a ``TUIApplication`` in unit tests.
+
+Usage::
+
+    async with TUIHarness() as h:
+        await h.type_keys("hello")
+        await h.press("enter")
+        assert "hello" in h.capture_output()
+
+The harness owns:
+
+- a ``PipeInput`` — bytes written with ``send_text()`` look like keystrokes
+- a ``DummyOutput`` — swallows rendering but the app still thinks it has a TTY
+- a background task running ``app.run_async()``
+- a scriptable ``FakeAgent`` that yields controllable responses
+
+Assertions read the app's *logical* state (input/output buffer text, queue
+messages, status line) rather than parsed terminal output — terminal-level
+correctness is covered by manual smoke, and tying unit tests to rendered
+ANSI bytes is brittle.
+
+Timing model: writing to the pipe is synchronous, but prompt_toolkit
+parses input on the event loop. Every driver method ends with an
+``asyncio.sleep(0)`` (or an explicit ``wait_for``) so the event loop has
+a chance to drain the pipe before the next assertion runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from typing import TYPE_CHECKING, Any
+
+from prompt_toolkit.application import create_app_session
+from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.output import DummyOutput
+
+if TYPE_CHECKING:
+    from nooa_cli.tui.tui_application import TUIApplication
+
+
+# ── key-name → terminal escape-sequence --------------------------------------
+
+# Only what the tests actually press. Extend as new tests demand it.
+_KEY_SEQUENCES: dict[str, str] = {
+    "enter": "\r",
+    "escape": "\x1b",
+    "q": "q",
+    "tab": "\t",
+    "backspace": "\x7f",
+    "up": "\x1b[A",
+    "down": "\x1b[B",
+    "right": "\x1b[C",
+    "left": "\x1b[D",
+    "home": "\x1b[H",
+    "end": "\x1b[F",
+    "pageup": "\x1b[5~",
+    "pagedown": "\x1b[6~",
+    "c-c": "\x03",
+    "c-d": "\x04",
+    "c-j": "\n",  # bare LF — used by prompt_toolkit as "Shift+Enter"
+    "s-enter": "\x1b\r",  # Alt+Enter / Esc+Enter — prompt_toolkit treats as newline
+}
+
+
+def _key_sequence(key: str) -> str:
+    try:
+        return _KEY_SEQUENCES[key.lower()]
+    except KeyError:
+        raise ValueError(
+            f"Unknown key {key!r}. Add it to _KEY_SEQUENCES in tui_app_harness."
+        ) from None
+
+
+# ── scriptable agent mock ----------------------------------------------------
+
+
+class ThreadGate:
+    """Small awaitable gate safe to set from a different event loop thread."""
+
+    def __init__(self, *, initially_set: bool = False) -> None:
+        self._set = initially_set
+        self._lock = threading.Lock()
+        self._waiters: list[asyncio.Future[None]] = []
+
+    def set(self) -> None:
+        with self._lock:
+            self._set = True
+            waiters = list(self._waiters)
+            self._waiters.clear()
+        for waiter in waiters:
+            if waiter.done():
+                continue
+            waiter.get_loop().call_soon_threadsafe(waiter.set_result, None)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._set = False
+
+    def is_set(self) -> bool:
+        with self._lock:
+            return self._set
+
+    async def wait(self) -> None:
+        with self._lock:
+            if self._set:
+                return
+            waiter: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+            self._waiters.append(waiter)
+        try:
+            await waiter
+        except asyncio.CancelledError:
+            with self._lock:
+                try:
+                    self._waiters.remove(waiter)
+                except ValueError:
+                    pass
+            raise
+
+
+class FakeAgent:
+    """Scriptable stand-in for ``TUIAgent`` used by harness tests.
+
+    Matches the per-turn contract: ``handle((queue_name, item))``
+    is invoked once per turn by the dispatcher, and returns a
+    ``RespondResult``-shaped object telling the dispatcher what to do
+    next.
+
+    Control knobs:
+
+    - ``self.script`` — callables run one per received message.
+    - ``self.block`` — when cleared, ``handle()`` awaits it before
+      returning, keeping the dispatcher (and spinner) visibly "working"
+      for as long as the test needs. Default: set, so handle returns
+      quickly.
+    - ``self.next_kind`` — the ``kind`` the FakeAgent returns by
+      default. Tests raise ``DispatcherExit`` to end the session, or
+      flip to ``"WAIT"`` to exercise multi-queue races.
+    """
+
+    def __init__(self) -> None:
+        from nooa.runtime.channels import QueueManager
+
+        self.script: list[Callable[[FakeAgent, str], Any]] = []
+        self.messages_received: list[str] = []
+        self.block = ThreadGate(initially_set=True)  # default: handle returns immediately
+        self.emit: Callable[[str], None] | None = None  # set by app
+        # Tests don't need event-mode channels, so no event_manager.
+        self.queue_manager = QueueManager()
+        self._user_messages_in = self.queue_manager.queue("user_messages")
+        self.user_messages = self._user_messages_in.reader
+        self.next_kind: str = "GET_USER_INPUT"
+
+    def emit_message(self, text: str) -> None:
+        """Render ``text`` as Markdown → ANSI and push to the output buffer.
+
+        Mirrors what the real frontend does with ``AgentMessage`` objects
+        (Rich Markdown renderer), so tests that assert on ANSI presence
+        exercise the same rendering path as production.
+        """
+        if self.emit is None:
+            return
+        import io as _io
+
+        from rich.console import Console
+        from rich.markdown import Markdown
+
+        buf = _io.StringIO()
+        Console(
+            file=buf, force_terminal=True, color_system="256", width=80, legacy_windows=False
+        ).print(Markdown(text))
+        self.emit(buf.getvalue())
+
+    async def handle(
+        self,
+        notification: dict[str, list],
+    ) -> Any:
+        """Per-turn stub: record inputs, run a scripted step, return a result.
+
+        Returns a simple namespace with ``kind`` (matches the shape
+        ``RespondResult`` exposes) so the dispatcher's ``getattr``
+        calls find what they need without the harness needing to
+        import the TUI agent's Pydantic model.
+        """
+        for items in notification.values():
+            for item in items:
+                self.messages_received.append(str(item))
+        if self.script:
+            step = self.script.pop(0)
+            await _maybe_await(step(self, item))
+        await self.block.wait()
+
+        class _Result:
+            pass
+
+        r = _Result()
+        r.kind = self.next_kind
+        return r
+
+    def queue(self, step: Callable[[FakeAgent, str], Any]) -> None:
+        """Add one scripted step to the end of the response sequence."""
+        self.script.append(step)
+
+
+async def _maybe_await(value: Any) -> Any:
+    if asyncio.iscoroutine(value):
+        return await value
+    return value
+
+
+# ── the harness itself -------------------------------------------------------
+
+
+class TUIHarness(AbstractAsyncContextManager["TUIHarness"]):
+    """Drive a ``TUIApplication`` from tests.
+
+    Enters as an async context manager: starts the app's event loop task
+    on ``__aenter__``, tears it down (with a timeout) on ``__aexit__``.
+    """
+
+    def __init__(
+        self, agent: FakeAgent | None = None, config: Any = None, full_screen: bool | None = None
+    ) -> None:
+        self.agent = agent or FakeAgent()
+        self._config = config
+        self._full_screen = full_screen
+        self._pipe_ctx: Any = None
+        self._session_ctx: Any = None
+        self._run_task: asyncio.Task | None = None
+        self.app: TUIApplication | None = None
+
+    async def __aenter__(self) -> TUIHarness:
+        self._pipe_ctx = create_pipe_input()
+        pipe = self._pipe_ctx.__enter__()
+        self._session_ctx = create_app_session(input=pipe, output=DummyOutput())
+        self._session_ctx.__enter__()
+
+        # Import locally so the stub can evolve without breaking harness
+        # consumers that don't import it.
+        from nooa_cli.tui.tui_application import TUIApplication
+        from prompt_toolkit.completion import WordCompleter
+
+        # Canonical slash/bang set that covers the completion tests. Production
+        # wiring passes a CommandRegistry-backed completer instead.
+        completer = WordCompleter(
+            ["/help", "/exit", "/clear", "/compact", "!bash", "!git"],
+            sentence=True,
+        )
+        kwargs = {}
+        if self._full_screen is not None:
+            kwargs["full_screen"] = self._full_screen
+        self.app = TUIApplication(
+            agent=self.agent,
+            completer=completer,
+            config=self._config,
+            **kwargs,
+        )
+        self._pipe = pipe
+
+        self._run_task = asyncio.create_task(self.app.run_async())
+        # Let the app install its input reader before the test sends keys.
+        await self._wait_for_app_ready()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        try:
+            # Cancel any pending agent task so FakeAgent.handle() awaiting
+            # on agent.block doesn't get orphaned at teardown.
+            if self.app is not None:
+                agent_task = getattr(self.app, "_agent_task", None)
+                if agent_task is not None and not agent_task.done():
+                    agent_task.cancel()
+                    try:
+                        await agent_task
+                    except (asyncio.CancelledError, BaseException):
+                        pass
+                self.app.exit()
+            if self._run_task is not None:
+                try:
+                    await asyncio.wait_for(self._run_task, timeout=2.0)
+                except (TimeoutError, asyncio.CancelledError):
+                    self._run_task.cancel()
+        finally:
+            if self._session_ctx is not None:
+                self._session_ctx.__exit__(None, None, None)
+            if self._pipe_ctx is not None:
+                self._pipe_ctx.__exit__(None, None, None)
+
+    async def _wait_for_app_ready(self) -> None:
+        """Spin until the underlying Application reports ready."""
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            app = self.app
+            if app is not None and app.is_running:
+                return
+            await asyncio.sleep(0.01)
+        raise RuntimeError("TUIApplication did not start within 2s")
+
+    # ── input driving --------------------------------------------------
+
+    async def type_keys(self, text: str) -> None:
+        """Send literal characters as if the user typed them."""
+        self._pipe.send_text(text)
+        await asyncio.sleep(0)
+
+    async def press(self, key: str) -> None:
+        """Press a named key (``"enter"``, ``"up"``, ``"c-c"``, …)."""
+        self._pipe.send_text(_key_sequence(key))
+        await asyncio.sleep(0)
+
+    async def submit_async(self, text: str) -> None:
+        """Type ``text`` and press Enter. Doesn't wait for any side-effect."""
+        await self.type_keys(text)
+        await self.press("enter")
+
+    # ── state-polling helpers -----------------------------------------
+
+    async def wait_for(
+        self, predicate: Callable[[], bool], timeout: float = 2.0, interval: float = 0.01
+    ) -> None:
+        """Yield control until ``predicate()`` returns truthy, or raise."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            await asyncio.sleep(interval)
+        raise AssertionError(
+            f"Predicate never became true within {timeout}s.\n"
+            f"  input={self.capture_input()!r}\n"
+            f"  output (tail)={self.capture_output()[-200:]!r}\n"
+            f"  queued={self.capture_queued()!r}\n"
+            f"  status={self.capture_status()!r}"
+        )
+
+    async def wait_input_equals(self, expected: str, timeout: float = 1.0) -> None:
+        await self.wait_for(lambda: self.capture_input() == expected, timeout=timeout)
+
+    async def wait_output_contains(self, needle: str, timeout: float = 1.0) -> None:
+        await self.wait_for(lambda: needle in self.capture_output(), timeout=timeout)
+
+    # ── introspection --------------------------------------------------
+
+    def capture_input(self) -> str:
+        assert self.app is not None
+        return self.app.input_buffer.text
+
+    def capture_output(self) -> str:
+        assert self.app is not None
+        return self.app.output_buffer.text
+
+    def capture_output_ansi(self) -> str:
+        """Raw (ANSI-bearing) output. ``capture_output`` strips ANSI; this
+        preserves it so ``\\x1b[`` round-trip tests can assert styling."""
+        assert self.app is not None
+        return "".join(self.app._output_ansi)
+
+    def capture_queued(self) -> list[str]:
+        """Return queued items (pending user messages) in submission order.
+
+        Reads ``agent._user_messages_in`` — the hidden InputQueue the
+        dispatcher pumps from — so tests see what the UI's queue
+        window is showing. Commands are no longer queued in app state;
+        they dispatch immediately via ``on_command``/``on_bang``.
+        """
+        assert self.app is not None
+        agent = getattr(self.app, "agent", None)
+        q = getattr(agent, "_user_messages_in", None) if agent is not None else None
+        if q is None:
+            return []
+        return [str(item) for item in q.snapshot()]
+
+    def capture_status(self) -> str:
+        assert self.app is not None
+        return self.app.status_text()

--- a/uv.lock
+++ b/uv.lock
@@ -1541,8 +1541,11 @@ name = "nooa-cli"
 source = { editable = "packages/nooa-cli" }
 dependencies = [
     { name = "click" },
-    { name = "nooa" },
+    { name = "nooa", extra = ["mcp", "memory"] },
+    { name = "prompt-toolkit" },
+    { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "rich" },
 ]
 
 [package.optional-dependencies]
@@ -1565,11 +1568,14 @@ datascience = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
-    { name = "nooa", editable = "." },
+    { name = "nooa", extras = ["mcp", "memory"], editable = "." },
     { name = "numpy", marker = "extra == 'datascience'", specifier = ">=1.24.0" },
     { name = "pandas", marker = "extra == 'datascience'", specifier = ">=2.0.0" },
     { name = "plotly", marker = "extra == 'datascience'", specifier = ">=5.0.0" },
+    { name = "prompt-toolkit", specifier = ">=3.0.41,<3.1.0" },
+    { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rich", specifier = ">=13.0.0" },
     { name = "scikit-learn", marker = "extra == 'datascience'", specifier = ">=1.3.0" },
     { name = "scipy", marker = "extra == 'datascience'", specifier = ">=1.10.0" },
     { name = "tree-sitter", marker = "extra == 'ast'", specifier = ">=0.23.0" },
@@ -1928,6 +1934,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -2908,6 +2926,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
     { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
     { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds the native terminal coding host on top of the shared `nooa_cli.coding` layer, so the TUI and the ACP adapter drive the same agent, the same session store, and the same skills rather than each carrying its own copy.

Stacked on #143 — please review that first. This targets `dev/acp-sessions`, so the diff shown here is TUI-only; GitHub retargets to `main` once #143 merges.

## What's here

- `nooa tui` — the interactive coding agent: sessions and resume, slash commands, MCP lifecycle commands, memory and reflection opt-ins, keep-going mode, toolbar extensions, and the event explorer.
- Adaptation to the merged session foundation: sessions moved from `nooa.sessions` to `nooa_cli.sessions`, `SessionStore.create()` renamed `host` to `origin` (the TUI records `origin="tui"` beside ACP's `origin="acp"`), and the transient `SessionResumed` / `SessionCleared` events restored — they are `EventBase`, so they stay out of `SESSION_EVENT_TYPES`, which is the set persisted with the session.

## One behaviour change worth noting

`turn_count` now counts **user turns only**. The live `record_user_message` path always did; the summary query also counted agent messages, so the two disagreed. #82 made them agree, and the test asserting the old value is updated rather than the merged behaviour. `turns()` still returns both roles, so it remains the longer of the two.

## Library directory

`CodingAgent` takes an optional `libs_dir`. The default is unchanged, so the TUI still resolves `<project>/.nooa/libs` via `get_project_dir()` — including when launched from a subdirectory, where it finds the project root rather than the subdirectory. Only the ACP host, which serves several workspaces from one process, passes an explicit workspace-scoped path.

## Verification

- 892 tests pass across `nooa-cli` and `nooa-acp`; full suite green
- `ruff check` / `ruff format --check` clean
- Rebased onto the reconciled #143 branch with no conflicts