### PR TITLE
feat(tui): unify fullscreen explorer interactions

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/activity_overlay.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/activity_overlay.py
@@ -13,6 +13,7 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 
+from .explorer_base import ExplorerInteraction, bar_with_action
 from .output import CodeExecution, Output, TableOutput, TextOutput
 from .subapp import SubviewKeyResult
 from .theme import COLORS
@@ -150,7 +151,44 @@ def _output_lines(output: Output, width: int, *, ansi: bool) -> list[str]:
     return _plain_wrap(str(output), width)
 
 
-class ActivityOverlayView:
+def _output_copy_text(output: Output) -> str:
+    """Return a stable, width-independent text representation of one output."""
+    if isinstance(output, TextOutput):
+        return output.content
+    if isinstance(output, TableOutput):
+        lines: list[str] = []
+        if output.title:
+            lines.append(output.title)
+        if output.show_header and output.columns:
+            lines.append("\t".join(str(column) for column in output.columns))
+        lines.extend("\t".join(str(cell) for cell in row) for row in output.rows)
+        if output.footer:
+            if lines:
+                lines.append("")
+            lines.append(output.footer)
+        return "\n".join(lines)
+    if isinstance(output, CodeExecution):
+        parts: list[str] = []
+        if output.code is not None:
+            parts.append(f"```python\n{output.code}\n```")
+        for label, value in (
+            ("stdout", output.stdout),
+            ("stderr", output.stderr),
+            ("error", output.error),
+            ("value", output.value),
+        ):
+            if value is not None:
+                parts.append(f"{label}:\n{value}")
+        return "\n\n".join(parts)
+    to_json = getattr(output, "to_json", None)
+    if callable(to_json):
+        import json
+
+        return json.dumps(to_json(), ensure_ascii=False, indent=2, sort_keys=True)
+    return str(output)
+
+
+class ActivityOverlayView(ExplorerInteraction):
     """Static activity snapshot shown as a full-screen in-app overlay."""
 
     title = "activity"
@@ -160,11 +198,22 @@ class ActivityOverlayView:
         self.offset = 0
         self._last_line_count = 0
         self._last_visible_lines = 0
+        self.native_selection = False
+        self._copy_handler = None
+        self._copy_status = ""
+
+    def copy_text(self) -> str | None:
+        """Serialize the activity snapshot from source data, never viewport text."""
+        parts = [_output_copy_text(output) for output in self.outputs]
+        return "\n\n".join(part for part in parts if part) or None
 
     def render(self, width: int, height: int) -> str:
         return render_activity_overlay(self, width, height, ansi=True)
 
     def handle_key(self, action: str, value: str = "") -> SubviewKeyResult:
+        interaction = self.handle_interaction_action(action)
+        if interaction != "ignored":
+            return interaction
         if action in {"quit", "escape", "enter"}:
             return "close"
         if action in {"down", "j", "scroll_down"}:
@@ -187,6 +236,14 @@ class ActivityOverlayView:
             return "handled"
         return "handled" if action == "text" else "ignored"
 
+    def handle_mouse(self, action: str, x: int, y: int) -> SubviewKeyResult:
+        if action == "click" and y == 0 and x >= getattr(self, "_copy_action_start", 10**9):
+            return self.handle_interaction_action("copy")
+        if action in {"scroll_up", "scroll_down"}:
+            self.scroll(-3 if action == "scroll_up" else 3)
+            return "handled"
+        return "ignored"
+
     def scroll(self, delta: int) -> None:
         max_offset = max(self._last_line_count - max(self._last_visible_lines, 1), 0)
         self.offset = min(max(self.offset + delta, 0), max_offset)
@@ -203,9 +260,14 @@ def render_activity_overlay(
 ) -> str:
     width = max(int(width), 40)
     height = max(int(height), 1)
-    header = _style_bar(" Activity ".ljust(width, "─")[:width], ansi=ansi)
+    header_label = " Activity "
+    copy_hint = view.copy_hint()
+    view._copy_action_start = max(width - len(f" {copy_hint} "), 0)
+    header = bar_with_action(header_label, copy_hint, width, ansi=ansi)
     footer = _style_bar(
-        " ↑/↓ scroll  PgUp/PgDn page  Home/End  Enter/Esc/q close ".ljust(width, "─")[:width],
+        (
+            f" ↑/↓ scroll  PgUp/PgDn page  Home/End  {view.selection_hint()}  Enter/Esc/q close "
+        ).ljust(width, "─")[:width],
         ansi=ansi,
     )
     body_height = max(height - 2, 0)

--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -12,9 +12,9 @@ from typing import Any
 from .explorer_base import (
     BAR_STYLE,
     ExplorerInteraction,
+    bar_with_action,
     highlight_terms,
     search_terms,
-    style_bar,
     style_fts_prompt,
     style_mode_label,
     wrap_plain_line,
@@ -74,6 +74,8 @@ class EventExplorerModel:
         self._last_detail_match_lines: list[int] = []
         self._last_detail_match_occurrences: list[tuple[int, int]] = []
         self._last_detail_visible_lines = 0
+        self._last_divider_y = 0
+        self._last_list_rows: dict[int, int] = {}
 
     @property
     def empty(self) -> bool:
@@ -196,6 +198,19 @@ class EventExplorerView(ExplorerInteraction):
 
     def __init__(self, event_manager: Any) -> None:
         self.model = EventExplorerModel(build_event_rows(event_manager))
+        self.native_selection = False
+        self._copy_handler = None
+        self._copy_status = ""
+
+    def copy_text(self) -> str | None:
+        row = self.model.current
+        if row is None:
+            return None
+        if row.markdown is not None:
+            return row.markdown
+        if row.code:
+            return row.code
+        return row.detail
 
     def render(self, width: int, height: int) -> str:
         return render_event_explorer(
@@ -204,6 +219,7 @@ class EventExplorerView(ExplorerInteraction):
             height,
             ansi=True,
             selection_hint=self.selection_hint(),
+            copy_hint=self.copy_hint(),
         )
 
     def handle_key(self, action: str, value: str = "") -> SubviewKeyResult:
@@ -904,6 +920,7 @@ def render_event_explorer(
     *,
     ansi: bool = False,
     selection_hint: str = "F2 select/copy",
+    copy_hint: str = "Ctrl+Y copy detail",
 ) -> str:
     """Render the current explorer state as text/ANSI."""
     width = max(int(width), 40)
@@ -915,9 +932,9 @@ def render_event_explorer(
     query = f" search={model.query!r}" if model.query else ""
     pos = f" {model.cursor + 1}/{match_count}" if match_count else " 0/0"
     match_label = f" match {model.cursor + 1}/{match_count}" if model.query and match_count else ""
-    header = style_bar(
-        f" {title}{pos} of {total}{match_label}{query} ".ljust(width, "─")[:width], ansi=ansi
-    )
+    header_label = f" {title}{pos} of {total}{match_label}{query} "
+    model._copy_action_start = max(width - len(f" {copy_hint} "), 0)
+    header = bar_with_action(header_label, copy_hint, width, ansi=ansi)
     pane_label = "events" if model.focus == "list" else "event text"
     if model.search_active:
         mode_text = "FTS MODE"
@@ -951,6 +968,7 @@ def render_event_explorer(
         footer = footer_plain
     body_height = max(height - 2, 0)
     model._last_divider_y = 0
+    model._last_list_rows = {}
     if not total:
         body = ["No events recorded."]
     elif row is None:
@@ -963,6 +981,7 @@ def render_event_explorer(
         start = max(0, end - list_count)
         body = []
         for visible_i in range(start, end):
+            model._last_list_rows[1 + len(body)] = visible_i
             row_i = model.matches[visible_i]
             item = model.rows[row_i]
             marker = (

--- a/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import re
 import textwrap
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -54,6 +55,18 @@ def style_fts_prompt(text: str, *, active: bool, ansi: bool) -> str:
     if not ansi or not active:
         return text
     return f"{FTS_ACTIVE_STYLE}{text}\x1b[0m"
+
+
+def bar_with_action(label: str, action: str, width: int, *, ansi: bool) -> str:
+    """Render a bar with a stable right-aligned action or status."""
+    width = max(int(width), 1)
+    action_text = f" {action} " if action else ""
+    if len(action_text) >= width:
+        plain = action_text[-width:]
+    else:
+        left = label[: max(width - len(action_text) - 1, 0)]
+        plain = left + "─" * max(width - len(left) - len(action_text), 0) + action_text
+    return style_bar(plain[:width], ansi=ansi)
 
 
 # ─── Text utilities ──────────────────────────────────────────────────────────
@@ -159,6 +172,7 @@ class ExplorerModel:
         self._last_detail_visible_lines = 0
         self._last_detail_match_lines: list[int] = []
         self._last_divider_y = 0
+        self._last_list_rows: dict[int, int] = {}
 
     @property
     def current_index(self) -> int | None:
@@ -272,7 +286,7 @@ class ExplorerConfig:
 
 
 class ExplorerInteraction:
-    """Shared mouse and native-selection behavior for explorer subviews."""
+    """Shared mouse, clipboard, and native-selection behavior for explorers."""
 
     detail_focus = "detail"
     native_selection = False
@@ -282,16 +296,60 @@ class ExplorerInteraction:
         """Disable terminal mouse reporting while native selection is active."""
         return not self.native_selection
 
-    def handle_interaction_action(self, action: str) -> SubviewKeyResult:
-        if action != "native_selection":
-            return "ignored"
-        self.native_selection = not self.native_selection
-        return "handled"
+    def set_copy_handler(self, handler: Callable[[str], bool]) -> None:
+        """Install the host-owned clipboard writer.
 
-    def handle_mouse(self, action: str, _x: int, y: int) -> SubviewKeyResult:
-        """Route wheel input to the pane under the pointer."""
+        Explorer models never write to the terminal or invoke platform tools
+        themselves. The surrounding ``TUIApplication`` owns that boundary.
+        """
+        self._copy_handler = handler
+
+    def copy_text(self) -> str | None:
+        """Return the source-backed payload for the selected item, if any."""
+        return None
+
+    def handle_interaction_action(self, action: str) -> SubviewKeyResult:
+        if action != "copy":
+            self._copy_status = ""
+        if action == "native_selection":
+            self.native_selection = not self.native_selection
+            return "handled"
+        if action == "copy":
+            text = self.copy_text()
+            if not text:
+                self._copy_status = "Nothing to copy"
+            else:
+                handler = getattr(self, "_copy_handler", None)
+                try:
+                    copied = bool(handler(text)) if handler is not None else False
+                except Exception:
+                    copied = False
+                self._copy_status = "Copied item" if copied else "Copy unavailable"
+            return "handled"
+        return "ignored"
+
+    def handle_mouse(self, action: str, x: int, y: int) -> SubviewKeyResult:
+        """Select rows, activate Copy, or route wheel input by pointer position."""
+        if action == "click":
+            copy_start = getattr(
+                self, "_copy_action_start", getattr(self.model, "_copy_action_start", None)
+            )
+            if y == 0 and copy_start is not None and x >= copy_start:
+                return self.handle_interaction_action("copy")
+            visible_index = getattr(self.model, "_last_list_rows", {}).get(y)
+            if visible_index is not None and getattr(self.model, "matches", None):
+                self._copy_status = ""
+                self.model.move(visible_index - self.model.cursor)
+                self.model.focus = "list"
+                return "handled"
+            if y > getattr(self.model, "_last_divider_y", 0):
+                self._copy_status = ""
+                self.model.focus = self.detail_focus
+                return "handled"
+            return "ignored"
         if action not in {"scroll_up", "scroll_down"}:
             return "ignored"
+        self._copy_status = ""
         delta = -3 if action == "scroll_up" else 3
         if y <= getattr(self.model, "_last_divider_y", 0):
             self.model.focus = "list"
@@ -303,6 +361,10 @@ class ExplorerInteraction:
 
     def selection_hint(self) -> str:
         return "F2 mouse/wheel" if self.native_selection else "F2 select/copy"
+
+    def copy_hint(self) -> str:
+        status = getattr(self, "_copy_status", "")
+        return status or "Copy item · Ctrl+Y"
 
 
 class ExplorerView(ExplorerInteraction):
@@ -322,6 +384,10 @@ class ExplorerView(ExplorerInteraction):
         self.config = config
         self.title = config.title
         self.pending_input: str | None = None
+        self.native_selection = False
+        self._copy_handler: Callable[[str], bool] | None = None
+        self._copy_status = ""
+        self._last_render_width = 80
 
     def format_row(self, row: Any, width: int) -> str:
         """Format a single row for the list. Override in subclasses."""
@@ -334,6 +400,10 @@ class ExplorerView(ExplorerInteraction):
     def handle_action(self, action: str, row: Any) -> SubviewKeyResult:
         """Handle a custom action on the current row. Override for custom behavior."""
         return "ignored"
+
+    def copy_text(self) -> str | None:
+        """Return source text only when a concrete explorer defines it."""
+        return None
 
     def render(self, width: int, height: int) -> str:
         return render_explorer(self, width, height, ansi=True)
@@ -432,6 +502,7 @@ def render_explorer(view: ExplorerView, width: int, height: int, *, ansi: bool =
     """
     width = max(int(width), 40)
     height = max(int(height), 1)
+    view._last_render_width = width
     model = view.model
     config = view.config
 
@@ -443,12 +514,10 @@ def render_explorer(view: ExplorerView, width: int, height: int, *, ansi: bool =
     pos = f" {model.cursor + 1}/{match_count}" if match_count else " 0/0"
     match_label = f" match {model.cursor + 1}/{match_count}" if model.query and match_count else ""
     query_display = f" search={model.query!r}" if model.query else ""
-    header = style_bar(
-        f" {config.title}{pos} of {total}{match_label}{query_display} ".ljust(width, "\u2500")[
-            :width
-        ],
-        ansi=ansi,
-    )
+    header_label = f" {config.title}{pos} of {total}{match_label}{query_display} "
+    copy_hint = view.copy_hint()
+    view._copy_action_start = max(width - len(f" {copy_hint} "), 0)
+    header = bar_with_action(header_label, copy_hint, width, ansi=ansi)
 
     # ── Footer ──
     pane_label = "list" if model.focus == "list" else config.detail_pane_name
@@ -488,6 +557,7 @@ def render_explorer(view: ExplorerView, width: int, height: int, *, ansi: bool =
     # ── Body ──
     body_height = max(height - 2, 0)
     model._last_divider_y = 0
+    model._last_list_rows = {}
 
     if not total:
         body = [config.empty_message]
@@ -504,6 +574,7 @@ def render_explorer(view: ExplorerView, width: int, height: int, *, ansi: bool =
 
         body = []
         for visible_i in range(start, end):
+            model._last_list_rows[1 + len(body)] = visible_i
             row_i = model.matches[visible_i]
             item = model.rows[row_i]
             marker = (

--- a/packages/nooa-cli/src/nooa_cli/tui/job_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/job_explorer.py
@@ -110,5 +110,11 @@ class JobExplorerView(ExplorerView):
                     lines.extend(wrap_plain_line(raw, width))
         return lines
 
+    def copy_text(self) -> str | None:
+        row = self.model.current
+        if row is None or not row.values:
+            return None
+        return "\n".join(str(value) for value in row.values)
+
     def handle_action(self, action: str, row: Any) -> SubviewKeyResult:
         return "ignored"

--- a/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
@@ -233,6 +233,10 @@ class MemoryExplorerView(ExplorerView):
                 lines.append(f"  → {target_id[:8]} {edge_type} ({weight:.2f})")
         return lines
 
+    def copy_text(self) -> str | None:
+        row = self.model.current
+        return None if row is None else row.content
+
     def handle_action(self, action: str, row: Any) -> SubviewKeyResult:
         if row is None:
             return "ignored"

--- a/packages/nooa-cli/src/nooa_cli/tui/session_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session_explorer.py
@@ -10,10 +10,10 @@ from dataclasses import dataclass
 from .explorer_base import (
     BAR_STYLE,
     ExplorerInteraction,
+    bar_with_action,
     display_line,
     render_markdown_lines,
     search_terms,
-    style_bar,
     style_fts_prompt,
     style_mode_label,
     wrap_plain_line,
@@ -61,6 +61,8 @@ class SessionExplorerModel:
         self.detail_tail_skip = 0
         self._last_detail_count_exact = True
         self._detail_cache: dict[tuple[str, int], list[str]] = {}
+        self._last_divider_y = 0
+        self._last_list_rows: dict[int, int] = {}
 
     @property
     def current_index(self) -> int | None:
@@ -176,6 +178,15 @@ class SessionExplorerView(ExplorerInteraction):
     def __init__(self, *, limit: int = 100) -> None:
         self.model = SessionExplorerModel(build_session_rows(limit=limit))
         self.pending_input: str | None = None
+        self.native_selection = False
+        self._copy_handler = None
+        self._copy_status = ""
+
+    def copy_text(self) -> str | None:
+        row = self.model.current
+        if row is None:
+            return None
+        return "\n".join(_detail_raw_lines(row))
 
     def render(self, width: int, height: int) -> str:
         return render_session_explorer(
@@ -184,6 +195,7 @@ class SessionExplorerView(ExplorerInteraction):
             height,
             ansi=True,
             selection_hint=self.selection_hint(),
+            copy_hint=self.copy_hint(),
         )
 
     def handle_key(self, action: str, value: str = "") -> SubviewKeyResult:
@@ -448,6 +460,7 @@ def render_session_explorer(
     *,
     ansi: bool = False,
     selection_hint: str = "F2 select/copy",
+    copy_hint: str = "Ctrl+Y copy detail",
 ) -> str:
     """Render the current session explorer state as text/ANSI."""
     width = max(int(width), 40)
@@ -463,10 +476,9 @@ def render_session_explorer(
         if model.session_query and model.search_scope == "sessions" and match_count
         else ""
     )
-    header = style_bar(
-        f" Session Explorer{pos} of {total}{match_label}{query} ".ljust(width, "─")[:width],
-        ansi=ansi,
-    )
+    header_label = f" Session Explorer{pos} of {total}{match_label}{query} "
+    model._copy_action_start = max(width - len(f" {copy_hint} "), 0)
+    header = bar_with_action(header_label, copy_hint, width, ansi=ansi)
     pane_label = "sessions" if model.focus == "list" else "session dialog"
     if model.search_active:
         mode_text = "FTS MODE"
@@ -499,6 +511,7 @@ def render_session_explorer(
 
     body_height = max(height - 2, 0)
     model._last_divider_y = 0
+    model._last_list_rows = {}
     if not total:
         body = ["No sessions found."]
     elif row is None:
@@ -515,6 +528,7 @@ def render_session_explorer(
         )
         body = []
         for visible_i in range(start, end):
+            model._last_list_rows[1 + len(body)] = visible_i
             row_i = model.matches[visible_i]
             item = model.rows[row_i]
             marker = (

--- a/packages/nooa-cli/src/nooa_cli/tui/todo_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/todo_explorer.py
@@ -132,5 +132,24 @@ class TodoExplorerView(ExplorerView):
 
         return lines
 
+    def copy_text(self) -> str | None:
+        row = self.model.current
+        if row is None:
+            return None
+        lines = [
+            f"Todo: [{row.id}] {row.title}",
+            f"Status: {row.status}",
+            f"Created: {row.created_at}",
+        ]
+        if row.deps:
+            lines.append(f"Dependencies: {', '.join(row.deps)}")
+        if row.notes:
+            lines.extend(("", "Notes:", row.notes))
+        if row.comments:
+            lines.extend(("", "Comments:"))
+            for comment in row.comments:
+                lines.extend((f"[{comment.created_at}]", comment.body))
+        return "\n".join(lines).rstrip()
+
     def handle_action(self, action: str, row: Any) -> SubviewKeyResult:
         return "ignored"

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -467,6 +467,7 @@ class _NativeSelectionBufferControl(BufferControl):
             MouseModifier.ALT in mouse_event.modifiers
             or MouseModifier.SHIFT in mouse_event.modifiers
         ):
+            self._mouse_down_position = None
             return NotImplemented
         if self._transcript_drag_callback is not None and self._transcript_drag_callback(
             mouse_event
@@ -487,6 +488,7 @@ class _NativeSelectionCompletionsMenuControl(CompletionsMenuControl):
             MouseModifier.ALT in mouse_event.modifiers
             or MouseModifier.SHIFT in mouse_event.modifiers
         ):
+            self._mouse_down_position = None
             return NotImplemented
         return super().mouse_handler(mouse_event)
 
@@ -528,20 +530,34 @@ class _SubviewControl(FormattedTextControl):
     ) -> None:
         super().__init__(*args, **kwargs)
         self._mouse_callback = mouse_callback
+        self._mouse_down_position: tuple[int, int] | None = None
 
     def mouse_handler(self, mouse_event: MouseEvent):
         if (
             MouseModifier.ALT in mouse_event.modifiers
             or MouseModifier.SHIFT in mouse_event.modifiers
         ):
+            self._mouse_down_position = None
             return NotImplemented
-        action = {
-            MouseEventType.SCROLL_UP: "scroll_up",
-            MouseEventType.SCROLL_DOWN: "scroll_down",
-        }.get(mouse_event.event_type)
-        if action is not None and self._mouse_callback(
-            action, mouse_event.position.x, mouse_event.position.y
-        ):
+        point = (mouse_event.position.x, mouse_event.position.y)
+        if mouse_event.event_type is MouseEventType.MOUSE_DOWN:
+            self._mouse_down_position = point if mouse_event.button is MouseButton.LEFT else None
+            return None
+        if mouse_event.event_type is MouseEventType.MOUSE_MOVE:
+            if self._mouse_down_position != point:
+                self._mouse_down_position = None
+            return None
+        if mouse_event.event_type is MouseEventType.MOUSE_UP:
+            is_click = mouse_event.button is MouseButton.LEFT and self._mouse_down_position == point
+            self._mouse_down_position = None
+            action = "click" if is_click else None
+        else:
+            self._mouse_down_position = None
+            action = {
+                MouseEventType.SCROLL_UP: "scroll_up",
+                MouseEventType.SCROLL_DOWN: "scroll_down",
+            }.get(mouse_event.event_type)
+        if action is not None and self._mouse_callback(action, *point):
             return None
         return super().mouse_handler(mouse_event)
 
@@ -1377,6 +1393,9 @@ class TUIApplication:
         if self._active_subview_done is not None and not self._active_subview_done.done():
             return
         self._cancel_fullscreen_drag()
+        set_copy_handler = getattr(view, "set_copy_handler", None)
+        if callable(set_copy_handler):
+            set_copy_handler(self._copy_to_clipboard)
         self._active_subview = view
         loop = asyncio.get_running_loop()
         self._active_subview_done = loop.create_future()

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -1443,3 +1443,41 @@ async def test_tui_app_session_explorer_resume_prefills_input(monkeypatch) -> No
 
         assert h.app.active_subview is None
         assert h.capture_input() == "/session resume aaaa0000"
+
+
+def test_event_explorer_copy_preserves_semantic_markdown() -> None:
+    from nooa_cli.tui.event_explorer import EventExplorerView
+
+    markdown = "## User input\n\n```python\nprint('exact')\n```"
+    event = _FakeEvent("TUIUserInput", text="print exact")
+    view = EventExplorerView(SimpleNamespace(items=lambda: [("1", event)]))
+    view.model.rows[0].markdown = markdown
+    copied: list[str] = []
+    view.set_copy_handler(lambda text: copied.append(text) or True)
+
+    assert view.handle_key("copy") == "handled"
+    assert copied == [markdown]
+
+
+def test_session_explorer_copy_preserves_unwrapped_dialog() -> None:
+    from nooa_cli.tui.session_explorer import SessionExplorerModel, SessionExplorerView
+
+    view = SessionExplorerView.__new__(SessionExplorerView)
+    view.model = SessionExplorerModel(
+        [
+            _session_row(
+                "aaaa0000-0000-0000-0000-000000000001",
+                "copy session",
+                [("user", "a very long source line"), ("agent", "exact answer")],
+            )
+        ]
+    )
+    view.native_selection = False
+    view._copy_handler = None
+    view._copy_status = ""
+
+    copied = view.copy_text()
+
+    assert copied is not None
+    assert "You:\n  a very long source line" in copied
+    assert "OO:\n  exact answer" in copied

--- a/packages/nooa-cli/tests/tui/test_explorer_shared.py
+++ b/packages/nooa-cli/tests/tui/test_explorer_shared.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 from nooa_cli.interactive import AgentJobState, AgentJobSummary
 from nooa_cli.interactive.runtime import JobSnapshot
+from nooa_cli.tui.activity_overlay import ActivityOverlayView
 from nooa_cli.tui.event_explorer import (
     highlight_terms_with_current,
 )
@@ -26,6 +27,7 @@ from nooa_cli.tui.job_explorer import (
     JobExplorerView,
     build_job_rows,
 )
+from nooa_cli.tui.output import CodeExecution, TableOutput, TextOutput
 from nooa_cli.tui.todo_explorer import (
     TodoExplorerView,
     build_todo_rows,
@@ -212,6 +214,63 @@ class TestExplorerView:
         assert view.model.focus == "detail"
         assert view.model.detail_offset == 3
 
+    def test_mouse_click_selects_visible_row_and_focuses_list(self):
+        view = self._make_view(8)
+        view.render(80, 18)
+
+        assert view.handle_mouse("click", 12, 3) == "handled"
+        assert view.model.cursor == 2
+        assert view.model.focus == "list"
+
+    def test_ctrl_y_copies_current_detail_through_host_callback(self):
+        class CopyView(ExplorerView):
+            def detail_lines(self, row, width):
+                return ["rendered", "detail"]
+
+            def copy_text(self):
+                return "exact\ndetail"
+
+        view = CopyView(
+            ExplorerModel([MagicMock(search_text="copy me")]),
+            ExplorerConfig(title="Copy Explorer"),
+        )
+        copied = []
+        view.set_copy_handler(lambda text: copied.append(text) or True)
+
+        assert view.handle_key("copy") == "handled"
+        assert copied == ["exact\ndetail"]
+        assert "Copied item" in view.render(80, 12).splitlines()[0]
+
+    def test_header_copy_action_is_clickable(self):
+        class CopyView(ExplorerView):
+            def detail_lines(self, row, width):
+                return ["rendered detail"]
+
+            def copy_text(self):
+                return "clicked detail"
+
+        view = CopyView(
+            ExplorerModel([MagicMock(search_text="copy me")]),
+            ExplorerConfig(title="Copy Explorer"),
+        )
+        copied = []
+        view.set_copy_handler(lambda text: copied.append(text) or True)
+        view.render(80, 12)
+
+        assert view.handle_mouse("click", 79, 0) == "handled"
+        assert copied == ["clicked detail"]
+
+    def test_copy_failure_is_visible_without_closing_explorer(self):
+        class CopyView(ExplorerView):
+            def copy_text(self):
+                return "copy me"
+
+        view = CopyView(self._make_view().model, ExplorerConfig(title="Test Explorer"))
+        view.set_copy_handler(lambda _text: False)
+
+        assert view.handle_key("copy") == "handled"
+        assert "Copy unavailable" in view.render(80, 12).splitlines()[0]
+
     def test_render_empty(self):
         rows = []
         model = ExplorerModel(rows)
@@ -236,6 +295,65 @@ def test_subview_control_preserves_vt_mouse_position_for_wheel_dispatch():
 
     assert control.mouse_handler(event) is None
     assert calls == [("scroll_down", 12, 7)]
+
+
+def test_subview_control_dispatches_left_click_with_coordinates():
+    calls = []
+    control = _SubviewControl(
+        "explorer",
+        mouse_callback=lambda action, x, y: calls.append((action, x, y)) or True,
+    )
+    down = MouseEvent(
+        position=Point(x=9, y=4),
+        event_type=MouseEventType.MOUSE_DOWN,
+        button=MouseButton.LEFT,
+        modifiers=frozenset(),
+    )
+    up = MouseEvent(
+        position=Point(x=9, y=4),
+        event_type=MouseEventType.MOUSE_UP,
+        button=MouseButton.LEFT,
+        modifiers=frozenset(),
+    )
+
+    assert control.mouse_handler(down) is None
+    assert control.mouse_handler(up) is None
+    assert calls == [("click", 9, 4)]
+
+
+def test_subview_control_ignores_release_without_matching_press() -> None:
+    calls = []
+    control = _SubviewControl(
+        "explorer",
+        mouse_callback=lambda action, x, y: calls.append((action, x, y)) or True,
+    )
+    release = MouseEvent(
+        position=Point(x=9, y=4),
+        event_type=MouseEventType.MOUSE_UP,
+        button=MouseButton.LEFT,
+        modifiers=frozenset(),
+    )
+
+    assert control.mouse_handler(release) is NotImplemented
+    assert calls == []
+
+
+def test_subview_control_does_not_turn_drag_into_click() -> None:
+    calls = []
+    control = _SubviewControl(
+        "explorer",
+        mouse_callback=lambda action, x, y: calls.append((action, x, y)) or True,
+    )
+    events = [
+        MouseEvent(Point(x=9, y=4), MouseEventType.MOUSE_DOWN, MouseButton.LEFT, frozenset()),
+        MouseEvent(Point(x=10, y=4), MouseEventType.MOUSE_MOVE, MouseButton.LEFT, frozenset()),
+        MouseEvent(Point(x=9, y=4), MouseEventType.MOUSE_UP, MouseButton.LEFT, frozenset()),
+    ]
+
+    assert control.mouse_handler(events[0]) is None
+    assert control.mouse_handler(events[1]) is None
+    assert control.mouse_handler(events[2]) is NotImplemented
+    assert calls == []
 
 
 # ─── Job explorer tests ──────────────────────────────────────────────────────
@@ -383,3 +501,41 @@ class TestTodoExplorer:
         view = TodoExplorerView(build_todo_rows(todo_mgr))
         output = view.render(80, 24)
         assert "No todos." in output
+
+
+def test_activity_overlay_copies_full_semantic_snapshot() -> None:
+    view = ActivityOverlayView([TextOutput("first line\nsecond line", "info")])
+    copied: list[str] = []
+    view.set_copy_handler(lambda text: copied.append(text) or True)
+
+    assert view.handle_key("copy") == "handled"
+    assert copied == ["first line\nsecond line"]
+    assert "Copied item" in view.render(80, 10).splitlines()[0]
+
+
+def test_activity_overlay_copy_is_width_independent_and_preserves_code() -> None:
+    code = "value = '" + "x" * 140 + "'\nprint(value)"
+    view = ActivityOverlayView(
+        [
+            TableOutput(
+                columns=["Field", "Value"],
+                rows=[["phase", "executing_python"]],
+                footer="Still running.",
+            ),
+            CodeExecution(tool_call_id="call-1", code=code, stdout="done\n"),
+        ]
+    )
+
+    before = view.copy_text()
+    view.render(40, 8)
+    narrow = view.copy_text()
+    view.render(160, 20)
+
+    assert (
+        narrow
+        == before
+        == (
+            "Field\tValue\nphase\texecuting_python\n\nStill running."
+            f"\n\n```python\n{code}\n```\n\nstdout:\ndone\n"
+        )
+    )

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -385,6 +385,36 @@ async def test_explorer_f2_temporarily_restores_native_terminal_selection():
         await asyncio.wait_for(opened, timeout=1)
 
 
+async def test_explorer_ctrl_y_uses_host_clipboard(monkeypatch):
+    from unittest.mock import MagicMock
+
+    from nooa_cli.tui.explorer_base import ExplorerConfig, ExplorerModel, ExplorerView
+
+    class CopyView(ExplorerView):
+        def detail_lines(self, row, width):
+            return ["rendered detail"]
+
+        def copy_text(self):
+            return "semantic detail"
+
+    copied = []
+    view = CopyView(
+        ExplorerModel([MagicMock(search_text="copy me")]),
+        ExplorerConfig(title="Copy Explorer"),
+    )
+    async with TUIHarness() as h:
+        monkeypatch.setattr(h.app, "_copy_to_clipboard", lambda value: copied.append(value) or True)
+        opened = asyncio.create_task(h.app.open_subview(view))
+        await h.wait_for(lambda: h.app.active_subview is view)
+
+        await h.press("c-y")
+        await h.wait_for(lambda: copied == ["semantic detail"])
+        assert "Copied item" in view.render(80, 10)
+
+        await h.press("q")
+        await asyncio.wait_for(opened, timeout=1)
+
+
 async def test_oauth_modal_ctrl_y_copies_full_authorization_url(monkeypatch):
     url = "https://login.example.test/authorize?state=" + "a" * 500
     copied = []


### PR DESCRIPTION
## Summary

- give event, session, memory, job, todo, and activity explorers a shared fullscreen visual language
- add mouse row selection and pane-aware wheel scrolling while preserving F2 native terminal selection
- add source-backed copy actions via Ctrl+Y and clickable header controls, routed through the host clipboard boundary
- preserve exact Markdown/code/session content rather than copying wrapped or ANSI-rendered viewport text

## Validation

- `uv run --project packages/nooa-cli pytest -q packages/nooa-cli/tests/tui/test_explorer_shared.py packages/nooa-cli/tests/tui/test_event_explorer.py packages/nooa-cli/tests/tui/test_tui_app_behavior.py packages/nooa-cli/tests/tui/test_activity_render.py` (217 passed)
- full `packages/nooa-cli/tests/tui` suite: 1107 passed; two known macOS `/var` vs `/private/var` failures and one pre-existing flaky resize test (both resize cases passed when rerun directly)
- Ruff check and format check
- scoped Pyright: 0 errors, 0 warnings
- `git diff --check`