### PR TITLE
fix(arc_agi_3): attach skip guards to the test, not a helper

### DIFF
--- a/examples/arc_agi_3/tests/test_offline_e2e.py
+++ b/examples/arc_agi_3/tests/test_offline_e2e.py
@@ -43,11 +43,6 @@ def _have_sdk() -> bool:
         return False
 
 
-@pytest.mark.skipif(not _have_sdk(), reason="ARC-AGI-3 SDK not installed (`uv sync --extra arc`)")
-@pytest.mark.skipif(
-    not os.environ.get("ARC_LLM_API_KEY") or not os.environ.get("ARC_API_KEY"),
-    reason="needs ARC_LLM_API_KEY (gateway) + ARC_API_KEY (offline game download)",
-)
 def _traces_contain(run: Path, needle: str) -> int:
     """Count occurrences of ``needle`` inside llm.input_messages spans (the exact
     bytes sent to the model) across a run's OTLP traces."""
@@ -69,6 +64,11 @@ def _traces_contain(run: Path, needle: str) -> int:
     return hits
 
 
+@pytest.mark.skipif(not _have_sdk(), reason="ARC-AGI-3 SDK not installed (`uv sync --extra arc`)")
+@pytest.mark.skipif(
+    not os.environ.get("ARC_LLM_API_KEY") or not os.environ.get("ARC_API_KEY"),
+    reason="needs ARC_LLM_API_KEY (gateway) + ARC_API_KEY (offline game download)",
+)
 def test_offline_run_makes_progress(tmp_path: Path) -> None:
     results_root = tmp_path / "results" / "arc_agi_3"
     proc = subprocess.run(


### PR DESCRIPTION
## What does this PR do?

Both `skipif` markers in `tests/test_offline_e2e.py` (SDK-present and credentials-present) decorate `_traces_contain`, a plain helper, where pytest markers have no effect. The actual test, `test_offline_run_makes_progress`, sits below them unguarded — so running the suite without `ARC_LLM_API_KEY` / `ARC_API_KEY` fails the test on a missing artifact instead of skipping with the intended reason string.

This moves both markers onto the test function. Verbatim move, no other changes.

## Related issues

None filed; happy to open one if you prefer tracking it that way.

## Checklist

- [x] Marker move only; `python -m ast` parses the file (ruff/pytest not run locally — lines moved verbatim)
- [x] Tests: this PR is itself the test fix — without credentials the suite now skips with the documented reason instead of erroring
- [x] No docs or API impact
- [x] No new source files