### PR TITLE
fix: Python-API eval metadata fallback and memory README

### DIFF
--- a/packages/nooa-memory/src/nooa_memory/README.md
+++ b/packages/nooa-memory/src/nooa_memory/README.md
@@ -5,8 +5,7 @@ Agents. Toggle it on per agent; it changes no core framework code. Its defining
 idea: **the agent authors and curates its own memories** through native tools —
 rather than a harness extracting them behind the agent's back.
 
-- Runnable demos + measured results: [`examples/memory_bench/`](../../../examples/memory_bench/)
-  and the quickstart [`examples/quickstart/12_memory.py`](../../../../examples/quickstart/12_memory.py).
+- Runnable demo: [`examples/quickstart/12_memory.py`](../../../../examples/quickstart/12_memory.py).
 
 ---
 
@@ -300,8 +299,8 @@ def my_llm_reconciler(cluster):                 # list[Memory] (old->new) -> (cu
     ...
 ```
 
-See `examples/memory_bench/reflecting.py` (`make_llm_reasoner`) and `longmemeval.py`
-(`make_llm_reconciler`) for working implementations.
+The stubs above are the contract. [`examples/quickstart/12_memory.py`](../../../../examples/quickstart/12_memory.py)
+shows the deterministic (no-LLM) reflection path.
 
 **When does reflection help?** Empirically (real gpt-5.4):
 
@@ -397,8 +396,9 @@ agent.event_manager.on("MemoryWritten", lambda e: print("wrote", e.memory_id, e.
 
 ## When does memory help?
 
-Measured with real gpt-5.4 + text-embedding-3-large (see
-[`examples/memory_bench/`](../../../examples/memory_bench/)):
+Measured internally with gpt-5.4 + text-embedding-3-large (the bench harness is
+not published in this repository). For a runnable offline demo see
+[`examples/quickstart/12_memory.py`](../../../../examples/quickstart/12_memory.py):
 
 | demo | what it isolates | result |
 |---|---|---|
@@ -446,5 +446,5 @@ Tests: [`tests/memory/`](../../tests/memory/).
 - `numpy`/`sqlite-vec` backends are exact/brute-force — fine to ~10⁵ vectors; beyond
   that prefer a Chroma backend.
 
-See [`examples/memory_bench/`](../../../examples/memory_bench/) for runnable
-benchmarks and measured behavior.
+See [`examples/quickstart/12_memory.py`](../../../../examples/quickstart/12_memory.py)
+for a runnable demo.

--- a/packages/nooa-memory/tests/memory/test_memory_readme.py
+++ b/packages/nooa-memory/tests/memory/test_memory_readme.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The packaged README must not point readers at files that are not in the repo."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_README = Path(__file__).resolve().parents[2] / "src" / "nooa_memory" / "README.md"
+_MARKDOWN_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+
+def test_readme_does_not_cite_missing_memory_bench():
+    """Issue #104: examples/memory_bench/ is not in the public repository."""
+    text = _README.read_text()
+    assert "memory_bench" not in text, (
+        "README cites examples/memory_bench/, which is not in this repository. "
+        "Point at examples/quickstart/12_memory.py instead."
+    )
+
+
+def test_readme_relative_markdown_links_resolve():
+    """Every relative markdown link from the README must exist on disk."""
+    text = _README.read_text()
+    missing: list[str] = []
+    for href in _MARKDOWN_LINK.findall(text):
+        target = href.split("#", 1)[0].strip()
+        if not target or target.startswith(("http://", "https://", "mailto:")):
+            continue
+        resolved = (_README.parent / target).resolve()
+        if not resolved.exists():
+            missing.append(href)
+    assert missing == [], f"README links that do not exist: {missing}"

--- a/util/eval_pipeline/src/eval_pipeline/evaluator.py
+++ b/util/eval_pipeline/src/eval_pipeline/evaluator.py
@@ -367,7 +367,10 @@ class Evaluator:
             writer = ExperimentWriter(output_dir=experiment_dir, experiment_name=self.name)
         writer.start(
             suite_name=self.name,
-            models=[self._model_metadata.get(m, {"id": m}) for m in model_ids],
+            # YAML/from_config fills _model_metadata with ModelSpec dicts. The
+            # documented Python API does not, so fall back to the model id
+            # string — EvalMetadata.models accepts either.
+            models=[self._model_metadata.get(m, m) for m in model_ids],
             tests=[t.name for t in tests_to_run],
             runs=runs,
         )

--- a/util/eval_pipeline/tests/test_evaluator.py
+++ b/util/eval_pipeline/tests/test_evaluator.py
@@ -864,5 +864,52 @@ class TestCloneEvaluatorWithTests:
         assert evaluator.tests["orig"].agent_class is MockAgent  # original untouched
 
 
+# =============================================================================
+# Tests for the documented plain-Python Evaluator API (#152)
+# =============================================================================
+
+
+class TestEvaluatorPythonApiRun:
+    """Evaluator(models={...}) must run without YAML/_model_metadata."""
+
+    @pytest.mark.asyncio
+    async def test_run_without_model_metadata_writes_valid_jsonl(self, tmp_path):
+        """Documented Python API: constructing Evaluator with a models dict
+        and calling run() must not raise pydantic ValidationError.
+
+        writer.start() previously fell back to {"id": m}, which is neither a
+        ModelSpec (missing model_name) nor a string.
+        """
+        evaluator = Evaluator(
+            models={"gpt-4": MockClient()},
+            output_dir=tmp_path,
+            name="python_api",
+        )
+        evaluator.add_test(
+            name="sentiment",
+            agent_class=MockAgent,
+            method="classify",
+            data=[{"kwargs": {"text": "I love this!"}, "expected": "positive"}],
+            scorers=[MockScorer()],
+        )
+
+        results = await evaluator.run(models=["gpt-4"])
+
+        assert results.total == 1
+        assert results.output_file is not None
+        assert results.output_file.exists()
+
+        import json
+
+        from eval_pipeline.eval_types import EvalMetadataLine
+
+        first_line = results.output_file.read_text().splitlines()[0]
+        metadata_line = EvalMetadataLine.model_validate(json.loads(first_line))
+        models = metadata_line.metadata.models
+        assert models, "metadata must record the model used"
+        recorded_ids = [m if isinstance(m, str) else m.id for m in models]
+        assert "gpt-4" in recorded_ids
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What does this PR do?

Two small fixes:

**Eval Python API (`#152`).** `Evaluator.run()` crashed with a Pydantic `ValidationError` when constructed the way the README documents — `Evaluator(models={...})` plus `await evaluator.run()` — instead of via YAML/`from_config`. `writer.start()` fell back to `{"id": m}`, which is neither a valid `ModelSpec` (missing required `model_name`) nor a string. The fallback is now the model id string, which `EvalMetadata.models: list[ModelSpec | str]` already accepts. The YAML path still writes full `ModelSpec` dicts. Adds a regression test that runs the documented API and checks the JSONL metadata line.

**Memory README (`#104`).** `packages/nooa-memory/src/nooa_memory/README.md` pointed at `examples/memory_bench/` in four places. That directory is not in the public repo, so “runnable demos + measured results” 404’d. Links now go to `examples/quickstart/12_memory.py`. The measured-results table is kept, labeled as internal (harness not published). Adds tests that the README does not cite `memory_bench` and that every relative markdown link resolves on disk.

## Related issues

Closes #152
Closes #104

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [x] Docs updated if behaviour or public APIs changed
- [x] New source files carry an SPDX license header