### PR TITLE
feat(tui): add copy actions to Markdown code blocks

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Markdown rendering with semantic copy affordances for fenced code blocks."""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any
+
+from rich.console import Console, ConsoleOptions, RenderResult
+from rich.markdown import CodeBlock, Markdown
+from rich.syntax import Syntax
+from rich.text import Text
+
+_COPY_URI_PREFIX = "nooa-copy://"
+
+
+class _CopyableCodeBlock(CodeBlock):
+    """Rich code block with a clickable, source-backed Copy label."""
+
+    @classmethod
+    def create(cls, markdown: Markdown, token: Any) -> _CopyableCodeBlock:
+        node_info = token.info or ""
+        lexer_name = node_info.partition(" ")[0] or "text"
+        copyable = markdown
+        assert isinstance(copyable, CopyableMarkdown)
+        action_id = copyable._action_for_token(token)
+        return cls(lexer_name, markdown.code_theme, action_id)
+
+    def __init__(self, lexer_name: str, theme: str, action_id: str | None) -> None:
+        super().__init__(lexer_name, theme)
+        self.action_id = action_id
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        if self.action_id is not None:
+            header = Text(justify="right")
+            if self.lexer_name != "text":
+                header.append(f"{self.lexer_name} · ", style="dim")
+            header.append(
+                "Copy",
+                style=f"bold underline link {_COPY_URI_PREFIX}{self.action_id}",
+            )
+            yield header
+        yield Syntax(
+            str(self.text).rstrip(),
+            self.lexer_name,
+            theme=self.theme,
+            word_wrap=True,
+            padding=1,
+        )
+
+
+class CopyableMarkdown(Markdown):
+    """Rich Markdown that exposes exact fenced-code payloads by stable action ID."""
+
+    elements = {
+        **Markdown.elements,
+        "fence": _CopyableCodeBlock,
+        "code_block": _CopyableCodeBlock,
+    }
+
+    def __init__(self, markup: str, **kwargs: Any) -> None:
+        super().__init__(markup, **kwargs)
+        self.copy_actions: dict[str, str] = {}
+        self._token_actions: dict[int, str] = {}
+        # Allocate metadata eagerly. This keeps source provenance available even
+        # before Rich performs a render and makes replay reuse the same IDs.
+        for token in self.parsed:
+            if token.type in {"fence", "code_block"}:
+                self._register_token(token)
+
+    def _register_token(self, token: Any) -> str | None:
+        payload = str(token.content)
+        if payload.endswith("\n"):
+            payload = payload[:-1]
+        if not payload:
+            return None
+        # The identifier appears in ANSI presentation metadata, but authority
+        # remains in the separately retained mapping. A random ID prevents
+        # model-authored Markdown links from impersonating generated controls.
+        action_id = secrets.token_urlsafe(18)
+        self._token_actions[id(token)] = action_id
+        # Markdown parsers include the structural newline before the closing
+        # fence. Clipboard UX conventionally excludes that one delimiter.
+        self.copy_actions[action_id] = payload
+        return action_id
+
+    def _action_for_token(self, token: Any) -> str | None:
+        if id(token) in self._token_actions:
+            return self._token_actions[id(token)]
+        return self._register_token(token)

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import re
 from bisect import bisect_right
 from collections import OrderedDict
 from collections.abc import Sequence
@@ -22,6 +23,9 @@ from .terminal_safety import (
 )
 
 _MAX_PROJECTED_WIDTHS = 2
+_COPY_LINK_RE = re.compile(r"\x1b\]8;[^\x07\x1b\r\n]*;([^\x07\x1b\r\n]*)(?:\x07|\x1b\\)")
+_SGR_RE = re.compile(r"\x1b\[[0-9:;]*m")
+_COPY_URI_PREFIX = "nooa-copy://"
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,6 +60,7 @@ class _Record:
     ansi: str
     plain: str
     has_separator: bool = False
+    copy_regions: tuple[tuple[int, int, str], ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -219,6 +224,59 @@ class FullscreenTranscriptModel:
             offset = record_stop
         return "".join(pieces)
 
+    def copy_action_at(self, *, x: int, y: int, width: int, height: int) -> str | None:
+        """Return the exact code payload behind a visible Copy label."""
+        hit = self._selection_hit(x=x, y=y, width=width, height=height)
+        if hit is None:
+            return None
+        records, _bases = self._record_indexes()
+        record = records.get(hit.record_id)
+        if record is None:
+            return None
+        for start, stop, payload in record.copy_regions:
+            if start <= hit.before < stop:
+                return payload
+        return None
+
+    @staticmethod
+    def _copy_regions(
+        ansi: str, copy_actions: dict[str, str] | None
+    ) -> tuple[tuple[int, int, str], ...]:
+        """Map custom OSC-8 links to ANSI-free record character offsets."""
+        if not copy_actions:
+            return ()
+        regions: list[tuple[int, int, str]] = []
+        active: tuple[int, str] | None = None
+        plain_offset = 0
+        cursor = 0
+        while cursor < len(ansi):
+            sgr = _SGR_RE.match(ansi, cursor)
+            if sgr is not None:
+                cursor = sgr.end()
+                continue
+            link = _COPY_LINK_RE.match(ansi, cursor)
+            if link is not None:
+                uri = link.group(1)
+                if uri.startswith(_COPY_URI_PREFIX):
+                    action_id = uri[len(_COPY_URI_PREFIX) :]
+                    payload = copy_actions.get(action_id)
+                    if payload is not None:
+                        active = (plain_offset, payload)
+                elif not uri and active is not None:
+                    start, payload = active
+                    if plain_offset > start:
+                        regions.append((start, plain_offset, payload))
+                    active = None
+                cursor = link.end()
+                continue
+            plain_offset += 1
+            cursor += 1
+        if active is not None:
+            start, payload = active
+            if plain_offset > start:
+                regions.append((start, plain_offset, payload))
+        return tuple(regions)
+
     def _selection_hit(self, *, x: int, y: int, width: int, height: int) -> _SelectionHit | None:
         width = max(1, width)
         height = max(1, height)
@@ -256,7 +314,13 @@ class FullscreenTranscriptModel:
         start, stop = row.source_spans[selected]
         return _SelectionHit(record.record_id, start, stop)
 
-    def append(self, source: str, *, record_id: int | None = None) -> None:
+    def append(
+        self,
+        source: str,
+        *,
+        record_id: int | None = None,
+        copy_actions: dict[str, str] | None = None,
+    ) -> None:
         safe = sanitize_transcript_ansi(source)
         plain = strip_safe_ansi(safe)
         first_record = not self._records
@@ -267,7 +331,14 @@ class FullscreenTranscriptModel:
             self._next_record_id += 1
         else:
             self._next_record_id = max(self._next_record_id, record_id + 1)
-        record = _Record(record_id, separator + safe, separator + plain, bool(separator))
+        record_ansi = separator + safe
+        record = _Record(
+            record_id,
+            record_ansi,
+            separator + plain,
+            bool(separator),
+            self._copy_regions(record_ansi, copy_actions),
+        )
         prior_ends_newline = self._ends_newline
         self._records.append(record)
         if record.plain:
@@ -316,10 +387,13 @@ class FullscreenTranscriptModel:
         sources: list[str],
         *,
         record_ids: list[int] | None = None,
+        copy_actions: list[dict[str, str]] | None = None,
     ) -> None:
         """Reproject semantic records while preserving explicit record identity."""
         if record_ids is not None and len(record_ids) != len(sources):
             raise ValueError("record_ids must have one item per source")
+        if copy_actions is not None and len(copy_actions) != len(sources):
+            raise ValueError("copy_actions must have one item per source")
         old_anchor = self._viewport.anchor
         old_records = {record.record_id: record for record in self._records}
         available: dict[str, list[int]] = {}
@@ -339,7 +413,17 @@ class FullscreenTranscriptModel:
                 if not matches and record_id == self._next_record_id:
                     self._next_record_id += 1
             self._next_record_id = max(self._next_record_id, record_id + 1)
-            rebuilt.append(_Record(record_id, separator + safe, separator + plain, bool(separator)))
+            record_ansi = separator + safe
+            actions = None if copy_actions is None else copy_actions[index]
+            rebuilt.append(
+                _Record(
+                    record_id,
+                    record_ansi,
+                    separator + plain,
+                    bool(separator),
+                    self._copy_regions(record_ansi, actions),
+                )
+            )
             accumulated_plain += separator + plain
         self._records = rebuilt
         self._projectable_record_count = sum(bool(record.plain) for record in rebuilt)
@@ -395,7 +479,17 @@ class FullscreenTranscriptModel:
         if self._records and self._records[0].has_separator:
             first = self._records[0]
             stripped_record_id = first.record_id
-            self._records[0] = _Record(first.record_id, first.ansi[1:], first.plain[1:], False)
+            self._records[0] = _Record(
+                first.record_id,
+                first.ansi[1:],
+                first.plain[1:],
+                False,
+                tuple(
+                    (max(0, start - 1), max(0, stop - 1), payload)
+                    for start, stop, payload in first.copy_regions
+                    if stop > 1
+                ),
+            )
             # Selection endpoints are record-local character offsets. Removing
             # the synthetic joining newline must not move a selection that is
             # wholly contained in the surviving record.

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -1015,15 +1015,39 @@ class Session:
         """
         assert self._app is not None
 
-        rendered = self._render_to_ansi(renderable)
         from .config import DisplayMode
+        from .copyable_markdown import CopyableMarkdown
 
         full_screen = getattr(self._app, "display_mode", None) is DisplayMode.FULLSCREEN
+        if full_screen:
+            from rich.markdown import Markdown
+
+            if type(renderable) is Markdown:
+                renderable = CopyableMarkdown(
+                    renderable.markup,
+                    code_theme=renderable.code_theme,
+                    justify=renderable.justify,
+                    style=renderable.style,
+                    hyperlinks=renderable.hyperlinks,
+                    inline_code_lexer=renderable.inline_code_lexer,
+                    inline_code_theme=renderable.inline_code_theme,
+                )
+        rendered = self._render_to_ansi(renderable)
         replay = (lambda r=renderable: self._render_to_ansi(r)) if full_screen else None
+        code_copy_actions = (
+            dict(renderable.copy_actions) if isinstance(renderable, CopyableMarkdown) else None
+        )
         if replay is None:
             self._app.emit_block(rendered, event_id=event_id, tags=tags, keep=keep)
         else:
-            self._app.emit_block(rendered, replay=replay, event_id=event_id, tags=tags, keep=keep)
+            self._app.emit_block(
+                rendered,
+                replay=replay,
+                event_id=event_id,
+                tags=tags,
+                keep=keep,
+                code_copy_actions=code_copy_actions,
+            )
 
     def _get_command_runner(self):
         """Return the TUI-local command runner, creating it lazily for tests."""

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -197,12 +197,17 @@ class _FullscreenTranscriptControl(FormattedTextControl):
         scroll_callback: Callable[[int], None],
         mouse_navigation_enabled: Callable[[], bool],
         selection_callback: Callable[[str, int, int], None],
+        code_action_at: Callable[[int, int], str | None],
+        copy_code_callback: Callable[[str], None],
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
         self._scroll_callback = scroll_callback
         self._mouse_navigation_enabled = mouse_navigation_enabled
         self._selection_callback = selection_callback
+        self._code_action_at = code_action_at
+        self._copy_code_callback = copy_code_callback
+        self._pressed_code_payload: str | None = None
         self._render_width: int | None = None
         self._render_height: int | None = None
         self._dragging = False
@@ -254,9 +259,11 @@ class _FullscreenTranscriptControl(FormattedTextControl):
             # Stop any application drag/autoscroll without clearing the visible
             # selection; the modified gesture belongs to the terminal.
             self.cancel_drag()
+            self._pressed_code_payload = None
             return NotImplemented
         if not self._mouse_navigation_enabled():
             self.cancel_drag()
+            self._pressed_code_payload = None
             return NotImplemented
 
         delta = _fullscreen_wheel_delta(mouse_event)
@@ -271,9 +278,30 @@ class _FullscreenTranscriptControl(FormattedTextControl):
             and mouse_event.button is MouseButton.LEFT
         ):
             self.cancel_drag()
+            payload = self._code_action_at(x, y)
+            if payload is not None:
+                self._pressed_code_payload = payload
+                return None
+            self._pressed_code_payload = None
             self._dragging = True
             self._drag_position = (x, y)
             self._selection_callback("start", x, y)
+            return None
+        if (
+            mouse_event.event_type is MouseEventType.MOUSE_MOVE
+            and self._pressed_code_payload is not None
+        ):
+            if self._code_action_at(x, y) != self._pressed_code_payload:
+                self._pressed_code_payload = None
+            return None
+        if (
+            mouse_event.event_type is MouseEventType.MOUSE_UP
+            and self._pressed_code_payload is not None
+        ):
+            payload = self._pressed_code_payload
+            self._pressed_code_payload = None
+            if self._code_action_at(x, y) == payload:
+                self._copy_code_callback(payload)
             return None
         if mouse_event.event_type is MouseEventType.MOUSE_MOVE and self._dragging:
             # tmux cannot forward a release that happens outside its pane.  In
@@ -306,6 +334,8 @@ class _FullscreenTranscriptControl(FormattedTextControl):
         if mouse_event.event_type is MouseEventType.MOUSE_UP and self._dragging:
             self._finish_drag(x, y, moved=self._drag_moved)
             return None
+        if mouse_event.event_type is MouseEventType.MOUSE_UP:
+            self._pressed_code_payload = None
         return super().mouse_handler(mouse_event)
 
     @property
@@ -622,6 +652,7 @@ class TranscriptBlock:
     resident_bytes: int = 0
     replay_cache: dict[int, str] = field(default_factory=dict)
     fullscreen_rendered: str | None = None
+    code_copy_actions: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -900,6 +931,8 @@ class TUIApplication:
                     scroll_callback=self._scroll_fullscreen_transcript,
                     mouse_navigation_enabled=lambda: self._fullscreen_mouse_navigation,
                     selection_callback=self._handle_fullscreen_selection,
+                    code_action_at=self._fullscreen_code_action_at,
+                    copy_code_callback=self._start_fullscreen_selection_copy,
                 ),
                 wrap_lines=False,
                 # The model virtualizes formatted content to exactly the visible
@@ -1516,6 +1549,16 @@ class TUIApplication:
         if not isinstance(control, _FullscreenTranscriptControl) or not control.dragging:
             return False
         return control.handle_external_mouse(mouse_event, below=True)
+
+    def _fullscreen_code_action_at(self, x: int, y: int) -> str | None:
+        """Resolve a code-copy action at one visible transcript cell."""
+        width, height = self._transcript_viewport_size()
+        return self._fullscreen_transcript.copy_action_at(
+            x=x,
+            y=y,
+            width=width,
+            height=height,
+        )
 
     def _handle_fullscreen_selection(self, action: str, x: int, y: int) -> None:
         """Apply one mouse-selection transition and copy on button release."""
@@ -2209,6 +2252,7 @@ class TUIApplication:
         event_id: str | None = None,
         tags: set[str] | frozenset[str] | None = None,
         keep: bool = False,
+        code_copy_actions: dict[str, str] | None = None,
     ) -> None:
         """Enqueue one ANSI-bearing block for the transcript.
 
@@ -2231,6 +2275,7 @@ class TUIApplication:
             event_id=str(event_id) if event_id is not None else None,
             tags=frozenset(str(t) for t in (tags or ())),
             keep=keep,
+            code_copy_actions=dict(code_copy_actions or {}),
         )
 
         # Before the consumer is up (pre-run_async) we're single-threaded
@@ -2241,7 +2286,11 @@ class TUIApplication:
             rendered = self._render_transcript_source(block.source)
             evicted = self._retain_transcript_block(block, rendered)
             if self._is_fullscreen:
-                self._fullscreen_transcript.append(rendered, record_id=block.transcript_record_id)
+                self._fullscreen_transcript.append(
+                    rendered,
+                    record_id=block.transcript_record_id,
+                    copy_actions=block.code_copy_actions,
+                )
                 self._fullscreen_transcript.evict_prefix(evicted)
                 self._app.invalidate()
                 return
@@ -2297,12 +2346,22 @@ class TUIApplication:
         Python container overhead is deliberately outside this byte contract.
         """
         source_bytes = len(block.source.encode("utf-8"))
+        copy_action_bytes = sum(
+            len(action_id.encode("utf-8")) + len(payload.encode("utf-8"))
+            for action_id, payload in block.code_copy_actions.items()
+        )
         replay_cache_bytes = sum(
             len(source.encode("utf-8")) for source in block.replay_cache.values()
         )
         rendered_bytes = len(rendered.encode("utf-8"))
         plain_bytes = len(_strip_ansi(rendered).encode("utf-8"))
-        return source_bytes + replay_cache_bytes + (2 * rendered_bytes) + (5 * plain_bytes)
+        return (
+            source_bytes
+            + copy_action_bytes
+            + replay_cache_bytes
+            + (2 * rendered_bytes)
+            + (5 * plain_bytes)
+        )
 
     def _retain_transcript_block(self, block: TranscriptBlock, rendered: str) -> int:
         block.transcript_epoch = self._transcript_epoch
@@ -2364,7 +2423,11 @@ class TUIApplication:
         rendered = self._render_transcript_source(block.source)
         evicted = self._retain_transcript_block(block, rendered)
         if self._is_fullscreen:
-            self._fullscreen_transcript.append(rendered, record_id=block.transcript_record_id)
+            self._fullscreen_transcript.append(
+                rendered,
+                record_id=block.transcript_record_id,
+                copy_actions=block.code_copy_actions,
+            )
             self._fullscreen_transcript.evict_prefix(evicted)
             self._app.invalidate()
             return
@@ -2765,6 +2828,7 @@ class TUIApplication:
                 block.transcript_record_id if block.transcript_record_id is not None else index
                 for index, block in enumerate(self._transcript_blocks)
             ],
+            copy_actions=[block.code_copy_actions for block in self._transcript_blocks],
         )
         self._fullscreen_invalidate_count += 1
         self._app.invalidate()

--- a/packages/nooa-cli/tests/tui/test_agent_event_renderer.py
+++ b/packages/nooa-cli/tests/tui/test_agent_event_renderer.py
@@ -459,3 +459,55 @@ def test_file_edit_does_not_confuse_bounded_content_with_a_truncated_diff() -> N
     _fire_file_edit(agent.event_manager, content_complete=False, diff_complete=True)
 
     assert not any(isinstance(item, Text) and "truncated" in str(item) for item in emitted)
+
+
+def test_session_emit_text_adds_code_copy_metadata_only_in_fullscreen() -> None:
+    from nooa_cli.tui.config import DisplayMode
+    from nooa_cli.tui.copyable_markdown import CopyableMarkdown
+    from nooa_cli.tui.session import Session
+
+    class FakeApp:
+        display_mode = DisplayMode.FULLSCREEN
+
+        def __init__(self) -> None:
+            self.calls = []
+
+        def emit_block(self, text, **kwargs) -> None:
+            self.calls.append((text, kwargs))
+
+    session = Session.__new__(Session)
+    session._app = FakeApp()
+    session._render_to_ansi = lambda renderable: (
+        str(renderable.markup) if isinstance(renderable, Markdown) else str(renderable)
+    )
+
+    Session._emit_text(session, Markdown("```python\nx = 1\n```"))
+
+    _text, kwargs = session._app.calls[0]
+    assert callable(kwargs["replay"])
+    assert list(kwargs["code_copy_actions"].values()) == ["x = 1"]
+    assert isinstance(kwargs["replay"].__defaults__[0], CopyableMarkdown)
+
+
+def test_session_emit_text_leaves_native_markdown_without_copy_metadata() -> None:
+    from nooa_cli.tui.config import DisplayMode
+    from nooa_cli.tui.session import Session
+
+    class FakeApp:
+        display_mode = DisplayMode.NATIVE
+
+        def __init__(self) -> None:
+            self.calls = []
+
+        def emit_block(self, text, **kwargs) -> None:
+            self.calls.append((text, kwargs))
+
+    session = Session.__new__(Session)
+    session._app = FakeApp()
+    session._render_to_ansi = lambda renderable: str(renderable.markup)
+
+    Session._emit_text(session, Markdown("```python\nx = 1\n```"))
+
+    _text, kwargs = session._app.calls[0]
+    assert "replay" not in kwargs
+    assert "code_copy_actions" not in kwargs

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -2422,3 +2422,177 @@ def test_fullscreen_retention_hard_byte_cap_can_evict_oversized_newest_block(
     assert app._transcript_blocks == []
     assert app._fullscreen_transcript_bytes == 0
     assert app._fullscreen_transcript.text == ""
+
+
+def _copyable_markdown_ansi(markdown: str, *, width: int = 60):
+    from io import StringIO
+
+    from nooa_cli.tui.copyable_markdown import CopyableMarkdown
+    from nooa_cli.tui.theme import CATPPUCCIN_THEME
+    from rich.console import Console
+
+    renderable = CopyableMarkdown(markdown)
+    buffer = StringIO()
+    Console(
+        file=buffer,
+        force_terminal=True,
+        color_system="256",
+        width=width,
+        theme=CATPPUCCIN_THEME,
+    ).print(renderable)
+    return renderable, buffer.getvalue()
+
+
+def _copy_label_position(model, *, width: int, height: int) -> tuple[int, int]:
+    formatted = model.formatted_text(width=width, height=height)
+    lines = "".join(text for _style, text, *_rest in formatted).splitlines()
+    for y, line in enumerate(lines):
+        if "Copy" in line:
+            return line.index("Copy"), y
+    raise AssertionError("copy label was not rendered")
+
+
+def test_copyable_markdown_exposes_exact_fenced_code_payloads() -> None:
+    renderable, ansi = _copyable_markdown_ansi(
+        "before\n\n```python title=demo\nprint('one')\n```\n\n```\n  exact spacing  \n```"
+    )
+
+    assert "Copy" in ansi
+    assert list(renderable.copy_actions.values()) == ["print('one')", "  exact spacing  "]
+
+
+def test_copyable_markdown_does_not_offer_copy_for_empty_fence() -> None:
+    renderable, ansi = _copyable_markdown_ansi("```python\n```")
+
+    assert renderable.copy_actions == {}
+    assert "Copy" not in ansi
+
+
+def test_model_authored_internal_link_cannot_forge_code_copy_action() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+
+    renderable, ansi = _copyable_markdown_ansi(
+        "[Copy](nooa-copy://code-0)\n\n```python\nSECRET\n```", width=60
+    )
+    model = FullscreenTranscriptModel()
+    model.append(ansi, copy_actions=renderable.copy_actions)
+    formatted = model.formatted_text(width=60, height=20)
+    lines = "".join(text for _style, text, *_rest in formatted).splitlines()
+    copy_positions = [(line.index("Copy"), y) for y, line in enumerate(lines) if "Copy" in line]
+
+    assert len(copy_positions) == 2
+    assert (
+        model.copy_action_at(x=copy_positions[0][0], y=copy_positions[0][1], width=60, height=20)
+        is None
+    )
+    assert (
+        model.copy_action_at(x=copy_positions[1][0], y=copy_positions[1][1], width=60, height=20)
+        == "SECRET"
+    )
+
+
+def test_identical_code_blocks_keep_distinct_copy_targets() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+
+    renderable, ansi = _copyable_markdown_ansi(
+        "```python\nsame()\n```\n\n```python\nsame()\n```", width=60
+    )
+    assert len(renderable.copy_actions) == 2
+    model = FullscreenTranscriptModel()
+    model.append(ansi, copy_actions=renderable.copy_actions)
+    formatted = model.formatted_text(width=60, height=30)
+    lines = "".join(text for _style, text, *_rest in formatted).splitlines()
+    positions = [(line.index("Copy"), y) for y, line in enumerate(lines) if "Copy" in line]
+
+    assert len(positions) == 2
+    assert [model.copy_action_at(x=x, y=y, width=60, height=30) for x, y in positions] == [
+        "same()",
+        "same()",
+    ]
+
+
+def test_fullscreen_copy_action_hit_testing_survives_resize() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+
+    renderable, ansi = _copyable_markdown_ansi("```python\nprint('exact')\n```", width=60)
+    model = FullscreenTranscriptModel()
+    model.append(ansi, record_id=7, copy_actions=renderable.copy_actions)
+
+    x, y = _copy_label_position(model, width=60, height=20)
+    assert model.copy_action_at(x=x, y=y, width=60, height=20) == "print('exact')"
+    assert model.copy_action_at(x=max(0, x - 1), y=y, width=60, height=20) is None
+
+    renderable, resized = _copyable_markdown_ansi("```python\nprint('exact')\n```", width=42)
+    model.replace(
+        [resized],
+        record_ids=[7],
+        copy_actions=[renderable.copy_actions],
+    )
+    x, y = _copy_label_position(model, width=42, height=20)
+    assert model.copy_action_at(x=x, y=y, width=42, height=20) == "print('exact')"
+
+
+def test_fullscreen_code_copy_click_copies_source_without_starting_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nooa_cli.tui.tui_application import _ClipboardResult
+    from prompt_toolkit.mouse_events import MouseEventType
+
+    app = _make_fullscreen_app()
+    renderable, ansi = _copyable_markdown_ansi("```python\nprint('exact')\n```", width=60)
+    app.emit_block(ansi, code_copy_actions=renderable.copy_actions)
+    app._transcript_viewport_size = lambda: (60, 20)
+    copied: list[str] = []
+    monkeypatch.setattr(
+        app,
+        "_copy_to_clipboard_result",
+        lambda text: copied.append(text) or _ClipboardResult(True, "test"),
+    )
+    assert app._output_window is not None
+    control = app._output_window.content
+    control.create_content(60, 20)
+    x, y = _copy_label_position(app._fullscreen_transcript, width=60, height=20)
+
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_DOWN, x=x, y=y))
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_UP, x=x, y=y))
+
+    assert copied == ["print('exact')"]
+    assert app._fullscreen_transcript.selected_text() == ""
+    assert app._transient_status_text == "Copied 14 characters"
+
+
+def test_code_copy_metadata_tracks_prefix_eviction() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+
+    first, first_ansi = _copyable_markdown_ansi("```python\nfirst()\n```", width=60)
+    second, second_ansi = _copyable_markdown_ansi("```python\nsecond()\n```", width=60)
+    model = FullscreenTranscriptModel()
+    model.append(first_ansi, record_id=1, copy_actions=first.copy_actions)
+    model.append(second_ansi, record_id=2, copy_actions=second.copy_actions)
+    model.evict_prefix(1)
+
+    x, y = _copy_label_position(model, width=60, height=20)
+    assert model.copy_action_at(x=x, y=y, width=60, height=20) == "second()"
+
+
+def test_fullscreen_code_copy_drag_away_does_not_copy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from prompt_toolkit.mouse_events import MouseEventType
+
+    app = _make_fullscreen_app()
+    renderable, ansi = _copyable_markdown_ansi("```python\nprint('exact')\n```", width=60)
+    app.emit_block(ansi, code_copy_actions=renderable.copy_actions)
+    app._transcript_viewport_size = lambda: (60, 20)
+    copied: list[str] = []
+    monkeypatch.setattr(app, "_start_fullscreen_selection_copy", copied.append)
+    assert app._output_window is not None
+    control = app._output_window.content
+    control.create_content(60, 20)
+    x, y = _copy_label_position(app._fullscreen_transcript, width=60, height=20)
+
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_DOWN, x=x, y=y))
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_MOVE, x=0, y=y))
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_UP, x=x, y=y))
+
+    assert copied == []


### PR DESCRIPTION
## Summary

- render a clickable Copy action above non-empty fenced Markdown code blocks in fullscreen mode
- retain exact source code as semantic metadata instead of reconstructing it from wrapped or syntax-highlighted terminal text
- preserve copy actions across resize replay and transcript retention eviction
- route clicks through the existing non-blocking clipboard path with standard success/failure feedback
- isolate native display modes and protect the internal action scheme from model-authored link spoofing

## Validation

- `uv run --project packages/nooa-cli pytest -q packages/nooa-cli/tests/tui/test_fullscreen_transcript.py packages/nooa-cli/tests/tui/test_agent_event_renderer.py` (142 passed)
- full `packages/nooa-cli/tests/tui` suite: 1106 passed; only the two known unrelated macOS `/var` vs `/private/var` path-alias failures
- Ruff check and format check
- scoped Pyright: 0 errors, 0 warnings
- `git diff --check`
- independent review: no blocker, high, or medium findings