### PR TITLE
Add durable operation coordination for SQLite 🤖🤖🤖

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to follow semantic versioning.
 ## [Unreleased]
 
 - Initial public release of NVIDIA Object-Oriented Agents (NOOA).
+- Added a SQLite durable-operation ledger with request identity, renewable leases, fencing, transition history, and explicit unknown outcomes.
+- Added additive SQLite schema migration, fail-closed operation decoding, authoritative database time, and explicit unknown-outcome reconciliation.
 - Security: MCP server configurations no longer expand host environment variables
   from `${VAR}` placeholders. Trusted caller code must resolve secrets and pass
   their values explicitly.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,53 @@ uv run nooa start-dev        # trace viewer on http://localhost:5001
 
 If the viewer isn't running, tracing is silently disabled — no configuration needed either way.
 
+### 4. Coordinate resumable operations
+
+For workflows that cross a process boundary, use the durable operation ledger
+to separate execution ownership from the event history:
+
+```python
+from nooa.storage import EffectClass, ExecutionKey, SQLiteStorageManager
+
+storage = SQLiteStorageManager("agent.db")
+store = storage.execution_store
+key = ExecutionKey("workflow-1", "tool-call-1")
+claim = store.claim(key, {"customer_id": "42"}, effect_class=EffectClass.IDEMPOTENT)
+
+if claim.executable:
+    try:
+        result = call_idempotent_service(customer_id="42")
+        store.complete_success(claim, result)
+    except TimeoutError:
+        store.complete_unknown(claim, "service response was ambiguous")
+else:
+    result = claim.record.result
+```
+
+The ledger shares the SQLite storage manager's transaction lock and provides
+stable operation identity, request conflict detection, renewable leases,
+fencing against stale workers, append-only transition history, and terminal
+replay. Expired pure or idempotent work may be reclaimed. Other effect classes
+become `UNKNOWN` for explicit reconciliation instead of being run again.
+
+An `UNKNOWN` operation is not automatically retried. After querying the
+external system or applying a domain-specific reconciliation procedure, resolve
+it explicitly:
+
+```python
+store.reconcile_success(key, {"remote_id": "result-123"})
+# or, only after proving the effect did not happen:
+store.reconcile_failure(key, RuntimeError("remote transaction was rolled back"))
+```
+
+SQLite databases created by earlier NOOA versions are migrated additively. The
+existing event, tag, and snapshot records are preserved while the operation
+ledger tables are added.
+
+This does not claim exactly-once behavior for an arbitrary external service.
+Use the same idempotency key at that service; if the service outcome cannot be
+proved, preserve it as `UNKNOWN`.
+
 ## Learn more
 
 - **[Notebook tutorials](https://github.com/NVIDIA-NeMo/labs-OO-Agents/blob/main/notebook_tutorials/README.md)** — guided Colab-friendly walkthroughs for your first agent, strategy selection, and CodeAct's live-object workflow. More notebooks are planned.

--- a/src/nooa/runtime/event_manager.py
+++ b/src/nooa/runtime/event_manager.py
@@ -74,8 +74,8 @@ class EventManager:
     """Unified event pipeline with string-tagged access.
 
     All events flow through add() which:
-    1. Notifies subscribers via on()
-    2. Records event (if record=True)
+    1. Records event (if record=True)
+    2. Notifies subscribers via on()
     3. Assigns a string tag ("1", "2", etc.)
 
     String tags provide stable access:
@@ -101,6 +101,11 @@ class EventManager:
         """
         self._backend: EventBackend = backend if backend is not None else InMemoryBackend()
         self._handlers: dict[str, list[EventHandler]] = defaultdict(list)
+        # Recorded events are notified at most once by this manager. This closes
+        # the acknowledgement-loss window between a durable store and the
+        # caller receiving the assigned tag. Cross-process delivery requires a
+        # durable delivery ledger and is intentionally outside this change.
+        self._notified_event_ids: set[str] = set()
 
         # Runtime event query override (set via set_event_query())
         self._event_query: EventQuery | None = None
@@ -138,32 +143,37 @@ class EventManager:
         if event_format is not None and "truncation_event_format" not in event.metadata:
             event.metadata["truncation_event_format"] = event_format
 
-        # Emit to handlers
-        self._emit(event)
-
         # Runtime events are never recorded, regardless of record parameter
         if event._role == Role.RUNTIME_EVENT:
             record = False
 
-        # Optionally store with assigned tag
-        if record:
-            # Does the event already have a tag? Use it. Otherwise let the
-            # backend allocate one — backend-driven allocation guarantees
-            # that multiple managers writing through the same backend
-            # never hand out the same tag.
-            if isinstance(event, Summary) and event.summary_tag:
-                tag = event.summary_tag
-                self._validate_tag(tag)
-            else:
-                tag = self._backend.allocate_next_tag()
+        if not record:
+            self._emit(event)
+            return str(event.id)
 
-            # Set tag on event and store via backend
-            event.tag = tag
-            self._backend.store(tag, event)
+        # A retry may reach add() after the backend committed the row but
+        # before the original caller received the tag. Reuse the durable tag
+        # instead of appending a second row for the same event identity.
+        existing_tag = self._backend.find_tag(event)
+        if existing_tag is not None:
+            event.tag = existing_tag
+            self._emit_once(event)
+            return existing_tag
 
-            return tag
+        # Backend-driven allocation guarantees that multiple managers writing
+        # through the same backend never hand out the same tag.
+        if isinstance(event, Summary) and event.summary_tag:
+            tag = event.summary_tag
+            self._validate_tag(tag)
+        else:
+            tag = self._backend.allocate_next_tag()
 
-        return str(event.id)
+        # Persist before notifying observers. A failed persistence attempt
+        # therefore cannot expose an event that is absent from the backend.
+        event.tag = tag
+        self._backend.store(tag, event)
+        self._emit_once(event)
+        return tag
 
     def register_event_type(self, cls: type[EventBase]) -> None:
         """Register a custom EventBase subclass for deserialization.
@@ -259,6 +269,18 @@ class EventManager:
                 handler(event)
             except Exception:
                 logger.warning("Wildcard handler %r raised", handler, exc_info=True)
+
+    def _emit_once(self, event: EventBase) -> None:
+        """Notify observers once for a recorded event identity.
+
+        The set is scoped to this manager instance. It prevents duplicate
+        callbacks during retries in one process; durable cross-process
+        delivery acknowledgement is a separate storage concern.
+        """
+        if event.id in self._notified_event_ids:
+            return
+        self._emit(event)
+        self._notified_event_ids.add(event.id)
 
     # === Middleware (intercept) ===
 
@@ -482,8 +504,12 @@ class EventManager:
         Returns:
             True if found and removed, False if not found.
         """
+        event = self._backend.get(key) or self._backend.get_by_id(key)
+
         # Try as tag first
         if self._backend.remove(key):
+            if event is not None:
+                self._notified_event_ids.discard(event.id)
             return True
 
         # Fallback: find tag by UUID, then remove
@@ -491,7 +517,10 @@ class EventManager:
         if event is not None:
             tag = self._backend.find_tag(event)
             if tag:
-                return self._backend.remove(tag)
+                removed = self._backend.remove(tag)
+                if removed:
+                    self._notified_event_ids.discard(event.id)
+                return removed
 
         return False
 
@@ -501,6 +530,7 @@ class EventManager:
         # manager to reset since handlers/middleware/event_query are
         # subscriber state, not event state.
         self._backend.clear()
+        self._notified_event_ids.clear()
 
     # === Archive Operations ===
 

--- a/src/nooa/storage/__init__.py
+++ b/src/nooa/storage/__init__.py
@@ -2,6 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 """Agent persistence — StorageManager protocol and implementations."""
 
+from nooa.storage.durable_execution import (
+    CorruptExecutionStateError,
+    EffectClass,
+    ExecutionAlreadyRunningError,
+    ExecutionClaim,
+    ExecutionConflictError,
+    ExecutionKey,
+    ExecutionReconciliationError,
+    ExecutionRecord,
+    ExecutionStatus,
+    ExecutionStore,
+    ExecutionTransition,
+    LeaseLostError,
+    SQLiteExecutionStore,
+    initialize_execution_schema,
+    request_hash,
+)
 from nooa.storage.in_memory import InMemoryStorageManager
 from nooa.storage.json_snapshot import snapshot_from_json, snapshot_to_json
 from nooa.storage.manager import StorageManager
@@ -16,9 +33,22 @@ from nooa.storage.sqlite import (
 
 __all__ = [
     "AgentSnapshot",
+    "CorruptExecutionStateError",
+    "EffectClass",
+    "ExecutionAlreadyRunningError",
+    "ExecutionClaim",
+    "ExecutionConflictError",
+    "ExecutionKey",
+    "ExecutionReconciliationError",
+    "ExecutionRecord",
+    "ExecutionStatus",
+    "ExecutionStore",
+    "ExecutionTransition",
     "InMemoryStorageManager",
+    "LeaseLostError",
     "SKIP",
     "SQLiteStorageManager",
+    "SQLiteExecutionStore",
     "SessionAlreadyActiveError",
     "StorageManager",
     "deserialize",
@@ -28,4 +58,6 @@ __all__ = [
     "snapshotable",
     "snapshot_from_json",
     "snapshot_to_json",
+    "initialize_execution_schema",
+    "request_hash",
 ]

--- a/src/nooa/storage/durable_execution.py
+++ b/src/nooa/storage/durable_execution.py
@@ -1,0 +1,745 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Durable operation coordination for resumable agent workflows.
+
+This module deliberately separates durable operation state from the event
+stream.  Events are an audit/context projection; an operation record is the
+coordination primitive used to decide whether a side effect may run again.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import sqlite3
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+
+class ExecutionStatus(StrEnum):
+    """Durable states exposed by the operation ledger."""
+
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    UNKNOWN = "unknown"
+
+
+class EffectClass(StrEnum):
+    """Effect guarantees required to interpret a retry safely."""
+
+    PURE = "pure"
+    IDEMPOTENT = "idempotent"
+    TRANSACTIONAL = "transactional"
+    COMPENSATABLE = "compensatable"
+    IRREVERSIBLE = "irreversible"
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionKey:
+    """Stable identity of one logical operation."""
+
+    workflow_id: str
+    operation_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionRecord:
+    """Immutable view of a row in the operation ledger."""
+
+    key: ExecutionKey
+    request_hash: str
+    status: ExecutionStatus
+    effect_class: EffectClass
+    attempt: int
+    lease_generation: int
+    lease_expires_at: float | None
+    result: Any
+    error: dict[str, str] | None
+    updated_at: float
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionClaim:
+    """The result of claiming an operation.
+
+    A claim with ``owner_token`` is executable by the caller.  A claim with a
+    missing token is a terminal replay and must not execute the effect again.
+    """
+
+    record: ExecutionRecord
+    owner_token: str | None
+
+    @property
+    def executable(self) -> bool:
+        return self.owner_token is not None
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionTransition:
+    """Append-only audit record for one operation state transition."""
+
+    sequence: int
+    key: ExecutionKey
+    from_status: ExecutionStatus | None
+    to_status: ExecutionStatus
+    attempt: int
+    lease_generation: int
+    occurred_at: float
+    detail: str
+
+
+class ExecutionConflictError(RuntimeError):
+    """Raised when an operation ID is reused with different input."""
+
+
+class ExecutionAlreadyRunningError(RuntimeError):
+    """Raised when a live lease belongs to another worker."""
+
+
+class LeaseLostError(RuntimeError):
+    """Raised when a stale worker tries to commit an operation."""
+
+
+class CorruptExecutionStateError(RuntimeError):
+    """Raised when durable operation state cannot be safely decoded."""
+
+
+class ExecutionReconciliationError(RuntimeError):
+    """Raised when an unknown operation cannot be explicitly reconciled."""
+
+
+def request_hash(request: Any) -> str:
+    """Return a stable SHA-256 hash for a JSON-compatible request."""
+
+    payload = json.dumps(request, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+@runtime_checkable
+class ExecutionStore(Protocol):
+    """Backend-neutral durable operation contract."""
+
+    def get(self, key: ExecutionKey) -> ExecutionRecord | None:
+        """Read the current durable state for ``key``."""
+        ...
+
+    def history(self, key: ExecutionKey) -> list[ExecutionTransition]:
+        """Read the append-only transition history for ``key``."""
+        ...
+
+    def claim(
+        self,
+        key: ExecutionKey,
+        request: Any,
+        *,
+        effect_class: EffectClass = EffectClass.IDEMPOTENT,
+        lease_seconds: float = 30.0,
+    ) -> ExecutionClaim:
+        """Acquire an execution lease or return a terminal replay."""
+        ...
+
+    def renew(self, claim: ExecutionClaim, *, lease_seconds: float = 30.0) -> ExecutionClaim:
+        """Renew an owned execution lease."""
+        ...
+
+    def complete_success(self, claim: ExecutionClaim, result: Any) -> ExecutionRecord:
+        """Commit a successful result."""
+        ...
+
+    def complete_failure(self, claim: ExecutionClaim, error: Exception) -> ExecutionRecord:
+        """Commit a known failure."""
+        ...
+
+    def complete_unknown(self, claim: ExecutionClaim, reason: str) -> ExecutionRecord:
+        """Commit an ambiguous outcome."""
+        ...
+
+    def reconcile_success(self, key: ExecutionKey, result: Any) -> ExecutionRecord:
+        """Explicitly resolve an UNKNOWN operation as successful."""
+        ...
+
+    def reconcile_failure(self, key: ExecutionKey, error: Exception) -> ExecutionRecord:
+        """Explicitly resolve an UNKNOWN operation as failed."""
+        ...
+
+
+DURABLE_EXECUTION_SCHEMA = """
+CREATE TABLE IF NOT EXISTS durable_operations (
+    workflow_id       TEXT NOT NULL,
+    operation_id      TEXT NOT NULL,
+    request_hash      TEXT NOT NULL,
+    status            TEXT NOT NULL,
+    effect_class      TEXT NOT NULL,
+    attempt           INTEGER NOT NULL,
+    lease_generation  INTEGER NOT NULL,
+    lease_token       TEXT,
+    lease_expires_at  REAL,
+    result            TEXT,
+    error             TEXT,
+    updated_at        REAL NOT NULL,
+    PRIMARY KEY (workflow_id, operation_id)
+);
+CREATE INDEX IF NOT EXISTS idx_durable_operations_status
+    ON durable_operations(status, lease_expires_at);
+
+CREATE TABLE IF NOT EXISTS durable_operation_transitions (
+    sequence          INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_id       TEXT NOT NULL,
+    operation_id      TEXT NOT NULL,
+    from_status       TEXT,
+    to_status         TEXT NOT NULL,
+    attempt           INTEGER NOT NULL,
+    lease_generation  INTEGER NOT NULL,
+    occurred_at       REAL NOT NULL,
+    detail            TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_durable_operation_transitions_key
+    ON durable_operation_transitions(workflow_id, operation_id, sequence);
+"""
+
+
+def initialize_execution_schema(connection: sqlite3.Connection) -> None:
+    """Create the additive durable-operation tables for a SQLite database."""
+
+    for statement in DURABLE_EXECUTION_SCHEMA.split(";"):
+        statement = statement.strip()
+        if statement:
+            connection.execute(statement)
+
+
+class SQLiteExecutionStore:
+    """SQLite-backed operation ledger with leases and fencing tokens.
+
+    The store provides at-most-one *live owner* for a logical operation.  It
+    cannot make an external side effect atomic with SQLite; callers must use
+    an idempotency key at the effect boundary or treat an interrupted call as
+    ``UNKNOWN``.  This is the deliberate distributed-systems contract.
+    """
+
+    _SCHEMA = DURABLE_EXECUTION_SCHEMA
+
+    _RETRYABLE_AFTER_LEASE = frozenset({EffectClass.PURE, EffectClass.IDEMPOTENT})
+
+    def __init__(
+        self,
+        database: str | Path | sqlite3.Connection,
+        *,
+        clock: Callable[[], float] | None = None,
+        lock: threading.RLock | None = None,
+    ) -> None:
+        self._lock = lock or threading.RLock()
+        self._clock = clock
+        if isinstance(database, (str, Path)):
+            self._conn = sqlite3.connect(
+                str(database),
+                timeout=30.0,
+                isolation_level=None,
+                check_same_thread=False,
+            )
+            self._owns_connection = True
+            self._conn.execute("PRAGMA busy_timeout = 30000")
+        else:
+            self._conn = database
+            self._owns_connection = False
+        initialize_execution_schema(self._conn)
+
+    def close(self) -> None:
+        """Close the connection when this store created it."""
+
+        if self._owns_connection:
+            self._conn.close()
+
+    def get(self, key: ExecutionKey) -> ExecutionRecord | None:
+        """Read the current durable state for ``key``."""
+
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM durable_operations WHERE workflow_id = ? AND operation_id = ?",
+                (key.workflow_id, key.operation_id),
+            ).fetchone()
+        return self._record_from_row(row) if row is not None else None
+
+    def history(self, key: ExecutionKey) -> list[ExecutionTransition]:
+        """Return the append-only transition history for ``key``."""
+
+        with self._lock:
+            rows = self._conn.execute(
+                """SELECT sequence, workflow_id, operation_id, from_status,
+                          to_status, attempt, lease_generation, occurred_at, detail
+                   FROM durable_operation_transitions
+                   WHERE workflow_id = ? AND operation_id = ?
+                   ORDER BY sequence""",
+                (key.workflow_id, key.operation_id),
+            ).fetchall()
+        return [self._transition_from_row(row) for row in rows]
+
+    def claim(
+        self,
+        key: ExecutionKey,
+        request: Any,
+        *,
+        effect_class: EffectClass = EffectClass.IDEMPOTENT,
+        lease_seconds: float = 30.0,
+    ) -> ExecutionClaim:
+        """Claim a logical operation or return its terminal replay.
+
+        A live lease raises ``ExecutionAlreadyRunningError``.  An expired
+        lease is taken over with a higher fencing generation.  Terminal rows
+        are returned without an owner token, so callers cannot accidentally
+        execute a completed or uncertain effect twice.
+        """
+
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        hashed_request = request_hash(request)
+        token = secrets.token_urlsafe(24)
+
+        with self._transaction():
+            now = self._now()
+            row = self._conn.execute(
+                "SELECT * FROM durable_operations WHERE workflow_id = ? AND operation_id = ?",
+                (key.workflow_id, key.operation_id),
+            ).fetchone()
+            if row is None:
+                self._conn.execute(
+                    """INSERT INTO durable_operations
+                    (workflow_id, operation_id, request_hash, status, effect_class,
+                     attempt, lease_generation, lease_token, lease_expires_at,
+                     result, error, updated_at)
+                    VALUES (?, ?, ?, ?, ?, 1, 1, ?, ?, NULL, NULL, ?)""",
+                    (
+                        key.workflow_id,
+                        key.operation_id,
+                        hashed_request,
+                        ExecutionStatus.RUNNING,
+                        effect_class,
+                        token,
+                        now + lease_seconds,
+                        now,
+                    ),
+                )
+                self._append_transition(
+                    key,
+                    from_status=None,
+                    to_status=ExecutionStatus.RUNNING,
+                    attempt=1,
+                    lease_generation=1,
+                    occurred_at=now,
+                    detail="claimed",
+                )
+                return ExecutionClaim(
+                    self._record_from_row(
+                        self._conn.execute(
+                            "SELECT * FROM durable_operations WHERE workflow_id = ? AND operation_id = ?",
+                            (key.workflow_id, key.operation_id),
+                        ).fetchone()
+                    ),
+                    token,
+                )
+
+            record = self._record_from_row(row)
+            if record.request_hash != hashed_request:
+                raise ExecutionConflictError(
+                    f"operation {key.workflow_id!r}/{key.operation_id!r} already has a different request"
+                )
+            if record.effect_class is not effect_class:
+                raise ExecutionConflictError(
+                    f"operation {key.workflow_id!r}/{key.operation_id!r} already has a different effect class"
+                )
+            if record.status is not ExecutionStatus.RUNNING:
+                return ExecutionClaim(record, None)
+            if record.lease_expires_at is not None and record.lease_expires_at > now:
+                raise ExecutionAlreadyRunningError(
+                    f"operation {key.workflow_id!r}/{key.operation_id!r} is leased until "
+                    f"{record.lease_expires_at:.6f}"
+                )
+
+            if record.effect_class not in self._RETRYABLE_AFTER_LEASE:
+                reason = (
+                    "lease expired after a potentially applied side effect; "
+                    "manual reconciliation is required"
+                )
+                self._conn.execute(
+                    """UPDATE durable_operations
+                    SET status = ?, lease_token = NULL, lease_expires_at = NULL,
+                        error = ?, updated_at = ?
+                    WHERE workflow_id = ? AND operation_id = ?
+                      AND status = ? AND lease_generation = ?""",
+                    (
+                        ExecutionStatus.UNKNOWN,
+                        json.dumps({"type": "UnknownOutcome", "message": reason}),
+                        now,
+                        key.workflow_id,
+                        key.operation_id,
+                        ExecutionStatus.RUNNING,
+                        record.lease_generation,
+                    ),
+                )
+                self._append_transition(
+                    key,
+                    from_status=ExecutionStatus.RUNNING,
+                    to_status=ExecutionStatus.UNKNOWN,
+                    attempt=record.attempt,
+                    lease_generation=record.lease_generation,
+                    occurred_at=now,
+                    detail="unsafe lease expiry",
+                )
+                unknown_row = self._conn.execute(
+                    "SELECT * FROM durable_operations WHERE workflow_id = ? AND operation_id = ?",
+                    (key.workflow_id, key.operation_id),
+                ).fetchone()
+                return ExecutionClaim(self._record_from_row(unknown_row), None)
+
+            next_generation = record.lease_generation + 1
+            self._conn.execute(
+                """UPDATE durable_operations
+                SET attempt = ?, lease_generation = ?, lease_token = ?,
+                    lease_expires_at = ?, updated_at = ?
+                WHERE workflow_id = ? AND operation_id = ?
+                  AND status = ? AND lease_generation = ?""",
+                (
+                    record.attempt + 1,
+                    next_generation,
+                    token,
+                    now + lease_seconds,
+                    now,
+                    key.workflow_id,
+                    key.operation_id,
+                    ExecutionStatus.RUNNING,
+                    record.lease_generation,
+                ),
+            )
+            self._append_transition(
+                key,
+                from_status=ExecutionStatus.RUNNING,
+                to_status=ExecutionStatus.RUNNING,
+                attempt=record.attempt + 1,
+                lease_generation=next_generation,
+                occurred_at=now,
+                detail="expired lease reclaimed",
+            )
+            return ExecutionClaim(
+                self._record_from_row(
+                    self._conn.execute(
+                        "SELECT * FROM durable_operations WHERE workflow_id = ? AND operation_id = ?",
+                        (key.workflow_id, key.operation_id),
+                    ).fetchone()
+                ),
+                token,
+            )
+
+    def renew(self, claim: ExecutionClaim, *, lease_seconds: float = 30.0) -> ExecutionClaim:
+        """Extend a live lease and return an updated claim.
+
+        Renewal is fenced by both the opaque token and monotonic generation.
+        An already-expired lease cannot be revived by its former owner.
+        """
+
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        if claim.owner_token is None:
+            raise LeaseLostError("terminal claims cannot be renewed")
+        with self._transaction():
+            now = self._now()
+            expires_at = now + lease_seconds
+            cursor = self._conn.execute(
+                """UPDATE durable_operations
+                SET lease_expires_at = ?, updated_at = ?
+                WHERE workflow_id = ? AND operation_id = ?
+                  AND status = ? AND lease_token = ?
+                  AND lease_generation = ? AND lease_expires_at > ?""",
+                (
+                    expires_at,
+                    now,
+                    claim.record.key.workflow_id,
+                    claim.record.key.operation_id,
+                    ExecutionStatus.RUNNING,
+                    claim.owner_token,
+                    claim.record.lease_generation,
+                    now,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise LeaseLostError(
+                    f"lease lost for {claim.record.key.workflow_id!r}/{claim.record.key.operation_id!r}"
+                )
+            row = self._conn.execute(
+                "SELECT * FROM durable_operations WHERE workflow_id = ? AND operation_id = ?",
+                (claim.record.key.workflow_id, claim.record.key.operation_id),
+            ).fetchone()
+        return ExecutionClaim(self._record_from_row(row), claim.owner_token)
+
+    def complete_success(self, claim: ExecutionClaim, result: Any) -> ExecutionRecord:
+        """Commit a result only if ``claim`` still owns the lease."""
+
+        return self._complete(claim, ExecutionStatus.SUCCEEDED, result=result, error=None)
+
+    def complete_failure(self, claim: ExecutionClaim, error: Exception) -> ExecutionRecord:
+        """Commit a known execution failure only if the lease is current."""
+
+        return self._complete(
+            claim,
+            ExecutionStatus.FAILED,
+            result=None,
+            error={"type": type(error).__name__, "message": str(error)},
+        )
+
+    def complete_unknown(self, claim: ExecutionClaim, reason: str) -> ExecutionRecord:
+        """Record an ambiguous external outcome without retrying it."""
+
+        return self._complete(
+            claim,
+            ExecutionStatus.UNKNOWN,
+            result=None,
+            error={"type": "UnknownOutcome", "message": reason},
+        )
+
+    def reconcile_success(self, key: ExecutionKey, result: Any) -> ExecutionRecord:
+        """Resolve an UNKNOWN operation after an external status check."""
+
+        return self._reconcile(key, ExecutionStatus.SUCCEEDED, result=result, error=None)
+
+    def reconcile_failure(self, key: ExecutionKey, error: Exception) -> ExecutionRecord:
+        """Resolve an UNKNOWN operation after proving the effect did not occur."""
+
+        return self._reconcile(
+            key,
+            ExecutionStatus.FAILED,
+            result=None,
+            error={"type": type(error).__name__, "message": str(error)},
+        )
+
+    def _reconcile(
+        self,
+        key: ExecutionKey,
+        status: ExecutionStatus,
+        *,
+        result: Any,
+        error: dict[str, str] | None,
+    ) -> ExecutionRecord:
+        encoded_result = json.dumps(result, ensure_ascii=False) if result is not None else None
+        encoded_error = json.dumps(error, ensure_ascii=False) if error is not None else None
+        with self._transaction():
+            now = self._now()
+            row = self._conn.execute(
+                "SELECT * FROM durable_operations WHERE workflow_id = ? AND operation_id = ?",
+                (key.workflow_id, key.operation_id),
+            ).fetchone()
+            if row is None:
+                raise ExecutionReconciliationError(f"operation {key!r} does not exist")
+            record = self._record_from_row(row)
+            if record.status is not ExecutionStatus.UNKNOWN:
+                raise ExecutionReconciliationError(
+                    f"operation {key!r} is {record.status.value}, not unknown"
+                )
+            self._conn.execute(
+                """UPDATE durable_operations
+                   SET status = ?, result = ?, error = ?, updated_at = ?
+                   WHERE workflow_id = ? AND operation_id = ? AND status = ?""",
+                (
+                    status,
+                    encoded_result,
+                    encoded_error,
+                    now,
+                    key.workflow_id,
+                    key.operation_id,
+                    ExecutionStatus.UNKNOWN,
+                ),
+            )
+            self._append_transition(
+                key,
+                from_status=ExecutionStatus.UNKNOWN,
+                to_status=status,
+                attempt=record.attempt,
+                lease_generation=record.lease_generation,
+                occurred_at=now,
+                detail="reconciled success"
+                if status is ExecutionStatus.SUCCEEDED
+                else "reconciled failure",
+            )
+            resolved = self._conn.execute(
+                "SELECT * FROM durable_operations WHERE workflow_id = ? AND operation_id = ?",
+                (key.workflow_id, key.operation_id),
+            ).fetchone()
+        return self._record_from_row(resolved)
+
+    def _complete(
+        self,
+        claim: ExecutionClaim,
+        status: ExecutionStatus,
+        *,
+        result: Any,
+        error: dict[str, str] | None,
+    ) -> ExecutionRecord:
+        if claim.owner_token is None:
+            raise LeaseLostError("terminal claims cannot commit")
+        encoded_result = json.dumps(result, ensure_ascii=False) if result is not None else None
+        encoded_error = json.dumps(error, ensure_ascii=False) if error is not None else None
+        with self._transaction():
+            now = self._now()
+            cursor = self._conn.execute(
+                """UPDATE durable_operations
+                SET status = ?, lease_token = NULL, lease_expires_at = NULL,
+                    result = ?, error = ?, updated_at = ?
+                WHERE workflow_id = ? AND operation_id = ?
+                  AND status = ? AND lease_token = ?
+                  AND lease_generation = ? AND lease_expires_at > ?""",
+                (
+                    status,
+                    encoded_result,
+                    encoded_error,
+                    now,
+                    claim.record.key.workflow_id,
+                    claim.record.key.operation_id,
+                    ExecutionStatus.RUNNING,
+                    claim.owner_token,
+                    claim.record.lease_generation,
+                    now,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise LeaseLostError(
+                    f"lease lost for {claim.record.key.workflow_id!r}/{claim.record.key.operation_id!r}"
+                )
+            self._append_transition(
+                claim.record.key,
+                from_status=ExecutionStatus.RUNNING,
+                to_status=status,
+                attempt=claim.record.attempt,
+                lease_generation=claim.record.lease_generation,
+                occurred_at=now,
+                detail={
+                    ExecutionStatus.SUCCEEDED: "completed",
+                    ExecutionStatus.FAILED: "failed",
+                    ExecutionStatus.UNKNOWN: "outcome marked unknown",
+                }[status],
+            )
+            row = self._conn.execute(
+                "SELECT * FROM durable_operations WHERE workflow_id = ? AND operation_id = ?",
+                (claim.record.key.workflow_id, claim.record.key.operation_id),
+            ).fetchone()
+        return self._record_from_row(row)
+
+    def _append_transition(
+        self,
+        key: ExecutionKey,
+        *,
+        from_status: ExecutionStatus | None,
+        to_status: ExecutionStatus,
+        attempt: int,
+        lease_generation: int,
+        occurred_at: float,
+        detail: str,
+    ) -> None:
+        self._conn.execute(
+            """INSERT INTO durable_operation_transitions
+            (workflow_id, operation_id, from_status, to_status, attempt,
+             lease_generation, occurred_at, detail)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                key.workflow_id,
+                key.operation_id,
+                from_status,
+                to_status,
+                attempt,
+                lease_generation,
+                occurred_at,
+                detail,
+            ),
+        )
+
+    @contextmanager
+    def _transaction(self) -> Iterator[None]:
+        """Run one write transaction without leaking the shared lock.
+
+        The lock is released even if SQLite rejects ``BEGIN IMMEDIATE``. If a
+        commit fails, a best-effort rollback leaves the connection reusable.
+        """
+
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                yield
+                self._conn.execute("COMMIT")
+            except BaseException:
+                try:
+                    self._conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    pass
+                raise
+
+    def _now(self) -> float:
+        """Return test-injected time or SQLite's connection-local UTC time."""
+
+        if self._clock is not None:
+            return self._clock()
+        row = self._conn.execute("SELECT (julianday('now') - 2440587.5) * 86400.0").fetchone()
+        if row is None:
+            raise RuntimeError("SQLite did not return an authoritative timestamp")
+        return float(row[0])
+
+    @staticmethod
+    def _record_from_row(row: sqlite3.Row | tuple[Any, ...]) -> ExecutionRecord:
+        try:
+            (
+                workflow_id,
+                operation_id,
+                hashed_request,
+                status,
+                effect_class,
+                attempt,
+                lease_generation,
+                _lease_token,
+                lease_expires_at,
+                encoded_result,
+                encoded_error,
+                updated_at,
+            ) = row
+            return ExecutionRecord(
+                key=ExecutionKey(workflow_id, operation_id),
+                request_hash=hashed_request,
+                status=ExecutionStatus(status),
+                effect_class=EffectClass(effect_class),
+                attempt=attempt,
+                lease_generation=lease_generation,
+                lease_expires_at=lease_expires_at,
+                result=json.loads(encoded_result) if encoded_result is not None else None,
+                error=json.loads(encoded_error) if encoded_error is not None else None,
+                updated_at=updated_at,
+            )
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise CorruptExecutionStateError("durable operation row is unreadable") from exc
+
+    @staticmethod
+    def _transition_from_row(row: sqlite3.Row | tuple[Any, ...]) -> ExecutionTransition:
+        try:
+            (
+                sequence,
+                workflow_id,
+                operation_id,
+                from_status,
+                to_status,
+                attempt,
+                lease_generation,
+                occurred_at,
+                detail,
+            ) = row
+            return ExecutionTransition(
+                sequence=sequence,
+                key=ExecutionKey(workflow_id, operation_id),
+                from_status=ExecutionStatus(from_status) if from_status is not None else None,
+                to_status=ExecutionStatus(to_status),
+                attempt=attempt,
+                lease_generation=lease_generation,
+                occurred_at=occurred_at,
+                detail=detail,
+            )
+        except (TypeError, ValueError) as exc:
+            raise CorruptExecutionStateError("durable transition row is unreadable") from exc

--- a/src/nooa/storage/sqlite.py
+++ b/src/nooa/storage/sqlite.py
@@ -40,6 +40,10 @@ from nooa.events import (
     TuiSessionCleared,
     TuiSessionResumed,
 )
+from nooa.storage.durable_execution import (
+    SQLiteExecutionStore,
+    initialize_execution_schema,
+)
 from nooa.storage.json_snapshot import snapshot_from_dict, snapshot_to_dict
 from nooa.storage.snapshot import AgentSnapshot
 
@@ -99,7 +103,7 @@ for _cls in (
         )
     _CORE_TYPES[_key] = _cls
 
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
 
 _SCHEMA = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -212,13 +216,22 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     conn.executescript(_SCHEMA)
     row = conn.execute("SELECT version FROM schema_version").fetchone()
     if row is None:
+        initialize_execution_schema(conn)
         conn.execute("INSERT INTO schema_version (version) VALUES (?)", (_SCHEMA_VERSION,))
         conn.commit()
+    elif row[0] == 1:
+        # Version 2 is additive: existing event, tag, and snapshot rows remain
+        # untouched while the durable-operation tables are created atomically.
+        with conn:
+            initialize_execution_schema(conn)
+            conn.execute("UPDATE schema_version SET version = ?", (_SCHEMA_VERSION,))
     elif row[0] != _SCHEMA_VERSION:
         raise RuntimeError(
             f"SQLite schema version mismatch: DB has v{row[0]}, "
             f"code expects v{_SCHEMA_VERSION}. Migration required."
         )
+    else:
+        initialize_execution_schema(conn)
 
 
 class SQLiteEventBackend:
@@ -745,6 +758,7 @@ class SQLiteStorageManager:
             _ensure_schema(self._conn)
             self._backend = SQLiteEventBackend(self._conn, lock=self._db_lock)
             self._backend._on_io_error = self._reconnect
+            self._execution_store = SQLiteExecutionStore(self._conn, lock=self._db_lock)
         except Exception:
             self.close()
             raise
@@ -797,10 +811,17 @@ class SQLiteStorageManager:
             raise
         self._conn = new_conn
         self._backend._conn = self._conn
+        self._execution_store._conn = self._conn
 
     @property
     def event_backend(self) -> SQLiteEventBackend:
         return self._backend
+
+    @property
+    def execution_store(self) -> SQLiteExecutionStore:
+        """Durable operation ledger sharing this manager's transaction boundary."""
+
+        return self._execution_store
 
     @property
     def path(self) -> Path | None:

--- a/tests/test_durable_execution_fault_schedules.py
+++ b/tests/test_durable_execution_fault_schedules.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Large deterministic fault schedule for durable execution recovery."""
+
+import random
+
+import pytest
+
+from nooa.storage import (
+    EffectClass,
+    ExecutionKey,
+    ExecutionStatus,
+    LeaseLostError,
+    SQLiteExecutionStore,
+)
+
+
+def test_10_000_seeded_recovery_schedules():
+    now = [0.0]
+    store = SQLiteExecutionStore(":memory:", clock=lambda: now[0])
+    effect_classes = tuple(EffectClass)
+
+    for seed in range(10_000):
+        randomizer = random.Random(seed)
+        effect_class = randomizer.choice(effect_classes)
+        key = ExecutionKey("seeded-faults", str(seed))
+        request = {"seed": seed, "payload": randomizer.randrange(1_000_000)}
+        now[0] = float(seed * 10)
+        first = store.claim(key, request, effect_class=effect_class, lease_seconds=2)
+
+        if randomizer.choice((True, False)):
+            store.complete_success(first, {"seed": seed})
+            replay = store.claim(key, request, effect_class=effect_class)
+            assert not replay.executable
+            assert replay.record.status is ExecutionStatus.SUCCEEDED
+            continue
+
+        now[0] += 3.0
+        recovery = store.claim(key, request, effect_class=effect_class, lease_seconds=2)
+        with pytest.raises(LeaseLostError):
+            store.complete_success(first, {"stale": seed})
+
+        if effect_class in {EffectClass.PURE, EffectClass.IDEMPOTENT}:
+            assert recovery.executable
+            assert recovery.record.attempt == 2
+            store.complete_success(recovery, {"seed": seed})
+        else:
+            assert not recovery.executable
+            assert recovery.record.status is ExecutionStatus.UNKNOWN
+
+        terminal = store.claim(key, request, effect_class=effect_class)
+        assert not terminal.executable
+        assert terminal.record.status in {ExecutionStatus.SUCCEEDED, ExecutionStatus.UNKNOWN}

--- a/tests/test_durable_execution_store.py
+++ b/tests/test_durable_execution_store.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for durable operation ownership and replay."""
+
+import multiprocessing
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from nooa.storage import (
+    CorruptExecutionStateError,
+    EffectClass,
+    ExecutionAlreadyRunningError,
+    ExecutionConflictError,
+    ExecutionKey,
+    ExecutionReconciliationError,
+    ExecutionStatus,
+    ExecutionStore,
+    LeaseLostError,
+    SQLiteExecutionStore,
+    SQLiteStorageManager,
+)
+
+
+def _claim_in_process(database: str, start, results) -> None:
+    store = SQLiteExecutionStore(database)
+    try:
+        start.wait()
+        try:
+            claim = store.claim(ExecutionKey("process-workflow", "tool-1"), {"value": 7})
+            results.put("winner" if claim.executable else "replay")
+        except ExecutionAlreadyRunningError:
+            results.put("loser")
+    finally:
+        store.close()
+
+
+def test_terminal_success_is_replayed_without_reexecuting(tmp_path):
+    store = SQLiteExecutionStore(tmp_path / "run.db")
+    key = ExecutionKey("workflow-1", "tool-1")
+
+    claim = store.claim(key, {"value": 7}, effect_class=EffectClass.IDEMPOTENT)
+    record = store.complete_success(claim, {"answer": 42})
+    replay = store.claim(key, {"value": 7})
+
+    assert record.status is ExecutionStatus.SUCCEEDED
+    assert not replay.executable
+    assert replay.record.result == {"answer": 42}
+    assert replay.record.attempt == 1
+
+
+def test_same_operation_id_rejects_different_request(tmp_path):
+    store = SQLiteExecutionStore(tmp_path / "run.db")
+    key = ExecutionKey("workflow-1", "tool-1")
+    store.claim(key, {"value": 7})
+
+    with pytest.raises(ExecutionConflictError):
+        store.claim(key, {"value": 8})
+
+
+def test_same_operation_id_rejects_different_effect_class(tmp_path):
+    store = SQLiteExecutionStore(tmp_path / "run.db")
+    key = ExecutionKey("workflow-1", "tool-1")
+    store.claim(key, {"value": 7}, effect_class=EffectClass.IRREVERSIBLE)
+
+    with pytest.raises(ExecutionConflictError):
+        store.claim(key, {"value": 7}, effect_class=EffectClass.PURE)
+
+
+def test_live_lease_allows_only_one_owner(tmp_path):
+    store = SQLiteExecutionStore(tmp_path / "run.db")
+    key = ExecutionKey("workflow-1", "tool-1")
+    store.claim(key, {"value": 7}, lease_seconds=60)
+
+    with pytest.raises(ExecutionAlreadyRunningError):
+        store.claim(key, {"value": 7}, lease_seconds=60)
+
+
+def test_expired_lease_fences_stale_worker(tmp_path):
+    now = [100.0]
+    store = SQLiteExecutionStore(tmp_path / "run.db", clock=lambda: now[0])
+    key = ExecutionKey("workflow-1", "tool-1")
+    first = store.claim(key, {"value": 7}, lease_seconds=5)
+
+    now[0] = 106.0
+    second = store.claim(key, {"value": 7}, lease_seconds=5)
+
+    assert second.record.attempt == 2
+    assert second.record.lease_generation > first.record.lease_generation
+    with pytest.raises(LeaseLostError):
+        store.complete_success(first, "stale")
+    assert store.complete_success(second, "fresh").result == "fresh"
+
+
+@pytest.mark.parametrize(
+    "effect_class",
+    [EffectClass.TRANSACTIONAL, EffectClass.COMPENSATABLE, EffectClass.IRREVERSIBLE],
+)
+def test_unsafe_expired_lease_becomes_unknown(tmp_path, effect_class):
+    now = [100.0]
+    store = SQLiteExecutionStore(tmp_path / "run.db", clock=lambda: now[0])
+    key = ExecutionKey("workflow-1", f"{effect_class}-operation")
+    first = store.claim(key, {"value": 7}, effect_class=effect_class, lease_seconds=5)
+
+    now[0] = 106.0
+    recovery = store.claim(key, {"value": 7}, effect_class=effect_class, lease_seconds=5)
+
+    assert not recovery.executable
+    assert recovery.record.status is ExecutionStatus.UNKNOWN
+    assert recovery.record.attempt == 1
+    with pytest.raises(LeaseLostError):
+        store.complete_success(first, "stale")
+
+
+def test_renew_extends_lease_and_expired_owner_cannot_renew(tmp_path):
+    now = [100.0]
+    store = SQLiteExecutionStore(tmp_path / "run.db", clock=lambda: now[0])
+    key = ExecutionKey("workflow-1", "tool-1")
+    claim = store.claim(key, {}, lease_seconds=5)
+
+    now[0] = 104.0
+    renewed = store.renew(claim, lease_seconds=10)
+    assert renewed.record.lease_expires_at == 114.0
+
+    now[0] = 115.0
+    with pytest.raises(LeaseLostError):
+        store.renew(renewed, lease_seconds=10)
+
+
+def test_expired_owner_cannot_commit_without_a_takeover(tmp_path):
+    now = [100.0]
+    store = SQLiteExecutionStore(tmp_path / "run.db", clock=lambda: now[0])
+    claim = store.claim(ExecutionKey("workflow-1", "tool-1"), {}, lease_seconds=5)
+
+    now[0] = 105.0
+
+    with pytest.raises(LeaseLostError):
+        store.complete_success(claim, "late")
+
+
+def test_failed_transaction_start_releases_shared_lock():
+    connection = sqlite3.connect(":memory:")
+    lock = threading.RLock()
+    store = SQLiteExecutionStore(connection, lock=lock)
+    connection.close()
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        store.claim(ExecutionKey("workflow", "operation"), {})
+
+    acquired_from_another_thread: list[bool] = []
+
+    def acquire_lock() -> None:
+        acquired = lock.acquire(timeout=1)
+        acquired_from_another_thread.append(acquired)
+        if acquired:
+            lock.release()
+
+    worker = threading.Thread(target=acquire_lock)
+    worker.start()
+    worker.join(timeout=2)
+
+    assert acquired_from_another_thread == [True]
+
+
+def test_unknown_outcome_is_terminal_and_preserves_reason(tmp_path):
+    store = SQLiteExecutionStore(tmp_path / "run.db")
+    key = ExecutionKey("workflow-1", "external-call-1")
+    claim = store.claim(key, {"charge": 100}, effect_class=EffectClass.IRREVERSIBLE)
+
+    store.complete_unknown(claim, "transport closed after remote acceptance")
+    replay = store.claim(key, {"charge": 100}, effect_class=EffectClass.IRREVERSIBLE)
+
+    assert replay.record.status is ExecutionStatus.UNKNOWN
+    assert replay.record.error == {
+        "type": "UnknownOutcome",
+        "message": "transport closed after remote acceptance",
+    }
+    assert not replay.executable
+
+
+def test_unknown_outcome_can_only_be_resolved_explicitly(tmp_path):
+    store = SQLiteExecutionStore(tmp_path / "run.db")
+    key = ExecutionKey("workflow-1", "external-call-1")
+    claim = store.claim(key, {"charge": 100}, effect_class=EffectClass.IRREVERSIBLE)
+    store.complete_unknown(claim, "response was lost")
+
+    resolved = store.reconcile_success(key, {"charge_id": "ch_123"})
+    assert resolved.status is ExecutionStatus.SUCCEEDED
+    assert resolved.result == {"charge_id": "ch_123"}
+    assert (
+        store.claim(key, {"charge": 100}, effect_class=EffectClass.IRREVERSIBLE).record.status
+        is ExecutionStatus.SUCCEEDED
+    )
+
+    with pytest.raises(ExecutionReconciliationError):
+        store.reconcile_failure(key, RuntimeError("cannot change a resolved operation"))
+
+
+def test_corrupt_terminal_payload_fails_closed(tmp_path):
+    path = tmp_path / "run.db"
+    store = SQLiteExecutionStore(path)
+    key = ExecutionKey("workflow-1", "tool-1")
+    claim = store.claim(key, {})
+    store.complete_success(claim, {"answer": 42})
+    store._conn.execute(
+        "UPDATE durable_operations SET result = ? WHERE workflow_id = ? AND operation_id = ?",
+        ("{not-json", key.workflow_id, key.operation_id),
+    )
+    store._conn.commit()
+
+    with pytest.raises(CorruptExecutionStateError):
+        store.get(key)
+
+
+def test_v1_database_migrates_additive_operation_tables(tmp_path):
+    path = tmp_path / "legacy.db"
+    connection = sqlite3.connect(path)
+    connection.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+    connection.execute("INSERT INTO schema_version (version) VALUES (1)")
+    connection.commit()
+    connection.close()
+
+    with SQLiteStorageManager(path) as storage:
+        version = storage._conn.execute("SELECT version FROM schema_version").fetchone()[0]
+        assert version == 2
+        claim = storage.execution_store.claim(ExecutionKey("workflow", "operation"), {})
+        assert claim.executable
+
+
+def test_transition_history_is_append_only(tmp_path):
+    now = [100.0]
+    store = SQLiteExecutionStore(tmp_path / "run.db", clock=lambda: now[0])
+    key = ExecutionKey("workflow-1", "tool-1")
+    first = store.claim(key, {}, lease_seconds=5)
+    now[0] = 106.0
+    second = store.claim(key, {}, lease_seconds=5)
+    store.complete_success(second, {"answer": 42})
+
+    history = store.history(key)
+    assert [transition.detail for transition in history] == [
+        "claimed",
+        "expired lease reclaimed",
+        "completed",
+    ]
+    assert [transition.lease_generation for transition in history] == [1, 2, 2]
+    with pytest.raises(LeaseLostError):
+        store.complete_success(first, "stale")
+
+
+def test_two_connections_share_lease_and_fencing(tmp_path):
+    path = tmp_path / "run.db"
+    first = SQLiteExecutionStore(path)
+    second = SQLiteExecutionStore(path)
+    key = ExecutionKey("workflow-1", "tool-1")
+
+    claim = first.claim(key, {"value": 7}, lease_seconds=60)
+    with pytest.raises(ExecutionAlreadyRunningError):
+        second.claim(key, {"value": 7}, lease_seconds=60)
+
+    assert first.complete_failure(claim, RuntimeError("boom")).status is ExecutionStatus.FAILED
+    assert second.claim(key, {"value": 7}).record.status is ExecutionStatus.FAILED
+
+    first.close()
+    second.close()
+
+
+def test_concurrent_claims_have_one_winner(tmp_path):
+    path = tmp_path / "run.db"
+    key = ExecutionKey("workflow-1", "tool-1")
+
+    def claim() -> str:
+        store = SQLiteExecutionStore(path)
+        try:
+            return "winner" if store.claim(key, {"value": 7}).executable else "replay"
+        except ExecutionAlreadyRunningError:
+            return "loser"
+        finally:
+            store.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = list(pool.map(lambda _: claim(), range(2)))
+
+    assert sorted(outcomes) == ["loser", "winner"]
+
+
+def test_claim_is_process_safe(tmp_path):
+    context = multiprocessing.get_context("spawn")
+    start = context.Event()
+    results = context.Queue()
+    path = str(tmp_path / "run.db")
+    workers = [
+        context.Process(target=_claim_in_process, args=(path, start, results)) for _ in range(2)
+    ]
+
+    for worker in workers:
+        worker.start()
+    start.set()
+    for worker in workers:
+        worker.join(timeout=15)
+
+    assert all(worker.exitcode == 0 for worker in workers)
+    assert sorted(results.get(timeout=2) for _ in workers) == ["loser", "winner"]
+
+
+def test_store_accepts_existing_connection():
+    connection = sqlite3.connect(":memory:")
+    store = SQLiteExecutionStore(connection)
+    assert isinstance(store, ExecutionStore)
+    claim = store.claim(ExecutionKey("workflow", "operation"), {})
+    assert claim.executable
+    connection.close()
+
+
+def test_sqlite_storage_manager_exposes_shared_execution_store(tmp_path):
+    with SQLiteStorageManager(tmp_path / "agent.db") as storage:
+        key = ExecutionKey("workflow", "operation")
+        claim = storage.execution_store.claim(key, {"value": 7})
+        storage.execution_store.complete_success(claim, {"answer": 42})
+
+        assert storage.execution_store.get(key).result == {"answer": 42}

--- a/tests/test_event_manager_persistence_order.py
+++ b/tests/test_event_manager_persistence_order.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for event persistence ordering and retry identity."""
+
+import pytest
+
+from nooa.context_blocks import EventBase
+from nooa.events import Task
+from nooa.runtime.event_backend import InMemoryBackend
+from nooa.runtime.event_manager import EventManager
+
+
+class FailBeforeStoreBackend(InMemoryBackend):
+    """Fail once before writing the event."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.failed = False
+
+    def store(self, tag: str, event: EventBase) -> None:
+        if not self.failed:
+            self.failed = True
+            raise RuntimeError("store failed before commit")
+        super().store(tag, event)
+
+
+class CommitThenRaiseBackend(InMemoryBackend):
+    """Commit once, then lose the acknowledgement returned by store()."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.failed = False
+
+    def store(self, tag: str, event: EventBase) -> None:
+        super().store(tag, event)
+        if not self.failed:
+            self.failed = True
+            raise RuntimeError("acknowledgement lost after commit")
+
+
+def test_recorded_event_is_persisted_before_observer_notification() -> None:
+    manager = EventManager()
+    visible_during_callback: list[bool] = []
+    manager.on(
+        "Task", lambda event: visible_during_callback.append(manager.get(event.id) is not None)
+    )
+
+    tag = manager.add(Task(prompt="ordered"))
+
+    assert visible_during_callback == [True]
+    assert manager.get(tag) is not None
+
+
+def test_store_failure_does_not_notify_an_unpersisted_event() -> None:
+    backend = FailBeforeStoreBackend()
+    manager = EventManager(backend)
+    notifications: list[str] = []
+    manager.on("Task", lambda event: notifications.append(event.id))
+    event = Task(prompt="retry")
+
+    with pytest.raises(RuntimeError, match="before commit"):
+        manager.add(event)
+
+    assert notifications == []
+    assert len(backend) == 0
+
+    tag = manager.add(event)
+    assert notifications == [event.id]
+    assert manager.get(tag) is not None
+
+
+def test_committed_event_retry_reuses_tag_and_notifies_once() -> None:
+    backend = CommitThenRaiseBackend()
+    manager = EventManager(backend)
+    notifications: list[str] = []
+    manager.on("Task", lambda event: notifications.append(event.id))
+    event = Task(prompt="ambiguous acknowledgement")
+
+    with pytest.raises(RuntimeError, match="after commit"):
+        manager.add(event)
+
+    retry_tag = manager.add(event)
+
+    assert retry_tag == event.tag
+    assert len(backend) == 1
+    assert notifications == [event.id]
+
+
+def test_observer_failure_does_not_undo_persisted_event() -> None:
+    manager = EventManager()
+
+    def failing_observer(_event: Task) -> None:
+        raise RuntimeError("observer failed")
+
+    manager.on("Task", failing_observer)
+    tag = manager.add(Task(prompt="observer failure"))
+
+    assert manager.get(tag) is not None


### PR DESCRIPTION
## What does this PR do?

This PR adds durable operation coordination to SQLite-backed workflows that may be interrupted, retried, or resumed across multiple workers.

The new ledger persists logical operation identifiers, request fingerprints, effect-safety classifications, leases, fencing generations, terminal states, outcome transitions, and operation history. Expired operations are reclaimed only when retrying is safe. Ambiguous external outcomes remain UNKNOWN until explicitly reconciled, and stale workers cannot commit after their leases expire.

Existing SQLite databases are migrated additively while preserving event, tag, and snapshot data. Recorded events are persisted before subscribers are notified. If persistence succeeds but the acknowledgement is lost, retrying the same logical operation ID reuses its existing durable identity instead of creating a duplicate.

The change adds tests for migration, corruption handling, leases, fencing, concurrency, multi-process execution, reconciliation, event ordering, and deterministic recovery schedules.

Full repository validation passes with 6,632 tests passed, 7 skipped, and 284 deselected.

This change does not claim universal exactly-once behavior for arbitrary external services. Ambiguous external outcomes require external reconciliation or idempotency support.

## Related issues

No related issue.

## Checklist

- [x] Code follows the project style; lint and formatting checks pass.
- [x] Tests were added or updated and are passing.
- [x] Documentation was updated for the new public behavior.
- [x] New source files include SPDX license headers.
