### PR TITLE
feat(eval): unify capability A/B comparisons and clarify strategy prompts

### DIFF
--- a/scripts/CAPABILITY_AB.md
+++ b/scripts/CAPABILITY_AB.md
@@ -1,0 +1,54 @@
+# Capability A/B testing
+
+`scripts/capability_ab.py` compares any two git revisions across the capability
+suite. Both revisions run fresh in isolated worktrees with the same credentials,
+model endpoints, dependency extras, run count, and concurrency. The resulting
+Markdown and JSON reports include aggregate, model, tier, error, case-collapse,
+token, run-variance, and paired task-bootstrap statistics.
+
+## Full comparison
+
+```bash
+set -a
+source .env
+set +a
+
+uv run python scripts/capability_ab.py main HEAD \
+  --models claude-haiku,gpt-5.4-mini,nemotron3-nano-30b,claude-opus-4-8 \
+  --runs 3 \
+  --parallel 40
+```
+
+Without `--models`, the runner uses `agent_models` from the selected config.
+Use `--require-clean` in automation when review findings should produce a
+non-zero exit code. Infrastructure-invalid arms always fail.
+
+## Config semantics
+
+A relative `--config` path is resolved separately inside each revision. This is
+appropriate for release checks because changes to capability agents, data, and
+scorers are part of the revision being reviewed.
+
+An absolute `--config` path is shared verbatim between arms. This holds the
+harness constant for experiments on framework, model, API, agent, or prompt
+changes and also permits private model definitions without committing them.
+
+```bash
+uv run python scripts/capability_ab.py BASE_SHA HEAD \
+  --config /absolute/path/to/six-model-config.yaml \
+  --models model-a,model-b,model-c
+```
+
+## Reuse and arm order
+
+Runs are fresh by default. `--reuse` reuses an arm only when its revision,
+config content, models, repetitions, concurrency, filters, timeout, and cache
+settings match its recorded signature. Candidate-first order matches the
+release workflow; use `--base-first` when desired and record the choice.
+
+## Release integration
+
+`scripts/make_release.py` calls the same `run_ab()` implementation with the
+release model matrix, policy thresholds, and result reuse enabled. The release
+script remains responsible for version tags, builds, human approval, GitHub
+release creation, and publishing; it no longer owns a separate A/B engine.

--- a/scripts/capability_ab.py
+++ b/scripts/capability_ab.py
@@ -1,0 +1,975 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run a fresh capability A/B comparison between two git revisions.
+
+Both revisions execute in isolated worktrees against the same model endpoints
+and credentials. A relative config path is resolved inside each revision so
+test-harness changes remain part of the comparison; an absolute config path is
+shared verbatim between arms when the harness must be held constant.
+
+Examples:
+
+    uv run python scripts/capability_ab.py v0.0.8 HEAD
+
+    uv run python scripts/capability_ab.py main HEAD \
+      --config /tmp/six-model-capability.yaml \
+      --models claude-haiku,gpt-5.4-mini,nemotron3-nano-30b
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULT_CONFIG = Path("tests/capability/config.yaml")
+DEFAULT_RUNS = 3
+DEFAULT_PARALLEL = 40
+DEFAULT_BOOTSTRAP_SAMPLES = 100_000
+DEFAULT_SEED = 20260819
+
+# Release-policy defaults. Callers may supply a different policy without
+# changing how arms are prepared or how results are parsed.
+STABLE_FLOOR = 0.60
+AGGREGATE_NOISE_PTS = 5.0
+MAX_ERROR_RATE = 0.50
+COLLAPSE_BEFORE = 0.80
+COLLAPSE_AFTER = 0.20
+
+BOLD, DIM, RED, YELLOW, GREEN, RESET = (
+    ("\033[1m", "\033[2m", "\033[31m", "\033[33m", "\033[32m", "\033[0m")
+    if sys.stdout.isatty()
+    else ("", "", "", "", "", "")
+)
+
+CaseKey = tuple[str, str, str]
+TaskKey = tuple[str, str]
+
+
+class CapabilityABError(RuntimeError):
+    """Raised when an A/B arm is invalid or infrastructure preparation fails."""
+
+
+@dataclass(frozen=True)
+class ComparisonPolicy:
+    stable_floor: float = STABLE_FLOOR
+    aggregate_noise_points: float = AGGREGATE_NOISE_PTS
+    max_error_rate: float = MAX_ERROR_RATE
+    collapse_before: float = COLLAPSE_BEFORE
+    collapse_after: float = COLLAPSE_AFTER
+
+
+@dataclass
+class ArmResults:
+    """Parsed results for one revision."""
+
+    label: str
+    result_path: Path | None = None
+    by_case: dict[CaseKey, list[bool]] = field(default_factory=lambda: defaultdict(list))
+    case_tier: dict[CaseKey, str] = field(default_factory=dict)
+    by_task: dict[TaskKey, list[bool]] = field(default_factory=lambda: defaultdict(list))
+    task_tier: dict[TaskKey, str] = field(default_factory=dict)
+    by_run: dict[int, list[bool]] = field(default_factory=lambda: defaultdict(list))
+    errors: dict[CaseKey, dict[str, int]] = field(
+        default_factory=lambda: defaultdict(lambda: defaultdict(int))
+    )
+    output_tokens: int = 0
+    total_tokens: int = 0
+    errored: int = 0
+
+    def error_rate(self) -> float:
+        _, total = self.counts()
+        return self.errored / total if total else 0.0
+
+    def rate(self, key: CaseKey) -> float | None:
+        values = self.by_case.get(key)
+        return statistics.mean(values) if values else None
+
+    def counts(self) -> tuple[int, int]:
+        flags = [flag for values in self.by_case.values() for flag in values]
+        return sum(flags), len(flags)
+
+    def overall(self) -> float:
+        passed, total = self.counts()
+        return passed / total if total else 0.0
+
+    def tier_counts(self) -> dict[str, tuple[int, int]]:
+        grouped: dict[str, list[bool]] = defaultdict(list)
+        for key, flags in self.by_case.items():
+            grouped[self.case_tier.get(key, "stable")].extend(flags)
+        return {tier: (sum(flags), len(flags)) for tier, flags in grouped.items()}
+
+    def per_model(self) -> dict[str, float]:
+        grouped: dict[str, list[bool]] = defaultdict(list)
+        for (model, _, _), flags in self.by_case.items():
+            grouped[model].extend(flags)
+        return {model: statistics.mean(flags) for model, flags in grouped.items() if flags}
+
+    def model_names(self) -> set[str]:
+        return {model for model, _, _ in self.by_case}
+
+
+@dataclass
+class Diff:
+    regressions: list[str] = field(default_factory=list)
+    new_errors: list[str] = field(default_factory=list)
+    beyond_noise: list[str] = field(default_factory=list)
+    added: list[str] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+    models_changed: list[str] = field(default_factory=list)
+    floor_breach: str | None = None
+    markdown: str = ""
+    statistics: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def clean(self) -> bool:
+        return not (
+            self.regressions
+            or self.new_errors
+            or self.beyond_noise
+            or self.removed
+            or self.floor_breach
+        )
+
+
+@dataclass
+class ABRunResult:
+    base: ArmResults
+    head: ArmResults
+    diff: Diff
+    base_sha: str
+    head_sha: str
+    report_path: Path
+    summary_path: Path
+
+
+def _run(
+    command: list[str],
+    *,
+    cwd: Path,
+    capture: bool = True,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    if not capture:
+        print(f"  {DIM}$ {' '.join(command)}{RESET}", flush=True)
+    environment = os.environ.copy()
+    if command and command[0] == "uv":
+        # Each isolated checkout owns its own project environment. Inheriting
+        # the caller's VIRTUAL_ENV makes uv warn and risks targeting the wrong
+        # environment for pip-interface commands.
+        environment.pop("VIRTUAL_ENV", None)
+    process = subprocess.run(
+        command,
+        cwd=cwd,
+        env=environment,
+        text=True,
+        capture_output=capture,
+        check=False,
+    )
+    if check and process.returncode != 0:
+        detail = (process.stderr or process.stdout or "").strip()
+        raise CapabilityABError(
+            f"command failed ({process.returncode}): {' '.join(command)}\n{detail}"
+        )
+    return process
+
+
+def _git(repo: Path, *arguments: str, check: bool = True) -> str:
+    return _run(["git", *arguments], cwd=repo, check=check).stdout.strip()
+
+
+def parse_results(path: Path, label: str) -> ArmResults:
+    """Parse an eval JSONL file, retaining model/test/case granularity."""
+    arm = ArmResults(label=label, result_path=path)
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if record.get("_type") != "result":
+            continue
+
+        model = str(record.get("model") or "?")
+        test_name = str(record.get("test_name") or record.get("agent_class") or "?")
+        test_case = str(record.get("test_case") or test_name)
+        tier = str(record.get("tier") or "stable")
+        passed = bool(record.get("passed"))
+        case_key = (model, test_name, test_case)
+        task_key = (test_name, test_case)
+
+        arm.by_case[case_key].append(passed)
+        arm.case_tier.setdefault(case_key, tier)
+        arm.by_task[task_key].append(passed)
+        arm.task_tier.setdefault(task_key, tier)
+        try:
+            run_id = int(record.get("run_id", 1))
+        except (TypeError, ValueError):
+            run_id = 1
+        arm.by_run[run_id].append(passed)
+
+        if record.get("error_type"):
+            arm.errors[case_key][str(record["error_type"])] += 1
+            arm.errored += 1
+        arm.output_tokens += int(record.get("output_tokens") or 0)
+        arm.total_tokens += int(record.get("total_tokens") or 0)
+    return arm
+
+
+def newest_eval(output_dir: Path) -> Path | None:
+    found = sorted(output_dir.rglob("*.noo-eval.jsonl"), key=lambda path: path.stat().st_mtime)
+    return found[-1] if found else None
+
+
+def configured_models(config: Path) -> list[str]:
+    """Return the config's declared agent-model matrix."""
+    document = yaml.safe_load(config.read_text()) or {}
+    models = document.get("agent_models")
+    if isinstance(models, list) and models:
+        return [str(model) for model in models]
+    mapping = document.get("models")
+    if isinstance(mapping, dict) and mapping:
+        return [str(model) for model in mapping]
+    raise CapabilityABError(f"{config} declares neither agent_models nor models")
+
+
+def _percentile(values: list[float], probability: float) -> float:
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * probability
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] * (1 - fraction) + ordered[upper] * fraction
+
+
+def _bootstrap_rates(
+    before: dict[TaskKey, list[bool]],
+    after: dict[TaskKey, list[bool]],
+    tasks: list[TaskKey],
+    *,
+    samples: int,
+    seed: int,
+) -> dict[str, Any]:
+    if not tasks:
+        return {}
+    before_rates = [statistics.mean(before[task]) for task in tasks]
+    after_rates = [statistics.mean(after[task]) for task in tasks]
+    deltas = [new - old for old, new in zip(before_rates, after_rates, strict=True)]
+    rng = random.Random(seed)
+    boot_delta: list[float] = []
+    for _ in range(samples):
+        indices = [rng.randrange(len(tasks)) for _ in tasks]
+        boot_delta.append(statistics.mean(deltas[index] for index in indices))
+    return {
+        "tasks": len(tasks),
+        "before_rate": statistics.mean(before_rates),
+        "after_rate": statistics.mean(after_rates),
+        "delta": statistics.mean(deltas),
+        "delta_ci95": [_percentile(boot_delta, 0.025), _percentile(boot_delta, 0.975)],
+        "improved_tasks": sum(delta > 0 for delta in deltas),
+        "regressed_tasks": sum(delta < 0 for delta in deltas),
+        "tied_tasks": sum(delta == 0 for delta in deltas),
+    }
+
+
+def bootstrap_comparison(
+    base: ArmResults,
+    head: ArmResults,
+    *,
+    samples: int = DEFAULT_BOOTSTRAP_SAMPLES,
+    seed: int = DEFAULT_SEED,
+) -> dict[str, Any]:
+    """Paired task-clustered uncertainty, retaining all model/run observations."""
+    shared = sorted(set(base.by_task) & set(head.by_task))
+    results: dict[str, Any] = {
+        "overall": _bootstrap_rates(base.by_task, head.by_task, shared, samples=samples, seed=seed),
+        "bootstrap_samples": samples,
+        "seed": seed,
+    }
+    tiers = sorted(
+        {base.task_tier.get(task, head.task_tier.get(task, "stable")) for task in shared}
+    )
+    for index, tier in enumerate(tiers, start=1):
+        tasks = [
+            task
+            for task in shared
+            if base.task_tier.get(task, head.task_tier.get(task, "stable")) == tier
+        ]
+        results[tier] = _bootstrap_rates(
+            base.by_task,
+            head.by_task,
+            tasks,
+            samples=samples,
+            seed=seed + index,
+        )
+
+    per_model: dict[str, Any] = {}
+    for index, model in enumerate(sorted(base.model_names() & head.model_names()), start=100):
+        before = {
+            (test, case): flags
+            for (candidate, test, case), flags in base.by_case.items()
+            if candidate == model
+        }
+        after = {
+            (test, case): flags
+            for (candidate, test, case), flags in head.by_case.items()
+            if candidate == model
+        }
+        tasks = sorted(set(before) & set(after))
+        per_model[model] = _bootstrap_rates(
+            before, after, tasks, samples=samples, seed=seed + index
+        )
+    results["per_model"] = per_model
+
+    def run_rates(arm: ArmResults) -> list[float]:
+        return [statistics.mean(flags) for _, flags in sorted(arm.by_run.items())]
+
+    base_runs, head_runs = run_rates(base), run_rates(head)
+    results["run_rates"] = {
+        "before": base_runs,
+        "after": head_runs,
+        "before_population_sd": statistics.pstdev(base_runs) if len(base_runs) > 1 else 0.0,
+        "after_population_sd": statistics.pstdev(head_runs) if len(head_runs) > 1 else 0.0,
+    }
+    return results
+
+
+def _mark(delta: float, *, inverse: bool = False) -> str:
+    if delta == 0:
+        return "➖"
+    good = delta < 0 if inverse else delta > 0
+    return "✅" if good else "❌"
+
+
+def _bar(base_rate: float, head_rate: float, width: int = 20) -> str:
+    now, was = round(head_rate * width), round(base_rate * width)
+    shared = min(now, was)
+    gained, lost = max(0, now - was), max(0, was - now)
+    return "🟦" * shared + "🟩" * gained + "🟥" * lost + "⬜" * (width - shared - gained - lost)
+
+
+def compare(
+    base: ArmResults,
+    head: ArmResults,
+    prev_tag: str,
+    sha: str,
+    runs: int = DEFAULT_RUNS,
+    *,
+    policy: ComparisonPolicy | None = None,
+    bootstrap_samples: int = DEFAULT_BOOTSTRAP_SAMPLES,
+    seed: int = DEFAULT_SEED,
+) -> Diff:
+    """Classify a capability delta and render a release-compatible report."""
+    policy = policy or ComparisonPolicy()
+    diff = Diff()
+    base_passed, base_total = base.counts()
+    head_passed, head_total = head.counts()
+    base_rate, head_rate = base.overall(), head.overall()
+    delta_points = (head_rate - base_rate) * 100
+
+    shared_models = base.model_names() & head.model_names()
+    diff.models_changed = sorted((base.model_names() | head.model_names()) - shared_models)
+
+    for key in sorted(set(base.by_case) | set(head.by_case)):
+        model, test_name, test_case = key
+        if model not in shared_models:
+            continue
+        before_rate, after_rate = base.rate(key), head.rate(key)
+        display = f"{model}/{test_name}/{test_case}"
+        if before_rate is None:
+            diff.added.append(display)
+            continue
+        if after_rate is None:
+            diff.removed.append(display)
+            continue
+        if before_rate >= policy.collapse_before and after_rate <= policy.collapse_after:
+            diff.regressions.append(
+                f"| `{test_name}` | `{test_case}` | {model} | {before_rate:.0%} | "
+                f"{after_rate:.0%} | {(after_rate - before_rate) * 100:+.1f}% ❌ |"
+            )
+        previous_errors = set(base.errors.get(key, {}))
+        for error_type, count in head.errors.get(key, {}).items():
+            if error_type not in previous_errors:
+                diff.new_errors.append(
+                    f"| `{test_name}` | `{test_case}` | {model} | {count}× `{error_type}` | "
+                    "0 before |"
+                )
+
+    if delta_points < -policy.aggregate_noise_points:
+        diff.beyond_noise.append(
+            f"overall {delta_points:+.1f} pts (band ±{policy.aggregate_noise_points:g})"
+        )
+    base_models, head_models = base.per_model(), head.per_model()
+    for model in sorted(set(base_models) & set(head_models)):
+        delta = (head_models[model] - base_models[model]) * 100
+        if delta < -policy.aggregate_noise_points:
+            diff.beyond_noise.append(f"{model} {delta:+.1f} pts")
+
+    base_tiers, head_tiers = base.tier_counts(), head.tier_counts()
+    for tier in sorted(set(base_tiers) & set(head_tiers)):
+        old_passed, old_total = base_tiers[tier]
+        new_passed, new_total = head_tiers[tier]
+        if not (old_total and new_total):
+            continue
+        delta = (new_passed / new_total - old_passed / old_total) * 100
+        if delta < -policy.aggregate_noise_points:
+            diff.beyond_noise.append(f"{tier} tier {delta:+.1f} pts")
+
+    stable_passed, stable_total = head_tiers.get("stable", (0, 0))
+    stable_rate = stable_passed / stable_total if stable_total else 0.0
+    if stable_total and stable_rate < policy.stable_floor:
+        diff.floor_breach = f"stable tier at {stable_rate:.1%}, floor is {policy.stable_floor:.0%}"
+
+    diff.statistics = bootstrap_comparison(base, head, samples=bootstrap_samples, seed=seed)
+    overall_stats = diff.statistics.get("overall", {})
+
+    markdown: list[str] = ["## 🧪 Capability Test Results", ""]
+    if diff.floor_breach:
+        markdown.append(f"❌ **Release BLOCKED** — {diff.floor_breach}")
+    elif diff.clean:
+        markdown.append(
+            f"✅ **Release OK** — Stable tier at {stable_rate:.1%} "
+            f"(floor: {policy.stable_floor:.0%}), no regressions beyond noise"
+        )
+    else:
+        markdown.append(
+            f"⚠️ **Review required** — Stable tier at {stable_rate:.1%} "
+            f"(floor: {policy.stable_floor:.0%}), {len(diff.regressions)} collapse(s), "
+            f"{len(diff.new_errors)} new error type(s), {len(diff.removed)} removed test(s)"
+        )
+    markdown += [
+        "",
+        "---",
+        "",
+        f"**{head_rate:.1%}** {_bar(base_rate, head_rate)} **{delta_points:+.1f}%**",
+        "",
+        f"{head_passed}/{head_total} samples passing *({head_passed - base_passed:+d} from {prev_tag})*",
+        "",
+        f"| Metric | {prev_tag} | This revision | Change |",
+        "|--------|----------|---------------|--------|",
+        f"| Samples Passed | {base_passed}/{base_total} | {head_passed}/{head_total} | "
+        f"{head_passed - base_passed:+d} {_mark(head_passed - base_passed)} |",
+        f"| Success Rate | {base_rate:.1%} | {head_rate:.1%} | "
+        f"{delta_points:+.1f}% {_mark(delta_points)} |",
+        f"| Collapsed cases | — | {len(diff.regressions)} | "
+        f"{len(diff.regressions)} {_mark(len(diff.regressions), inverse=True)} |",
+        f"| New error types | — | {len(diff.new_errors)} | "
+        f"{len(diff.new_errors)} {_mark(len(diff.new_errors), inverse=True)} |",
+        f"| Output Tokens | {base.output_tokens:,} | {head.output_tokens:,} | "
+        f"{head.output_tokens - base.output_tokens:+,} |",
+        f"| Total Tokens | {base.total_tokens:,} | {head.total_tokens:,} | "
+        f"{head.total_tokens - base.total_tokens:+,} |",
+    ]
+    if overall_stats:
+        low, high = overall_stats["delta_ci95"]
+        markdown += [
+            f"| Task-bootstrap delta (95% CI) | — | {overall_stats['delta'] * 100:+.2f} pts | "
+            f"{low * 100:+.2f} to {high * 100:+.2f} pts |",
+        ]
+
+    markdown += [
+        "",
+        "<details>",
+        "<summary>📊 Per-model breakdown</summary>",
+        "",
+        f"| Model | {prev_tag} | This revision | Change | 95% task-bootstrap CI |",
+        "|-------|----------|---------------|--------|-----------------------|",
+    ]
+    model_stats = diff.statistics.get("per_model", {})
+    for model in sorted(set(base_models) | set(head_models)):
+        if model not in base_models or model not in head_models:
+            markdown.append(f"| {model} | — | — | only in one arm | — |")
+            continue
+        delta = (head_models[model] - base_models[model]) * 100
+        stats = model_stats.get(model, {})
+        ci = stats.get("delta_ci95")
+        rendered_ci = f"{ci[0] * 100:+.2f} to {ci[1] * 100:+.2f}" if ci else "—"
+        markdown.append(
+            f"| {model} | {base_models[model]:.1%} | {head_models[model]:.1%} | "
+            f"{delta:+.1f} {_mark(delta)} | {rendered_ci} |"
+        )
+    markdown += ["", "</details>", "", "<details>", "<summary>📊 Per-tier breakdown</summary>", ""]
+    markdown += [
+        f"| Tier | {prev_tag} | This revision | Change | Expected |",
+        "|------|----------|---------------|--------|----------|",
+    ]
+    for tier in sorted(set(base_tiers) | set(head_tiers)):
+        old_passed, old_total = base_tiers.get(tier, (0, 0))
+        new_passed, new_total = head_tiers.get(tier, (0, 0))
+        old_rate = old_passed / old_total if old_total else 0.0
+        new_rate = new_passed / new_total if new_total else 0.0
+        delta = (new_rate - old_rate) * 100
+        expected = f"≥{policy.stable_floor:.0%}" if tier == "stable" else "—"
+        markdown.append(
+            f"| {tier.title()} | {old_passed}/{old_total} ({old_rate:.1%}) | "
+            f"{new_passed}/{new_total} ({new_rate:.1%}) | {new_passed - old_passed:+d} / "
+            f"{delta:+.1f}% {_mark(delta)} | {expected} |"
+        )
+    markdown += ["", "</details>", ""]
+
+    if diff.regressions:
+        markdown += [
+            "<details open>",
+            "<summary>❌ Collapsed cases</summary>",
+            "",
+            f"| Test | Case | Model | {prev_tag} | This revision | Change |",
+            "|------|------|-------|----------|---------------|--------|",
+            *diff.regressions,
+            "",
+            "</details>",
+            "",
+        ]
+    if diff.new_errors:
+        markdown += [
+            "<details open>",
+            "<summary>❌ New error types</summary>",
+            "",
+            "| Test | Case | Model | This revision | Baseline |",
+            "|------|------|-------|---------------|----------|",
+            *diff.new_errors,
+            "",
+            "</details>",
+            "",
+        ]
+
+    markdown += [
+        "<details>",
+        "<summary>📋 Per-test breakdown</summary>",
+        "",
+        "| Test / case | Status |",
+        "|-------------|--------|",
+    ]
+    for task in sorted(set(base.by_task) | set(head.by_task)):
+        flags = head.by_task.get(task)
+        display = "/".join(task)
+        if flags is None:
+            markdown.append(f"| `{display}` | ⬜ removed |")
+            continue
+        icon = "✅" if all(flags) else "❌"
+        new = " *(new)*" if task not in base.by_task else ""
+        markdown.append(f"| `{display}` | {icon} {sum(flags)}/{len(flags)}{new} |")
+    markdown += [
+        "",
+        "</details>",
+        "",
+        f"*{prev_tag} → `{sha[:8]}`* | *{len(head.model_names())} models × {runs} runs* | "
+        "*both arms run fresh*",
+    ]
+    diff.markdown = "\n".join(markdown)
+    return diff
+
+
+def print_comparison(base: ArmResults, head: ArmResults, diff: Diff) -> None:
+    base_passed, base_total = base.counts()
+    head_passed, head_total = head.counts()
+    delta = (head.overall() - base.overall()) * 100
+    print(f"\n{BOLD}{'═' * 72}{RESET}")
+    print(f"{BOLD} CAPABILITY A/B   {base.label} → {head.label}{RESET}")
+    print(f" {DIM}{len(head.model_names())} models · {len(head.by_task)} tasks{RESET}")
+    print(f"{BOLD}{'═' * 72}{RESET}\n")
+    print(f" {_bar(base.overall(), head.overall())}")
+    print(
+        f" {BOLD}{head.overall():.1%}{RESET}  {delta:+.1f} pts   "
+        f"{head_passed}/{head_total} passing ({head_passed - base_passed:+d})"
+    )
+    print("\n PER MODEL")
+    base_models, head_models = base.per_model(), head.per_model()
+    for model in sorted(set(base_models) | set(head_models)):
+        if model not in base_models or model not in head_models:
+            print(f"   {model:<30} only in one arm")
+            continue
+        model_delta = (head_models[model] - base_models[model]) * 100
+        print(
+            f"   {model:<30} {base_models[model]:>6.1%} → "
+            f"{head_models[model]:>6.1%}  {model_delta:+5.1f}"
+        )
+    verdict = "OK" if diff.clean else "REVIEW REQUIRED"
+    if diff.floor_breach:
+        verdict = "BLOCKED"
+    print(f"\n{BOLD} VERDICT: {verdict}{RESET}")
+
+
+def discover_env_extras(repo: Path) -> list[str]:
+    """Return installed, out-of-lock packages that fresh worktrees need."""
+    lock_path = repo / "uv.lock"
+    locked = {
+        name.lower()
+        for name in re.findall(r'^name = "([^"]+)"', lock_path.read_text(), re.MULTILINE)
+    }
+    frozen = _run(["uv", "pip", "freeze"], cwd=repo).stdout.splitlines()
+    extras: list[str] = []
+    for raw in frozen:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("-e "):
+            name, location = "", line[3:]
+        elif " @ " in line:
+            name, _, location = line.partition(" @ ")
+        elif "==" in line:
+            name, location = line.split("==", maxsplit=1)[0], ""
+        else:
+            continue
+        resolved = location.strip().removeprefix("file://")
+        if resolved.startswith(str(repo)):
+            continue
+        if name.strip().lower() in locked:
+            continue
+        extras.append(line.removeprefix("-e ").strip())
+    return extras
+
+
+@contextmanager
+def isolated_worktree(repo: Path, revision: str, label: str) -> Iterator[Path]:
+    root = Path(tempfile.mkdtemp(prefix=f"nooa-capability-{label}-"))
+    tree = root / "tree"
+    _git(repo, "worktree", "add", "--detach", str(tree), revision)
+    try:
+        yield tree
+    finally:
+        _git(repo, "worktree", "remove", "--force", str(tree), check=False)
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def _prepare_tree(
+    tree: Path,
+    *,
+    env_file: Path | None,
+    extra_packages: list[str],
+) -> None:
+    if env_file and env_file.exists():
+        target = tree / ".env"
+        shutil.copyfile(env_file, target)
+        target.chmod(0o600)
+    _run(
+        ["uv", "sync", "--all-extras", "--no-extra", "sandbox", "--inexact"],
+        cwd=tree,
+    )
+    if extra_packages:
+        python = tree / ".venv" / "bin" / "python"
+        _run(
+            ["uv", "pip", "install", "--python", str(python), *extra_packages],
+            cwd=tree,
+        )
+
+
+def _config_for_tree(config: Path, tree: Path) -> Path:
+    return config if config.is_absolute() else tree / config
+
+
+def _config_digest(config: Path) -> str:
+    return hashlib.sha256(config.read_bytes()).hexdigest()[:16]
+
+
+def _run_arm(
+    tree: Path,
+    *,
+    label: str,
+    revision: str,
+    config: Path,
+    models: list[str],
+    runs: int,
+    parallel: int,
+    output_dir: Path,
+    limit: int | None,
+    timeout: int | None,
+    test_filter: str | None,
+    no_cache: bool,
+    trace_files: bool,
+    reuse: bool,
+    max_error_rate: float,
+) -> ArmResults:
+    resolved_config = _config_for_tree(config, tree)
+    if not resolved_config.exists():
+        raise CapabilityABError(f"{label}: config does not exist: {resolved_config}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    marker = output_dir / "run.json"
+    signature = {
+        "revision": revision,
+        "config": str(config),
+        "config_digest": _config_digest(resolved_config),
+        "models": models,
+        "runs": runs,
+        "parallel": parallel,
+        "limit": limit,
+        "timeout": timeout,
+        "test_filter": test_filter,
+        "no_cache": no_cache,
+        "trace_files": trace_files,
+    }
+    existing = newest_eval(output_dir)
+    if reuse and existing and marker.exists():
+        if json.loads(marker.read_text()) == signature:
+            print(f"  {GREEN}✓{RESET} {label}: reusing {existing.name}")
+            return parse_results(existing, label)
+
+    command = [
+        "uv",
+        "run",
+        "--no-sync",
+        "python",
+        "-m",
+        "eval_pipeline",
+        "--config",
+        str(resolved_config),
+        "--models",
+        ",".join(models),
+        "--runs",
+        str(runs),
+        "--parallel",
+        str(parallel),
+        "--output-dir",
+        str(output_dir),
+        "-q",
+    ]
+    if limit:
+        command += ["--limit", str(limit)]
+    if timeout:
+        command += ["--timeout", str(timeout)]
+    if test_filter:
+        command += ["--test", test_filter]
+    if no_cache:
+        command.append("--no-cache")
+    if trace_files:
+        command.append("--trace-files")
+
+    print(f"\n{BOLD}▶ {label}: {len(models)} models × {runs} runs{RESET}")
+    _run(command, cwd=tree, capture=False)
+    produced = newest_eval(output_dir)
+    if not produced:
+        raise CapabilityABError(f"{label}: no .noo-eval.jsonl produced under {output_dir}")
+    arm = parse_results(produced, label)
+    if not arm.by_case:
+        raise CapabilityABError(f"{label}: eval produced no usable result records")
+    if arm.error_rate() > max_error_rate:
+        raise CapabilityABError(
+            f"{label}: {arm.error_rate():.0%} of samples errored; refusing to compare infrastructure failure"
+        )
+    marker.write_text(json.dumps(signature, indent=2, sort_keys=True))
+    return arm
+
+
+def run_ab(
+    *,
+    repo: Path,
+    base_ref: str,
+    head_ref: str,
+    config: Path = DEFAULT_CONFIG,
+    models: list[str] | None = None,
+    runs: int = DEFAULT_RUNS,
+    parallel: int = DEFAULT_PARALLEL,
+    output_root: Path | None = None,
+    experiment: str | None = None,
+    env_file: Path | None = None,
+    extra_packages: list[str] | None = None,
+    limit: int | None = None,
+    timeout: int | None = None,
+    test_filter: str | None = None,
+    no_cache: bool = False,
+    trace_files: bool = False,
+    reuse: bool = False,
+    head_first: bool = True,
+    policy: ComparisonPolicy | None = None,
+    bootstrap_samples: int = DEFAULT_BOOTSTRAP_SAMPLES,
+    seed: int = DEFAULT_SEED,
+) -> ABRunResult:
+    """Run and compare two revisions using isolated, identically prepared arms."""
+    repo = repo.resolve()
+    base_sha = _git(repo, "rev-parse", base_ref)
+    head_sha = _git(repo, "rev-parse", head_ref)
+    config = config if config.is_absolute() else Path(config)
+    model_config = config if config.is_absolute() else repo / config
+    selected_models = models or configured_models(model_config)
+    if not selected_models:
+        raise CapabilityABError("no models selected")
+    policy = policy or ComparisonPolicy()
+
+    output_root = (output_root or repo / "tmp" / "capability-ab").resolve()
+    if experiment is None:
+        timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+        experiment = f"{timestamp}_{base_sha[:8]}_{head_sha[:8]}"
+    experiment_dir = output_root / experiment
+    experiment_dir.mkdir(parents=True, exist_ok=True)
+
+    packages = list(extra_packages) if extra_packages is not None else discover_env_extras(repo)
+    env_file = env_file or repo / ".env"
+
+    with ExitStack() as stack:
+        base_tree = stack.enter_context(isolated_worktree(repo, base_sha, "base"))
+        head_tree = stack.enter_context(isolated_worktree(repo, head_sha, "head"))
+        print(f"{BOLD}Preparing isolated worktrees{RESET}", flush=True)
+        _prepare_tree(base_tree, env_file=env_file, extra_packages=packages)
+        _prepare_tree(head_tree, env_file=env_file, extra_packages=packages)
+
+        arguments = {
+            "config": config,
+            "models": selected_models,
+            "runs": runs,
+            "parallel": parallel,
+            "limit": limit,
+            "timeout": timeout,
+            "test_filter": test_filter,
+            "no_cache": no_cache,
+            "trace_files": trace_files,
+            "reuse": reuse,
+            "max_error_rate": policy.max_error_rate,
+        }
+
+        def run_base() -> ArmResults:
+            return _run_arm(
+                base_tree,
+                label=f"BASE ({base_ref}@{base_sha[:8]})",
+                revision=base_sha,
+                output_dir=experiment_dir / "base",
+                **arguments,
+            )
+
+        def run_head() -> ArmResults:
+            return _run_arm(
+                head_tree,
+                label=f"HEAD ({head_ref}@{head_sha[:8]})",
+                revision=head_sha,
+                output_dir=experiment_dir / "head",
+                **arguments,
+            )
+
+        if head_first:
+            head, base = run_head(), run_base()
+        else:
+            base, head = run_base(), run_head()
+
+    diff = compare(
+        base,
+        head,
+        base_ref,
+        head_sha,
+        runs,
+        policy=policy,
+        bootstrap_samples=bootstrap_samples,
+        seed=seed,
+    )
+    report_path = experiment_dir / "capability-report.md"
+    summary_path = experiment_dir / "summary.json"
+    report_path.write_text(diff.markdown)
+    summary = {
+        "base_ref": base_ref,
+        "base_sha": base_sha,
+        "head_ref": head_ref,
+        "head_sha": head_sha,
+        "models": selected_models,
+        "runs": runs,
+        "parallel": parallel,
+        "base_result": str(base.result_path),
+        "head_result": str(head.result_path),
+        "base_counts": base.counts(),
+        "head_counts": head.counts(),
+        "clean": diff.clean,
+        "floor_breach": diff.floor_breach,
+        "regressions": diff.regressions,
+        "new_errors": diff.new_errors,
+        "beyond_noise": diff.beyond_noise,
+        "statistics": diff.statistics,
+        "policy": asdict(policy),
+    }
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True))
+    print_comparison(base, head, diff)
+    print(f"\n  markdown: {report_path}")
+    print(f"  summary:  {summary_path}")
+    return ABRunResult(
+        base=base,
+        head=head,
+        diff=diff,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        report_path=report_path,
+        summary_path=summary_path,
+    )
+
+
+def _split_models(value: str | None) -> list[str] | None:
+    if value is None:
+        return None
+    return [model.strip() for model in value.split(",") if model.strip()]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("base_ref", help="baseline git revision")
+    parser.add_argument("head_ref", nargs="?", default="HEAD", help="candidate revision")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument(
+        "--models",
+        help="comma-separated models; defaults to agent_models in the selected config",
+    )
+    parser.add_argument("--runs", type=int, default=DEFAULT_RUNS)
+    parser.add_argument("--parallel", type=int, default=DEFAULT_PARALLEL)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--experiment")
+    parser.add_argument("--env-file", type=Path)
+    parser.add_argument("--extra-package", action="append", default=None)
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--timeout", type=int)
+    parser.add_argument("--test", dest="test_filter")
+    parser.add_argument("--no-cache", action="store_true")
+    parser.add_argument("--trace-files", action="store_true")
+    parser.add_argument("--reuse", action="store_true")
+    parser.add_argument("--base-first", action="store_true")
+    parser.add_argument("--bootstrap-samples", type=int, default=DEFAULT_BOOTSTRAP_SAMPLES)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument(
+        "--require-clean",
+        action="store_true",
+        help="exit 1 when the comparison needs review; infrastructure failures always exit 1",
+    )
+    arguments = parser.parse_args()
+
+    try:
+        result = run_ab(
+            repo=REPO,
+            base_ref=arguments.base_ref,
+            head_ref=arguments.head_ref,
+            config=arguments.config,
+            models=_split_models(arguments.models),
+            runs=arguments.runs,
+            parallel=arguments.parallel,
+            output_root=arguments.output_dir,
+            experiment=arguments.experiment,
+            env_file=arguments.env_file,
+            extra_packages=arguments.extra_package,
+            limit=arguments.limit,
+            timeout=arguments.timeout,
+            test_filter=arguments.test_filter,
+            no_cache=arguments.no_cache,
+            trace_files=arguments.trace_files,
+            reuse=arguments.reuse,
+            head_first=not arguments.base_first,
+            bootstrap_samples=arguments.bootstrap_samples,
+            seed=arguments.seed,
+        )
+    except CapabilityABError as error:
+        print(f"{RED}error: {error}{RESET}", file=sys.stderr)
+        return 1
+    return 1 if arguments.require_clean and not result.diff.clean else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -25,17 +25,18 @@ delta is attributable to our code.
 from __future__ import annotations
 
 import argparse
-import json
-import re
 import shutil
 import subprocess
 import sys
 import tempfile
-from collections import defaultdict
 from contextlib import contextmanager
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NoReturn
+
+try:
+    from scripts import capability_ab
+except ImportError:  # `python scripts/make_release.py`
+    import capability_ab
 
 REPO = Path(__file__).resolve().parent.parent
 
@@ -273,585 +274,48 @@ def build_and_smoke(tag: str, sha: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class ArmResults:
-    """Everything one checkout's eval run produced, indexed for comparison."""
-
-    label: str
-    # test_case ("sentiment_single_001") -> pass flags across every model and run
-    by_case: dict[str, list[bool]] = field(default_factory=lambda: defaultdict(list))
-    case_tier: dict[str, str] = field(default_factory=dict)
-    # (model, test_name) -> pass flags; the granularity collapse detection needs
-    by_test: dict[tuple[str, str], list[bool]] = field(default_factory=lambda: defaultdict(list))
-    errors: dict[tuple[str, str], dict[str, int]] = field(
-        default_factory=lambda: defaultdict(lambda: defaultdict(int))
-    )
-    output_tokens: int = 0
-    total_tokens: int = 0
-    errored: int = 0
-
-    def error_rate(self) -> float:
-        _, total = self.counts()
-        return self.errored / total if total else 0.0
-
-    def rate(self, key: tuple[str, str]) -> float | None:
-        results = self.by_test.get(key)
-        return sum(results) / len(results) if results else None
-
-    def counts(self) -> tuple[int, int]:
-        flags = [p for rs in self.by_case.values() for p in rs]
-        return sum(flags), len(flags)
-
-    def overall(self) -> float:
-        passed, total = self.counts()
-        return passed / total if total else 0.0
-
-    def tier_counts(self) -> dict[str, tuple[int, int]]:
-        acc: dict[str, list[bool]] = defaultdict(list)
-        for case, flags in self.by_case.items():
-            acc[self.case_tier.get(case, "stable")].extend(flags)
-        return {t: (sum(f), len(f)) for t, f in acc.items()}
-
-    def per_model(self) -> dict[str, float]:
-        acc: dict[str, list[bool]] = defaultdict(list)
-        for (model, _), results in self.by_test.items():
-            acc[model].extend(results)
-        return {m: sum(r) / len(r) for m, r in acc.items() if r}
-
-
-def parse_results(path: Path, label: str) -> ArmResults:
-    arm = ArmResults(label=label)
-    for line in path.read_text().splitlines():
-        if not line.strip():
-            continue
-        try:
-            rec = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if rec.get("_type") != "result":
-            continue
-        passed = bool(rec.get("passed"))
-        test_name = rec.get("test_name") or rec.get("agent_class", "?")
-        case = rec.get("test_case") or test_name
-        arm.by_case[case].append(passed)
-        arm.case_tier.setdefault(case, rec.get("tier") or "stable")
-        arm.by_test[(rec.get("model", "?"), test_name)].append(passed)
-        if rec.get("error_type"):
-            arm.errors[(rec.get("model", "?"), test_name)][rec["error_type"]] += 1
-            arm.errored += 1
-        arm.output_tokens += rec.get("output_tokens") or 0
-        arm.total_tokens += rec.get("total_tokens") or 0
-    return arm
-
-
-def env_extras() -> list[str]:
-    """Install specs present in this venv but absent from `uv.lock`.
-
-    The NVIDIA model aliases the gate resolves through (`claude-haiku`,
-    `nemotron3-nano-30b`, …) ship in `nemo-oo-agents-nvidia`, which is installed
-    from a local path and deliberately not in the lock. A freshly synced
-    worktree would not have it, so those models would fail to resolve on the
-    baseline arm and the two sides would not be comparable. Mirroring whatever
-    the current env carries keeps both arms resolving the same aliases.
-    """
-    locked = {
-        name.lower()
-        for name in re.findall(r'^name = "([^"]+)"', (REPO / "uv.lock").read_text(), re.MULTILINE)
-    }
-    extras: list[str] = []
-    for raw in run(["uv", "pip", "freeze"]).stdout.splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        # freeze emits three shapes, and all three occur in this project:
-        #   -e file:///path          editable install
-        #   name @ file:///path      direct-URL (non-editable) install
-        #   name==version            ordinary registry install
-        if line.startswith("-e "):
-            name, location = "", line[3:]
-        elif " @ " in line:
-            name, _, location = line.partition(" @ ")
-        elif "==" in line:
-            name, location = line.split("==")[0], ""
-        else:
-            continue
-
-        # CRITICAL: skip anything inside this checkout. `uv pip freeze` lists
-        # the workspace packages themselves as local installs pointing at REPO,
-        # and mirroring those would put HEAD's nooa into the baseline worktree —
-        # silently comparing HEAD against itself.
-        if location.strip().removeprefix("file://").startswith(str(REPO)):
-            continue
-        if name.strip().lower() in locked:
-            continue
-        # The worktree is disposable, so a plain (non-editable) install is fine.
-        extras.append(line.removeprefix("-e ").strip())
-    return extras
-
-
-def newest_eval(out_dir: Path) -> Path | None:
-    """Most recent `.noo-eval.jsonl` under `out_dir`.
-
-    Recursive on purpose: eval_pipeline writes into a timestamped subdirectory
-    (`capability_<ts>_p40/capability_<ts>.noo-eval.jsonl`), not into the
-    `--output-dir` root, so a plain glob finds nothing.
-    """
-    found = sorted(out_dir.rglob("*.noo-eval.jsonl"), key=lambda p: p.stat().st_mtime)
-    return found[-1] if found else None
-
-
-def run_capability_arm(
-    tree: Path,
-    label: str,
-    cache_key: str,
-    models: list[str],
-    runs: int,
-    limit: int | None,
-) -> ArmResults:
-    """Run the capability suite in `tree`, reusing cached results when present.
-
-    The script has two human gates and a run takes a while; without a cache,
-    aborting at the review prompt costs another full paid run to get back. The
-    signature covers models/runs/limit so a cheap smoke run never gets mistaken
-    for a real gate run.
-    """
-    out_dir = REPO / "tmp" / "release-check" / cache_key
-    out_dir.mkdir(parents=True, exist_ok=True)
-    marker = out_dir / "run.json"
-    signature = {"models": sorted(models), "runs": runs, "limit": limit}
-
-    existing = newest_eval(out_dir)
-    if existing and marker.exists() and json.loads(marker.read_text()) == signature:
-        ok(f"{label}: reusing cached results ({existing.name})")
-        return parse_results(existing, label)
-
-    scope = f"{len(models)} models × {runs} runs" + (f" × {limit} samples" if limit else "")
-    print(f"  {DIM}{label}: full suite × {scope}{RESET}")
-
-    if tree != REPO:
-        # A worktree is a clean git checkout, so gitignored local config does
-        # not come with it. Without .env the baseline arm has no credentials and
-        # every sample fails with "Missing credentials" — which reads as a
-        # spectacular improvement rather than a broken run.
-        dotenv = REPO / ".env"
-        if dotenv.exists():
-            target = tree / ".env"
-            shutil.copyfile(dotenv, target)
-            target.chmod(0o600)
-            print(f"  {DIM}copied .env into the worktree (removed with it){RESET}")
-
-        print(f"  {DIM}syncing {tree}...{RESET}")
-        # --inexact: this repo's dev env legitimately carries packages that are
-        # not in the lock (see env_extras), and an exact sync would strip them.
-        run(
-            ["uv", "sync", "--all-extras", "--no-extra", "sandbox", "--inexact"],
-            cwd=tree,
-            capture=True,
-        )
-        extras = env_extras()
-        if extras:
-            print(f"  {DIM}mirroring {len(extras)} out-of-lock package(s) into the worktree{RESET}")
-            # --python is load-bearing. `uv sync`/`uv run` are project commands
-            # and use the worktree's .venv, but `uv pip install` is a pip
-            # interface command that honours VIRTUAL_ENV — which this script
-            # inherits from its own `uv run`, pointing at the MAIN repo venv.
-            # Without --python the packages land back in the developer's env and
-            # the worktree silently has no model aliases.
-            venv_python = tree / ".venv" / "bin" / "python"
-            run(
-                ["uv", "pip", "install", "--python", str(venv_python), *extras],
-                cwd=tree,
-                capture=True,
-            )
-            # Fail here rather than 5 minutes into an eval that resolves no
-            # models: this exact mistake produced "Config models: []".
-            installed = run(
-                ["uv", "pip", "list", "--python", str(venv_python)], cwd=tree
-            ).stdout.lower()
-            for spec in extras:
-                name = Path(spec.removeprefix("file://")).name.lower()
-                if name and name not in installed.replace("_", "-"):
-                    die(f"{label}: {name} did not install into {venv_python}")
-
-    cmd = [
-        "uv",
-        "run",
-        # The env for each arm is prepared above; --no-sync keeps `uv run` from
-        # touching it again mid-run (and from mutating the developer's own venv
-        # on the HEAD arm).
-        "--no-sync",
-        "python",
-        "-m",
-        "eval_pipeline",
-        "--config",
-        str(CAPABILITY_CONFIG),
-        "--models",
-        ",".join(models),
-        "--runs",
-        str(runs),
-        "--parallel",
-        str(GATE_PARALLEL),
-        "--output-dir",
-        str(out_dir),
-    ]
-    if limit:
-        cmd += ["--limit", str(limit)]
-    run(cmd, cwd=tree, capture=False)
-
-    produced = newest_eval(out_dir)
-    if not produced:
-        die(f"{label}: eval produced no .noo-eval.jsonl under {out_dir}")
-    arm = parse_results(produced, label)
-    # The eval CLI exits 0 even when every sample errors, so these two checks are
-    # the only thing standing between an infrastructure outage and a meaningless
-    # report. A broken BASELINE arm is the dangerous case: it reads as a huge
-    # improvement and sails through the gate as "no regressions". Refuse to
-    # compare rather than emit numbers that describe the network.
-    if not arm.by_case:
-        die(f"{label}: eval produced no usable results — check credentials and model aliases")
-    if arm.error_rate() > MAX_ERROR_RATE:
-        top = sorted(((n, e) for d in arm.errors.values() for e, n in d.items()), reverse=True)[:1]
-        detail = f" (most common: {top[0][1]})" if top else ""
-        die(
-            f"{label}: {arm.error_rate():.0%} of samples errored{detail} — "
-            f"this is an infrastructure failure, not a capability result"
-        )
-    marker.write_text(json.dumps(signature))
-    return arm
-
-
-@contextmanager
-def worktree_at(tag: str):
-    """A detached worktree at `tag`, cleaned up afterwards.
-
-    Each arm runs entirely against its own checkout — its own nooa, its own
-    capability config and agents. That keeps each side self-consistent (HEAD's
-    test agents may use APIs the old nooa lacks), at the cost that a change to
-    the harness itself shows up as a capability delta. Tests that exist on only
-    one side are reported separately rather than compared.
-    """
-    tmp = Path(tempfile.mkdtemp(prefix="nooa-release-"))
-    path = tmp / "tree"
-    git("worktree", "add", "--detach", str(path), tag)
-    try:
-        yield path
-    finally:
-        git("worktree", "remove", "--force", str(path), check=False)
-        shutil.rmtree(tmp, ignore_errors=True)
-
-
-@dataclass
-class Diff:
-    regressions: list[str] = field(default_factory=list)
-    new_errors: list[str] = field(default_factory=list)
-    beyond_noise: list[str] = field(default_factory=list)
-    added: list[str] = field(default_factory=list)
-    removed: list[str] = field(default_factory=list)
-    models_changed: list[str] = field(default_factory=list)
-    floor_breach: str | None = None
-    markdown: str = ""
-
-    @property
-    def clean(self) -> bool:
-        # `removed` counts, `added` does not: a test that vanished may be hiding
-        # a regression, whereas a new test has no baseline to regress from.
-        return not (
-            self.regressions
-            or self.new_errors
-            or self.beyond_noise
-            or self.removed
-            or self.floor_breach
-        )
-
-
-def _mark(delta: float, *, inverse: bool = False) -> str:
-    """Trend marker matching the MR report's vocabulary."""
-    if delta == 0:
-        return "➖"
-    good = delta < 0 if inverse else delta > 0
-    return "✅" if good else "❌"
-
-
-def _bar(base_rate: float, head_rate: float, width: int = 20) -> str:
-    """Blue up to the shared level, green for gain / red for loss, grey for the rest."""
-    now, was = round(head_rate * width), round(base_rate * width)
-    shared = min(now, was)
-    gained, lost = max(0, now - was), max(0, was - now)
-    return "🟦" * shared + "🟩" * gained + "🟥" * lost + "⬜" * (width - shared - gained - lost)
-
-
-def compare(
-    base: ArmResults, head: ArmResults, prev_tag: str, sha: str, runs: int = GATE_RUNS
-) -> Diff:
-    diff = Diff()
-    bp, bt = base.counts()
-    hp, ht = head.counts()
-    b, h = base.overall(), head.overall()
-    delta_pts = (h - b) * 100
-
-    # A model present in only one arm makes every one of its tests look added or
-    # removed. That is a change to GATE_MODELS, not to the test suite, so it is
-    # tracked separately and never counted as a disappearing test.
-    shared_models = {m for m, _ in base.by_test} & {m for m, _ in head.by_test}
-    diff.models_changed = sorted(
-        ({m for m, _ in base.by_test} | {m for m, _ in head.by_test}) - shared_models
-    )
-
-    # ---- collapse / new-error detection, at (model, test) granularity -------
-    # Per-test deltas are reported only on collapse. With ~3 samples per test
-    # per run a per-test wobble is mostly noise, and a report that lists every
-    # wobble trains people to skim past the part that matters.
-    for key in sorted(set(base.by_test) | set(head.by_test)):
-        model, test = key
-        if model not in shared_models:
-            continue
-        br, hr = base.rate(key), head.rate(key)
-        if br is None:
-            diff.added.append(f"{model}/{test}")
-            continue
-        if hr is None:
-            # Counts against `clean`: deleting or renaming a failing test would
-            # otherwise erase the regression it represents, and the run would
-            # report "no regressions" while quietly testing less than before.
-            diff.removed.append(f"{model}/{test}")
-            continue
-        if br >= COLLAPSE_BEFORE and hr <= COLLAPSE_AFTER:
-            diff.regressions.append(
-                f"| `{test}` | {model} | {br:.0%} | {hr:.0%} | {(hr - br) * 100:+.1f}% ❌ |"
-            )
-        before = set(base.errors.get(key, {}))
-        for etype, count in head.errors.get(key, {}).items():
-            if etype not in before:
-                diff.new_errors.append(f"| `{test}` | {model} | {count}× `{etype}` | 0 before |")
-
-    if delta_pts < -AGGREGATE_NOISE_PTS:
-        diff.beyond_noise.append(f"overall {delta_pts:+.1f} pts (band ±{AGGREGATE_NOISE_PTS})")
-    bm, hm = base.per_model(), head.per_model()
-    for model in sorted(set(bm) & set(hm)):
-        d = (hm[model] - bm[model]) * 100
-        if d < -AGGREGATE_NOISE_PTS:
-            diff.beyond_noise.append(f"{model} {d:+.1f} pts")
-
-    # Per tier as well as overall: a stable-tier regression can be masked in the
-    # aggregate by frontier tests improving at the same time, which is exactly
-    # the trade nobody wants to make silently.
-    tiers_head, tiers_base = head.tier_counts(), base.tier_counts()
-    for tier in sorted(set(tiers_head) & set(tiers_base)):
-        p0, t0 = tiers_base[tier]
-        p1, t1 = tiers_head[tier]
-        if not (t0 and t1):
-            continue
-        d = (p1 / t1 - p0 / t0) * 100
-        if d < -AGGREGATE_NOISE_PTS:
-            diff.beyond_noise.append(f"{tier} tier {d:+.1f} pts")
-
-    # ---- floor gate --------------------------------------------------------
-    # An absolute floor, not a delta threshold. A low floor survives run-to-run
-    # LLM variance while still catching catastrophe; the delta stays advisory.
-    stable_p, stable_t = tiers_head.get("stable", (0, 0))
-    stable_rate = stable_p / stable_t if stable_t else 0.0
-    if stable_t and stable_rate < STABLE_FLOOR:
-        diff.floor_breach = f"stable tier at {stable_rate:.1%}, floor is {STABLE_FLOOR:.0%}"
-
-    # ---- markdown ----------------------------------------------------------
-    md: list[str] = ["## 🧪 Capability Test Results", ""]
-    if diff.floor_breach:
-        md.append(f"❌ **Release BLOCKED** — {diff.floor_breach}")
-    elif diff.clean:
-        md.append(
-            f"✅ **Release OK** — Stable tier at {stable_rate:.1%} "
-            f"(floor: {STABLE_FLOOR:.0%}), no regressions beyond noise"
-        )
-    else:
-        md.append(
-            f"⚠️ **Review required** — Stable tier at {stable_rate:.1%} "
-            f"(floor: {STABLE_FLOOR:.0%}), {len(diff.regressions)} collapse(s), "
-            f"{len(diff.new_errors)} new error type(s), "
-            f"{len(diff.removed)} removed test(s)"
-        )
-    md += [
-        "",
-        "---",
-        "",
-        f"**{h:.1%}** {_bar(b, h)} **{delta_pts:+.1f}%**",
-        "",
-        f"{hp}/{ht} tests passing *({hp - bp:+d} from {prev_tag})*",
-        "",
-        "| Metric | " + prev_tag + " | This release | Change |",
-        "|--------|----------|--------------|--------|",
-        f"| Tests Passed | {bp}/{bt} | {hp}/{ht} | {hp - bp:+d} {_mark(hp - bp)} |",
-        f"| Success Rate | {b:.1%} | {h:.1%} | {delta_pts:+.1f}% {_mark(delta_pts)} |",
-        f"| Collapsed tests | — | {len(diff.regressions)} | "
-        f"{len(diff.regressions)} {_mark(len(diff.regressions), inverse=True)} |",
-        f"| New error types | — | {len(diff.new_errors)} | "
-        f"{len(diff.new_errors)} {_mark(len(diff.new_errors), inverse=True)} |",
-        f"| Output Tokens | {base.output_tokens:,} | {head.output_tokens:,} | "
-        f"{head.output_tokens - base.output_tokens:+,} |",
-        f"| Total Tokens | {base.total_tokens:,} | {head.total_tokens:,} | "
-        f"{head.total_tokens - base.total_tokens:+,} |",
-        "",
-        "<details>",
-        "<summary>📊 Per-tier breakdown</summary>",
-        "",
-        f"| Tier | {prev_tag} | This release | Change | Expected |",
-        "|------|----------|--------------|--------|----------|",
-    ]
-    for tier in sorted(set(tiers_head) | set(tiers_base)):
-        p0, t0 = tiers_base.get(tier, (0, 0))
-        p1, t1 = tiers_head.get(tier, (0, 0))
-        r0 = p0 / t0 if t0 else 0.0
-        r1 = p1 / t1 if t1 else 0.0
-        d = (r1 - r0) * 100
-        expected = f"≥{STABLE_FLOOR:.0%}" if tier == "stable" else "—"
-        md.append(
-            f"| {tier.title()} | {p0}/{t0} ({r0:.1%}) | {p1}/{t1} ({r1:.1%}) | "
-            f"{p1 - p0:+d} / {d:+.1f}% {_mark(d)} | {expected} |"
-        )
-    md += ["", "</details>", ""]
-
-    if diff.regressions:
-        md += [
-            "<details open>",
-            "<summary>❌ Collapsed tests</summary>",
-            "",
-            f"| Test | Model | {prev_tag} | This release | Change |",
-            "|------|-------|----------|--------------|--------|",
-            *diff.regressions,
-            "",
-            "</details>",
-            "",
-        ]
-    if diff.new_errors:
-        md += [
-            "<details open>",
-            "<summary>❌ New error types</summary>",
-            "",
-            "| Test | Model | This release | Baseline |",
-            "|------|-------|--------------|----------|",
-            *diff.new_errors,
-            "",
-            "</details>",
-            "",
-        ]
-
-    md += [
-        "<details>",
-        "<summary>📋 Per-test breakdown</summary>",
-        "",
-        "| Test | Status |",
-        "|------|--------|",
-    ]
-    for case in sorted(set(head.by_case) | set(base.by_case)):
-        flags = head.by_case.get(case)
-        if flags is None:
-            md.append(f"| {case} | ⬜ removed |")
-            continue
-        icon = "✅" if all(flags) else "❌"
-        new = " *(new)*" if case not in base.by_case else ""
-        md.append(f"| {case} | {icon} {sum(flags)}/{len(flags)}{new} |")
-    md += [
-        "",
-        "</details>",
-        "",
-        f"*{prev_tag} → `{sha[:8]}`* | *{len({m for m, _ in head.by_test})} models × "
-        f"{runs} runs* | *both arms run fresh*",
-    ]
-    diff.markdown = "\n".join(md)
-
-    # ---- terminal view -----------------------------------------------------
-    print()
-    print(f"{BOLD}{'═' * 72}{RESET}")
-    print(f"{BOLD} CAPABILITY DIFF   {prev_tag} → HEAD ({sha[:8]}){RESET}")
-    n_models = len({m for m, _ in head.by_test})
-    print(f" {DIM}{n_models} models · {len(head.by_case)} cases · {runs} runs{RESET}")
-    print(f"{BOLD}{'═' * 72}{RESET}\n")
-    print(f" {_bar(b, h)}")
-    colour = RED if delta_pts < -AGGREGATE_NOISE_PTS else (GREEN if delta_pts > 0 else "")
-    print(
-        f" {BOLD}{h:.1%}{RESET}  {colour}{delta_pts:+.1f} pts{RESET}   "
-        f"{hp}/{ht} passing ({hp - bp:+d})\n"
-    )
-
-    print(f" {BOLD}PER TIER{RESET}")
-    for tier in sorted(set(tiers_head) | set(tiers_base)):
-        p0, t0 = tiers_base.get(tier, (0, 0))
-        p1, t1 = tiers_head.get(tier, (0, 0))
-        r0, r1 = (p0 / t0 if t0 else 0.0), (p1 / t1 if t1 else 0.0)
-        d = (r1 - r0) * 100
-        c = RED if d < -AGGREGATE_NOISE_PTS else ""
-        print(f"   {tier:<12} {r0:>6.1%} → {r1:>6.1%}  {c}{d:+5.1f}{RESET}  ({p1}/{t1})")
-
-    print(f"\n {BOLD}PER MODEL{RESET}")
-    for model in sorted(set(bm) | set(hm)):
-        if model not in bm or model not in hm:
-            print(f"   {model:<26} {DIM}only in one arm{RESET}")
-            continue
-        d = (hm[model] - bm[model]) * 100
-        c = RED if d < -AGGREGATE_NOISE_PTS else ""
-        print(f"   {model:<26} {bm[model]:>6.1%} → {hm[model]:>6.1%}  {c}{d:+5.1f}{RESET}")
-
-    if diff.regressions:
-        print(
-            f"\n {BOLD}{RED}COLLAPSED{RESET} {DIM}(≥{COLLAPSE_BEFORE:.0%} → "
-            f"≤{COLLAPSE_AFTER:.0%}){RESET}"
-        )
-        for row in diff.regressions:
-            print(f"   {RED}!{RESET} {row.strip('|').replace('|', ' ').replace('`', '')}")
-    if diff.new_errors:
-        print(f"\n {BOLD}{RED}NEW ERROR TYPES{RESET}")
-        for row in diff.new_errors:
-            print(f"   {RED}!{RESET} {row.strip('|').replace('|', ' ').replace('`', '')}")
-    if diff.added or diff.removed or diff.models_changed:
-        print(f"\n {BOLD}TEST SET CHANGES{RESET}")
-        for line in diff.added[:10]:
-            print(f"   {GREEN}+{RESET} {line} {DIM}(no baseline){RESET}")
-        if len(diff.added) > 10:
-            print(f"   {DIM}… and {len(diff.added) - 10} more added{RESET}")
-        for line in diff.removed[:10]:
-            print(f"   {RED}-{RESET} {line} {DIM}(gone from HEAD){RESET}")
-        if len(diff.removed) > 10:
-            print(f"   {DIM}… and {len(diff.removed) - 10} more removed{RESET}")
-        for model in diff.models_changed:
-            print(f"   {YELLOW}~{RESET} {model} {DIM}ran in only one arm — not compared{RESET}")
-
-    print(f"\n{BOLD}{'─' * 72}{RESET}")
-    if diff.floor_breach:
-        print(f" {RED}VERDICT: BLOCKED — {diff.floor_breach}.{RESET}")
-    elif diff.clean:
-        print(
-            f" {GREEN}VERDICT: OK — stable tier {stable_rate:.1%}, no regressions "
-            f"beyond noise.{RESET}"
-        )
-    else:
-        print(
-            f" {YELLOW}VERDICT: {len(diff.regressions)} collapse(s), "
-            f"{len(diff.new_errors)} new error type(s), "
-            f"{len(diff.beyond_noise)} aggregate drop(s), "
-            f"{len(diff.removed)} removed test(s) — REVIEW REQUIRED.{RESET}"
-        )
-    print(f"{BOLD}{'─' * 72}{RESET}")
-    return diff
+# Re-export the pure comparison API for callers and existing release tests.
+ArmResults = capability_ab.ArmResults
+Diff = capability_ab.Diff
+parse_results = capability_ab.parse_results
+compare = capability_ab.compare
+_bar = capability_ab._bar
+_mark = capability_ab._mark
 
 
 def capability_diff(
     prev_tag: str, sha: str, models: list[str], runs: int, limit: int | None
 ) -> Diff:
+    """Run the shared commit-to-commit capability A/B workflow for a release."""
     step(f"Capability diff vs {prev_tag} (both arms run fresh)")
-    # The cache key carries the scope, so a `--limit 1` smoke run and a real
-    # gate run never share a directory.
     scope = f"m{len(models)}r{runs}" + (f"l{limit}" if limit else "")
-    head_arm = run_capability_arm(
-        REPO, f"HEAD ({sha[:8]})", f"{sha[:12]}-{scope}", models, runs, limit
+    experiment = f"release-{prev_tag.replace('/', '_')}-{sha[:12]}-{scope}"
+    result = capability_ab.run_ab(
+        repo=REPO,
+        base_ref=prev_tag,
+        head_ref=sha,
+        config=CAPABILITY_CONFIG,
+        models=models,
+        runs=runs,
+        parallel=GATE_PARALLEL,
+        output_root=REPO / "tmp" / "release-check",
+        experiment=experiment,
+        env_file=REPO / ".env",
+        limit=limit,
+        reuse=True,
+        head_first=True,
+        policy=capability_ab.ComparisonPolicy(
+            stable_floor=STABLE_FLOOR,
+            aggregate_noise_points=AGGREGATE_NOISE_PTS,
+            max_error_rate=MAX_ERROR_RATE,
+            collapse_before=COLLAPSE_BEFORE,
+            collapse_after=COLLAPSE_AFTER,
+        ),
     )
-    with worktree_at(prev_tag) as tree:
-        base_arm = run_capability_arm(
-            tree, prev_tag, f"{prev_tag.replace('/', '_')}-{scope}", models, runs, limit
-        )
-    diff = compare(base_arm, head_arm, prev_tag, sha, runs)
     REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    REPORT_PATH.write_text(diff.markdown)
+    REPORT_PATH.write_text(result.diff.markdown)
     print(f"\n  {DIM}markdown report: {REPORT_PATH}{RESET}")
-    return diff
+    return result.diff
 
 
 # ---------------------------------------------------------------------------

--- a/src/nooa/strategies/codeact.py
+++ b/src/nooa/strategies/codeact.py
@@ -568,6 +568,21 @@ Standard Python builtins and agent instance (`self`) are available."""
         - `execute_python(code)` — run a code cell
         - `return_result(value)` — submit your final answer (also callable from inside `execute_python`)
 
+        ## Current call contract
+
+        Execute the current method invocation shown in the task. Do not write,
+        redefine, or explain an implementation of that method unless its return
+        type explicitly asks for source code. Existing public methods on `self`
+        are callable tools, not methods you need to implement. Treat the current
+        parameter variables as the live task: do not substitute invented test
+        inputs or redefine the agent class. Compute from those variables and
+        return the resulting value.
+
+        Submit the requested return value itself — never a status report saying
+        that work was implemented, completed, or tested. Before returning, check
+        the value against the annotated return type. For batch results, preserve
+        input order and cardinality unless the method contract says otherwise.
+
         ## When to use which tool
 
         Use `return_result(...)` directly for simple answers determinable from the inputs alone (yes/no, one field, a single lookup).
@@ -2431,6 +2446,12 @@ Standard Python builtins and agent instance (`self`) are available."""
         """
         from pydantic import Field
 
+        value_contract = (
+            f"The `result` argument is the value returned by the current `{method_name}` "
+            "call for its live inputs, not a description, implementation, test, or status "
+            "report about completing the call. "
+        )
+
         def return_result(result: Any = None) -> Any:
             """Return the final result for the task.
 
@@ -2478,7 +2499,7 @@ Standard Python builtins and agent instance (`self`) are available."""
             type_name = _format_type(return_type)
             if schema_type is Any and schema_type is not return_type:
                 description = (
-                    f"Return the final result for the task. "
+                    f"{value_contract}"
                     f"Call this ONLY when you have computed the final answer. "
                     f"Expected return type: {type_name}. "
                     f"IMPORTANT: This type cannot be passed directly via this tool. "
@@ -2495,7 +2516,7 @@ Standard Python builtins and agent instance (`self`) are available."""
                     description += f"\n\nReturn type reference:\n{type_doc}"
             else:
                 description = (
-                    f"Return the final result for the task. "
+                    f"{value_contract}"
                     f"Call this ONLY when you have computed the final answer. "
                     f"Expected return type: {type_name}. "
                     f"Tip: prefer calling return_result(variable) from within execute_python() "

--- a/src/nooa/strategies/predict.py
+++ b/src/nooa/strategies/predict.py
@@ -102,6 +102,15 @@ class PredictStrategy(GenerationStrategy):
         3. Follows the exact schema structure
         4. Contains no extra fields beyond the schema
 
+        Base factual claims only on information present in the rendered inputs.
+        Values displayed before or after an explicit truncation or elision marker
+        are known values; use them normally. For a displayed suffix, count from
+        the right: the last shown value is the collection's last item, the value
+        before it is second-to-last, and so on. The marker stands only for omitted
+        entries. Never assume what those omitted entries contain. If the requested
+        claim depends on them, use the return schema's uncertainty or unanswerable
+        representation when one is available.
+
         The LLM will automatically format your output as JSON."""
         ...
 

--- a/tests/strategies/test_codeact_annotated_return.py
+++ b/tests/strategies/test_codeact_annotated_return.py
@@ -100,6 +100,8 @@ class TestAnnotatedReturnTypeDescriptions:
         # Should not have description
         assert "description" not in result_field
         assert result_field["type"] == "string"
+        assert "current `my_method` call for its live inputs" in tool.description
+        assert "not a description, implementation, test, or status report" in tool.description
 
     def test_build_return_result_tool_with_field(self):
         """Test that existing Field descriptions are preserved."""

--- a/tests/test_capability_ab.py
+++ b/tests/test_capability_ab.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the standalone commit-to-commit capability A/B runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import capability_ab
+
+
+def _write_results(path: Path, rows: list[dict]) -> Path:
+    path.write_text("\n".join(json.dumps({"_type": "result", **row}) for row in rows))
+    return path
+
+
+def test_configured_models_prefers_agent_model_matrix(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text("agent_models:\n  - model-a\n  - model-b\nmodels:\n  scorer: scorer-model\n")
+
+    assert capability_ab.configured_models(config) == ["model-a", "model-b"]
+
+
+def test_absolute_config_is_shared_and_relative_config_is_per_tree(tmp_path):
+    tree = tmp_path / "tree"
+    shared = tmp_path / "shared.yaml"
+
+    assert capability_ab._config_for_tree(shared.resolve(), tree) == shared.resolve()
+    assert capability_ab._config_for_tree(Path("tests/config.yaml"), tree) == (
+        tree / "tests/config.yaml"
+    )
+
+
+def test_parser_keeps_duplicate_case_ids_separate_by_test(tmp_path):
+    path = _write_results(
+        tmp_path / "results.jsonl",
+        [
+            {
+                "model": "model-a",
+                "test_name": "agent_help",
+                "test_case": "shared_001",
+                "tier": "stable",
+                "run_id": 1,
+                "passed": True,
+            },
+            {
+                "model": "model-a",
+                "test_name": "agent_no_help",
+                "test_case": "shared_001",
+                "tier": "stable",
+                "run_id": 1,
+                "passed": False,
+            },
+        ],
+    )
+
+    arm = capability_ab.parse_results(path, "arm")
+
+    assert len(arm.by_task) == 2
+    assert arm.counts() == (1, 2)
+
+
+def test_task_clustered_bootstrap_reports_uniform_improvement(tmp_path):
+    base_rows: list[dict] = []
+    head_rows: list[dict] = []
+    for task in range(8):
+        for run in range(3):
+            common = {
+                "model": "model-a",
+                "test_name": f"test_{task}",
+                "test_case": f"case_{task}",
+                "tier": "stable",
+                "run_id": run + 1,
+            }
+            base_rows.append({**common, "passed": False})
+            head_rows.append({**common, "passed": True})
+    base = capability_ab.parse_results(_write_results(tmp_path / "base.jsonl", base_rows), "base")
+    head = capability_ab.parse_results(_write_results(tmp_path / "head.jsonl", head_rows), "head")
+
+    stats = capability_ab.bootstrap_comparison(base, head, samples=500, seed=7)
+
+    assert stats["overall"]["delta"] == 1.0
+    assert stats["overall"]["delta_ci95"] == [1.0, 1.0]
+
+
+def test_eval_command_options_are_recorded_in_cache_signature(tmp_path, monkeypatch):
+    """A changed run option must not silently reuse an incompatible result."""
+    tree = tmp_path / "tree"
+    tree.mkdir()
+    config = tree / "config.yaml"
+    config.write_text("agent_models: [model-a]\n")
+    output = tmp_path / "output"
+    output.mkdir()
+    result_path = output / "prior.noo-eval.jsonl"
+    _write_results(
+        result_path,
+        [
+            {
+                "model": "model-a",
+                "test_name": "test",
+                "test_case": "case",
+                "tier": "stable",
+                "run_id": 1,
+                "passed": True,
+            }
+        ],
+    )
+    (output / "run.json").write_text("{}")
+    called = False
+
+    def fake_run(*args, **kwargs):
+        nonlocal called
+        called = True
+        return type("Process", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(capability_ab, "_run", fake_run)
+    capability_ab._run_arm(
+        tree,
+        label="arm",
+        revision="abc",
+        config=Path("config.yaml"),
+        models=["model-a"],
+        runs=3,
+        parallel=40,
+        output_dir=output,
+        limit=None,
+        timeout=900,
+        test_filter=None,
+        no_cache=True,
+        trace_files=False,
+        reuse=True,
+        max_error_rate=0.5,
+    )
+
+    assert called, "mismatched signature must execute instead of reusing prior output"

--- a/tests/test_make_release.py
+++ b/tests/test_make_release.py
@@ -117,6 +117,31 @@ def test_flags_collapse_and_new_error_type(mr, tmp_path):
     assert not diff.clean
 
 
+def test_case_collapse_is_not_hidden_by_passing_sibling_case(mr, tmp_path):
+    """Collapse detection must retain test-case granularity.
+
+    Grouping only by (model, test_name) makes this look like a 50% test-family
+    result and misses that one case fell from 100% to 0%.
+    """
+    base_rows = [
+        ("claude-haiku", "truncation", case, "stable", True, None)
+        for case in ("visible_suffix", "hidden_middle")
+        for _ in range(3)
+    ]
+    head_rows = [
+        ("claude-haiku", "truncation", case, "stable", case == "hidden_middle", None)
+        for case in ("visible_suffix", "hidden_middle")
+        for _ in range(3)
+    ]
+    base = mr.parse_results(write_eval(tmp_path / "b.jsonl", base_rows), "base")
+    head = mr.parse_results(write_eval(tmp_path / "h.jsonl", head_rows), "head")
+
+    diff = mr.compare(base, head, "base", "head")
+
+    assert len(diff.regressions) == 1
+    assert "visible_suffix" in diff.regressions[0]
+
+
 def test_tier_regression_is_caught_when_aggregate_is_flat(mr, tmp_path):
     """Frontier gains must not mask a stable-tier drop.
 
@@ -191,7 +216,7 @@ def test_added_tests_are_listed_but_do_not_block(mr, tmp_path):
     head = mr.parse_results(write_eval(tmp_path / "h.jsonl", head_rows), "head")
     diff = mr.compare(base, head, "v0.0.8", "abc123456789")
 
-    assert diff.added == ["claude-haiku/brand_new"]
+    assert diff.added == ["claude-haiku/brand_new/brand_new_001"]
     assert diff.removed == []
     assert "*(new)*" in diff.markdown
     assert diff.clean
@@ -210,7 +235,10 @@ def test_removed_test_is_not_clean(mr, tmp_path):
     head = mr.parse_results(write_eval(tmp_path / "h.jsonl", head_rows), "head")
     diff = mr.compare(base, head, "v0.0.8", "abc123456789")
 
-    assert sorted(diff.removed) == ["claude-haiku/router_multi", "gpt-5.4-mini/router_multi"]
+    assert sorted(diff.removed) == [
+        "claude-haiku/router_multi/router_multi_001",
+        "gpt-5.4-mini/router_multi/router_multi_001",
+    ]
     assert not diff.clean, "a disappearing test must not report as clean"
     assert "removed test(s)" in diff.markdown
 
@@ -245,6 +273,18 @@ def test_markdown_report_has_the_expected_sections(mr, tmp_path):
     md = mr.compare(base, head, "v0.0.8", "abc123456789", runs=3).markdown
 
     assert md.startswith("## 🧪 Capability Test Results")
-    for section in ("Per-tier breakdown", "Per-test breakdown", "| Tests Passed |", "Total Tokens"):
+    for section in (
+        "Per-model breakdown",
+        "Per-tier breakdown",
+        "Per-test breakdown",
+        "| Samples Passed |",
+        "Task-bootstrap delta",
+        "Total Tokens",
+    ):
         assert section in md
     assert md.rstrip().endswith("*2 models × 3 runs* | *both arms run fresh*")
+
+
+def test_release_script_reuses_shared_capability_comparator(mr):
+    assert mr.compare is mr.capability_ab.compare
+    assert mr.parse_results is mr.capability_ab.parse_results

--- a/tests/tools/test_builtin_libs.py
+++ b/tests/tools/test_builtin_libs.py
@@ -46,6 +46,25 @@ def test_codeact_strategy_instructions_no_longer_has_decomposition():
     assert "Task decomposition" not in src
 
 
+def test_codeact_strategy_instructions_define_current_call_contract():
+    from nooa.strategies.codeact import CodeActStrategy
+
+    src = inspect.getsource(CodeActStrategy.strategy_instructions)
+    assert "Execute the current method invocation" in src
+    assert "Submit the requested return value itself" in src
+    assert "input order and cardinality" in src
+
+
+def test_predict_strategy_instructions_handle_incomplete_evidence():
+    from nooa.strategies.predict import PredictStrategy
+
+    src = inspect.getsource(PredictStrategy.strategy_instructions)
+    assert "before or after an explicit truncation or elision marker" in src
+    assert "the right: the last shown value" in src
+    assert "before it is second-to-last" in src
+    assert "Never assume what those omitted entries contain" in src
+
+
 def test_context_api_not_in_protected_blocks():
     """context_api and events_api should not be registered as protected blocks."""
     from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary

- Add `scripts/capability_ab.py`, a reusable runner for comparing any two Git revisions across configured capability models.
- Refactor `scripts/make_release.py` to use the shared A/B engine instead of maintaining separate comparison logic.
- Clarify the CodeAct contract around executing the current live method call and returning its requested value.
- Clarify Predict behavior for rendered inputs containing truncation or elision markers.
- Add regression tests and usage documentation.

## Motivation

Capability comparisons were coupled to the release workflow, making them awkward to use for prompt, framework, API, or agent changes. The release comparator also grouped results too broadly, allowing a failing case to be masked by passing sibling cases.

This change provides one comparison implementation for both standalone experiments and release regression checks.

## A/B runner

The new runner supports:

- Arbitrary base and candidate Git revisions
- Detached isolated worktrees for both arms
- Fresh runs by default
- Explicit model matrices or models from the capability config
- Shared absolute configs or revision-local relative configs
- Signature-validated result reuse
- Per-model, per-tier, and per-case comparisons
- Case-level collapse and new-error detection
- Paired task-clustered bootstrap confidence intervals
- Markdown and machine-readable JSON reports

`make_release.py` now delegates its capability comparison to this runner while retaining responsibility for versioning, publishing, and release policy.

## Six-model capability result

The prompt changes were evaluated across 116 tasks, 3 fresh repetitions, and 6 models: 2,088 samples per arm and 4,176 total. Caching was disabled and both arms used the same configuration, parallelism, and timeout.

| Model | Baseline | Candidate | Change |
|---|---:|---:|---:|
| Claude Haiku | 98.3% | 99.4% | +1.1 pts |
| Claude Opus 4.8 | 98.6% | 98.9% | +0.3 pts |
| GPT-5.4 mini | 86.8% | 92.2% | +5.5 pts |
| Nemotron3 Nano 30B | 86.5% | 89.1% | +2.6 pts |
| Nemotron 3.5 Lightning | 85.6% | 90.5% | +4.9 pts |
| Nemotron-3 Super v3 | 98.3% | 99.4% | +1.1 pts |

Overall:

- Baseline: 1,928/2,088 (92.3%)
- Candidate: 1,982/2,088 (94.9%)
- Change: +54 solves / +2.59 points
- Paired task-bootstrap 95% CI: +0.96 to +4.31 points

Stable tier improved by 55 solves, from 93.8% to 96.7%, with a 95% CI of +1.34 to +4.70 points.

Frontier changed from 79.6% to 79.2%; the -0.46-point estimate was statistically inconclusive.

The prompt A/B was run before the final rebase; the production prompt edits are unchanged by the rebase.

## Review findings

The comparison policy reports **review required**:

- Two individual cases changed from 3/3 to 0/3:
  - Lightning structured extraction omitted one required source concept.
  - Nano returned the correct complex-calculation value but did not execute code, failing the mode scorer. An earlier candidate run passed this case 3/3, indicating unstable tool-use behavior.
- Lightning introduced three validation failures across two stateful order cases.
- The baseline had one 1,800-second Lightning timeout; the candidate had none.

These findings are retained for review rather than addressed with fixture-specific prompt text. All six model-level point estimates and the statistically significant aggregate result improved.

No capability fixtures, expected answers, scorers, test agents, or model-specific prompt branches were changed.

## Validation

- Full suite: 6,653 passed, 4 skipped, 284 deselected
- Focused A/B, release, and prompt-contract tests: 36 passed
- Ruff: passed
- Real two-arm external smoke comparison: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added capability A/B comparison tooling for evaluating two revisions with isolated environments, configurable policies, caching, and Markdown, JSON, and terminal reports.
  - Integrated capability comparisons into the release workflow.
  - Improved CodeAct guidance to use live inputs and return correctly typed values.
  - Improved prediction guidance for truncated or incomplete evidence.

- **Bug Fixes**
  - Enhanced comparison accuracy for case-level results, bootstrap analysis, cache validation, and detailed reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->