### PR TITLE
fix(tools): allow file operations outside shell cwd

### DIFF
--- a/examples/cybergym/nooa_cybergym/shell_tools.py
+++ b/examples/cybergym/nooa_cybergym/shell_tools.py
@@ -63,11 +63,21 @@ class Match:
 
     Pass any ``Match`` to ``self.shell.replace(match, new_text)``. Print it to
     view numbered lines. Slice with ``match[start:end]`` (1-indexed inclusive
-    line numbers) to narrow the region before replacing.
+    line numbers) to narrow the region before replacing. ``resolved_path`` is
+    required so the anchor remains bound to that file if the shell cwd changes.
     """
 
-    def __init__(self, path: str, start: int, end: int, text: str):
+    def __init__(
+        self,
+        path: str,
+        start: int,
+        end: int,
+        text: str,
+        *,
+        resolved_path: str | Path,
+    ):
         self._path = path
+        self._resolved_path = str(Path(resolved_path).resolve())
         self._start = start
         self._end = end
         self._text = text
@@ -76,6 +86,11 @@ class Match:
     def path(self) -> str:
         """File path."""
         return self._path
+
+    @property
+    def resolved_path(self) -> str:
+        """Canonical file path captured when this match was created."""
+        return self._resolved_path
 
     @property
     def start(self) -> int:
@@ -120,7 +135,13 @@ class Match:
             idx_start = start - self._start
             idx_end = stop - self._start + 1
             text = "".join(lines[idx_start:idx_end])
-            return Match(self._path, start, stop, text)
+            return Match(
+                self._path,
+                start,
+                stop,
+                text,
+                resolved_path=self._resolved_path,
+            )
 
         raise TypeError(f"indices must be int or slice, not {type(key).__name__}")
 
@@ -444,7 +465,7 @@ class ShellTools(Skill):
             return None
 
         anchors: list[tuple[str, int]] = []
-        file_cache: dict[str, list[str]] = {}
+        file_cache: dict[str, tuple[Path, list[str]]] = {}
         for raw in rg_out.splitlines():
             raw = raw.strip()
             if not raw:
@@ -507,13 +528,22 @@ class ShellTools(Skill):
             if mpath not in file_cache:
                 resolved = (self.cwd / mpath).resolve()
                 try:
-                    file_cache[mpath] = resolved.read_text().splitlines(keepends=True)
+                    lines = resolved.read_text().splitlines(keepends=True)
+                    file_cache[mpath] = (resolved, lines)
                 except OSError:
                     return None
-            lines = file_cache[mpath]
+            resolved, lines = file_cache[mpath]
             if not (1 <= line_no <= len(lines)):
                 return None
-            out.append(Match(mpath, line_no, line_no, lines[line_no - 1]))
+            out.append(
+                Match(
+                    mpath,
+                    line_no,
+                    line_no,
+                    lines[line_no - 1],
+                    resolved_path=resolved,
+                )
+            )
         return out
 
     @staticmethod
@@ -640,9 +670,9 @@ class ShellTools(Skill):
             start = max(1, start)
             end = min(total, end)
             text = "".join(all_lines[start - 1 : end])
-            return Match(str(path), start, end, text)
+            return Match(str(path), start, end, text, resolved_path=resolved)
 
-        return Match(str(path), 1, total, content)
+        return Match(str(path), 1, total, content, resolved_path=resolved)
 
     async def read_binary(self, path: str, lines=None) -> str:
         """Hex + ASCII dump of a binary file.
@@ -701,7 +731,7 @@ class ShellTools(Skill):
         """
         if isinstance(target, Match):
             new_text = old_or_new
-            resolved = (self.cwd / target.path).resolve()
+            resolved = Path(target.resolved_path)
             content = resolved.read_text()
             all_lines = content.splitlines(keepends=True)
 

--- a/packages/nooa-cli/src/nooa_cli/coding/activity.py
+++ b/packages/nooa-cli/src/nooa_cli/coding/activity.py
@@ -320,7 +320,7 @@ class ActivityShellTools(Skill):
     @wraps(ShellTools.read)
     async def read(
         self,
-        path: Annotated[str, spec(description="File path (relative to cwd)")],
+        path: Annotated[str, spec(description="File path (relative to cwd or absolute)")],
         lines: Annotated[
             tuple[int, int] | None,
             spec(description="(start, end) 1-indexed inclusive, or None for whole file"),
@@ -348,7 +348,9 @@ class ActivityShellTools(Skill):
         if not isinstance(path, str):
             return await self._shell.replace(target, old_or_new, new)
 
-        resolved = self._resolve_path(path)
+        resolved = (
+            Path(target.resolved_path) if isinstance(target, Match) else self._resolve_path(path)
+        )
         if isinstance(target, Match):
             old_text = target.text
             start_line = target.start
@@ -392,7 +394,7 @@ class ActivityShellTools(Skill):
     @wraps(ShellTools.write_file)
     async def write_file(
         self,
-        path: Annotated[str, spec(description="File path (relative to cwd)")],
+        path: Annotated[str, spec(description="File path (relative to cwd or absolute)")],
         content: Annotated[str, spec(description="Full file content")],
     ) -> FileWrite:
         resolved = self._resolve_path(path)

--- a/packages/nooa-cli/src/nooa_cli/tools/repo_tools.py
+++ b/packages/nooa-cli/src/nooa_cli/tools/repo_tools.py
@@ -267,7 +267,7 @@ def _line_match(path: Path, line_no: int) -> Match | None:
         return None
     if not (1 <= line_no <= len(lines)):
         return None
-    return Match(str(path), line_no, line_no, lines[line_no - 1])
+    return Match(str(path), line_no, line_no, lines[line_no - 1], resolved_path=path)
 
 
 def _symbol_anchor_pairs(path: Path, symbols: list[str]) -> list[tuple[str, Match]]:
@@ -286,7 +286,18 @@ def _symbol_anchor_pairs(path: Path, symbols: list[str]) -> list[tuple[str, Matc
         except ValueError:
             continue
         if 1 <= line_no <= len(lines):
-            pairs.append((symbol, Match(str(path), line_no, line_no, lines[line_no - 1])))
+            pairs.append(
+                (
+                    symbol,
+                    Match(
+                        str(path),
+                        line_no,
+                        line_no,
+                        lines[line_no - 1],
+                        resolved_path=path,
+                    ),
+                )
+            )
     return pairs
 
 

--- a/packages/nooa-cli/tests/test_coding_activity.py
+++ b/packages/nooa-cli/tests/test_coding_activity.py
@@ -87,6 +87,26 @@ async def test_match_replace_at_end_of_file_reports_the_unterminated_text(tmp_pa
     assert (tmp_path / "example.txt").read_text() == "one\ntwo\nchanged"
 
 
+async def test_match_replace_after_cwd_change_emits_original_path(tmp_path):
+    shell, events = _observed_shell(tmp_path)
+    original = tmp_path / "example.txt"
+    original.write_text("before\n")
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "example.txt").write_text("wrong file\n")
+    try:
+        match = await shell.read("example.txt")
+        await shell.run("cd other")
+        await shell.replace(match, "after")
+    finally:
+        await shell.close()
+
+    edit = next(event for event in events if isinstance(event, FileEdit))
+    assert edit.path == str(original)
+    assert original.read_text() == "after"
+    assert (other / "example.txt").read_text() == "wrong file\n"
+
+
 async def test_observing_an_overwrite_does_not_break_binary_file_replacement(tmp_path):
     shell, events = _observed_shell(tmp_path)
     (tmp_path / "binary.dat").write_bytes(b"\xff\xfe")

--- a/src/nooa/tools/shell_tools.py
+++ b/src/nooa/tools/shell_tools.py
@@ -72,11 +72,21 @@ class Match:
 
     Pass any ``Match`` to ``self.shell.replace(match, new_text)``. Print it to
     view numbered lines. Slice with ``match[start:end]`` (1-indexed inclusive
-    line numbers) to narrow the region before replacing.
+    line numbers) to narrow the region before replacing. ``resolved_path`` is
+    required so the anchor remains bound to that file if the shell cwd changes.
     """
 
-    def __init__(self, path: str, start: int, end: int, text: str):
+    def __init__(
+        self,
+        path: str,
+        start: int,
+        end: int,
+        text: str,
+        *,
+        resolved_path: str | Path,
+    ):
         self._path = path
+        self._resolved_path = str(Path(resolved_path).resolve())
         self._start = start
         self._end = end
         self._text = text
@@ -85,6 +95,11 @@ class Match:
     def path(self) -> str:
         """File path."""
         return self._path
+
+    @property
+    def resolved_path(self) -> str:
+        """Canonical file path captured when this match was created."""
+        return self._resolved_path
 
     @property
     def start(self) -> int:
@@ -129,7 +144,13 @@ class Match:
             idx_start = start - self._start
             idx_end = stop - self._start + 1
             text = "".join(lines[idx_start:idx_end])
-            return Match(self._path, start, stop, text)
+            return Match(
+                self._path,
+                start,
+                stop,
+                text,
+                resolved_path=self._resolved_path,
+            )
 
         raise TypeError(f"indices must be int or slice, not {type(key).__name__}")
 
@@ -350,14 +371,8 @@ class ShellTools(Skill):
         await self._session.close()
 
     def _resolve_path(self, path: str) -> Path:
-        """Resolve a file-operation path and require it to remain inside cwd."""
-        root = self.cwd.resolve()
-        resolved = (root / path).resolve()
-        try:
-            resolved.relative_to(root)
-        except ValueError as exc:
-            raise ValueError(f"path escapes ShellTools cwd: {path}") from exc
-        return resolved
+        """Resolve a file-operation path relative to cwd when not absolute."""
+        return (self.cwd / path).resolve()
 
     async def run(
         self,
@@ -501,7 +516,7 @@ class ShellTools(Skill):
             return None
 
         anchors: list[tuple[str, int]] = []
-        file_cache: dict[str, list[str]] = {}
+        file_cache: dict[str, tuple[Path, list[str]]] = {}
         for raw in rg_out.splitlines():
             raw = raw.strip()
             if not raw:
@@ -564,13 +579,22 @@ class ShellTools(Skill):
             if mpath not in file_cache:
                 try:
                     resolved = self._resolve_path(mpath)
-                    file_cache[mpath] = resolved.read_text().splitlines(keepends=True)
+                    lines = resolved.read_text().splitlines(keepends=True)
+                    file_cache[mpath] = (resolved, lines)
                 except (OSError, ValueError):
                     return None
-            lines = file_cache[mpath]
+            resolved, lines = file_cache[mpath]
             if not (1 <= line_no <= len(lines)):
                 return None
-            out.append(Match(mpath, line_no, line_no, lines[line_no - 1]))
+            out.append(
+                Match(
+                    mpath,
+                    line_no,
+                    line_no,
+                    lines[line_no - 1],
+                    resolved_path=resolved,
+                )
+            )
         return out
 
     @staticmethod
@@ -661,7 +685,7 @@ class ShellTools(Skill):
 
     async def read(
         self,
-        path: Annotated[str, spec(description="File path (relative to cwd)")],
+        path: Annotated[str, spec(description="File path (relative to cwd or absolute)")],
         lines: Annotated[
             tuple[int, int] | None,
             spec(description="(start, end) 1-indexed inclusive, or None for whole file"),
@@ -674,7 +698,7 @@ class ShellTools(Skill):
         Slice with match[start:end] to narrow the region.
 
         Args:
-            path: File path (relative to cwd).
+            path: File path (relative to cwd or absolute).
             lines: Optional (start, end) range, 1-indexed inclusive.
 
         Returns:
@@ -690,9 +714,9 @@ class ShellTools(Skill):
             start = max(1, start)
             end = min(total, end)
             text = "".join(all_lines[start - 1 : end])
-            return Match(str(path), start, end, text)
+            return Match(str(path), start, end, text, resolved_path=resolved)
 
-        return Match(str(path), 1, total, content)
+        return Match(str(path), 1, total, content, resolved_path=resolved)
 
     async def replace(
         self,
@@ -722,7 +746,7 @@ class ShellTools(Skill):
         """
         if isinstance(target, Match):
             new_text = old_or_new
-            resolved = self._resolve_path(target.path)
+            resolved = Path(target.resolved_path)
             content = resolved.read_text()
             all_lines = content.splitlines(keepends=True)
 
@@ -778,14 +802,14 @@ class ShellTools(Skill):
 
     async def write_file(
         self,
-        path: Annotated[str, spec(description="File path (relative to cwd)")],
+        path: Annotated[str, spec(description="File path (relative to cwd or absolute)")],
         content: Annotated[str, spec(description="Full file content")],
     ) -> FileWrite:
         """
         Create or overwrite a file with content (no shell quoting needed).
 
         Args:
-            path: File path (relative to cwd).
+            path: File path (relative to cwd or absolute).
             content: Full file content.
         """
         resolved = self._resolve_path(path)

--- a/src/nooa/tools/shell_tools.py
+++ b/src/nooa/tools/shell_tools.py
@@ -86,7 +86,13 @@ class Match:
         resolved_path: str | Path,
     ):
         self._path = path
-        self._resolved_path = str(Path(resolved_path).resolve())
+        anchor = Path(resolved_path)
+        if not anchor.is_absolute():
+            # resolve() on a relative path resolves against the *process* cwd,
+            # which is not the shell cwd — so a relative anchor would silently
+            # point at a different file. Fail loudly instead.
+            raise ValueError(f"Match.resolved_path must be absolute, got {str(resolved_path)!r}")
+        self._resolved_path = str(anchor.resolve())
         self._start = start
         self._end = end
         self._text = text

--- a/tests/tools/test_shell_tools_modern.py
+++ b/tests/tools/test_shell_tools_modern.py
@@ -14,6 +14,7 @@ Strategy:
 
 from __future__ import annotations
 
+import json
 import random
 import shutil
 import string
@@ -121,6 +122,59 @@ async def test_match_anchor_is_editable(repo: Path):
     m = next(x for x in r.matches if x.path == "a.py")
     await sh.replace(m, "fooo = 999\n")
     assert "fooo = 999" in (repo / "a.py").read_text()
+
+
+@pytest.mark.asyncio
+async def test_repeated_noncontiguous_search_path_keeps_resolved_path(repo: Path, monkeypatch):
+    """A cached path must not inherit the preceding result's resolved path."""
+
+    class FakeSession:
+        async def run_with_timeout_flag(self, command, timeout):
+            del command, timeout
+            records = [
+                {
+                    "type": "match",
+                    "data": {"path": {"text": path}, "line_number": 1},
+                }
+                for path in ("a.py", "b.txt", "a.py")
+            ]
+            return "\n".join(json.dumps(record) for record in records), "", 0, False
+
+    async def fake_get_session():
+        return FakeSession()
+
+    sh = ShellTools(cwd=str(repo))
+    monkeypatch.setattr(sh, "_get_session", fake_get_session)
+
+    matches = await sh._harvest_matches(
+        "grep -rn 'match' .",
+        "a.py:1:match\nb.txt:1:match\na.py:1:match\n",
+    )
+
+    assert matches is not None
+    assert [match.path for match in matches] == ["a.py", "b.txt", "a.py"]
+    assert [Path(match.resolved_path) for match in matches] == [
+        repo / "a.py",
+        repo / "b.txt",
+        repo / "a.py",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_match_stays_bound_after_cwd_change(repo: Path):
+    sh = ShellTools(cwd=str(repo))
+    other = repo / "other"
+    other.mkdir()
+    (other / "a.py").write_text("fooo = 1\n")
+
+    result = await sh.run("grep -n 'fooo = 1' a.py")
+    assert result.matches
+    match = result.matches[0]
+    await sh.run("cd other")
+    await sh.replace(match, "fooo = 999\n")
+
+    assert "fooo = 999" in (repo / "a.py").read_text()
+    assert (other / "a.py").read_text() == "fooo = 1\n"
 
 
 # --------------------------------------------------------------------------

--- a/tests/tools/test_shell_tools_modern_behavior.py
+++ b/tests/tools/test_shell_tools_modern_behavior.py
@@ -43,7 +43,7 @@ def test_match_requires_resolved_path():
 
 
 def test_shell_result_timeout_flag_preserves_positional_matches_argument():
-    match = Match("example.py", 1, 1, "value\n", resolved_path="example.py")
+    match = Match("example.py", 1, 1, "value\n", resolved_path="/tmp/example.py")
     result = ShellResult("value", "", 0, [match], timed_out=True)
 
     assert result.matches == [match]
@@ -139,3 +139,24 @@ async def test_close_terminates_underlying_bash_session(sh):
     assert r2.success
     assert "restarted" in r2.stdout
     await sh.close()
+
+
+def test_match_rejects_a_relative_resolved_path(tmp_path, monkeypatch):
+    """The anchor must be absolute, or it silently binds to the process cwd.
+
+    Path.resolve() on a relative path resolves against os.getcwd(), which is
+    not the shell cwd — so a caller passing a relative path would produce a
+    Match pointing at a different file, with no error. Every caller passes an
+    absolute path today; this keeps that a rule rather than a convention.
+    """
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError, match="absolute"):
+        Match("f.txt", 1, 1, "hello\n", resolved_path="f.txt")
+
+
+def test_match_keeps_an_absolute_resolved_path(tmp_path):
+    """The supported form is unaffected."""
+    target = tmp_path / "f.txt"
+    target.write_text("hello\n")
+    match = Match("f.txt", 1, 1, "hello\n", resolved_path=target)
+    assert match.resolved_path == str(target.resolve())

--- a/tests/tools/test_shell_tools_modern_behavior.py
+++ b/tests/tools/test_shell_tools_modern_behavior.py
@@ -37,8 +37,13 @@ async def test_run_reports_failure(sh):
     assert r.timed_out is False
 
 
+def test_match_requires_resolved_path():
+    with pytest.raises(TypeError, match="resolved_path"):
+        Match("example.py", 1, 1, "value\n")  # type: ignore[call-arg]
+
+
 def test_shell_result_timeout_flag_preserves_positional_matches_argument():
-    match = Match("example.py", 1, 1, "value\n")
+    match = Match("example.py", 1, 1, "value\n", resolved_path="example.py")
     result = ShellResult("value", "", 0, [match], timed_out=True)
 
     assert result.matches == [match]
@@ -81,20 +86,40 @@ async def test_write_file_is_overwrite(sh, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_file_operations_reject_paths_outside_cwd(sh, tmp_path):
-    outside = tmp_path.parent / f"{tmp_path.name}-outside.txt"
-    outside.write_text("secret")
+async def test_file_operations_allow_paths_outside_cwd(sh, tmp_path):
+    sibling = tmp_path.parent / f"{tmp_path.name}-sibling"
+    sibling.mkdir()
+    relative = f"../{sibling.name}/relative.txt"
+    absolute = sibling / "absolute.txt"
 
-    with pytest.raises(ValueError, match="escapes ShellTools cwd"):
-        await sh.read(f"../{outside.name}")
-    with pytest.raises(ValueError, match="escapes ShellTools cwd"):
-        await sh.replace(f"../{outside.name}", "secret", "changed")
-    with pytest.raises(ValueError, match="escapes ShellTools cwd"):
-        await sh.replace(Match(f"../{outside.name}", 1, 1, "secret"), "changed")
-    with pytest.raises(ValueError, match="escapes ShellTools cwd"):
-        await sh.write_file(str(outside), "overwritten")
+    await sh.write_file(relative, "one\ntwo\n")
+    assert (await sh.read(relative)).text == "one\ntwo\n"
 
-    assert outside.read_text() == "secret"
+    await sh.replace(relative, "one", "changed")
+    await sh.replace(
+        Match(relative, 2, 2, "two\n", resolved_path=sibling / "relative.txt"), "replaced"
+    )
+    assert (sibling / "relative.txt").read_text() == "changed\nreplaced"
+
+    await sh.write_file(str(absolute), "absolute")
+    assert (await sh.read(str(absolute))).text == "absolute"
+
+
+@pytest.mark.asyncio
+async def test_match_from_read_stays_bound_after_cwd_change(sh, tmp_path):
+    original = tmp_path / "original.txt"
+    original.write_text("before\n")
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "original.txt").write_text("wrong file\n")
+
+    match = await sh.read("original.txt")
+    sliced = match[1:1]
+    await sh.run("cd other")
+    await sh.replace(sliced, "after")
+
+    assert original.read_text() == "after"
+    assert (other / "original.txt").read_text() == "wrong file\n"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove the cwd containment check from `ShellTools` file path resolution
- continue resolving relative paths from the persistent shell cwd while accepting parent-relative and absolute paths
- document the expanded path forms in `ShellTools` and `ActivityShellTools`
- cover read, write, path replacement, and `Match` replacement outside the current directory

## Why
`ShellTools.run()` already allows `cd` to any accessible directory and updates the tool cwd. Rejecting equivalent paths in `read`, `replace`, and `write_file` was inconsistent and did not provide a meaningful boundary.

## Verification
- `uv run pytest -q tests/tools/test_shell_tools_modern_behavior.py packages/nooa-cli/tests/test_coding_activity.py` — 20 passed
- `uv run pytest -q tests/tools` — 275 passed
- `uv run pytest -q packages/nooa-cli/tests` — 970 passed, 2 unrelated reproducible macOS `/var` vs `/private/var` failures
- `uv run ruff check src/nooa/tools/shell_tools.py packages/nooa-cli/src/nooa_cli/coding/activity.py tests/tools/test_shell_tools_modern_behavior.py`
- `uv run ruff format --check src/nooa/tools/shell_tools.py packages/nooa-cli/src/nooa_cli/coding/activity.py tests/tools/test_shell_tools_modern_behavior.py`
- `git diff --check origin/dev/tui...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File operations now support relative and absolute paths, including locations outside the current working directory.
  * Reading, writing, and content replacement work reliably with external file locations.
  * Matches remain associated with their original files when the working directory changes.

* **Documentation**
  * Updated path descriptions to clarify support for relative and absolute paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->