### PR TITLE
fix(cli): show only the head of large diffs

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/coding/activity.py
+++ b/packages/nooa-cli/src/nooa_cli/coding/activity.py
@@ -58,7 +58,7 @@ def _edit_diff(
     if _diff_input_is_too_large(old_text) or _diff_input_is_too_large(new_text):
         return _omitted_diff(path, "file content exceeds the safe diff preview limit")
 
-    output = TruncatingStringIO(limit=_MAX_EVENT_TEXT_CHARS)
+    lines: list[str] = []
     adjusted_hunk = False
     for line in unified_diff(
         old_text.splitlines(keepends=True),
@@ -71,8 +71,24 @@ def _edit_diff(
             new_count = _line_count(new_text)
             line = f"@@ -{start_line},{old_count} +{start_line},{new_count} @@\n"
             adjusted_hunk = True
-        output.write(line)
-    return output.getvalue(), not output.was_truncated
+        lines.extend(line.splitlines(keepends=True))
+
+    diff = "".join(lines)
+    if len(diff) <= _MAX_EVENT_TEXT_CHARS:
+        return diff, True
+
+    head: list[str] = []
+    head_chars = 0
+    for index, line in enumerate(lines):
+        omitted_after_line = len(lines) - index - 1
+        marker = f"… +{omitted_after_line} lines\n"
+        if head_chars + len(line) + len(marker) > _MAX_EVENT_TEXT_CHARS:
+            break
+        head.append(line)
+        head_chars += len(line)
+
+    omitted = len(lines) - len(head)
+    return "".join(head) + f"… +{omitted} lines\n", False
 
 
 class FileEdit(EventBase):  # type: ignore[misc]

--- a/packages/nooa-cli/tests/test_coding_activity.py
+++ b/packages/nooa-cli/tests/test_coding_activity.py
@@ -112,6 +112,28 @@ async def test_large_text_file_keeps_a_real_line_oriented_diff(tmp_path):
     assert "a//" not in edit.diff
 
 
+def test_large_diff_keeps_only_the_head_and_reports_omitted_lines(monkeypatch):
+    old = "".join(f"old {index}\n" for index in range(100))
+    new = "".join(f"new {index}\n" for index in range(100))
+
+    monkeypatch.setattr(activity, "_MAX_EVENT_TEXT_CHARS", 10_000)
+    complete_diff, complete = activity._edit_diff("large.txt", old, new, start_line=None)
+    assert complete is True
+
+    limit = 160
+    monkeypatch.setattr(activity, "_MAX_EVENT_TEXT_CHARS", limit)
+    preview, complete = activity._edit_diff("large.txt", old, new, start_line=None)
+
+    preview_lines = preview.splitlines()
+    complete_lines = complete_diff.splitlines()
+    kept_lines = preview_lines[:-1]
+    assert complete is False
+    assert len(preview) <= limit
+    assert kept_lines == complete_lines[: len(kept_lines)]
+    assert preview_lines[-1] == f"… +{len(complete_lines) - len(kept_lines)} lines"
+    assert "<truncated-output>" not in preview
+
+
 async def test_diff_generation_has_a_separate_input_safety_limit(tmp_path, monkeypatch):
     monkeypatch.setattr(activity, "_MAX_DIFF_INPUT_CHARS", 100)
     shell, events = _observed_shell(tmp_path)
@@ -205,8 +227,10 @@ async def test_activity_payloads_are_bounded(tmp_path):
     )
 
     assert edit.new_text.startswith("str(len=50000,")
-    assert edit.diff.startswith("<truncated-output>")
-    assert "--- a/large.txt" in edit.diff
+    assert edit.diff.startswith("--- a/large.txt\n+++ b/large.txt\n")
+    assert edit.diff.endswith(" lines\n")
+    assert "… +" in edit.diff
+    assert "<truncated-output>" not in edit.diff
     assert "str(len=" not in edit.diff
     assert edit.content_complete is False
     assert edit.diff_complete is False


### PR DESCRIPTION
## Summary
- replace generic first-and-last truncation for large `FileEdit.diff` payloads with a head-only unified-diff preview
- append `… +N lines` with the exact number of omitted rendered diff lines
- preserve complete diffs unchanged and keep `diff_complete` accurate
- add regression coverage for prefix preservation, output bounds, and omitted-line counts

## Verification
- `uv run pytest -q packages/nooa-cli/tests/test_coding_activity.py` — 11 passed
- `uv run ruff format --check packages/nooa-cli/src/nooa_cli/coding/activity.py packages/nooa-cli/tests/test_coding_activity.py`
- `uv run ruff check packages/nooa-cli/src/nooa_cli/coding/activity.py packages/nooa-cli/tests/test_coding_activity.py`
- `git diff --check origin/dev/tui...HEAD`
- full `packages/nooa-cli/tests` run: 970 passed, 2 unrelated macOS temp-path failures (both reproduce in isolation):
  - `TestBangShell::test_get_bang_shell_syncs_cwd` (`/private/var` vs `/var`)
  - `test_connect_prompts_for_missing_secret_and_saves_it` (same temp-path alias mismatch)
