### PR TITLE
fix(tui): harden fullscreen interaction and queued input

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/interactive/local_agent.py
+++ b/packages/nooa-cli/src/nooa_cli/interactive/local_agent.py
@@ -727,7 +727,10 @@ class LocalAgentRunner:
                 value for value in self._user_messages.snapshot() if isinstance(value, str)
             )
             pending_inputs = self._pending_user_messages
-        self._update_pending_inputs(pending_inputs)
+            # Publish before releasing the lifecycle transaction. Otherwise a
+            # concurrent submit can publish a newer snapshot first and then be
+            # overwritten by this stale withdrawal snapshot.
+            self._update_pending_inputs(pending_inputs)
         return True, None if item is None else str(item)
 
     def cancel_tasks(self, tasks: list[asyncio.Task[Any]]) -> None:

--- a/packages/nooa-cli/src/nooa_cli/interactive/local_agent.py
+++ b/packages/nooa-cli/src/nooa_cli/interactive/local_agent.py
@@ -473,7 +473,10 @@ class LocalAgentRunner:
                 )
                 return False
             self._pending_user_messages = pending_inputs
-        self._update_pending_inputs(pending_inputs)
+            # Publish while dequeue is still excluded by the lifecycle lock.
+            # Otherwise a newer empty dequeue snapshot can be overwritten by
+            # this older submit snapshot after the lock is released.
+            self._update_pending_inputs(pending_inputs)
         return True
 
     def ensure_dispatcher(self, *, start_with_race: bool = False) -> None:

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -74,7 +74,14 @@ def render_history_replay_to_ansi(output: HistoryReplay, width: int) -> str:
         )
     for turn in output.turns:
         if turn.role == "user":
-            bc.print(Text(f" You: {turn.content}", style=f"{user_color} on {COLORS['surface0']}"))
+            # Apply the style at the print boundary so Rich extends the
+            # background through padding on every explicit or wrapped row.
+            bc.print(
+                Text(f" You: {turn.content}"),
+                style=f"{user_color} on {COLORS['surface0']}",
+                justify="left",
+                overflow="fold",
+            )
         else:
             bc.print(Text("OO:", style=f"bold {dim}"))
             bc.print(Markdown(turn.content), style=dim)

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -48,7 +48,6 @@ def render_history_replay_to_ansi(output: HistoryReplay, width: int) -> str:
     from rich.text import Text
 
     dim = COLORS["overlay1"]
-    user_color = COLORS["subtext1"]
 
     render_width = max(int(width), 1)
     buf = io.StringIO()
@@ -74,14 +73,11 @@ def render_history_replay_to_ansi(output: HistoryReplay, width: int) -> str:
         )
     for turn in output.turns:
         if turn.role == "user":
-            # Apply the style at the print boundary so Rich extends the
-            # background through padding on every explicit or wrapped row.
-            bc.print(
-                Text(f" You: {turn.content}"),
-                style=f"{user_color} on {COLORS['surface0']}",
-                justify="left",
-                overflow="fold",
-            )
+            # Reuse the live renderer so resumed and newly submitted messages
+            # have identical prompt glyphs, colors, padding, and wrapping.
+            from .user_message import render_user_bar
+
+            buf.write(render_user_bar(turn.content, render_width, COLORS))
         else:
             bc.print(Text("OO:", style=f"bold {dim}"))
             bc.print(Markdown(turn.content), style=dim)

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -26,6 +26,7 @@ from .output import (
     HistoryReplay,
     Output,
     RichOutput,
+    SplashScreen,
     StartupInfo,
     StopReasonOutput,
     TableOutput,
@@ -305,6 +306,7 @@ class TerminalFrontend:
             HelpOutput: self._render_help,
             AgentMessage: self._render_agent_message,
             CodeExecution: self._render_code_execution,
+            SplashScreen: self._render_splash,
             StartupInfo: self._render_startup,
             ClearScreen: self._render_clear,
             Thinking: self._render_thinking,
@@ -556,6 +558,32 @@ class TerminalFrontend:
             return
 
         # Single write to the real terminal
+        stream.write(rendered)
+        stream.flush()
+
+    def _render_splash(self, _output: SplashScreen) -> None:
+        """Render the logo through the app-owned transcript in fullscreen mode."""
+        from .splash import render_splash_to_ansi
+
+        stream = self._console.console.file
+        replay_width = getattr(stream, "replay_width", None)
+        width = (
+            replay_width(self._console.console.width or 80)
+            if callable(replay_width)
+            else self._console.console.width or 80
+        )
+        rendered = render_splash_to_ansi(width)
+        emit_with_replay = getattr(stream, "emit_with_replay", None)
+        if getattr(stream, "supports_semantic_replay", False) is True and callable(
+            emit_with_replay
+        ):
+            emit_with_replay(
+                rendered,
+                lambda s=stream, w=width: render_splash_to_ansi(
+                    s.replay_width(w) if callable(getattr(s, "replay_width", None)) else w
+                ),
+            )
+            return
         stream.write(rendered)
         stream.flush()
 

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -566,10 +566,10 @@ class TerminalFrontend:
         from .splash import render_splash_to_ansi
 
         stream = self._console.console.file
-        replay_width = getattr(stream, "replay_width", None)
+        layout_width = getattr(stream, "layout_width", None)
         width = (
-            replay_width(self._console.console.width or 80)
-            if callable(replay_width)
+            layout_width(self._console.console.width or 80)
+            if callable(layout_width)
             else self._console.console.width or 80
         )
         rendered = render_splash_to_ansi(width)
@@ -580,7 +580,7 @@ class TerminalFrontend:
             emit_with_replay(
                 rendered,
                 lambda s=stream, w=width: render_splash_to_ansi(
-                    s.replay_width(w) if callable(getattr(s, "replay_width", None)) else w
+                    s.layout_width(w) if callable(getattr(s, "layout_width", None)) else w
                 ),
             )
             return

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -321,7 +321,7 @@ class FullscreenTranscriptModel:
             record_ansi,
             separator + plain,
             bool(separator),
-            safe_hyperlink_spans(record_ansi),
+            safe_hyperlink_spans(record_ansi, already_sanitized=True),
         )
         prior_ends_newline = self._ends_newline
         self._records.append(record)
@@ -401,7 +401,7 @@ class FullscreenTranscriptModel:
                     record_ansi,
                     separator + plain,
                     bool(separator),
-                    safe_hyperlink_spans(record_ansi),
+                    safe_hyperlink_spans(record_ansi, already_sanitized=True),
                 )
             )
             accumulated_plain += separator + plain
@@ -465,7 +465,7 @@ class FullscreenTranscriptModel:
                 record_ansi,
                 first.plain[1:],
                 False,
-                safe_hyperlink_spans(record_ansi),
+                safe_hyperlink_spans(record_ansi, already_sanitized=True),
             )
             # Selection endpoints are record-local character offsets. Removing
             # the synthetic joining newline must not move a selection that is

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -702,6 +702,7 @@ class FullscreenTranscriptModel:
             fragments.append(("", "\n"))
         selected = self._selection_bounds()
         records, record_bases = self._record_indexes()
+        has_hyperlinks = any(row.hyperlinks for row in rows)
         for index, row in enumerate(rows):
             if index:
                 fragments.append(("", "\n"))
@@ -732,7 +733,7 @@ class FullscreenTranscriptModel:
                         link_start, link_stop, target = row.hyperlinks[link_index]
                         if link_start < source_stop and link_stop > source_start:
                             link = target
-                if row.hyperlinks:
+                if has_hyperlinks:
                     sequence = f"\x1b]8;;{link}\x1b\\" if link is not None else "\x1b]8;;\x1b\\"
                     fragments.append(("[ZeroWidthEscape]", sequence))
                 for style, char in display_chars[start:stop]:

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -8,7 +8,6 @@ from bisect import bisect_right
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from hashlib import sha256
 from unicodedata import normalize
 
 from prompt_toolkit.data_structures import Point
@@ -17,7 +16,6 @@ from rich.cells import split_graphemes
 from wcwidth import wcswidth
 
 from .terminal_safety import (
-    hyperlink_at_plain_offset,
     project_prompt_toolkit_ansi,
     safe_hyperlink_spans,
     sanitize_transcript_ansi,
@@ -87,7 +85,9 @@ class FullscreenTranscriptModel:
         self._projection_index_cache: OrderedDict[int, dict[int, tuple[list[int], list[int]]]] = (
             OrderedDict()
         )
-        self._formatted_cache: OrderedDict[tuple[int, int, int, int], FormattedText] = OrderedDict()
+        self._formatted_cache: OrderedDict[tuple[int, int, int, int, int], FormattedText] = (
+            OrderedDict()
+        )
         self._ends_newline = False
         self._selection_anchor: _SelectionHit | None = None
         self._selection_active: _SelectionHit | None = None
@@ -107,6 +107,7 @@ class FullscreenTranscriptModel:
         *,
         width: int | None = None,
         height: int | None = None,
+        render_counter: int = 0,
     ) -> FormattedText:
         """Return safe rows, optionally virtualized to the visible viewport."""
         if width is None:
@@ -124,12 +125,17 @@ class FullscreenTranscriptModel:
                 # Short histories belong next to the bottom chrome regardless
                 # of whether navigation has explicitly anchored their sole page.
                 top_padding = height - len(rows)
-        key = (width, top, len(rows), top_padding)
+        hyperlink_marker = render_counter & 1
+        key = (width, top, len(rows), top_padding, hyperlink_marker)
         cached = self._formatted_cache.get(key)
         if cached is not None:
             self._formatted_cache.move_to_end(key)
             return cached
-        result = self._format_rows(rows, top_padding=top_padding)
+        result = self._format_rows(
+            rows,
+            top_padding=top_padding,
+            hyperlink_marker=hyperlink_marker,
+        )
         self._formatted_cache[key] = result
         while len(self._formatted_cache) > _MAX_PROJECTED_WIDTHS:
             self._formatted_cache.popitem(last=False)
@@ -211,7 +217,12 @@ class FullscreenTranscriptModel:
         record = records.get(hit.record_id)
         if record is None:
             return None
-        return hyperlink_at_plain_offset(record.ansi, hit.before)
+        for start, stop, target in record.hyperlinks:
+            if start <= hit.before < stop:
+                return target
+            if start > hit.before:
+                break
+        return None
 
     def clear_selection(self) -> None:
         """Discard renderer-owned selection without changing the viewport."""
@@ -696,7 +707,13 @@ class FullscreenTranscriptModel:
             (("", ""),),
         )
 
-    def _format_rows(self, rows: Sequence[_ProjectedRow], *, top_padding: int = 0) -> FormattedText:
+    def _format_rows(
+        self,
+        rows: Sequence[_ProjectedRow],
+        *,
+        top_padding: int = 0,
+        hyperlink_marker: int = 0,
+    ) -> FormattedText:
         fragments: list[tuple[str, str]] = []
         for _ in range(top_padding):
             fragments.append(("", "\n"))
@@ -714,7 +731,6 @@ class FullscreenTranscriptModel:
             display_spans = self._grapheme_spans(display_chars)
             base = record_bases[record.record_id]
             link_index = 0
-            link_markers: dict[str, str] = {}
             for offset, (start, stop, _cells) in enumerate(display_spans):
                 highlighted = False
                 link: str | None = None
@@ -738,10 +754,9 @@ class FullscreenTranscriptModel:
                     fragments.append(("[ZeroWidthEscape]", sequence))
                 for style, char in display_chars[start:stop]:
                     if link is not None:
-                        marker = link_markers.setdefault(
-                            link, sha256(link.encode()).hexdigest()[:12]
-                        )
-                        style = f"{style} class:native-hyperlink-{marker}".strip()
+                        # Alternating the bounded marker each frame forces OSC-8
+                        # cells to repaint when only their target changes.
+                        style = (f"{style} class:native-hyperlink-{hyperlink_marker}").strip()
                     if highlighted:
                         style = f"{style} class:selected".strip()
                     fragments.append((style, char))

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -16,6 +16,7 @@ from rich.cells import split_graphemes
 from wcwidth import wcswidth
 
 from .terminal_safety import (
+    hyperlink_at_plain_offset,
     project_prompt_toolkit_ansi,
     sanitize_transcript_ansi,
     strip_safe_ansi,
@@ -192,6 +193,17 @@ class FullscreenTranscriptModel:
         self._selection_active = self._selection_hit(x=x, y=y, width=width, height=height)
         self._formatted_cache.clear()
 
+    def hyperlink_at(self, *, x: int, y: int, width: int, height: int) -> str | None:
+        """Return the safe OSC-8 target under one visible transcript cell."""
+        hit = self._selection_hit(x=x, y=y, width=width, height=height, clamp=False)
+        if hit is None:
+            return None
+        records, _bases = self._record_indexes()
+        record = records.get(hit.record_id)
+        if record is None:
+            return None
+        return hyperlink_at_plain_offset(record.ansi, hit.before)
+
     def clear_selection(self) -> None:
         """Discard renderer-owned selection without changing the viewport."""
         self._selection_anchor = None
@@ -219,7 +231,15 @@ class FullscreenTranscriptModel:
             offset = record_stop
         return "".join(pieces)
 
-    def _selection_hit(self, *, x: int, y: int, width: int, height: int) -> _SelectionHit | None:
+    def _selection_hit(
+        self,
+        *,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        clamp: bool = True,
+    ) -> _SelectionHit | None:
         width = max(1, width)
         height = max(1, height)
         rows = self._projection(width)
@@ -238,6 +258,8 @@ class FullscreenTranscriptModel:
         if record is None:
             return None
         if not display_spans or not row.source_spans:
+            if not clamp:
+                return None
             insertion = min(
                 len(record.plain), self._character_offset(record, row.anchor.source_offset)
             )
@@ -245,6 +267,9 @@ class FullscreenTranscriptModel:
 
         cell = max(0, x)
         occupied = 0
+        total_cells = sum(max(1, cells) for _start, _stop, cells in display_spans)
+        if not clamp and cell >= total_cells:
+            return None
         selected = len(display_spans) - 1
         for index, (_start, _stop, cells) in enumerate(display_spans):
             next_occupied = occupied + max(1, cells)

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -218,9 +218,12 @@ class FullscreenTranscriptModel:
         if record is None:
             return None
         for start, stop, target in record.hyperlinks:
-            if start <= hit.before < stop:
+            # Rendering promotes any hyperlink overlap to the whole displayed
+            # grapheme. Use the same rule for hit-testing when an OSC-8
+            # boundary falls between a base character and combining mark.
+            if start < hit.after and stop > hit.before:
                 return target
-            if start > hit.before:
+            if start >= hit.after:
                 break
         return None
 

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -8,6 +8,7 @@ from bisect import bisect_right
 from collections import OrderedDict
 from collections.abc import Sequence
 from dataclasses import dataclass
+from hashlib import sha256
 from unicodedata import normalize
 
 from prompt_toolkit.data_structures import Point
@@ -18,6 +19,7 @@ from wcwidth import wcswidth
 from .terminal_safety import (
     hyperlink_at_plain_offset,
     project_prompt_toolkit_ansi,
+    safe_hyperlink_spans,
     sanitize_transcript_ansi,
     strip_safe_ansi,
 )
@@ -57,6 +59,7 @@ class _Record:
     ansi: str
     plain: str
     has_separator: bool = False
+    hyperlinks: tuple[tuple[int, int, str], ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,6 +67,7 @@ class _ProjectedRow:
     anchor: ViewportAnchor
     fragments: tuple[tuple[str, str], ...]
     source_spans: tuple[tuple[int, int], ...] = ()
+    hyperlinks: tuple[tuple[int, int, str], ...] = ()
 
 
 class FullscreenTranscriptModel:
@@ -292,7 +296,14 @@ class FullscreenTranscriptModel:
             self._next_record_id += 1
         else:
             self._next_record_id = max(self._next_record_id, record_id + 1)
-        record = _Record(record_id, separator + safe, separator + plain, bool(separator))
+        record_ansi = separator + safe
+        record = _Record(
+            record_id,
+            record_ansi,
+            separator + plain,
+            bool(separator),
+            safe_hyperlink_spans(record_ansi),
+        )
         prior_ends_newline = self._ends_newline
         self._records.append(record)
         if record.plain:
@@ -364,7 +375,16 @@ class FullscreenTranscriptModel:
                 if not matches and record_id == self._next_record_id:
                     self._next_record_id += 1
             self._next_record_id = max(self._next_record_id, record_id + 1)
-            rebuilt.append(_Record(record_id, separator + safe, separator + plain, bool(separator)))
+            record_ansi = separator + safe
+            rebuilt.append(
+                _Record(
+                    record_id,
+                    record_ansi,
+                    separator + plain,
+                    bool(separator),
+                    safe_hyperlink_spans(record_ansi),
+                )
+            )
             accumulated_plain += separator + plain
         self._records = rebuilt
         self._projectable_record_count = sum(bool(record.plain) for record in rebuilt)
@@ -420,7 +440,14 @@ class FullscreenTranscriptModel:
         if self._records and self._records[0].has_separator:
             first = self._records[0]
             stripped_record_id = first.record_id
-            self._records[0] = _Record(first.record_id, first.ansi[1:], first.plain[1:], False)
+            record_ansi = first.ansi[1:]
+            self._records[0] = _Record(
+                first.record_id,
+                record_ansi,
+                first.plain[1:],
+                False,
+                safe_hyperlink_spans(record_ansi),
+            )
             # Selection endpoints are record-local character offsets. Removing
             # the synthetic joining newline must not move a selection that is
             # wholly contained in the surviving record.
@@ -525,6 +552,7 @@ class FullscreenTranscriptModel:
                         ViewportAnchor(record.record_id, row_source_offset, row_semantic_offset),
                         tuple(row),
                         tuple(row_source_spans),
+                        record.hyperlinks,
                     )
                 )
                 source_offset += 1
@@ -556,6 +584,7 @@ class FullscreenTranscriptModel:
                         ViewportAnchor(record.record_id, row_source_offset, row_semantic_offset),
                         tuple(row),
                         tuple(row_source_spans),
+                        record.hyperlinks,
                     )
                 )
                 row = []
@@ -575,6 +604,7 @@ class FullscreenTranscriptModel:
                         ViewportAnchor(record.record_id, row_source_offset, row_semantic_offset),
                         tuple(row),
                         tuple(row_source_spans),
+                        record.hyperlinks,
                     )
                 )
                 row = []
@@ -588,6 +618,7 @@ class FullscreenTranscriptModel:
                     ViewportAnchor(record.record_id, row_source_offset, row_semantic_offset),
                     tuple(row),
                     tuple(row_source_spans),
+                    record.hyperlinks,
                 )
             )
         return rows
@@ -649,33 +680,46 @@ class FullscreenTranscriptModel:
         for _ in range(top_padding):
             fragments.append(("", "\n"))
         selected = self._selection_bounds()
-        if selected is None:
-            records: dict[int, _Record] = {}
-            record_bases: dict[int, int] = {}
-        else:
-            records, record_bases = self._record_indexes()
+        records, record_bases = self._record_indexes()
         for index, row in enumerate(rows):
             if index:
                 fragments.append(("", "\n"))
-            if selected is None:
-                fragments.extend(row.fragments)
-                continue
             record = records.get(row.anchor.record_id)
-            if record is None:
+            if record is None or not row.source_spans:
                 fragments.extend(row.fragments)
                 continue
             display_chars = [(style, char) for style, text in row.fragments for char in text]
             display_spans = self._grapheme_spans(display_chars)
             base = record_bases[record.record_id]
+            link_index = 0
+            link_markers: dict[str, str] = {}
             for offset, (start, stop, _cells) in enumerate(display_spans):
                 highlighted = False
+                link: str | None = None
                 if offset < len(row.source_spans):
                     source_start, source_stop = row.source_spans[offset]
-                    highlighted = (
-                        base + source_start < selected[1] and base + source_stop > selected[0]
-                    )
-                cluster = display_chars[start:stop]
-                for style, char in cluster:
+                    if selected is not None:
+                        highlighted = (
+                            base + source_start < selected[1] and base + source_stop > selected[0]
+                        )
+                    while (
+                        link_index < len(row.hyperlinks)
+                        and row.hyperlinks[link_index][1] <= source_start
+                    ):
+                        link_index += 1
+                    if link_index < len(row.hyperlinks):
+                        link_start, link_stop, target = row.hyperlinks[link_index]
+                        if link_start < source_stop and link_stop > source_start:
+                            link = target
+                if row.hyperlinks:
+                    sequence = f"\x1b]8;;{link}\x1b\\" if link is not None else "\x1b]8;;\x1b\\"
+                    fragments.append(("[ZeroWidthEscape]", sequence))
+                for style, char in display_chars[start:stop]:
+                    if link is not None:
+                        marker = link_markers.setdefault(
+                            link, sha256(link.encode()).hexdigest()[:12]
+                        )
+                        style = f"{style} class:native-hyperlink-{marker}".strip()
                     if highlighted:
                         style = f"{style} class:selected".strip()
                     fragments.append((style, char))

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -137,7 +137,8 @@ class FullscreenTranscriptModel:
             hyperlink_marker=hyperlink_marker,
         )
         self._formatted_cache[key] = result
-        while len(self._formatted_cache) > _MAX_PROJECTED_WIDTHS:
+        # Each geometry has two alternating hyperlink-marker variants.
+        while len(self._formatted_cache) > 2 * _MAX_PROJECTED_WIDTHS:
             self._formatted_cache.popitem(last=False)
         return result
 

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -16,8 +16,8 @@ from rich.cells import split_graphemes
 from wcwidth import wcswidth
 
 from .terminal_safety import (
+    _hyperlink_spans_from_safe_ansi,
     project_prompt_toolkit_ansi,
-    safe_hyperlink_spans,
     sanitize_transcript_ansi,
     strip_safe_ansi,
 )
@@ -321,7 +321,7 @@ class FullscreenTranscriptModel:
             record_ansi,
             separator + plain,
             bool(separator),
-            safe_hyperlink_spans(record_ansi, already_sanitized=True),
+            _hyperlink_spans_from_safe_ansi(record_ansi),
         )
         prior_ends_newline = self._ends_newline
         self._records.append(record)
@@ -401,7 +401,7 @@ class FullscreenTranscriptModel:
                     record_ansi,
                     separator + plain,
                     bool(separator),
-                    safe_hyperlink_spans(record_ansi, already_sanitized=True),
+                    _hyperlink_spans_from_safe_ansi(record_ansi),
                 )
             )
             accumulated_plain += separator + plain
@@ -465,7 +465,7 @@ class FullscreenTranscriptModel:
                 record_ansi,
                 first.plain[1:],
                 False,
-                safe_hyperlink_spans(record_ansi, already_sanitized=True),
+                _hyperlink_spans_from_safe_ansi(record_ansi),
             )
             # Selection endpoints are record-local character offsets. Removing
             # the synthetic joining newline must not move a selection that is

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from bisect import bisect_right
 from collections import OrderedDict
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from hashlib import sha256
 from unicodedata import normalize
@@ -73,7 +73,12 @@ class _ProjectedRow:
 class FullscreenTranscriptModel:
     """Ordered transcript plus bounded, incremental visual-row projections."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        show_trailing_blank: bool | Callable[[], bool] = True,
+    ) -> None:
+        self._show_trailing_blank = show_trailing_blank
         self._records: list[_Record] = []
         self._projectable_record_count = 0
         self._next_record_id = 0
@@ -107,7 +112,7 @@ class FullscreenTranscriptModel:
         if width is None:
             width = max(1, *(max(0, wcswidth(line)) for line in self.text.split("\n")))
         width = max(1, width)
-        rows = self._projection(width)
+        rows = self._display_rows(width)
         top = 0
         top_padding = 0
         if height is not None:
@@ -132,7 +137,7 @@ class FullscreenTranscriptModel:
 
     def cursor_position(self, *, width: int, height: int = 1) -> Point:
         """Expose a cursor within the virtualized visible transcript."""
-        rows = self._projection(width)
+        rows = self._display_rows(width)
         if not rows:
             return Point(x=0, y=0)
         top = self.top_row(width=width, height=height)
@@ -147,7 +152,7 @@ class FullscreenTranscriptModel:
 
     def top_row(self, *, width: int, height: int) -> int:
         """Return the exact first visual row for the current viewport."""
-        rows = self._projection(width)
+        rows = self._display_rows(width)
         if not rows:
             return 0
         if self._viewport.follows_tail or self._viewport.anchor is None:
@@ -160,7 +165,7 @@ class FullscreenTranscriptModel:
 
     def scroll_visual_lines(self, delta: int, *, width: int, height: int) -> None:
         """Move the top visual row; positive deltas move toward the tail."""
-        rows = self._projection(width)
+        rows = self._display_rows(width)
         if not rows:
             self.jump_to_tail()
             return
@@ -174,7 +179,7 @@ class FullscreenTranscriptModel:
         self._formatted_cache.clear()
 
     def jump_to_start(self, *, width: int) -> None:
-        rows = self._projection(width)
+        rows = self._display_rows(width)
         if rows:
             self._viewport = ViewportState(False, rows[0].anchor)
             self._formatted_cache.clear()
@@ -246,7 +251,7 @@ class FullscreenTranscriptModel:
     ) -> _SelectionHit | None:
         width = max(1, width)
         height = max(1, height)
-        rows = self._projection(width)
+        rows = self._display_rows(width)
         top = self.top_row(width=width, height=height)
         top_padding = max(0, height - len(rows)) if len(rows) <= height else 0
         visual_y = max(0, min(height - 1, y))
@@ -491,6 +496,22 @@ class FullscreenTranscriptModel:
         self._projection_cache.clear()
         self._projection_index_cache.clear()
         self._formatted_cache.clear()
+
+    def _display_rows(self, width: int) -> Sequence[_ProjectedRow]:
+        """Return viewport rows, optionally omitting the synthetic final blank."""
+        rows = self._projection(width)
+        show_trailing_blank = self._show_trailing_blank
+        if callable(show_trailing_blank):
+            show_trailing_blank = show_trailing_blank()
+        if (
+            not show_trailing_blank
+            and self._viewport.follows_tail
+            and self._records
+            and self._ends_newline
+            and len(rows) > 1
+        ):
+            return rows[:-1]
+        return rows
 
     def _projection(self, width: int) -> list[_ProjectedRow]:
         width = max(1, width)

--- a/packages/nooa-cli/src/nooa_cli/tui/main.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/main.py
@@ -19,6 +19,21 @@ if TYPE_CHECKING:
     from .config import Config
 
 
+def _prepare_splash(config, frontend) -> list:
+    """Route fullscreen splash output through the app; print native splash now."""
+    if config.no_splash:
+        return []
+
+    from .config import DisplayMode, resolve_display_mode
+    from .output import SplashScreen
+    from .splash import show_splash
+
+    if resolve_display_mode(config.tui) is DisplayMode.FULLSCREEN:
+        return [SplashScreen()]
+    show_splash(frontend.raw_console)
+    return []
+
+
 async def main(
     config: "Config | None" = None,
     agent: "Agent | None" = None,
@@ -39,15 +54,13 @@ async def main(
     from .frontend import TerminalFrontend
     from .output import TextOutput, _RichReplayPayload
     from .session_manager import SESSIONS_DIR, build_resume_outputs
-    from .splash import show_splash
 
     if config is None:
         config = Config.load()
 
     # Terminal-specific: create frontend and splash screen
     frontend = TerminalFrontend(config)
-    if not config.no_splash:
-        show_splash(frontend.raw_console)
+    _splash_outputs = _prepare_splash(config, frontend)
 
     # Shared bootstrap: tracing, LLM, storage, agent, session manager
     result = await bootstrap(
@@ -58,7 +71,7 @@ async def main(
     )
 
     _startup_info = build_startup_info(result)
-    _initial_outputs = [*result.messages, _startup_info]
+    _initial_outputs = [*_splash_outputs, *result.messages, _startup_info]
 
     # Show resumed session history (interleaved with any rich content). Terminal
     # text/markdown outputs are deferred until Session.run(), after the frontend

--- a/packages/nooa-cli/src/nooa_cli/tui/output.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/output.py
@@ -133,6 +133,14 @@ class CodeExecution:
         }
 
 
+@dataclass(frozen=True)
+class SplashScreen:
+    """Responsive NOOA splash rendered by the active frontend."""
+
+    def to_json(self) -> dict:
+        return {"type": "splash"}
+
+
 @dataclass
 class StartupInfo:
     """Structured startup banner data."""
@@ -395,6 +403,7 @@ Output = (
     | HelpOutput
     | AgentMessage
     | CodeExecution
+    | SplashScreen
     | StartupInfo
     | ClearScreen
     | Thinking

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -118,11 +118,13 @@ class _EmitStream:
         self,
         emit: Callable[..., None],
         replay_width: Callable[[], int] | None = None,
+        layout_width: Callable[[], int] | None = None,
         clear: Callable[[], None] | None = None,
     ) -> None:
         self.supports_semantic_replay = True
         self._emit = emit
         self._replay_width = replay_width
+        self._layout_width = layout_width
         self._clear = clear
         self._buf: list[str] = []
         self._held = 0
@@ -154,6 +156,15 @@ class _EmitStream:
             return default
         try:
             return int(self._replay_width())
+        except Exception:
+            return default
+
+    def layout_width(self, default: int = 80) -> int:
+        """Return the full application viewport width for renderer-owned UI."""
+        if self._layout_width is None:
+            return self.replay_width(default)
+        try:
+            return int(self._layout_width())
         except Exception:
             return default
 
@@ -597,6 +608,7 @@ class Session:
                     file=_EmitStream(
                         self._app.emit_block,
                         replay_width=lambda app=self._app: app.transcript_columns(),
+                        layout_width=lambda app=self._app: app.output_columns(minimum=1),
                         clear=self._app.clear_transcript,
                     ),  # type: ignore[arg-type]
                     force_terminal=True,
@@ -1411,13 +1423,16 @@ class Session:
         agent_runner = getattr(self, "_local_agent_runner", None)
         if agent_runner is not None:
             await agent_runner.shutdown_queue_manager(flush=True)
+        app = getattr(self, "_app", None)
+        clear_handoffs = getattr(app, "clear_pending_input_handoffs", None)
+        if callable(clear_handoffs):
+            clear_handoffs()
         if self._session_manager is not None:
             # Save snapshot before closing so /clear, /session new, and
             # /session resume don't lose the current session's self.v/todo.
             storage = getattr(self.agent, "_storage", None)
             if storage is not None and hasattr(storage, "save_snapshot"):
                 try:
-                    app = getattr(self, "_app", None)
                     if app is not None:
                         await agent_runner.run_async(lambda: storage.save_snapshot(self.agent))
                     else:

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -1282,6 +1282,9 @@ class Session:
             self._app.emit_block(bar, **emit_kwargs)
         else:
             self._app.emit_block(bar, replay=replay, **emit_kwargs)
+        # This runs on the UI owner; emit_block has committed the transcript
+        # source, so queue fallback can now disappear without a blank frame.
+        self._app.complete_pending_input_handoff(text)
         self._renderer.reset_turn()
 
     def _loud_handler(self, _loop: asyncio.AbstractEventLoop, context: dict) -> None:

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -249,6 +249,8 @@ class Session:
         self._toolbar = ToolbarRegistry()
         self._initial_outputs = list(initial_outputs or [])
         self._session_title_requested = False
+        # Invalidates user-message UI callbacks queued before a session swap.
+        self._session_generation = 0
 
         # Streaming state shared with the AgentEventRenderer: the
         # tool_call_id → code map that pairs a preview with its matching
@@ -562,6 +564,7 @@ class Session:
         if agent_runner is not None:
 
             def _on_user_message_hook(text: str) -> None:
+                generation = self._session_generation
                 # DB writes run here on the agent loop thread (the on_get
                 # caller), keeping all sqlite access on one thread.
                 user_event_id = None
@@ -579,20 +582,31 @@ class Session:
                 app = self._app
                 loop = getattr(app, "_loop", None) if app is not None else None
                 if loop is None:
-                    self._on_user_message_ui(text, event_id=user_event_id, tags=user_tags)
+                    self._on_user_message_ui(
+                        text,
+                        event_id=user_event_id,
+                        tags=user_tags,
+                        session_generation=generation,
+                    )
                     return
                 try:
                     on_ui_loop = asyncio.get_running_loop() is loop
                 except RuntimeError:
                     on_ui_loop = False
                 if on_ui_loop:
-                    self._on_user_message_ui(text, event_id=user_event_id, tags=user_tags)
+                    self._on_user_message_ui(
+                        text,
+                        event_id=user_event_id,
+                        tags=user_tags,
+                        session_generation=generation,
+                    )
                 else:
                     loop.call_soon_threadsafe(
                         lambda: self._on_user_message_ui(
                             text,
                             event_id=user_event_id,
                             tags=user_tags,
+                            session_generation=generation,
                         )
                     )
 
@@ -1218,6 +1232,7 @@ class Session:
         *,
         event_id: str | None = None,
         tags: set[str] | frozenset[str] | None = None,
+        session_generation: int | None = None,
     ) -> None:
         """Render the user's submitted text as a full-width grey bar and
         reset per-turn renderer state.
@@ -1225,6 +1240,8 @@ class Session:
         DB bookkeeping (record_user) is handled by the on_get hook on
         the agent loop thread; this method only does UI work.
         """
+        if session_generation is not None and session_generation != self._session_generation:
+            return
         assert self._renderer is not None and self._app is not None
 
         bar = _build_user_bar(text, self._app, self._colors)
@@ -1423,6 +1440,9 @@ class Session:
         agent_runner = getattr(self, "_local_agent_runner", None)
         if agent_runner is not None:
             await agent_runner.shutdown_queue_manager(flush=True)
+        # Queue shutdown above lets old-session dequeue hooks finish. Invalidate
+        # only their already-scheduled UI work before changing session state.
+        self._session_generation = getattr(self, "_session_generation", 0) + 1
         app = getattr(self, "_app", None)
         clear_handoffs = getattr(app, "clear_pending_input_handoffs", None)
         if callable(clear_handoffs):

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -54,28 +54,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-def _hex_to_ansi256(hex_color: str) -> int:
-    """Convert a ``#rrggbb`` hex string to the nearest xterm-256 index.
-
-    Used when we render ANSI directly (e.g. the user-message bar) and
-    can't rely on Rich's width/wrap logic to emit correctly-padded
-    terminal output.
-    """
-    h = hex_color.lstrip("#")
-    r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
-
-    # 6x6x6 color cube starting at index 16.
-    def _q(v: int) -> int:
-        # 0,95,135,175,215,255 — standard xterm cube steps.
-        if v < 48:
-            return 0
-        if v < 115:
-            return 1
-        return (v - 35) // 40
-
-    return 16 + 36 * _q(r) + 6 * _q(g) + _q(b)
-
-
 def _effective_slash_output_to_agent(agent: Any, slash_result: Any) -> bool:
     """Return fresh output routing for a slash result.
 

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -24,7 +24,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from rich.cells import chop_cells, set_cell_size
 from rich.console import Console as RichConsole
 from rich.text import Text
 
@@ -34,6 +33,7 @@ from .terminal_safety import (
     normalize_transcript_block,
     sanitize_live_text,
 )
+from .user_message import render_user_bar
 
 logger = logging.getLogger(__name__)
 
@@ -106,22 +106,7 @@ def _effective_slash_output_to_agent(agent: Any, slash_result: Any) -> bool:
 
 
 def _build_user_bar(text: str, app: "TUIApplication", colors: dict) -> str:
-    """Build a highlighted user-message bar as safe raw ANSI.
-
-    Bypasses Rich because reconciling Rich's wrap/crop/overflow logic
-    with manual ``ljust`` padding is brittle across Rich versions and
-    terminal emulators — direct CSI emission always renders the full
-    width-spanning highlighted row the spec asks for.
-
-    Each input line becomes one bar row (or more when it wraps):
-      ``ESC[fg;bg m{prefix}{line}{padding}{ ESC[0m}\\n``
-    where the first row carries the ``❯`` prompt glyph and
-    continuation rows start flush-left.
-    """
-    # Prefer prompt_toolkit's live width — ``run_in_terminal`` will use
-    # this number when writing above the prompt. Falls back to the
-    # terminal_cols helper if the app output can't report.
-    cols: int
+    """Build a live highlighted user-message bar at the transcript width."""
     try:
         cols = app.transcript_columns()
     except Exception:
@@ -131,21 +116,7 @@ def _build_user_bar(text: str, app: "TUIApplication", colors: dict) -> str:
             from .tui_application import terminal_cols
 
             cols = max(terminal_cols(minimum=1) - 1, 1)
-
-    fg = _hex_to_ansi256(colors["text"])
-    bg = _hex_to_ansi256(colors["surface2"])
-    on = f"\x1b[38;5;{fg};48;5;{bg}m"
-    off = "\x1b[0m"
-
-    rows: list[str] = []
-    for i, line in enumerate(sanitize_live_text(text).split("\n")):
-        shown = f" ❯ {line} " if i == 0 else f" {line} "
-        # Rich's cell helpers preserve grapheme clusters and measure wide
-        # glyphs correctly.  Every row is exactly the safe content width,
-        # which is one cell narrower than the physical terminal.
-        chunks = chop_cells(shown, cols) or [""]
-        rows.extend(f"{on}{set_cell_size(chunk, cols)}{off}" for chunk in chunks)
-    return "\n".join(rows) + "\n"
+    return render_user_bar(text, cols, colors)
 
 
 class _EmitStream:

--- a/packages/nooa-cli/src/nooa_cli/tui/splash.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/splash.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import io
 import time
 from typing import Literal
 
@@ -88,6 +89,21 @@ def build_splash(width: int) -> Group:
     return Group(blank, Align.center(lab), Align.center(wordmark), Align.center(subtitle), blank)
 
 
+def render_splash_to_ansi(width: int) -> str:
+    """Render the responsive splash as ANSI for application-owned output."""
+    render_width = max(int(width), 1)
+    stream = io.StringIO()
+    console = Console(
+        file=stream,
+        width=render_width,
+        color_system="256",
+        force_terminal=True,
+        _environ={"COLUMNS": str(render_width), "LINES": "25"},
+    )
+    console.print(build_splash(render_width))
+    return stream.getvalue()
+
+
 def show_splash(console: Console, delay: float = 0.0) -> None:
     """Print the responsive NOOA splash without delaying normal startup."""
     console.print(build_splash(console.width))
@@ -95,4 +111,10 @@ def show_splash(console: Console, delay: float = 0.0) -> None:
         time.sleep(delay)
 
 
-__all__ = ["NOOA_ASCII", "build_splash", "show_splash", "splash_variant"]
+__all__ = [
+    "NOOA_ASCII",
+    "build_splash",
+    "render_splash_to_ansi",
+    "show_splash",
+    "splash_variant",
+]

--- a/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
@@ -172,6 +172,33 @@ def hyperlink_at_plain_offset(value: str, offset: int) -> str | None:
     return active if plain_offset == offset else None
 
 
+def safe_hyperlink_spans(value: str) -> tuple[tuple[int, int, str], ...]:
+    """Return safe OSC-8 targets as spans in ANSI-stripped character offsets."""
+    safe = sanitize_transcript_ansi(value)
+    spans: list[tuple[int, int, str]] = []
+    active: tuple[int, str] | None = None
+    plain_offset = 0
+    index = 0
+    while index < len(safe):
+        match = _SAFE_ANSI_RE.match(safe, index)
+        if match is not None:
+            sequence = match.group(0)
+            if sequence.startswith(f"{_ESC}]8;"):
+                if active is not None and active[0] < plain_offset:
+                    spans.append((active[0], plain_offset, active[1]))
+                payload = sequence[4:-1] if sequence.endswith("\x07") else sequence[4:-2]
+                _parameters, _separator, target = payload.partition(";")
+                url = safe_http_url(target)
+                active = (plain_offset, url) if url is not None else None
+            index = match.end()
+            continue
+        plain_offset += 1
+        index += 1
+    if active is not None and active[0] < plain_offset:
+        spans.append((active[0], plain_offset, active[1]))
+    return tuple(spans)
+
+
 def strip_safe_ansi(value: str) -> str:
     """Strip the presentation escapes accepted by ``sanitize_transcript_ansi``."""
     return _SAFE_ANSI_RE.sub("", value)

--- a/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
@@ -143,7 +143,10 @@ def safe_http_url(value: str | None) -> str | None:
     if (
         not value
         or len(value) > _MAX_SAFE_HTTP_URL_LENGTH
-        or any(character.isspace() for character in value)
+        or any(
+            character.isspace() or ord(character) < 0x20 or 0x7F <= ord(character) <= 0x9F
+            for character in value
+        )
     ):
         return None
     try:
@@ -157,25 +160,12 @@ def safe_http_url(value: str | None) -> str | None:
 
 def hyperlink_at_plain_offset(value: str, offset: int) -> str | None:
     """Return the active safe OSC-8 target at one ANSI-stripped character offset."""
-    safe = sanitize_transcript_ansi(value)
-    active: str | None = None
-    plain_offset = 0
-    index = 0
-    while index < len(safe):
-        match = _SAFE_ANSI_RE.match(safe, index)
-        if match is not None:
-            sequence = match.group(0)
-            if sequence.startswith(f"{_ESC}]8;"):
-                payload = sequence[4:-1] if sequence.endswith("\x07") else sequence[4:-2]
-                _parameters, _separator, target = payload.partition(";")
-                active = safe_http_url(target)
-            index = match.end()
-            continue
-        if plain_offset == offset:
-            return active
-        plain_offset += 1
-        index += 1
-    return active if plain_offset == offset else None
+    for start, stop, target in safe_hyperlink_spans(value):
+        if start <= offset < stop:
+            return target
+        if start > offset:
+            break
+    return None
 
 
 def safe_hyperlink_spans(value: str) -> tuple[tuple[int, int, str], ...]:

--- a/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import re
 import shutil
+from urllib.parse import urlsplit
 
 from rich.cells import split_graphemes
 
@@ -133,6 +134,42 @@ def sanitize_transcript_ansi(value: str) -> str:
             output.append(character)
         index += 1
     return "".join(output)
+
+
+def safe_http_url(value: str | None) -> str | None:
+    """Return a control-free HTTP(S) URL suitable for an explicit browser launch."""
+    if not value or any(character.isspace() for character in value):
+        return None
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return None
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    return value
+
+
+def hyperlink_at_plain_offset(value: str, offset: int) -> str | None:
+    """Return the active safe OSC-8 target at one ANSI-stripped character offset."""
+    safe = sanitize_transcript_ansi(value)
+    active: str | None = None
+    plain_offset = 0
+    index = 0
+    while index < len(safe):
+        match = _SAFE_ANSI_RE.match(safe, index)
+        if match is not None:
+            sequence = match.group(0)
+            if sequence.startswith(f"{_ESC}]8;"):
+                payload = sequence[4:-1] if sequence.endswith("\x07") else sequence[4:-2]
+                _parameters, _separator, target = payload.partition(";")
+                active = safe_http_url(target)
+            index = match.end()
+            continue
+        if plain_offset == offset:
+            return active
+        plain_offset += 1
+        index += 1
+    return active if plain_offset == offset else None
 
 
 def strip_safe_ansi(value: str) -> str:

--- a/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
@@ -168,11 +168,15 @@ def hyperlink_at_plain_offset(value: str, offset: int) -> str | None:
     return None
 
 
-def safe_hyperlink_spans(
-    value: str, *, already_sanitized: bool = False
-) -> tuple[tuple[int, int, str], ...]:
+def safe_hyperlink_spans(value: str) -> tuple[tuple[int, int, str], ...]:
     """Return safe OSC-8 targets as spans in ANSI-stripped character offsets."""
-    safe = value if already_sanitized else sanitize_transcript_ansi(value)
+    return _hyperlink_spans_from_safe_ansi(sanitize_transcript_ansi(value))
+
+
+def _hyperlink_spans_from_safe_ansi(
+    safe: str,
+) -> tuple[tuple[int, int, str], ...]:
+    """Extract hyperlink spans from text already normalized by this module."""
     spans: list[tuple[int, int, str]] = []
     active: tuple[int, str] | None = None
     plain_offset = 0

--- a/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
@@ -168,9 +168,11 @@ def hyperlink_at_plain_offset(value: str, offset: int) -> str | None:
     return None
 
 
-def safe_hyperlink_spans(value: str) -> tuple[tuple[int, int, str], ...]:
+def safe_hyperlink_spans(
+    value: str, *, already_sanitized: bool = False
+) -> tuple[tuple[int, int, str], ...]:
     """Return safe OSC-8 targets as spans in ANSI-stripped character offsets."""
-    safe = sanitize_transcript_ansi(value)
+    safe = value if already_sanitized else sanitize_transcript_ansi(value)
     spans: list[tuple[int, int, str]] = []
     active: tuple[int, str] | None = None
     plain_offset = 0

--- a/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
@@ -19,6 +19,8 @@ from rich.cells import split_graphemes
 
 _ESC = "\x1b"
 
+_MAX_SAFE_HTTP_URL_LENGTH = 2_048
+
 # This expression is used only after ``sanitize_transcript_ansi`` has reduced
 # the language to SGR and OSC-8.  It deliberately recognizes both OSC
 # terminators because Rich versions differ between BEL and ST.
@@ -138,7 +140,11 @@ def sanitize_transcript_ansi(value: str) -> str:
 
 def safe_http_url(value: str | None) -> str | None:
     """Return a control-free HTTP(S) URL suitable for an explicit browser launch."""
-    if not value or any(character.isspace() for character in value):
+    if (
+        not value
+        or len(value) > _MAX_SAFE_HTTP_URL_LENGTH
+        or any(character.isspace() for character in value)
+    ):
         return None
     try:
         parsed = urlsplit(value)

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2409,7 +2409,7 @@ class TUIApplication:
                 break
 
     def complete_pending_input_handoff(self, text: str) -> None:
-        """Retire the FIFO submissions represented by one consumed queue item."""
+        """Retire the submissions represented by one consumed queue item."""
         combined = ""
         consumed = 0
         for handoff in self._pending_input_handoff:
@@ -2418,6 +2418,13 @@ class TUIApplication:
             if combined == text or text.endswith(f"\n{combined}"):
                 del self._pending_input_handoff[:consumed]
                 break
+        else:
+            # A callback can arrive after another consumer has advanced the
+            # queue. Retire the matching admission without dropping older rows.
+            for index, handoff in enumerate(self._pending_input_handoff):
+                if handoff.text == text or text.endswith(f"\n{handoff.text}"):
+                    del self._pending_input_handoff[index]
+                    break
         if self._app.is_running:
             self._app.invalidate()
 

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -197,12 +197,14 @@ class _FullscreenTranscriptControl(FormattedTextControl):
         scroll_callback: Callable[[int], None],
         mouse_navigation_enabled: Callable[[], bool],
         selection_callback: Callable[[str, int, int], None],
+        link_callback: Callable[[int, int], bool],
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
         self._scroll_callback = scroll_callback
         self._mouse_navigation_enabled = mouse_navigation_enabled
         self._selection_callback = selection_callback
+        self._link_callback = link_callback
         self._render_width: int | None = None
         self._render_height: int | None = None
         self._dragging = False
@@ -304,7 +306,10 @@ class _FullscreenTranscriptControl(FormattedTextControl):
             self._selection_callback("extend", x, y)
             return None
         if mouse_event.event_type is MouseEventType.MOUSE_UP and self._dragging:
-            self._finish_drag(x, y, moved=self._drag_moved)
+            moved = self._drag_moved or self._drag_position != (x, y)
+            self._finish_drag(x, y, moved=moved)
+            if not moved:
+                self._link_callback(x, y)
             return None
         return super().mouse_handler(mouse_event)
 
@@ -770,6 +775,7 @@ class TUIApplication:
         self._transient_status_style = "class:status"
         self._transient_status_timer: asyncio.TimerHandle | None = None
         self._clipboard_task: asyncio.Task[None] | None = None
+        self._link_task: asyncio.Task[None] | None = None
 
         self._agent_controller = AgentController(
             _CallbackScheduler(self._schedule_agent_callback),
@@ -900,6 +906,7 @@ class TUIApplication:
                     scroll_callback=self._scroll_fullscreen_transcript,
                     mouse_navigation_enabled=lambda: self._fullscreen_mouse_navigation,
                     selection_callback=self._handle_fullscreen_selection,
+                    link_callback=self._open_fullscreen_link_at,
                 ),
                 wrap_lines=False,
                 # The model virtualizes formatted content to exactly the visible
@@ -1516,6 +1523,88 @@ class TUIApplication:
         if not isinstance(control, _FullscreenTranscriptControl) or not control.dragging:
             return False
         return control.handle_external_mouse(mouse_event, below=True)
+
+    def _open_fullscreen_link_at(self, x: int, y: int) -> bool:
+        """Open the safe HTTP(S) hyperlink under a click without affecting drag-copy."""
+        if not self._is_fullscreen:
+            return False
+        width, height = self._transcript_viewport_size()
+        url = self._fullscreen_transcript.hyperlink_at(x=x, y=y, width=width, height=height)
+        if url is None:
+            return False
+
+        # A browser on an SSH host is not the user's browser. Reuse the
+        # remote-aware clipboard path (OSC 52 fallback) so the URL reaches the
+        # terminal that received the click without launching anything remotely.
+        if os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY"):
+            self._start_fullscreen_selection_copy(url)
+            return True
+
+        # Opening a URL is irreversible. Ignore duplicate clicks while one
+        # launch is in flight rather than cancelling an await whose subprocess
+        # may already have accepted the request.
+        if self._link_task is not None and not self._link_task.done():
+            return True
+
+        async def open_link() -> None:
+            task = asyncio.current_task()
+            try:
+                opened = await self._open_local_url(url)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug("failed to open transcript hyperlink", exc_info=True)
+                opened = False
+            finally:
+                if self._link_task is task:
+                    self._link_task = None
+            if not opened:
+                # A local machine without a browser helper still gets a useful,
+                # explicit result instead of a swallowed click.
+                self._start_fullscreen_selection_copy(url)
+
+        self._link_task = asyncio.create_task(open_link())
+        return True
+
+    @staticmethod
+    def _browser_open_command(url: str) -> tuple[str, ...] | None:
+        """Return a direct-argv browser opener, avoiding shell interpretation."""
+        candidates = (
+            ("open", (url,)),
+            ("xdg-open", (url,)),
+            ("wslview", (url,)),
+            ("gio", ("open", url)),
+            ("rundll32.exe", ("url.dll,FileProtocolHandler", url)),
+        )
+        for executable, arguments in candidates:
+            path = shutil.which(executable)
+            if path is not None:
+                return (path, *arguments)
+        return None
+
+    async def _open_local_url(self, url: str) -> bool:
+        """Launch a validated URL with a cancellable local helper process."""
+        command = self._browser_open_command(url)
+        if command is None:
+            return False
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        except OSError:
+            return False
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5)
+        except asyncio.CancelledError:
+            await self._terminate_clipboard_process(process)
+            raise
+        except TimeoutError:
+            await self._terminate_clipboard_process(process)
+            return False
+        return process.returncode == 0
 
     def _handle_fullscreen_selection(self, action: str, x: int, y: int) -> None:
         """Apply one mouse-selection transition and copy on button release."""
@@ -2459,6 +2548,15 @@ class TUIApplication:
                     pass
                 if self._clipboard_task is clipboard_task:
                     self._clipboard_task = None
+            link_task = self._link_task
+            if link_task is not None:
+                link_task.cancel()
+                try:
+                    await link_task
+                except asyncio.CancelledError:
+                    pass
+                if self._link_task is link_task:
+                    self._link_task = None
             self._cancel_fullscreen_drag()
             # Restore sys.stdout / sys.stderr FIRST so any post-exit
             # prints from teardown code (spinner cleanup, snapshot save,

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -893,8 +893,9 @@ class TUIApplication:
         # tests and printable-transcript callers. Source-bearing blocks below
         # are the single retained representation used for terminal replay.
         self.output_buffer = Buffer(read_only=False)
+        self._status_region_occupied = False
         self._fullscreen_transcript = FullscreenTranscriptModel(
-            show_trailing_blank=lambda: not bool(self._status_rows())
+            show_trailing_blank=lambda: not self._status_region_occupied
         )
         # Fullscreen requests mouse reporting immediately so ordinary drag and
         # wheel gestures reach prompt_toolkit rather than terminal scrollback.
@@ -1009,6 +1010,7 @@ class TUIApplication:
                     lambda: self._fullscreen_transcript.formatted_text(
                         width=self._transcript_viewport_size()[0],
                         height=self._transcript_viewport_size()[1],
+                        render_counter=self._app.render_counter,
                     ),
                     focusable=False,
                     show_cursor=False,
@@ -1285,7 +1287,7 @@ class TUIApplication:
                 ),
                 filter=Condition(
                     lambda: (
-                        bool(self._status_rows())
+                        self._status_region_occupied
                         or not self._fullscreen_transcript.viewport.follows_tail
                     )
                 ),
@@ -2316,11 +2318,27 @@ class TUIApplication:
         self.input_buffer.cursor_position = len(self.input_buffer.text)
 
     def _pending_input_display(self) -> list[str]:
-        """Return text that queue chrome must show in the current frame."""
+        """Return runtime queue text plus admissions not yet reflected by it."""
         state = self._agent_controller.state
         pending = [] if state is None else list(state.pending_inputs)
         handoff = [item.text for item in self._pending_input_handoff]
-        return handoff or pending
+        if not handoff:
+            return pending
+        if not pending:
+            return handoff
+
+        # Runtime coalesces new admissions into its final queue item. Replace
+        # the represented suffix with the individual handoff rows, while
+        # retaining any runtime-owned prefix and every earlier queue item.
+        tail = pending[-1]
+        for represented in range(len(handoff), 0, -1):
+            combined = "\n".join(handoff[:represented])
+            if tail == combined:
+                return pending[:-1] + handoff
+            suffix = f"\n{combined}"
+            if tail.endswith(suffix):
+                return pending[:-1] + [tail[: -len(suffix)]] + handoff
+        return pending + handoff
 
     def submit_message(self, user_message: str) -> None:
         """Submit text through the current interactive agent."""
@@ -2367,10 +2385,8 @@ class TUIApplication:
         for handoff in self._pending_input_handoff:
             combined = f"{combined}\n{handoff.text}" if consumed else handoff.text
             consumed += 1
-            if combined == text:
+            if combined == text or text.endswith(f"\n{combined}"):
                 del self._pending_input_handoff[:consumed]
-                break
-            if not text.startswith(f"{combined}\n"):
                 break
         if self._app.is_running:
             self._app.invalidate()
@@ -2989,7 +3005,9 @@ class TUIApplication:
         return normalize_transcript_block(source, columns=self.transcript_columns())
 
     def _before_render(self, _app) -> None:
-        """Observe terminal geometry before prompt_toolkit renders a frame."""
+        """Observe frame-local status and terminal geometry before rendering."""
+        if self._is_fullscreen:
+            self._status_region_occupied = bool(self._status_rows())
         current = self._read_terminal_size()
         if current is None:
             return

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1072,6 +1072,7 @@ class TUIApplication:
                         self._scroll_fullscreen_transcript if self._is_fullscreen else None
                     ),
                 ),
+                wrap_lines=True,
                 dont_extend_height=True,
             ),
             filter=Condition(lambda: bool(_queue_pending()) or bool(self._command_queue_texts)),

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -227,6 +227,7 @@ class _FullscreenTranscriptControl(FormattedTextControl):
         self._link_callback = link_callback
         self._render_width: int | None = None
         self._render_height: int | None = None
+        self._formatted_geometry: tuple[int, int | None] | None = None
         self._dragging = False
         self._drag_moved = False
         self._drag_position = (0, 0)
@@ -240,12 +241,17 @@ class _FullscreenTranscriptControl(FormattedTextControl):
         return self._render_width, self._render_height
 
     def create_content(self, width: int, height: int | None):
-        # Window supplies current-frame geometry before requesting fragments.
-        # This avoids reusing Window.render_info from the previous frame on
-        # height-only resize and on the first frame after closing a subview.
+        # ``preferred_height`` asks for content with ``height=None`` before the
+        # concrete window height is allocated. Keep that measurement useful,
+        # but do not let its render-counter cache poison the paint that follows
+        # when bottom chrome changed this frame.
         self._render_width = max(1, width)
         if height is not None:
             self._render_height = max(1, height)
+        geometry = (self._render_width, self._render_height)
+        if geometry != self._formatted_geometry:
+            self._fragment_cache.clear()
+            self._formatted_geometry = geometry
         content = super().create_content(width, height)
 
         def get_line(index: int):

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2397,6 +2397,12 @@ class TUIApplication:
         if self._app.is_running:
             self._app.invalidate()
 
+    def clear_pending_input_handoffs(self) -> None:
+        """Discard optimistic queue rows after the runtime queue is flushed."""
+        self._pending_input_handoff.clear()
+        if self._app.is_running:
+            self._app.invalidate()
+
     def _schedule_agent_callback(self, callback: Callable[[], None]) -> None:
         """Marshal agent observation delivery onto the prompt-toolkit owner loop."""
         loop = self._loop

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -497,11 +497,13 @@ class _NativeSelectionBufferControl(BufferControl):
         *args: Any,
         transcript_drag_callback: Callable[[MouseEvent], bool] | None = None,
         transcript_scroll_callback: Callable[[int], None] | None = None,
+        selection_copy_callback: Callable[[str], None] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
         self._transcript_drag_callback = transcript_drag_callback
         self._transcript_scroll_callback = transcript_scroll_callback
+        self._selection_copy_callback = selection_copy_callback
 
     def mouse_handler(self, mouse_event: MouseEvent):
         if (
@@ -519,7 +521,20 @@ class _NativeSelectionBufferControl(BufferControl):
         if delta is not None and self._transcript_scroll_callback is not None:
             self._transcript_scroll_callback(delta)
             return None
-        return super().mouse_handler(mouse_event)
+        result = super().mouse_handler(mouse_event)
+        if (
+            mouse_event.event_type is MouseEventType.MOUSE_UP
+            and self.buffer.selection_state is not None
+            and self._selection_copy_callback is not None
+        ):
+            # macOS terminals consume Command-C themselves, but cannot see a
+            # prompt_toolkit-owned selection. Mirror a completed mouse
+            # selection to the system clipboard so Command-C has the expected
+            # result without deleting or hiding the selected composer text.
+            _document, clipboard_data = self.buffer.document.cut_selection()
+            if clipboard_data.text:
+                self._selection_copy_callback(clipboard_data.text)
+        return result
 
 
 class _NativeSelectionCompletionsMenuControl(CompletionsMenuControl):
@@ -1088,6 +1103,9 @@ class TUIApplication:
                 ),
                 transcript_scroll_callback=(
                     self._scroll_fullscreen_transcript if self._is_fullscreen else None
+                ),
+                selection_copy_callback=(
+                    self._copy_input_selection if self._is_fullscreen else None
                 ),
             ),
             wrap_lines=True,
@@ -1844,6 +1862,11 @@ class TUIApplication:
                 self._start_fullscreen_selection_copy(text)
         if self._app.is_running:
             self._app.invalidate()
+
+    def _copy_input_selection(self, text: str) -> None:
+        """Mirror a prompt_toolkit composer selection to app and system clipboards."""
+        self._app.clipboard.set_text(text)
+        self._start_fullscreen_selection_copy(text)
 
     def _start_fullscreen_selection_copy(self, text: str) -> None:
         """Copy without blocking prompt_toolkit's event loop on local helpers."""

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2852,6 +2852,8 @@ class TUIApplication:
                     await clipboard_task
                 except asyncio.CancelledError:
                     pass
+                except Exception:
+                    logger.debug("clipboard task failed during teardown", exc_info=True)
                 if self._clipboard_task is clipboard_task:
                     self._clipboard_task = None
             link_task = self._link_task
@@ -2861,6 +2863,8 @@ class TUIApplication:
                     await link_task
                 except asyncio.CancelledError:
                     pass
+                except Exception:
+                    logger.debug("link task failed during teardown", exc_info=True)
                 if self._link_task is link_task:
                     self._link_task = None
             self._cancel_fullscreen_drag()

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -173,7 +173,6 @@ class _GraphemeWindow(Window):
             escape_row = new_screen.zero_width_escapes[ypos + screen_y]
             for screen_x in range(xpos, xpos + width + 1):
                 escape_row.pop(screen_x, None)
-
             x = xpos
             logical_cell = 0
             for start, stop, cells in FullscreenTranscriptModel._grapheme_spans(styled_chars):
@@ -354,8 +353,12 @@ class _FullscreenTranscriptControl(FormattedTextControl):
             MouseEventType.MOUSE_UP,
         ):
             return False
+        width = max(1, self._render_width or 1)
         height = max(1, self._render_height or 1)
-        x = max(0, mouse_event.position.x)
+        # Coordinates are local to whichever chrome child received the event.
+        # Once a downward drag leaves the transcript, clamp to its true lower-
+        # right boundary instead of interpreting a right-side child's local x.
+        x = width - 1 if below else 0
         y = height - 1 if below else 0
         self._drag_moved = True
         self._drag_position = (x, y)
@@ -465,6 +468,12 @@ class _FullscreenDragBoundaryControl(FormattedTextControl):
         self._transcript_scroll_callback = transcript_scroll_callback
 
     def mouse_handler(self, mouse_event: MouseEvent):
+        if (
+            MouseModifier.ALT in mouse_event.modifiers
+            or MouseModifier.SHIFT in mouse_event.modifiers
+        ):
+            self._transcript_drag_callback(mouse_event)
+            return NotImplemented
         if self._transcript_drag_callback(mouse_event):
             return None
         delta = _fullscreen_wheel_delta(mouse_event)
@@ -493,6 +502,8 @@ class _NativeSelectionBufferControl(BufferControl):
             MouseModifier.ALT in mouse_event.modifiers
             or MouseModifier.SHIFT in mouse_event.modifiers
         ):
+            if self._transcript_drag_callback is not None:
+                self._transcript_drag_callback(mouse_event)
             return NotImplemented
         if self._transcript_drag_callback is not None and self._transcript_drag_callback(
             mouse_event
@@ -506,34 +517,99 @@ class _NativeSelectionBufferControl(BufferControl):
 
 
 class _NativeSelectionCompletionsMenuControl(CompletionsMenuControl):
-    """Completion menu that leaves native-selection modifiers unconsumed."""
+    """Completion menu that preserves native selection and transcript gestures."""
+
+    def __init__(
+        self,
+        *args: Any,
+        transcript_drag_callback: Callable[[MouseEvent], bool] | None = None,
+        transcript_scroll_callback: Callable[[int], None] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._transcript_drag_callback = transcript_drag_callback
+        self._transcript_scroll_callback = transcript_scroll_callback
 
     def mouse_handler(self, mouse_event: MouseEvent):
         if (
             MouseModifier.ALT in mouse_event.modifiers
             or MouseModifier.SHIFT in mouse_event.modifiers
         ):
+            if self._transcript_drag_callback is not None:
+                self._transcript_drag_callback(mouse_event)
             return NotImplemented
+        if self._transcript_drag_callback is not None and self._transcript_drag_callback(
+            mouse_event
+        ):
+            return None
+        delta = _fullscreen_wheel_delta(mouse_event)
+        if delta is not None and self._transcript_scroll_callback is not None:
+            self._transcript_scroll_callback(delta)
+            return None
         return super().mouse_handler(mouse_event)
+
+
+def _native_hyperlink_boundary(
+    fragments: list[tuple[str, str]], *, render_counter: int
+) -> list[tuple[str, str]]:
+    """Close transcript OSC-8 state before painting an adjacent chrome row."""
+    boundary = [("[ZeroWidthEscape]", "\x1b]8;;\x1b\\")]
+    for index, (style, text) in enumerate(fragments):
+        if not text:
+            boundary.append((style, text))
+            continue
+        # prompt_toolkit emits zero-width escapes only when their cell is
+        # repainted. Alternate one invisible class on the first chrome cell so
+        # every frame emits the close, without invalidating the whole row.
+        marker = f"class:native-hyperlink-boundary-{render_counter & 1}"
+        boundary.append((f"{style} {marker}".strip(), text[:1]))
+        if text[1:]:
+            boundary.append((style, text[1:]))
+        boundary.extend(fragments[index + 1 :])
+        break
+    return boundary
 
 
 class _ReturnToTailControl(FormattedTextControl):
     """One-row fullscreen affordance for resuming live transcript output."""
 
-    def __init__(self, callback: Callable[[], None]) -> None:
+    def __init__(
+        self,
+        callback: Callable[[], None],
+        *,
+        transcript_drag_callback: Callable[[MouseEvent], bool] | None = None,
+        transcript_scroll_callback: Callable[[int], None] | None = None,
+        render_counter: Callable[[], int] = lambda: 0,
+    ) -> None:
         super().__init__(
-            lambda: [("class:return-to-tail", "↓ Return to bottom (Ctrl+End)")],
+            lambda: _native_hyperlink_boundary(
+                [("class:return-to-tail", " ↓ Return to bottom (Ctrl+End)")],
+                render_counter=render_counter(),
+            ),
             focusable=False,
             show_cursor=False,
         )
         self._callback = callback
+        self._transcript_drag_callback = transcript_drag_callback
+        self._transcript_scroll_callback = transcript_scroll_callback
 
     def mouse_handler(self, mouse_event: MouseEvent):
         if (
-            mouse_event.button is not MouseButton.LEFT
-            or MouseModifier.ALT in mouse_event.modifiers
+            MouseModifier.ALT in mouse_event.modifiers
             or MouseModifier.SHIFT in mouse_event.modifiers
         ):
+            if self._transcript_drag_callback is not None:
+                self._transcript_drag_callback(mouse_event)
+            return NotImplemented
+        if self._transcript_drag_callback is not None and self._transcript_drag_callback(
+            mouse_event
+        ):
+            return None
+        delta = _fullscreen_wheel_delta(mouse_event)
+        if delta is not None and self._transcript_scroll_callback is not None:
+            self._transcript_scroll_callback(delta)
+            return None
+        if mouse_event.button is not MouseButton.LEFT:
             return NotImplemented
         if mouse_event.event_type is MouseEventType.MOUSE_DOWN:
             return None
@@ -971,11 +1047,23 @@ class TUIApplication:
                     rows.append(f"│ {line}")
             if not rows:
                 return []
-            return [("class:queue", "\n".join(rows))]
+            fragments = [("class:queue", "\n".join(rows))]
+            if self._is_fullscreen:
+                return _native_hyperlink_boundary(
+                    fragments, render_counter=self._app.render_counter
+                )
+            return fragments
 
         queue_window = ConditionalContainer(
             Window(
-                FormattedTextControl(_queue_formatted, focusable=False),
+                _FullscreenDragBoundaryControl(
+                    _queue_formatted,
+                    focusable=False,
+                    transcript_drag_callback=self._handle_fullscreen_drag_over_bottom_chrome,
+                    transcript_scroll_callback=(
+                        self._scroll_fullscreen_transcript if self._is_fullscreen else None
+                    ),
+                ),
                 dont_extend_height=True,
             ),
             filter=Condition(lambda: bool(_queue_pending()) or bool(self._command_queue_texts)),
@@ -1000,11 +1088,26 @@ class TUIApplication:
         )
         self._input_window = input_window
         optional_row = Dimension(min=0, preferred=1, max=1)
+
+        def _input_padding_window() -> Window:
+            return Window(
+                _FullscreenDragBoundaryControl(
+                    lambda: [("", " ")],
+                    focusable=False,
+                    transcript_drag_callback=self._handle_fullscreen_drag_over_bottom_chrome,
+                    transcript_scroll_callback=(
+                        self._scroll_fullscreen_transcript if self._is_fullscreen else None
+                    ),
+                ),
+                height=optional_row,
+                style=input_style,
+            )
+
         self._input_container = HSplit(
             [
-                Window(height=optional_row, char=" ", style=input_style),
+                _input_padding_window(),
                 input_window,
-                Window(height=optional_row, char=" ", style=input_style),
+                _input_padding_window(),
             ],
             style=input_style,
             # The children above have a one-row aggregate minimum.  Keep a
@@ -1021,6 +1124,10 @@ class TUIApplication:
                 if index:
                     fragments.append(("class:status", "   " if self._is_fullscreen else "\n\n"))
                 fragments.extend((style, sanitize_live_text(text)) for style, text in row)
+            if self._is_fullscreen:
+                return _native_hyperlink_boundary(
+                    fragments, render_counter=self._app.render_counter
+                )
             return fragments
 
         def _status_height() -> Dimension:
@@ -1047,14 +1154,20 @@ class TUIApplication:
 
         self._transient_status_container = ConditionalContainer(
             Window(
-                FormattedTextControl(
-                    lambda: [
-                        (
-                            self._transient_status_style,
-                            sanitize_live_text(self._transient_status_text),
-                        )
-                    ],
+                _FullscreenDragBoundaryControl(
+                    lambda: _native_hyperlink_boundary(
+                        [
+                            ("class:status", " "),
+                            (
+                                self._transient_status_style,
+                                sanitize_live_text(self._transient_status_text),
+                            ),
+                        ],
+                        render_counter=self._app.render_counter,
+                    ),
                     focusable=False,
+                    transcript_drag_callback=self._handle_fullscreen_drag_over_bottom_chrome,
+                    transcript_scroll_callback=self._scroll_fullscreen_transcript,
                 ),
                 height=1,
                 dont_extend_width=True,
@@ -1062,7 +1175,12 @@ class TUIApplication:
             filter=Condition(lambda: self._is_fullscreen and bool(self._transient_status_text)),
         )
 
-        self._return_to_tail_control = _ReturnToTailControl(self._jump_fullscreen_to_tail)
+        self._return_to_tail_control = _ReturnToTailControl(
+            self._jump_fullscreen_to_tail,
+            transcript_drag_callback=self._handle_fullscreen_drag_over_bottom_chrome,
+            transcript_scroll_callback=self._scroll_fullscreen_transcript,
+            render_counter=lambda: self._app.render_counter,
+        )
         self._return_to_tail_container = ConditionalContainer(
             Window(
                 self._return_to_tail_control,
@@ -1084,10 +1202,22 @@ class TUIApplication:
             label = self._session_label_fn() if self._session_label_fn is not None else ""
             current = self._read_terminal_size()
             columns = current[0] if current is not None else terminal_cols(minimum=1)
-            return format_session_rule(columns, label)
+            fragments = format_session_rule(columns, label)
+            if self._is_fullscreen:
+                return _native_hyperlink_boundary(
+                    fragments, render_counter=self._app.render_counter
+                )
+            return fragments
 
         session_rule = Window(
-            FormattedTextControl(_session_rule_formatted, focusable=False),
+            _FullscreenDragBoundaryControl(
+                _session_rule_formatted,
+                focusable=False,
+                transcript_drag_callback=self._handle_fullscreen_drag_over_bottom_chrome,
+                transcript_scroll_callback=(
+                    self._scroll_fullscreen_transcript if self._is_fullscreen else None
+                ),
+            ),
             height=optional_row,
         )
 
@@ -1117,11 +1247,18 @@ class TUIApplication:
 
         completions_window = ConditionalContainer(
             Window(
-                content=_NativeSelectionCompletionsMenuControl(),
+                content=_NativeSelectionCompletionsMenuControl(
+                    transcript_drag_callback=self._handle_fullscreen_drag_over_bottom_chrome,
+                    transcript_scroll_callback=(
+                        self._scroll_fullscreen_transcript if self._is_fullscreen else None
+                    ),
+                ),
                 width=Dimension(min=8),
                 height=_completions_height,
                 dont_extend_height=True,
-                right_margins=[ScrollbarMargin(display_arrows=True)],
+                right_margins=(
+                    [] if self._is_fullscreen else [ScrollbarMargin(display_arrows=True)]
+                ),
             ),
             filter=Condition(
                 lambda: (
@@ -1145,7 +1282,6 @@ class TUIApplication:
                         self._transient_status_container,
                         self._return_to_tail_container,
                     ],
-                    padding=1,
                 ),
                 filter=Condition(
                     lambda: (

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -150,12 +150,23 @@ class _GraphemeWindow(Window):
             for x in range(xpos, xpos + width):
                 row[x] = Char()
             fragments = ui_content.get_line(line_number)
-            styled_chars = [
-                (style, char)
-                for style, text, *_rest in fragments
-                if "[ZeroWidthEscape]" not in style
-                for char in text
-            ]
+            styled_chars: list[tuple[str, str]] = []
+            raw_at_offset: dict[int, str] = {}
+            for style, text, *_rest in fragments:
+                if "[ZeroWidthEscape]" in style:
+                    raw_at_offset[len(styled_chars)] = raw_at_offset.get(
+                        len(styled_chars), ""
+                    ) + str(text)
+                else:
+                    styled_chars.extend((style, char) for char in text)
+
+            # The superclass positions raw escapes using code-point widths. We
+            # replace its coordinates because this window projects extended
+            # graphemes atomically and can therefore use different cell widths.
+            escape_row = new_screen.zero_width_escapes[ypos + screen_y]
+            for screen_x in range(xpos, xpos + width + 1):
+                escape_row.pop(screen_x, None)
+
             x = xpos
             logical_cell = 0
             for start, stop, cells in FullscreenTranscriptModel._grapheme_spans(styled_chars):
@@ -175,6 +186,8 @@ class _GraphemeWindow(Window):
                 atom = Char(cluster, styled_chars[start][0] if start < stop else "")
                 atom.width = cells
                 if x < xpos + width:
+                    if sequence := raw_at_offset.get(start):
+                        escape_row[x] += sequence
                     row[x] = atom
                     for continuation in range(cells):
                         grapheme_coordinates[line_number, logical_cell + continuation] = (
@@ -185,6 +198,7 @@ class _GraphemeWindow(Window):
                         row[x + continuation] = Char("")
                 x += cells
                 logical_cell += cells
+
         return visible_lines, grapheme_coordinates
 
 
@@ -1159,6 +1173,7 @@ class TUIApplication:
             style=create_prompt_style(),
             full_screen=self._is_fullscreen,
             before_render=self._before_render,
+            after_render=self._after_render,
             # When the Application exits (e.g. /exit), erase the live
             # region so the final screen is just the committed
             # scrollback. Otherwise the empty ❯ from the input line
@@ -2801,6 +2816,12 @@ class TUIApplication:
             return
         if self.full_screen:
             self._observe_terminal_size(current)
+
+    def _after_render(self, app) -> None:
+        """Never leave terminal-native OSC-8 state open beyond one rendered frame."""
+        if self._is_fullscreen:
+            app.output.write_raw("\x1b]8;;\x1b\\")
+            app.output.flush()
 
     def _read_terminal_size(self) -> tuple[int, int] | None:
         try:

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -3059,8 +3059,11 @@ class TUIApplication:
     def _after_render(self, app) -> None:
         """Never leave terminal-native OSC-8 state open beyond one rendered frame."""
         if self._is_fullscreen:
-            app.output.write_raw("\x1b]8;;\x1b\\")
-            app.output.flush()
+            try:
+                app.output.write_raw("\x1b]8;;\x1b\\")
+                app.output.flush()
+            except Exception:
+                logger.debug("failed to close native hyperlink state", exc_info=True)
 
     def _read_terminal_size(self) -> tuple[int, int] | None:
         try:

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -454,18 +454,13 @@ def _fullscreen_wheel_delta(mouse_event: MouseEvent) -> int | None:
     }.get(mouse_event.event_type)
 
 
-class _FullscreenDragBoundaryControl(FormattedTextControl):
-    """Chrome control that hands pointer gestures back to the transcript.
-
-    prompt_toolkit routes mouse events to the window under the pointer. Without
-    this handoff, releasing over bottom chrome strands the transcript control's
-    drag lease, and wheel gestures over chrome never reach transcript scrolling.
-    """
+class _TranscriptGestureControlMixin:
+    """Forward transcript-wide pointer gestures received by adjacent controls."""
 
     def __init__(
         self,
         *args: Any,
-        transcript_drag_callback: Callable[[MouseEvent], bool],
+        transcript_drag_callback: Callable[[MouseEvent], bool] | None = None,
         transcript_scroll_callback: Callable[[int], None] | None = None,
         **kwargs: Any,
     ) -> None:
@@ -473,23 +468,42 @@ class _FullscreenDragBoundaryControl(FormattedTextControl):
         self._transcript_drag_callback = transcript_drag_callback
         self._transcript_scroll_callback = transcript_scroll_callback
 
-    def mouse_handler(self, mouse_event: MouseEvent):
+    def _forward_transcript_gesture(self, mouse_event: MouseEvent) -> tuple[bool, Any]:
+        """Return whether the shared policy handled the event and its result."""
         if (
             MouseModifier.ALT in mouse_event.modifiers
             or MouseModifier.SHIFT in mouse_event.modifiers
         ):
-            self._transcript_drag_callback(mouse_event)
-            return NotImplemented
-        if self._transcript_drag_callback(mouse_event):
-            return None
+            if self._transcript_drag_callback is not None:
+                self._transcript_drag_callback(mouse_event)
+            return True, NotImplemented
+        if self._transcript_drag_callback is not None and self._transcript_drag_callback(
+            mouse_event
+        ):
+            return True, None
         delta = _fullscreen_wheel_delta(mouse_event)
         if delta is not None and self._transcript_scroll_callback is not None:
             self._transcript_scroll_callback(delta)
-            return None
+            return True, None
+        return False, None
+
+
+class _FullscreenDragBoundaryControl(_TranscriptGestureControlMixin, FormattedTextControl):
+    """Chrome control that hands pointer gestures back to the transcript.
+
+    prompt_toolkit routes mouse events to the window under the pointer. Without
+    this handoff, releasing over bottom chrome strands the transcript control's
+    drag lease, and wheel gestures over chrome never reach transcript scrolling.
+    """
+
+    def mouse_handler(self, mouse_event: MouseEvent):
+        handled, result = self._forward_transcript_gesture(mouse_event)
+        if handled:
+            return result
         return super().mouse_handler(mouse_event)
 
 
-class _NativeSelectionBufferControl(BufferControl):
+class _NativeSelectionBufferControl(_TranscriptGestureControlMixin, BufferControl):
     """Composer control that hands transcript-wide pointer gestures to their owner."""
 
     def __init__(
@@ -500,27 +514,18 @@ class _NativeSelectionBufferControl(BufferControl):
         selection_copy_callback: Callable[[str], None] | None = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(*args, **kwargs)
-        self._transcript_drag_callback = transcript_drag_callback
-        self._transcript_scroll_callback = transcript_scroll_callback
+        super().__init__(
+            *args,
+            transcript_drag_callback=transcript_drag_callback,
+            transcript_scroll_callback=transcript_scroll_callback,
+            **kwargs,
+        )
         self._selection_copy_callback = selection_copy_callback
 
     def mouse_handler(self, mouse_event: MouseEvent):
-        if (
-            MouseModifier.ALT in mouse_event.modifiers
-            or MouseModifier.SHIFT in mouse_event.modifiers
-        ):
-            if self._transcript_drag_callback is not None:
-                self._transcript_drag_callback(mouse_event)
-            return NotImplemented
-        if self._transcript_drag_callback is not None and self._transcript_drag_callback(
-            mouse_event
-        ):
-            return None
-        delta = _fullscreen_wheel_delta(mouse_event)
-        if delta is not None and self._transcript_scroll_callback is not None:
-            self._transcript_scroll_callback(delta)
-            return None
+        handled, result = self._forward_transcript_gesture(mouse_event)
+        if handled:
+            return result
         result = super().mouse_handler(mouse_event)
         if (
             mouse_event.event_type is MouseEventType.MOUSE_UP
@@ -537,36 +542,15 @@ class _NativeSelectionBufferControl(BufferControl):
         return result
 
 
-class _NativeSelectionCompletionsMenuControl(CompletionsMenuControl):
+class _NativeSelectionCompletionsMenuControl(
+    _TranscriptGestureControlMixin, CompletionsMenuControl
+):
     """Completion menu that preserves native selection and transcript gestures."""
 
-    def __init__(
-        self,
-        *args: Any,
-        transcript_drag_callback: Callable[[MouseEvent], bool] | None = None,
-        transcript_scroll_callback: Callable[[int], None] | None = None,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self._transcript_drag_callback = transcript_drag_callback
-        self._transcript_scroll_callback = transcript_scroll_callback
-
     def mouse_handler(self, mouse_event: MouseEvent):
-        if (
-            MouseModifier.ALT in mouse_event.modifiers
-            or MouseModifier.SHIFT in mouse_event.modifiers
-        ):
-            if self._transcript_drag_callback is not None:
-                self._transcript_drag_callback(mouse_event)
-            return NotImplemented
-        if self._transcript_drag_callback is not None and self._transcript_drag_callback(
-            mouse_event
-        ):
-            return None
-        delta = _fullscreen_wheel_delta(mouse_event)
-        if delta is not None and self._transcript_scroll_callback is not None:
-            self._transcript_scroll_callback(delta)
-            return None
+        handled, result = self._forward_transcript_gesture(mouse_event)
+        if handled:
+            return result
         return super().mouse_handler(mouse_event)
 
 
@@ -591,7 +575,7 @@ def _native_hyperlink_boundary(
     return boundary
 
 
-class _ReturnToTailControl(FormattedTextControl):
+class _ReturnToTailControl(_TranscriptGestureControlMixin, FormattedTextControl):
     """One-row fullscreen affordance for resuming live transcript output."""
 
     def __init__(
@@ -609,27 +593,15 @@ class _ReturnToTailControl(FormattedTextControl):
             ),
             focusable=False,
             show_cursor=False,
+            transcript_drag_callback=transcript_drag_callback,
+            transcript_scroll_callback=transcript_scroll_callback,
         )
         self._callback = callback
-        self._transcript_drag_callback = transcript_drag_callback
-        self._transcript_scroll_callback = transcript_scroll_callback
 
     def mouse_handler(self, mouse_event: MouseEvent):
-        if (
-            MouseModifier.ALT in mouse_event.modifiers
-            or MouseModifier.SHIFT in mouse_event.modifiers
-        ):
-            if self._transcript_drag_callback is not None:
-                self._transcript_drag_callback(mouse_event)
-            return NotImplemented
-        if self._transcript_drag_callback is not None and self._transcript_drag_callback(
-            mouse_event
-        ):
-            return None
-        delta = _fullscreen_wheel_delta(mouse_event)
-        if delta is not None and self._transcript_scroll_callback is not None:
-            self._transcript_scroll_callback(delta)
-            return None
+        handled, result = self._forward_transcript_gesture(mouse_event)
+        if handled:
+            return result
         if mouse_event.button is not MouseButton.LEFT:
             return NotImplemented
         if mouse_event.event_type is MouseEventType.MOUSE_DOWN:

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1839,8 +1839,9 @@ class TUIApplication:
             await self._terminate_clipboard_process(process)
             raise
         except TimeoutError:
-            await self._terminate_clipboard_process(process)
-            return False
+            # Browser launchers can remain attached after successfully handing
+            # the URL off. Do not kill the helper or report a false failure.
+            return True
         return process.returncode == 0
 
     def _handle_fullscreen_selection(self, action: str, x: int, y: int) -> None:

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -636,6 +636,13 @@ class _ResizeReplayQueueItem:
     transcript_epoch: int
 
 
+@dataclass(frozen=True, slots=True, eq=False)
+class _PendingInputHandoff:
+    """One admitted submission awaiting transcript commit or withdrawal."""
+
+    text: str
+
+
 @dataclass(frozen=True)
 class _ClearTranscriptQueueItem:
     transcript_epoch: int
@@ -849,6 +856,9 @@ class TUIApplication:
         self._spinner_task: asyncio.Task | None = None
         self._command_status_text: str = ""
         self._command_queue_texts: list[str] = []
+        # Admitted text remains visible here until its accepted transcript
+        # block is committed. A worker may dequeue before the next paint.
+        self._pending_input_handoff: list[_PendingInputHandoff] = []
         self._llm_probe_status_text: str = ""
 
         self._prompt_processor = BeforeInput(PROMPT_MARKER, style="class:prompt")
@@ -919,10 +929,10 @@ class TUIApplication:
             else None
         )
 
-        # Queue chrome is a pure projection of the current agent state.
+        # Queue chrome is a pure projection of runtime state plus the short
+        # admission→transcript visibility handoff.
         def _queue_pending() -> list[str]:
-            state = self._agent_controller.state
-            return [] if state is None else list(state.pending_inputs)
+            return self._pending_input_display()
 
         def _queue_formatted():
             rows = []
@@ -1953,6 +1963,7 @@ class TUIApplication:
         def _(event):
             popped = _pop_last_queued()
             if popped is not None:
+                self.complete_pending_input_handoff(popped)
                 self.input_buffer.text = popped
                 self.input_buffer.cursor_position = len(popped)
                 return
@@ -2104,6 +2115,13 @@ class TUIApplication:
         self.input_buffer.text = self._history[self._history_cursor]
         self.input_buffer.cursor_position = len(self.input_buffer.text)
 
+    def _pending_input_display(self) -> list[str]:
+        """Return text that queue chrome must show in the current frame."""
+        state = self._agent_controller.state
+        pending = [] if state is None else list(state.pending_inputs)
+        handoff = [item.text for item in self._pending_input_handoff]
+        return handoff or pending
+
     def submit_message(self, user_message: str) -> None:
         """Submit text through the current interactive agent."""
         if self._agent_controller.state is None:
@@ -2117,9 +2135,45 @@ class TUIApplication:
             if problem:
                 self.emit_block(f"\x1b[31m{problem}\x1b[0m\n")
                 return
-        accepted = self._agent_controller.submit(user_message)
-        if not accepted:
+        # Register visibility before admission: another loop may consume and
+        # queue the accepted transcript echo before ``submit`` returns.
+        handoff = _PendingInputHandoff(user_message)
+        self._pending_input_handoff.append(handoff)
+        try:
+            accepted = self._agent_controller.submit(user_message)
+        except Exception:
+            self._discard_pending_input_handoff(handoff)
+            logger.debug("TUI message submission failed", exc_info=True)
             self.emit_block("\x1b[31mMessage rejected.\x1b[0m\n")
+            return
+        if not accepted:
+            self._discard_pending_input_handoff(handoff)
+            self.emit_block("\x1b[31mMessage rejected.\x1b[0m\n")
+            return
+        if self._app.is_running:
+            self._app.invalidate()
+
+    def _discard_pending_input_handoff(self, handoff: _PendingInputHandoff) -> None:
+        """Discard one exact optimistic admission without disturbing duplicates."""
+        for index, candidate in enumerate(self._pending_input_handoff):
+            if candidate is handoff:
+                self._pending_input_handoff.pop(index)
+                break
+
+    def complete_pending_input_handoff(self, text: str) -> None:
+        """Retire the FIFO submissions represented by one consumed queue item."""
+        combined = ""
+        consumed = 0
+        for handoff in self._pending_input_handoff:
+            combined = f"{combined}\n{handoff.text}" if consumed else handoff.text
+            consumed += 1
+            if combined == text:
+                del self._pending_input_handoff[:consumed]
+                break
+            if not text.startswith(f"{combined}\n"):
+                break
+        if self._app.is_running:
+            self._app.invalidate()
 
     def _schedule_agent_callback(self, callback: Callable[[], None]) -> None:
         """Marshal agent observation delivery onto the prompt-toolkit owner loop."""

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -35,7 +35,14 @@ from prompt_toolkit.filters import Condition
 from prompt_toolkit.formatted_text import ANSI, AnyFormattedText
 from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
 from prompt_toolkit.keys import Keys
-from prompt_toolkit.layout import ConditionalContainer, DynamicContainer, HSplit, Layout, Window
+from prompt_toolkit.layout import (
+    ConditionalContainer,
+    DynamicContainer,
+    HSplit,
+    Layout,
+    VSplit,
+    Window,
+)
 from prompt_toolkit.layout.containers import WindowAlign
 from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl, UIContent
 from prompt_toolkit.layout.dimension import Dimension
@@ -810,7 +817,9 @@ class TUIApplication:
         # tests and printable-transcript callers. Source-bearing blocks below
         # are the single retained representation used for terminal replay.
         self.output_buffer = Buffer(read_only=False)
-        self._fullscreen_transcript = FullscreenTranscriptModel()
+        self._fullscreen_transcript = FullscreenTranscriptModel(
+            show_trailing_blank=lambda: not bool(self._status_rows())
+        )
         # Fullscreen requests mouse reporting immediately so ordinary drag and
         # wheel gestures reach prompt_toolkit rather than terminal scrollback.
         # Option/Alt-drag can bypass reporting in supporting terminals; F6 is
@@ -1007,13 +1016,16 @@ class TUIApplication:
         # Status line at the bottom — shows spinner + session label.
         def _status_formatted():
             fragments: list[tuple[str, str]] = []
-            for index, row in enumerate(self._status_rows()):
+            rows = self._status_rows(include_transient=not self._is_fullscreen)
+            for index, row in enumerate(rows):
                 if index:
-                    fragments.append(("class:status", "\n\n"))
+                    fragments.append(("class:status", "   " if self._is_fullscreen else "\n\n"))
                 fragments.extend((style, sanitize_live_text(text)) for style, text in row)
             return fragments
 
         def _status_height() -> Dimension:
+            if self._is_fullscreen:
+                return Dimension(min=0, max=1, preferred=1)
             lines = self.status_text().splitlines()
             height = max(1, len(lines))
             # Status is useful chrome, not a reason to replace the entire UI
@@ -1031,6 +1043,23 @@ class TUIApplication:
         status_window = Window(
             self._status_control,
             height=_status_height,
+        )
+
+        self._transient_status_container = ConditionalContainer(
+            Window(
+                FormattedTextControl(
+                    lambda: [
+                        (
+                            self._transient_status_style,
+                            sanitize_live_text(self._transient_status_text),
+                        )
+                    ],
+                    focusable=False,
+                ),
+                height=1,
+                dont_extend_width=True,
+            ),
+            filter=Condition(lambda: self._is_fullscreen and bool(self._transient_status_text)),
         )
 
         self._return_to_tail_control = _ReturnToTailControl(self._jump_fullscreen_to_tail)
@@ -1108,15 +1137,35 @@ class TUIApplication:
         #   session rule — always visible while at the transcript tail
         #   input composer (one padding row above and below the input)
         #   completions (only while completing)
+        if self._is_fullscreen:
+            self._status_region_container = ConditionalContainer(
+                VSplit(
+                    [
+                        status_window,
+                        self._transient_status_container,
+                        self._return_to_tail_container,
+                    ],
+                    padding=1,
+                ),
+                filter=Condition(
+                    lambda: (
+                        bool(self._status_rows())
+                        or not self._fullscreen_transcript.viewport.follows_tail
+                    )
+                ),
+            )
+            status_region = self._status_region_container
+        else:
+            self._status_region_container = None
+            status_region = status_window
         main_children = [
-            status_window,
+            status_region,
             queue_window,
             session_rule,
             self._input_container,
             completions_window,
         ]
         if self._output_window is not None:
-            main_children.insert(0, self._return_to_tail_container)
             main_children.insert(0, self._output_window)
         main_container = HSplit(main_children, window_too_small=Window())
         self._main_container = main_container
@@ -3300,7 +3349,7 @@ class TUIApplication:
             self._ensure_spinner_task()
         self.invalidate()
 
-    def _status_rows(self) -> list[list[tuple[str, str]]]:
+    def _status_rows(self, *, include_transient: bool = True) -> list[list[tuple[str, str]]]:
         """Return dynamic status rows as independently styled fragments."""
         rows: list[list[tuple[str, str]]] = []
         state = self._agent_controller.state
@@ -3320,7 +3369,7 @@ class TUIApplication:
                 logger.debug("auxiliary status callback failed", exc_info=True)
         if auxiliary_status:
             rows.append([("class:status", auxiliary_status)])
-        if self._transient_status_text:
+        if include_transient and self._transient_status_text:
             rows.append([(self._transient_status_style, self._transient_status_text)])
         if self._command_status_text:
             rows.append([("class:status", self._command_status_text)])

--- a/packages/nooa-cli/src/nooa_cli/tui/user_message.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/user_message.py
@@ -8,10 +8,18 @@ from .terminal_safety import sanitize_live_text
 
 
 def _hex_to_ansi256(hex_color: str) -> int:
-    """Map an RGB hex color to the 6×6×6 ANSI-256 color cube."""
+    """Map an RGB hex color to the nearest xterm-256 color-cube entry."""
     value = hex_color.lstrip("#")
     red, green, blue = (int(value[index : index + 2], 16) for index in (0, 2, 4))
-    return 16 + 36 * round(red / 255 * 5) + 6 * round(green / 255 * 5) + round(blue / 255 * 5)
+
+    def quantize(channel: int) -> int:
+        if channel < 48:
+            return 0
+        if channel < 115:
+            return 1
+        return (channel - 35) // 40
+
+    return 16 + 36 * quantize(red) + 6 * quantize(green) + quantize(blue)
 
 
 def render_user_bar(text: str, cols: int, colors: dict[str, str]) -> str:

--- a/packages/nooa-cli/src/nooa_cli/tui/user_message.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/user_message.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared rendering for live and resumed user-message bars."""
+
+from rich.cells import chop_cells, set_cell_size
+
+from .terminal_safety import sanitize_live_text
+
+
+def _hex_to_ansi256(hex_color: str) -> int:
+    """Map an RGB hex color to the 6×6×6 ANSI-256 color cube."""
+    value = hex_color.lstrip("#")
+    red, green, blue = (int(value[index : index + 2], 16) for index in (0, 2, 4))
+    return 16 + 36 * round(red / 255 * 5) + 6 * round(green / 255 * 5) + round(blue / 255 * 5)
+
+
+def render_user_bar(text: str, cols: int, colors: dict[str, str]) -> str:
+    """Render one live or resumed user message as full-width highlighted rows."""
+    width = max(int(cols), 1)
+    foreground = _hex_to_ansi256(colors["text"])
+    background = _hex_to_ansi256(colors["surface2"])
+    style_on = f"\x1b[38;5;{foreground};48;5;{background}m"
+    style_off = "\x1b[0m"
+
+    rows: list[str] = []
+    for index, line in enumerate(sanitize_live_text(text).split("\n")):
+        shown = f" ❯ {line} " if index == 0 else f" {line} "
+        # Rich's cell helpers preserve grapheme clusters and measure wide
+        # glyphs correctly. Every row is exactly the safe content width.
+        chunks = chop_cells(shown, width) or [""]
+        rows.extend(f"{style_on}{set_cell_size(chunk, width)}{style_off}" for chunk in chunks)
+    return "\n".join(rows) + "\n"
+
+
+__all__ = ["render_user_bar"]

--- a/packages/nooa-cli/tests/test_local_agent_runtime.py
+++ b/packages/nooa-cli/tests/test_local_agent_runtime.py
@@ -633,6 +633,45 @@ def test_submit_state_publication_is_serialized_before_dequeue() -> None:
     runner.close()
 
 
+def test_withdraw_state_publication_is_serialized_before_submit() -> None:
+    agent = AgentStub()
+    runner = LocalAgentRunner(agent, emit_text=lambda _text: None, agent_id="local-1")
+    runner._task = SimpleNamespace(done=lambda: False)  # type: ignore[assignment]
+    agent._user_messages_in.put("old")
+
+    withdraw_publishing = threading.Event()
+    release_withdraw = threading.Event()
+    submit_finished = threading.Event()
+    original_update = runner._update_pending_inputs
+
+    def blocking_update(pending_inputs: tuple[str, ...]) -> None:
+        if pending_inputs == () and not withdraw_publishing.is_set():
+            withdraw_publishing.set()
+            assert release_withdraw.wait(timeout=1)
+        original_update(pending_inputs)
+
+    runner._update_pending_inputs = blocking_update  # type: ignore[method-assign]
+    withdraw_thread = threading.Thread(target=runner.withdraw_pending_input)
+    withdraw_thread.start()
+    assert withdraw_publishing.wait(timeout=1)
+
+    def submit() -> None:
+        runner.submit("new")
+        submit_finished.set()
+
+    submit_thread = threading.Thread(target=submit)
+    submit_thread.start()
+    assert not submit_finished.wait(timeout=0.05)
+
+    release_withdraw.set()
+    withdraw_thread.join(timeout=1)
+    submit_thread.join(timeout=1)
+    assert not withdraw_thread.is_alive()
+    assert not submit_thread.is_alive()
+    assert runner.state.pending_inputs == runner.pending_user_messages() == ("new",)
+    runner.close()
+
+
 def test_withdraw_pending_input_returns_text_and_publishes_state() -> None:
     agent = AgentStub()
     runner = LocalAgentRunner(agent, emit_text=lambda _text: None, agent_id="local-1")

--- a/packages/nooa-cli/tests/test_local_agent_runtime.py
+++ b/packages/nooa-cli/tests/test_local_agent_runtime.py
@@ -587,6 +587,52 @@ def test_submit_rejects_and_rolls_back_for_recorded_stopped_owner_loop() -> None
     runner.close()
 
 
+def test_submit_state_publication_is_serialized_before_dequeue() -> None:
+    agent = AgentStub()
+    runner = LocalAgentRunner(agent, emit_text=lambda _text: None, agent_id="local-1")
+    # Avoid dispatcher startup; invoke the concrete dequeue callback below.
+    runner._task = SimpleNamespace(done=lambda: False)  # type: ignore[assignment]
+
+    submit_publishing = threading.Event()
+    release_submit = threading.Event()
+    dequeue_finished = threading.Event()
+    original_update = runner._update_pending_inputs
+
+    def blocking_update(pending_inputs: tuple[str, ...]) -> None:
+        if pending_inputs == ("new",) and not submit_publishing.is_set():
+            submit_publishing.set()
+            assert release_submit.wait(timeout=1)
+        original_update(pending_inputs)
+
+    runner._update_pending_inputs = blocking_update  # type: ignore[method-assign]
+    submit_thread = threading.Thread(target=lambda: runner.submit("new"))
+    submit_thread.start()
+    assert submit_publishing.wait(timeout=1)
+
+    def dequeue() -> None:
+        runner._on_user_message_get(
+            "new",
+            generation=runner._binding_generation,
+            user_messages=runner._user_messages,
+            previous=None,
+        )
+        dequeue_finished.set()
+
+    dequeue_thread = threading.Thread(target=dequeue)
+    dequeue_thread.start()
+    # State publication remains inside the lifecycle transaction, so dequeue
+    # cannot publish its newer empty snapshot until submit finishes.
+    assert not dequeue_finished.wait(timeout=0.05)
+
+    release_submit.set()
+    submit_thread.join(timeout=1)
+    dequeue_thread.join(timeout=1)
+    assert not submit_thread.is_alive()
+    assert not dequeue_thread.is_alive()
+    assert runner.state.pending_inputs == runner.pending_user_messages() == ()
+    runner.close()
+
+
 def test_withdraw_pending_input_returns_text_and_publishes_state() -> None:
     agent = AgentStub()
     runner = LocalAgentRunner(agent, emit_text=lambda _text: None, agent_id="local-1")

--- a/packages/nooa-cli/tests/tui/test_activity_no_block.py
+++ b/packages/nooa-cli/tests/tui/test_activity_no_block.py
@@ -198,6 +198,7 @@ async def test_session_swap_uses_async_agent_dispatch():
     old_manager = MagicMock()
     old_manager.close = MagicMock()
     session._session_manager = old_manager
+    session._session_generation = 4
     new_manager = MagicMock()
     new_manager._storage = SimpleNamespace(event_backend=object())
 
@@ -228,6 +229,7 @@ async def test_session_swap_uses_async_agent_dispatch():
     assert used["async"] == 2
     assert used["sync"] == 0
     clear_handoffs.assert_called_once_with()
+    assert session._session_generation == 5
 
 
 @pytest.mark.asyncio

--- a/packages/nooa-cli/tests/tui/test_activity_no_block.py
+++ b/packages/nooa-cli/tests/tui/test_activity_no_block.py
@@ -211,7 +211,8 @@ async def test_session_swap_uses_async_agent_dispatch():
         used["sync"] += 1
         return fn()
 
-    session._app = SimpleNamespace()
+    clear_handoffs = MagicMock()
+    session._app = SimpleNamespace(clear_pending_input_handoffs=clear_handoffs)
 
     async def shutdown_queue_manager(*, flush):
         assert flush is True
@@ -226,6 +227,7 @@ async def test_session_swap_uses_async_agent_dispatch():
 
     assert used["async"] == 2
     assert used["sync"] == 0
+    clear_handoffs.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -41,7 +41,8 @@ def test_fullscreen_copy_and_return_actions_share_status_region() -> None:
     app._show_transient_status("Copied 5 characters", style="class:return-to-tail")
     app._scroll_fullscreen_transcript(-4)
 
-    status_container = app._main_container.children[1]
+    status_container = app._status_region_container
+    assert status_container is not None
     status_region = status_container.content
     assert isinstance(status_region, VSplit)
     assert app._transient_status_container in status_region.children
@@ -1169,6 +1170,21 @@ def test_fullscreen_after_render_closes_native_hyperlink_state() -> None:
     assert flushes == [None]
 
 
+@pytest.mark.parametrize("failure", ["write", "flush"])
+def test_fullscreen_after_render_tolerates_broken_output(failure: str) -> None:
+    app = _make_fullscreen_app()
+
+    def fail() -> None:
+        raise OSError("closed output")
+
+    if failure == "write":
+        app._app.output.write_raw = lambda _text: fail()  # type: ignore[method-assign]
+    else:
+        app._app.output.flush = fail  # type: ignore[method-assign]
+
+    app._after_render(app._app)
+
+
 def test_short_fullscreen_transcript_is_bottom_aligned_in_viewport() -> None:
     from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
     from prompt_toolkit.formatted_text import to_formatted_text
@@ -2003,6 +2019,29 @@ async def test_fullscreen_link_click_opens_safe_http_url(monkeypatch) -> None:
     await app._link_task
     assert calls == ["https://example.test/docs"]
     assert app._open_fullscreen_link_at(8, 0) is False
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_link_open_failure_copies_url(monkeypatch) -> None:
+    app = _make_fullscreen_app()
+    url = "https://example.test/docs"
+    app.emit_block(f"\x1b]8;;{url}\x1b\\link\x1b]8;;\x1b\\")
+    app._transcript_viewport_size = lambda: (20, 2)
+    copied: list[str] = []
+
+    async def fail_to_open(_url: str) -> bool:
+        return False
+
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
+    monkeypatch.delenv("SSH_TTY", raising=False)
+    monkeypatch.setattr(app, "_open_local_url", fail_to_open)
+    monkeypatch.setattr(app, "_start_fullscreen_selection_copy", copied.append)
+
+    assert app._open_fullscreen_link_at(1, 0) is True
+    task = app._link_task
+    assert task is not None
+    await task
+    assert copied == [url]
 
 
 @pytest.mark.asyncio

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -32,6 +32,51 @@ def test_fullscreen_shell_owns_alternate_screen_and_transcript_window() -> None:
     assert app._output_window is not None
 
 
+def test_fullscreen_copy_and_return_actions_share_status_region() -> None:
+    from prompt_toolkit.layout import VSplit
+
+    app = _make_fullscreen_app()
+    app.emit_block("".join(f"line {index}\n" for index in range(30)))
+    app._transcript_viewport_size = lambda: (20, 4)
+    app._show_transient_status("Copied 5 characters", style="class:return-to-tail")
+    app._scroll_fullscreen_transcript(-4)
+
+    status_container = app._main_container.children[1]
+    status_region = status_container.content
+    assert isinstance(status_region, VSplit)
+    assert app._transient_status_container in status_region.children
+    assert app._return_to_tail_container in status_region.children
+    assert bool(status_container.filter())
+    assert bool(app._transient_status_container.filter())
+    assert bool(app._return_to_tail_container.filter())
+
+
+def test_fullscreen_status_removes_visual_transcript_gap() -> None:
+    from prompt_toolkit.formatted_text import fragment_list_to_text, to_formatted_text
+
+    app = _make_fullscreen_app()
+    app.emit_block("answer\n")
+
+    assert not bool(app._status_region_container.filter())
+    assert (
+        fragment_list_to_text(
+            to_formatted_text(app._fullscreen_transcript.formatted_text(width=20, height=2))
+        )
+        == "answer\n"
+    )
+
+    app._command_status_text = "thinking..."
+
+    assert bool(app._status_region_container.filter())
+    assert app._fullscreen_transcript.text == "answer\n"
+    assert (
+        fragment_list_to_text(
+            to_formatted_text(app._fullscreen_transcript.formatted_text(width=20, height=1))
+        )
+        == "answer"
+    )
+
+
 def test_fullscreen_bootstrap_output_only_mutates_renderer_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1890,18 +1935,11 @@ async def test_fullscreen_copy_notice_expires_without_touching_command_status() 
         style="class:return-to-tail",
     )
     assert app._transient_status_text == "Copied 5 characters"
-    status_controls = [
-        child.content
-        for child in app._main_container.children
-        if hasattr(child, "content")
-        and hasattr(child.content, "text")
-        and "Copied 5 characters" in str(child.content.text())
-    ]
-    assert len(status_controls) == 1
+    assert bool(app._transient_status_container.filter())
     assert (
         "class:return-to-tail",
         "Copied 5 characters",
-    ) in status_controls[0].text()
+    ) in app._transient_status_container.content.content.text()
     await asyncio.sleep(0.03)
 
     assert app._transient_status_text == ""

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -103,6 +103,7 @@ def test_native_hyperlink_marker_vocabulary_is_bounded() -> None:
 
     assert marker_classes(0) == {"class:native-hyperlink-0"}
     assert marker_classes(1) == {"class:native-hyperlink-1"}
+    model._formatted_cache.clear()
     assert marker_classes(2) == {"class:native-hyperlink-0"}
 
 
@@ -669,7 +670,7 @@ def test_projection_caches_are_bounded_and_cleared() -> None:
         model.formatted_text(width=width)
 
     assert len(model._projection_cache) <= 2
-    assert len(model._formatted_cache) <= 2
+    assert len(model._formatted_cache) <= 2 * 2  # two marker variants per retained geometry
 
     model.clear()
     assert not model._projection_cache

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -207,6 +207,25 @@ def test_fullscreen_sanitizes_terminal_commands_without_native_width_wrapping(
     assert app._fullscreen_transcript.text == r"abcdef\x1b[2J" + "\n"
 
 
+def test_fullscreen_hyperlink_hit_testing_survives_projection_and_wrapping() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+
+    model = FullscreenTranscriptModel()
+    model.append(
+        "prefix \x1b]8;id=42;https://example.test/docs\x1b\\linked text"
+        "\x1b]8;;\x1b\\ suffix"
+    )
+
+    assert model.hyperlink_at(x=0, y=0, width=8, height=3) == "https://example.test/docs"
+    assert model.hyperlink_at(x=1, y=1, width=8, height=3) == "https://example.test/docs"
+    assert model.hyperlink_at(x=2, y=1, width=8, height=3) is None
+
+    blank = FullscreenTranscriptModel()
+    blank.append("\x1b]8;;https://example.test/docs\x1b\\foo\n\nbar\x1b]8;;\x1b\\")
+    assert blank.hyperlink_at(x=0, y=1, width=20, height=3) is None
+    assert blank.hyperlink_at(x=19, y=1, width=20, height=3) is None
+
+
 def test_fullscreen_projection_does_not_leak_osc8_control_payload() -> None:
     from prompt_toolkit.formatted_text import to_formatted_text
 
@@ -1595,6 +1614,108 @@ def test_fullscreen_selection_is_visibly_styled() -> None:
     selected = "".join(text for style, text, *_ in fragments if "selected" in style)
 
     assert selected == "bcd"
+
+
+def test_fullscreen_click_without_drag_activates_link_but_drag_does_not() -> None:
+    from prompt_toolkit.mouse_events import MouseEventType
+
+    app = _make_fullscreen_app()
+    app.emit_block("\x1b]8;;https://example.test/docs\x1b\\link\x1b]8;;\x1b\\ plain")
+    app._transcript_viewport_size = lambda: (20, 1)
+    opened: list[tuple[int, int]] = []
+    app._open_fullscreen_link_at = lambda x, y: opened.append((x, y)) or True
+    assert app._output_window is not None
+    control = app._output_window.content
+    control._link_callback = app._open_fullscreen_link_at
+    control.create_content(20, 1)
+
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_DOWN, x=1, y=0))
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_UP, x=1, y=0))
+    assert opened == [(1, 0)]
+
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_DOWN, x=1, y=0))
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_MOVE, x=2, y=0))
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_UP, x=2, y=0))
+    assert opened == [(1, 0)]
+
+    # A terminal may omit an intermediate motion report; a changed release
+    # coordinate still belongs to drag selection, never link activation.
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_DOWN, x=1, y=0))
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_UP, x=2, y=0))
+    assert opened == [(1, 0)]
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_link_click_opens_safe_http_url(monkeypatch) -> None:
+    app = _make_fullscreen_app()
+    app.emit_block("\x1b]8;;https://example.test/docs\x1b\\link\x1b]8;;\x1b\\")
+    app._transcript_viewport_size = lambda: (20, 2)
+    calls: list[str] = []
+
+    async def open_browser(url: str) -> bool:
+        calls.append(url)
+        return True
+
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
+    monkeypatch.delenv("SSH_TTY", raising=False)
+    monkeypatch.setattr(app, "_open_local_url", open_browser)
+
+    assert app._open_fullscreen_link_at(1, 0) is True
+    assert app._link_task is not None
+    await app._link_task
+    assert calls == ["https://example.test/docs"]
+    assert app._open_fullscreen_link_at(8, 0) is False
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_remote_link_click_copies_without_launching(monkeypatch) -> None:
+    app = _make_fullscreen_app()
+    app.emit_block("\x1b]8;;https://example.test/docs\x1b\\link\x1b]8;;\x1b\\")
+    app._transcript_viewport_size = lambda: (20, 2)
+    copied: list[str] = []
+
+    monkeypatch.setenv("SSH_CONNECTION", "client 1 server 2")
+    monkeypatch.setattr(
+        app,
+        "_start_fullscreen_selection_copy",
+        lambda text: copied.append(text),
+    )
+    async def forbidden_open(_url: str) -> bool:
+        raise AssertionError("remote clicks must not launch a host browser")
+    monkeypatch.setattr(app, "_open_local_url", forbidden_open)
+
+    assert app._open_fullscreen_link_at(1, 0) is True
+    assert copied == ["https://example.test/docs"]
+    assert app._link_task is None
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_rapid_link_clicks_do_not_duplicate_launch(monkeypatch) -> None:
+    app = _make_fullscreen_app()
+    app.emit_block("\x1b]8;;https://example.test/docs\x1b\\link\x1b]8;;\x1b\\")
+    app._transcript_viewport_size = lambda: (20, 2)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls: list[str] = []
+
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
+    monkeypatch.delenv("SSH_TTY", raising=False)
+
+    async def blocked_open(url: str) -> bool:
+        calls.append(url)
+        started.set()
+        await release.wait()
+        return True
+
+    monkeypatch.setattr(app, "_open_local_url", blocked_open)
+
+    assert app._open_fullscreen_link_at(1, 0) is True
+    await started.wait()
+    assert app._open_fullscreen_link_at(1, 0) is True
+    assert calls == ["https://example.test/docs"]
+    release.set()
+    assert app._link_task is not None
+    await app._link_task
 
 
 def test_fullscreen_click_without_drag_clears_selection_without_copy(monkeypatch) -> None:

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -66,6 +66,7 @@ def test_fullscreen_status_removes_visual_transcript_gap() -> None:
     )
 
     app._command_status_text = "thinking..."
+    app._before_render(app._app)
 
     assert bool(app._status_region_container.filter())
     assert app._fullscreen_transcript.text == "answer\n"
@@ -75,6 +76,56 @@ def test_fullscreen_status_removes_visual_transcript_gap() -> None:
         )
         == "answer"
     )
+
+
+def test_native_hyperlink_marker_vocabulary_is_bounded() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+
+    model = FullscreenTranscriptModel()
+    model.append(
+        " ".join(
+            f"\x1b]8;;https://example.test/{index}\x1b\\x\x1b]8;;\x1b\\" for index in range(64)
+        )
+    )
+
+    def marker_classes(render_counter: int) -> set[str]:
+        return {
+            token
+            for style, _text, *_ in model.formatted_text(
+                width=4_096,
+                height=1,
+                render_counter=render_counter,
+            )
+            for token in style.split()
+            if token.startswith("class:native-hyperlink-")
+        }
+
+    assert marker_classes(0) == {"class:native-hyperlink-0"}
+    assert marker_classes(1) == {"class:native-hyperlink-1"}
+    assert marker_classes(2) == {"class:native-hyperlink-0"}
+
+
+def test_fullscreen_status_occupancy_is_sampled_once_per_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _make_fullscreen_app()
+    app.emit_block("answer\n")
+    calls = 0
+
+    def status_rows(*, include_transient: bool = True):
+        del include_transient
+        nonlocal calls
+        calls += 1
+        return [[("class:status", "busy")]]
+
+    monkeypatch.setattr(app, "_status_rows", status_rows)
+    app._before_render(app._app)
+
+    assert calls == 1
+    app._fullscreen_transcript.formatted_text(width=20, height=2)
+    app._fullscreen_transcript.cursor_position(width=20, height=2)
+    assert bool(app._status_region_container.filter())
+    assert calls == 1
 
 
 def test_fullscreen_bootstrap_output_only_mutates_renderer_model(
@@ -1049,6 +1100,7 @@ async def test_fullscreen_link_at_exact_row_end_closes_before_lower_chrome() -> 
     target = "https://example.test/docs"
     app.emit_block(f"\x1b]8;;{target}\x1b\\12345678\x1b]8;;\x1b\\")
     app._command_status_text = "STATUS"
+    app._before_render(app._app)
     writes: list[tuple[str, str]] = []
     app._app.output.write_raw = lambda value: writes.append(("raw", value))  # type: ignore[method-assign]
     app._app.output.write = lambda value: writes.append(("text", value))  # type: ignore[method-assign]
@@ -1395,6 +1447,7 @@ async def test_fullscreen_drag_release_over_transient_notice_finishes_copy(monke
 
     monkeypatch.setattr(app, "_copy_to_local_clipboard_async", copy_locally)
     app._show_transient_status("Copying...")
+    app._before_render(app._app)
     assert app._output_window is not None
     transcript = app._output_window.content
     transcript.create_content(8, 3)

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -1462,6 +1462,48 @@ async def test_fullscreen_drag_release_over_transient_notice_finishes_copy(monke
     assert copied == ["zero\none\ntwo"]
 
 
+def test_transcript_control_reformats_when_frame_height_changes_after_measurement() -> None:
+    from prompt_toolkit.application.current import set_app
+
+    app = _make_fullscreen_app()
+    app.emit_block("one\ntwo\n")
+    assert app._output_window is not None
+    control = app._output_window.content
+
+    def lines(content) -> list[str]:
+        return [
+            "".join(text for _style, text in content.get_line(index))
+            for index in range(content.line_count)
+        ]
+
+    with set_app(app._app):
+        app._app.render_counter += 1
+        assert lines(control.create_content(20, 3)) == ["one", "two", " "]
+
+        # A newly occupied status row shrinks the transcript in the same frame.
+        # prompt_toolkit measures with height=None before painting at height=2.
+        app._status_region_occupied = True
+        app._app.render_counter += 1
+        control.preferred_height(20, 3, False, None)
+        assert lines(control.create_content(20, 2)) == ["one", "two"]
+
+        # Expanding the multiline composer shrinks the transcript once more;
+        # typing on that line keeps the same geometry on the following frame.
+        app._app.render_counter += 1
+        control.preferred_height(20, 2, False, None)
+        assert lines(control.create_content(20, 1)) == ["two"]
+        app._app.render_counter += 1
+        control.preferred_height(20, 1, False, None)
+        assert lines(control.create_content(20, 1)) == ["two"]
+
+        # When status chrome disappears, the synthetic trailing row returns in
+        # the same frame rather than one repaint later.
+        app._status_region_occupied = False
+        app._app.render_counter += 1
+        control.preferred_height(20, 1, False, None)
+        assert lines(control.create_content(20, 2)) == ["two", " "]
+
+
 def test_transcript_control_uses_current_frame_height_before_formatting() -> None:
     from prompt_toolkit.application.current import set_app
 

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -2528,6 +2528,8 @@ async def test_fullscreen_input_mouse_click_moves_cursor_and_drag_selects() -> N
         assert app.input_buffer.selection_state is None
 
     drag_app = _make_fullscreen_app()
+    copied: list[str] = []
+    drag_app._start_fullscreen_selection_copy = copied.append
     drag_app.input_buffer.text = "alpha beta"
     drag_control = drag_app._input_window.content
     drag_control.create_content(20, 1)
@@ -2539,6 +2541,8 @@ async def test_fullscreen_input_mouse_click_moves_cursor_and_drag_selects() -> N
 
     assert drag_app.input_buffer.document.selection_range() == (1, 5)
     assert drag_app.input_buffer.copy_selection().text == "lpha"
+    assert copied == ["lpha"]
+    assert drag_app._app.clipboard.get_data().text == "lpha"
 
 
 @pytest.mark.asyncio
@@ -2574,6 +2578,32 @@ async def test_fullscreen_input_shift_up_selects_and_typing_replaces() -> None:
 
         assert app.input_buffer.selection_state is None
         assert app.input_buffer.cursor_position == len("abcde!")
+
+
+def test_fullscreen_composer_mouse_selection_is_mirrored_non_destructively(monkeypatch) -> None:
+    from nooa_cli.tui.tui_application import _NativeSelectionBufferControl
+    from prompt_toolkit.application.current import set_app
+    from prompt_toolkit.layout.controls import BufferControl
+    from prompt_toolkit.mouse_events import MouseEventType
+    from prompt_toolkit.selection import SelectionState
+
+    app = _make_fullscreen_app()
+    copied: list[str] = []
+    app._start_fullscreen_selection_copy = copied.append
+    app.input_buffer.text = "copy this"
+    app.input_buffer.cursor_position = 4
+    app.input_buffer.selection_state = SelectionState(original_cursor_position=0)
+    control = app._input_window.content
+    assert isinstance(control, _NativeSelectionBufferControl)
+
+    monkeypatch.setattr(BufferControl, "mouse_handler", lambda _self, _event: None)
+    with set_app(app._app):
+        control.mouse_handler(_mouse_event(MouseEventType.MOUSE_UP, x=4))
+
+    assert copied == ["copy"]
+    assert app._app.clipboard.get_data().text == "copy"
+    assert app.input_buffer.text == "copy this"
+    assert app.input_buffer.selection_state is not None
 
 
 @pytest.mark.asyncio

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -321,6 +321,16 @@ def test_fullscreen_hyperlink_hit_testing_survives_projection_and_wrapping() -> 
     assert blank.hyperlink_at(x=19, y=1, width=20, height=3) is None
 
 
+def test_fullscreen_hyperlink_hit_testing_matches_combining_grapheme_rendering() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+
+    model = FullscreenTranscriptModel()
+    # The OSC-8 boundary lies inside one displayed grapheme (e + combining acute).
+    model.append("e\x1b]8;;https://example.test\x1b\\́\x1b]8;;\x1b\\")
+
+    assert model.hyperlink_at(x=0, y=0, width=20, height=1) == "https://example.test"
+
+
 def test_fullscreen_projection_keeps_osc8_only_as_zero_width_metadata() -> None:
     from prompt_toolkit.formatted_text import to_formatted_text
 

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -1345,6 +1345,17 @@ def test_fullscreen_semantic_replay_cache_avoids_duplicate_width_work() -> None:
     assert app._fullscreen_transcript.text == "semantic\n"
 
 
+def test_fullscreen_queue_window_measures_wrapped_multiline_message() -> None:
+    from nooa_cli.tui.tui_application import _PendingInputHandoff
+
+    app = _make_fullscreen_app()
+    app._pending_input_handoff = [_PendingInputHandoff("first line\n" + "wrapped " * 12)]
+    queue_window = app._main_container.children[2].content
+
+    assert bool(queue_window.wrap_lines()) is True
+    assert queue_window.preferred_height(20, 100).preferred > 2
+
+
 def test_fullscreen_wheel_is_guarded_by_explicit_mouse_navigation_policy() -> None:
     from prompt_toolkit.data_structures import Point
     from prompt_toolkit.mouse_events import MouseButton, MouseEvent, MouseEventType

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -1042,6 +1042,40 @@ def test_fullscreen_screen_preserves_native_osc8_metadata_across_wrapped_rows() 
 
 
 @pytest.mark.asyncio
+async def test_fullscreen_link_at_exact_row_end_closes_before_lower_chrome() -> None:
+    from prompt_toolkit.application.current import set_app
+
+    app = _make_fullscreen_app()
+    target = "https://example.test/docs"
+    app.emit_block(f"\x1b]8;;{target}\x1b\\12345678\x1b]8;;\x1b\\")
+    app._command_status_text = "STATUS"
+    writes: list[tuple[str, str]] = []
+    app._app.output.write_raw = lambda value: writes.append(("raw", value))  # type: ignore[method-assign]
+    app._app.output.write = lambda value: writes.append(("text", value))  # type: ignore[method-assign]
+
+    with set_app(app._app):
+        app._app.renderer.render(app._app, app._app.layout)
+
+    opening = f"\x1b]8;;{target}\x1b\\"
+    close = "\x1b]8;;\x1b\\"
+    opening_index = next(index for index, item in enumerate(writes) if item == ("raw", opening))
+    last_link_text = max(
+        index
+        for index, (kind, value) in enumerate(writes)
+        if kind == "text" and value in set("12345678")
+    )
+    close_index = next(
+        index
+        for index, item in enumerate(writes)
+        if index > last_link_text and item == ("raw", close)
+    )
+    status_index = next(
+        index for index, item in enumerate(writes) if item == ("text", "S") and index > close_index
+    )
+    assert opening_index < last_link_text < close_index < status_index
+
+
+@pytest.mark.asyncio
 async def test_fullscreen_renderer_emits_native_osc8_through_raw_output() -> None:
     from prompt_toolkit.application.current import set_app
 
@@ -1308,6 +1342,71 @@ def test_fullscreen_wheel_over_status_scrolls_transcript() -> None:
 
     assert result is None
     assert not app._fullscreen_transcript.viewport.follows_tail
+
+
+@pytest.mark.parametrize("region", ["queue", "session", "input-padding", "completions"])
+def test_fullscreen_wheel_over_bottom_chrome_scrolls_transcript(region: str) -> None:
+    from prompt_toolkit.mouse_events import MouseEventType
+
+    app = _make_fullscreen_app()
+    app.emit_block("".join(f"line {index}\n" for index in range(20)))
+    app._transcript_viewport_size = lambda: (12, 4)
+    controls = {
+        "queue": app._main_container.children[2].content.content,
+        "session": app._main_container.children[3].content,
+        "input-padding": app._input_container.children[0].content,
+        "completions": app._main_container.children[5].content.content,
+    }
+
+    result = controls[region].mouse_handler(_mouse_event(MouseEventType.SCROLL_UP, button=None))
+
+    assert result is None
+    assert not app._fullscreen_transcript.viewport.follows_tail
+
+
+def test_fullscreen_wheel_over_transient_notice_scrolls_transcript() -> None:
+    from prompt_toolkit.mouse_events import MouseEventType
+
+    app = _make_fullscreen_app()
+    app.emit_block("".join(f"line {index}\n" for index in range(20)))
+    app._transcript_viewport_size = lambda: (12, 4)
+    app._show_transient_status("Copied 5 characters")
+    control = app._transient_status_container.content.content
+
+    result = control.mouse_handler(_mouse_event(MouseEventType.SCROLL_UP, button=None))
+
+    assert result is None
+    assert not app._fullscreen_transcript.viewport.follows_tail
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_drag_release_over_transient_notice_finishes_copy(monkeypatch) -> None:
+    from nooa_cli.tui.tui_application import _ClipboardResult
+    from prompt_toolkit.mouse_events import MouseEventType
+
+    app = _make_fullscreen_app()
+    app.emit_block("zero\none\ntwo")
+    app._transcript_viewport_size = lambda: (8, 3)
+    copied = []
+
+    async def copy_locally(text: str) -> _ClipboardResult:
+        copied.append(text)
+        return _ClipboardResult(True, "test")
+
+    monkeypatch.setattr(app, "_copy_to_local_clipboard_async", copy_locally)
+    app._show_transient_status("Copying...")
+    assert app._output_window is not None
+    transcript = app._output_window.content
+    transcript.create_content(8, 3)
+    transcript.mouse_handler(_mouse_event(MouseEventType.MOUSE_DOWN, x=0, y=0))
+
+    control = app._transient_status_container.content.content
+    assert control.mouse_handler(_mouse_event(MouseEventType.MOUSE_UP, x=2, y=0)) is None
+    if app._clipboard_task is not None:
+        await app._clipboard_task
+
+    assert not transcript.dragging
+    assert copied == ["zero\none\ntwo"]
 
 
 def test_transcript_control_uses_current_frame_height_before_formatting() -> None:
@@ -2181,6 +2280,24 @@ def test_fullscreen_return_to_tail_affordance_is_visible_and_clickable() -> None
     assert app._return_to_tail_control.mouse_handler(up) is None
     assert app._fullscreen_transcript.viewport.follows_tail
     assert not bool(app._return_to_tail_container.filter())
+
+
+def test_fullscreen_wheel_over_return_to_tail_scrolls_transcript() -> None:
+    from prompt_toolkit.mouse_events import MouseEventType
+
+    app = _make_fullscreen_app()
+    app.emit_block("".join(f"line {index}\n" for index in range(20)))
+    app._transcript_viewport_size = lambda: (12, 4)
+    app._scroll_fullscreen_transcript(-4)
+    before = app._fullscreen_transcript.viewport
+
+    result = app._return_to_tail_control.mouse_handler(
+        _mouse_event(MouseEventType.SCROLL_UP, button=None)
+    )
+
+    assert result is None
+    assert app._fullscreen_transcript.viewport != before
+    assert not app._fullscreen_transcript.viewport.follows_tail
 
 
 def test_fullscreen_return_to_tail_affordance_preserves_native_mouse_escape() -> None:

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -2001,6 +2001,39 @@ def test_fullscreen_click_without_drag_activates_link_but_drag_does_not() -> Non
 
 
 @pytest.mark.asyncio
+async def test_local_browser_timeout_counts_as_dispatched_without_termination(monkeypatch) -> None:
+    app = _make_fullscreen_app()
+
+    class Process:
+        returncode = None
+
+        async def wait(self) -> None:
+            return None
+
+    process = Process()
+    terminated: list[object] = []
+
+    async def create_process(*_args, **_kwargs):
+        return process
+
+    async def time_out(awaitable, *, timeout):
+        assert timeout == 5
+        awaitable.close()
+        raise TimeoutError
+
+    async def terminate(candidate) -> None:
+        terminated.append(candidate)
+
+    monkeypatch.setattr(app, "_browser_open_command", lambda _url: ("open", "url"))
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_process)
+    monkeypatch.setattr(asyncio, "wait_for", time_out)
+    monkeypatch.setattr(app, "_terminate_clipboard_process", terminate)
+
+    assert await app._open_local_url("https://example.test/docs") is True
+    assert terminated == []
+
+
+@pytest.mark.asyncio
 async def test_fullscreen_link_click_opens_safe_http_url(monkeypatch) -> None:
     app = _make_fullscreen_app()
     app.emit_block("\x1b]8;;https://example.test/docs\x1b\\link\x1b]8;;\x1b\\")

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -212,8 +212,7 @@ def test_fullscreen_hyperlink_hit_testing_survives_projection_and_wrapping() -> 
 
     model = FullscreenTranscriptModel()
     model.append(
-        "prefix \x1b]8;id=42;https://example.test/docs\x1b\\linked text"
-        "\x1b]8;;\x1b\\ suffix"
+        "prefix \x1b]8;id=42;https://example.test/docs\x1b\\linked text\x1b]8;;\x1b\\ suffix"
     )
 
     assert model.hyperlink_at(x=0, y=0, width=8, height=3) == "https://example.test/docs"
@@ -226,18 +225,30 @@ def test_fullscreen_hyperlink_hit_testing_survives_projection_and_wrapping() -> 
     assert blank.hyperlink_at(x=19, y=1, width=20, height=3) is None
 
 
-def test_fullscreen_projection_does_not_leak_osc8_control_payload() -> None:
+def test_fullscreen_projection_keeps_osc8_only_as_zero_width_metadata() -> None:
     from prompt_toolkit.formatted_text import to_formatted_text
 
     app = _make_fullscreen_app()
     app.emit_block("\x1b]8;;https://example.test\x1b\\label\x1b]8;;\x1b\\\n")
 
-    rendered = "".join(
-        fragment[1] for fragment in to_formatted_text(app._fullscreen_transcript.formatted_text())
-    )
+    fragments = to_formatted_text(app._fullscreen_transcript.formatted_text())
+    rendered = "".join(text for style, text, *_ in fragments if "[ZeroWidthEscape]" not in style)
+    raw = "".join(text for style, text, *_ in fragments if "[ZeroWidthEscape]" in style)
+
     assert rendered == "label\n"
-    assert "example.test" not in rendered
-    assert "8;;" not in rendered
+    assert raw == "\x1b]8;;https://example.test\x1b\\" * len("label")
+
+
+def test_fullscreen_does_not_emit_native_metadata_for_unsafe_link_target() -> None:
+    from prompt_toolkit.formatted_text import to_formatted_text
+
+    app = _make_fullscreen_app()
+    app.emit_block("\x1b]8;;file:///tmp/secret\x1b\\label\x1b]8;;\x1b\\")
+
+    fragments = to_formatted_text(app._fullscreen_transcript.formatted_text())
+
+    assert "".join(text for _style, text, *_ in fragments) == "label\n"
+    assert all("[ZeroWidthEscape]" not in style for style, _text, *_ in fragments)
 
 
 def test_fullscreen_projection_drops_unsupported_colon_sgr_without_leaking_parameters() -> None:
@@ -948,6 +959,73 @@ def _fullscreen_window_cells(app, *, width: int, height: int) -> list[str]:
         ).rstrip()
         for y in range(height)
     ]
+
+
+def test_fullscreen_screen_preserves_native_osc8_metadata_across_wrapped_rows() -> None:
+    from prompt_toolkit.application.current import set_app
+    from prompt_toolkit.layout.mouse_handlers import MouseHandlers
+    from prompt_toolkit.layout.screen import Screen, WritePosition
+
+    app = _make_fullscreen_app()
+    app.emit_block(
+        "plain \x1b]8;id=docs;https://example.test/docs\x1b\\linked text\x1b]8;;\x1b\\ tail"
+    )
+    app._transcript_viewport_size = lambda: (8, 3)
+    assert app._output_window is not None
+    app._app.render_counter += 1
+    screen = Screen()
+    with set_app(app._app):
+        app._output_window.write_to_screen(
+            screen,
+            MouseHandlers(),
+            WritePosition(xpos=0, ypos=0, width=8, height=3),
+            parent_style="",
+            erase_bg=False,
+            z_index=None,
+        )
+
+    target = "\x1b]8;;https://example.test/docs\x1b\\"
+    close = "\x1b]8;;\x1b\\"
+    assert screen.zero_width_escapes[0][6] == target
+    assert screen.zero_width_escapes[1][0] == target
+    assert screen.zero_width_escapes[1][3] == close
+    assert all(
+        "id=docs" not in sequence
+        for row in screen.zero_width_escapes.values()
+        for sequence in row.values()
+    )
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_renderer_emits_native_osc8_through_raw_output() -> None:
+    from prompt_toolkit.application.current import set_app
+
+    app = _make_fullscreen_app()
+    app.emit_block("\x1b]8;;https://example.test/docs\x1b\\link\x1b]8;;\x1b\\")
+    raw_writes: list[str] = []
+    plain_writes: list[str] = []
+    app._app.output.write_raw = raw_writes.append  # type: ignore[method-assign]
+    app._app.output.write = plain_writes.append  # type: ignore[method-assign]
+
+    with set_app(app._app):
+        app._app.renderer.render(app._app, app._app.layout)
+
+    opening = "\x1b]8;;https://example.test/docs\x1b\\"
+    assert opening in "".join(raw_writes)
+    assert opening not in "".join(plain_writes)
+
+
+def test_fullscreen_after_render_closes_native_hyperlink_state() -> None:
+    app = _make_fullscreen_app()
+    writes: list[str] = []
+    flushes: list[None] = []
+    app._app.output.write_raw = writes.append  # type: ignore[method-assign]
+    app._app.output.flush = lambda: flushes.append(None)  # type: ignore[method-assign]
+
+    app._after_render(app._app)
+
+    assert writes == ["\x1b]8;;\x1b\\"]
+    assert flushes == [None]
 
 
 def test_short_fullscreen_transcript_is_bottom_aligned_in_viewport() -> None:
@@ -1680,8 +1758,10 @@ async def test_fullscreen_remote_link_click_copies_without_launching(monkeypatch
         "_start_fullscreen_selection_copy",
         lambda text: copied.append(text),
     )
+
     async def forbidden_open(_url: str) -> bool:
         raise AssertionError("remote clicks must not launch a host browser")
+
     monkeypatch.setattr(app, "_open_local_url", forbidden_open)
 
     assert app._open_fullscreen_link_at(1, 0) is True

--- a/packages/nooa-cli/tests/tui/test_resume_replay.py
+++ b/packages/nooa-cli/tests/tui/test_resume_replay.py
@@ -174,6 +174,28 @@ class TestBatchRendering:
         assert "world" in written
         assert "bye" in written
 
+    def test_resumed_user_message_highlight_spans_every_wrapped_row(self):
+        from nooa_cli.tui.frontend import render_history_replay_to_ansi
+        from nooa_cli.tui.terminal_safety import strip_safe_ansi
+        from prompt_toolkit.formatted_text import ANSI, to_formatted_text
+        from rich.cells import cell_len
+
+        replay = HistoryReplay(
+            turns=[HistoryTurn(role="user", content="first line\nhello wide 世界 this wraps")],
+            session_id="highlight",
+            show_header=False,
+            show_footer=False,
+        )
+
+        rendered = render_history_replay_to_ansi(replay, 20)
+        message_rows = [line for line in strip_safe_ansi(rendered).splitlines() if line]
+
+        assert len(message_rows) > 2
+        assert all(cell_len(line) == 20 for line in message_rows)
+        assert all(
+            "bg:" in style for style, text, *_ in to_formatted_text(ANSI(rendered)) if text != "\n"
+        )
+
     def test_history_renderer_honors_pathologically_narrow_width(self):
         from nooa_cli.tui.frontend import render_history_replay_to_ansi
         from nooa_cli.tui.terminal_safety import strip_safe_ansi

--- a/packages/nooa-cli/tests/tui/test_resume_replay.py
+++ b/packages/nooa-cli/tests/tui/test_resume_replay.py
@@ -190,6 +190,10 @@ class TestBatchRendering:
         rendered = render_history_replay_to_ansi(replay, 20)
         message_rows = [line for line in strip_safe_ansi(rendered).splitlines() if line]
 
+        from nooa_cli.tui.theme import COLORS
+        from nooa_cli.tui.user_message import render_user_bar
+
+        assert rendered.startswith(render_user_bar(replay.turns[0].content, 20, COLORS))
         assert len(message_rows) > 2
         assert all(cell_len(line) == 20 for line in message_rows)
         assert all(

--- a/packages/nooa-cli/tests/tui/test_session_plumbing.py
+++ b/packages/nooa-cli/tests/tui/test_session_plumbing.py
@@ -60,6 +60,23 @@ def test_session_emission_uses_only_resolved_display_mode_for_replay(monkeypatch
         app.complete_pending_input_handoff.assert_called_once_with("hello")
 
 
+def test_stale_user_message_ui_callback_is_ignored_after_session_swap() -> None:
+    from unittest.mock import Mock
+
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session._session_generation = 2
+    session._app = Mock()
+    session._renderer = Mock()
+
+    session._on_user_message_ui("old-session", session_generation=1)
+
+    session._app.emit_block.assert_not_called()
+    session._app.complete_pending_input_handoff.assert_not_called()
+    session._renderer.reset_turn.assert_not_called()
+
+
 def test_session_semantic_render_uses_isolated_consoles_across_threads(
     monkeypatch,
 ) -> None:

--- a/packages/nooa-cli/tests/tui/test_session_plumbing.py
+++ b/packages/nooa-cli/tests/tui/test_session_plumbing.py
@@ -39,6 +39,7 @@ def test_session_emission_uses_only_resolved_display_mode_for_replay(monkeypatch
             display_mode=mode,
             transcript_columns=lambda: 80,
             emit_block=Mock(),
+            complete_pending_input_handoff=Mock(),
             color_depth=8,
         )
         session = Session.__new__(Session)
@@ -56,6 +57,7 @@ def test_session_emission_uses_only_resolved_display_mode_for_replay(monkeypatch
         session._on_user_message_ui("hello")
         bar_kwargs = app.emit_block.call_args.kwargs
         assert ("replay" in bar_kwargs) is (mode is DisplayMode.FULLSCREEN)
+        app.complete_pending_input_handoff.assert_called_once_with("hello")
 
 
 def test_session_semantic_render_uses_isolated_consoles_across_threads(

--- a/packages/nooa-cli/tests/tui/test_splash.py
+++ b/packages/nooa-cli/tests/tui/test_splash.py
@@ -117,7 +117,11 @@ def test_fullscreen_splash_is_semantically_reflowable() -> None:
     def emit(text: str, replay=None) -> None:
         emitted.append((text, replay))
 
-    stream = _EmitStream(emit, replay_width=lambda: current_width)
+    stream = _EmitStream(
+        emit,
+        replay_width=lambda: current_width - 1,
+        layout_width=lambda: current_width,
+    )
     mock_console = MagicMock()
     mock_console.console.width = 120
     mock_console.console.file = stream
@@ -130,6 +134,12 @@ def test_fullscreen_splash_is_semantically_reflowable() -> None:
     rendered, replay = emitted[0]
     assert "NVIDIA LABS" in rendered
     assert callable(replay)
+    # The 80-column boundary must keep the wide variant rather than using
+    # the native-scrollback width (79), which deliberately reserves a column.
+    current_width = 80
+    wide = replay()
+    assert wide.count("\n") == 11
+
     current_width = 40
     compact = replay()
     assert "NVIDIA LABS" in compact

--- a/packages/nooa-cli/tests/tui/test_splash.py
+++ b/packages/nooa-cli/tests/tui/test_splash.py
@@ -5,7 +5,8 @@
 from __future__ import annotations
 
 import io
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 from nooa_cli.tui.splash import NOOA_ASCII, show_splash, splash_variant
@@ -72,3 +73,64 @@ def test_optional_delay_remains_available_for_embedders() -> None:
     with patch("nooa_cli.tui.splash.time.sleep") as sleep:
         show_splash(console, delay=0.25)
     sleep.assert_called_once_with(0.25)
+
+
+def test_fullscreen_routes_splash_into_initial_app_output() -> None:
+    from nooa_cli.tui.config import Config, DisplayMode
+    from nooa_cli.tui.main import _prepare_splash
+    from nooa_cli.tui.output import SplashScreen
+
+    frontend = SimpleNamespace(raw_console=MagicMock())
+    config = Config()
+    config.tui.display_mode = DisplayMode.FULLSCREEN
+
+    with patch("nooa_cli.tui.splash.show_splash") as show:
+        outputs = _prepare_splash(config, frontend)
+
+    assert outputs == [SplashScreen()]
+    show.assert_not_called()
+
+
+def test_native_mode_keeps_pre_application_splash() -> None:
+    from nooa_cli.tui.config import Config, DisplayMode
+    from nooa_cli.tui.main import _prepare_splash
+
+    frontend = SimpleNamespace(raw_console=MagicMock())
+    config = Config()
+    config.tui.display_mode = DisplayMode.NATIVE
+
+    with patch("nooa_cli.tui.splash.show_splash") as show:
+        outputs = _prepare_splash(config, frontend)
+
+    assert outputs == []
+    show.assert_called_once_with(frontend.raw_console)
+
+
+def test_fullscreen_splash_is_semantically_reflowable() -> None:
+    from nooa_cli.tui.frontend import TerminalFrontend
+    from nooa_cli.tui.output import SplashScreen
+    from nooa_cli.tui.session import _EmitStream
+
+    emitted = []
+    current_width = 100
+
+    def emit(text: str, replay=None) -> None:
+        emitted.append((text, replay))
+
+    stream = _EmitStream(emit, replay_width=lambda: current_width)
+    mock_console = MagicMock()
+    mock_console.console.width = 120
+    mock_console.console.file = stream
+    frontend = TerminalFrontend.__new__(TerminalFrontend)
+    frontend._console = mock_console
+
+    frontend._render_splash(SplashScreen())
+
+    assert len(emitted) == 1
+    rendered, replay = emitted[0]
+    assert "NVIDIA LABS" in rendered
+    assert callable(replay)
+    current_width = 40
+    compact = replay()
+    assert "NVIDIA LABS" in compact
+    assert compact != rendered

--- a/packages/nooa-cli/tests/tui/test_terminal_safety.py
+++ b/packages/nooa-cli/tests/tui/test_terminal_safety.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from nooa_cli.tui.session import _build_user_bar
 from nooa_cli.tui.terminal_safety import (
+    hyperlink_at_plain_offset,
     normalize_transcript_block,
     sanitize_transcript_ansi,
     strip_safe_ansi,
@@ -85,3 +86,15 @@ def test_user_bar_is_control_safe_cell_aware_and_reserves_final_column() -> None
     visible_lines = strip_safe_ansi(sanitize_transcript_ansi(bar)).splitlines()
     assert visible_lines
     assert all(cell_len(line) == 9 for line in visible_lines)
+
+
+def test_hyperlink_hit_testing_accepts_only_http_targets() -> None:
+    linked = "before \x1b]8;id=7;https://example.test/path\x1b\\label\x1b]8;;\x1b\\ after"
+
+    assert hyperlink_at_plain_offset(linked, 7) == "https://example.test/path"
+    assert hyperlink_at_plain_offset(linked, 11) == "https://example.test/path"
+    assert hyperlink_at_plain_offset(linked, 6) is None
+    assert hyperlink_at_plain_offset(linked, 12) is None
+
+    unsafe = "\x1b]8;;file:///tmp/secret\x1b\\local\x1b]8;;\x1b\\"
+    assert hyperlink_at_plain_offset(unsafe, 0) is None

--- a/packages/nooa-cli/tests/tui/test_terminal_safety.py
+++ b/packages/nooa-cli/tests/tui/test_terminal_safety.py
@@ -7,6 +7,7 @@ from nooa_cli.tui.session import _build_user_bar
 from nooa_cli.tui.terminal_safety import (
     hyperlink_at_plain_offset,
     normalize_transcript_block,
+    safe_http_url,
     sanitize_transcript_ansi,
     strip_safe_ansi,
 )
@@ -86,6 +87,10 @@ def test_user_bar_is_control_safe_cell_aware_and_reserves_final_column() -> None
     visible_lines = strip_safe_ansi(sanitize_transcript_ansi(bar)).splitlines()
     assert visible_lines
     assert all(cell_len(line) == 9 for line in visible_lines)
+
+
+def test_hyperlink_target_length_is_bounded() -> None:
+    assert safe_http_url("https://example.test/" + "a" * 9_000) is None
 
 
 def test_hyperlink_hit_testing_accepts_only_http_targets() -> None:

--- a/packages/nooa-cli/tests/tui/test_terminal_safety.py
+++ b/packages/nooa-cli/tests/tui/test_terminal_safety.py
@@ -8,6 +8,7 @@ from nooa_cli.tui.terminal_safety import (
     hyperlink_at_plain_offset,
     normalize_transcript_block,
     safe_http_url,
+    safe_hyperlink_spans,
     sanitize_transcript_ansi,
     strip_safe_ansi,
 )
@@ -90,7 +91,25 @@ def test_user_bar_is_control_safe_cell_aware_and_reserves_final_column() -> None
 
 
 def test_hyperlink_target_length_is_bounded() -> None:
-    assert safe_http_url("https://example.test/" + "a" * 9_000) is None
+    prefix = "https://example.test/"
+    exact = prefix + "a" * (2_048 - len(prefix))
+
+    assert safe_http_url(exact) == exact
+    assert safe_http_url(exact + "a") is None
+
+
+def test_safe_http_url_rejects_terminal_controls() -> None:
+    for codepoint in (*range(0x20), 0x7F, *range(0x80, 0xA0)):
+        url = f"https://example.test/a{chr(codepoint)}b"
+        assert safe_http_url(url) is None, f"accepted U+{codepoint:04X}"
+
+
+def test_safe_hyperlink_spans_reports_safe_label_bounds() -> None:
+    linked = "before \x1b]8;id=7;https://example.test/path\x1b\\label\x1b]8;;\x1b\\ after"
+    unsafe = "\x1b]8;;file:///tmp/secret\x1b\\local\x1b]8;;\x1b\\"
+
+    assert safe_hyperlink_spans(linked) == ((7, 12, "https://example.test/path"),)
+    assert safe_hyperlink_spans(unsafe) == ()
 
 
 def test_hyperlink_hit_testing_accepts_only_http_targets() -> None:

--- a/packages/nooa-cli/tests/tui/test_terminal_safety.py
+++ b/packages/nooa-cli/tests/tui/test_terminal_safety.py
@@ -83,6 +83,7 @@ def test_user_bar_is_control_safe_cell_aware_and_reserves_final_column() -> None
 
     colors = {"text": "#cdd6f4", "surface2": "#585b70"}
     bar = _build_user_bar("wide 界\x1b[2J\r", _App(), colors)  # type: ignore[arg-type]
+    assert bar.startswith("\x1b[38;5;189;48;5;59m")
 
     assert "\x1b[2J" not in bar
     visible_lines = strip_safe_ansi(sanitize_transcript_ansi(bar)).splitlines()

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -793,6 +793,21 @@ async def test_withdrawing_coalesced_input_retires_queue_handoff():
         assert h.app._pending_input_display() == []
 
 
+async def test_clearing_pending_handoffs_removes_old_session_queue_rows() -> None:
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("trigger")
+        await h.wait_for(lambda: h.app.is_thinking())
+        h.app.complete_pending_input_handoff("trigger")
+
+        h.app.submit_message("old-session")
+        assert h.app._pending_input_handoff
+
+        h.app.clear_pending_input_handoffs()
+
+        assert h.app._pending_input_handoff == []
+
+
 async def test_queue_multiple_enters_merge_into_one_item():
     """Successive Enters typed while the agent is working compose one
     queued message joined with newlines so the agent isn't asked to

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -705,6 +705,26 @@ async def test_admitted_input_stays_visible_until_accepted_echo_commits():
         assert h.app._pending_input_display() == []
 
 
+async def test_pending_display_preserves_runtime_queue_during_handoff(monkeypatch):
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("trigger")
+        await h.wait_for(lambda: h.app.is_thinking())
+        h.app.complete_pending_input_handoff("trigger")
+
+        h.app.submit_message("already-pending")
+        h.app.complete_pending_input_handoff("already-pending")
+        assert h.runner.state.pending_inputs == ("already-pending",)
+
+        monkeypatch.setattr(h.app._agent_controller, "submit", lambda _text: True)
+        h.app.submit_message("newly-admitted")
+
+        assert h.app._pending_input_display() == [
+            "already-pending",
+            "newly-admitted",
+        ]
+
+
 async def test_submission_exception_retires_only_new_handoff(monkeypatch):
     agent = _blocking_agent()
     async with TUIHarness(agent=agent) as h:
@@ -738,6 +758,23 @@ async def test_coalesced_accepted_echo_retires_all_submission_handoffs():
         h.app.complete_pending_input_handoff("one\ntwo")
         assert [item.text for item in h.app._pending_input_handoff] == ["one\ntwo"]
         h.app.complete_pending_input_handoff("one\ntwo")
+        assert h.app._pending_input_handoff == []
+
+
+async def test_coalesced_echo_with_runtime_prefix_retires_tui_handoffs():
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("trigger")
+        await h.wait_for(lambda: h.app.is_thinking())
+        h.app.complete_pending_input_handoff("trigger")
+
+        h.runner._user_messages.put("runtime-prefix")
+        h.app.submit_message("one")
+        h.app.submit_message("two")
+
+        assert h.runner._user_messages.snapshot() == ["runtime-prefix\none\ntwo"]
+        assert h.app._pending_input_display() == ["runtime-prefix", "one", "two"]
+        h.app.complete_pending_input_handoff("runtime-prefix\none\ntwo")
         assert h.app._pending_input_handoff == []
 
 

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -674,6 +674,88 @@ async def test_queue_displays_above_prompt_while_agent_working():
         await h.wait_for(lambda: h.capture_queued() == ["queued-msg"])
 
 
+async def test_admitted_input_stays_visible_until_accepted_echo_commits():
+    """A fast dequeue cannot create a blank composer→queue→transcript frame."""
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("trigger")
+        await h.wait_for(lambda: h.app.is_thinking())
+
+        # Harness submission bypasses Session's accepted-message UI callback;
+        # retire that setup-only handoff before testing the next admission.
+        h.app.complete_pending_input_handoff("trigger")
+
+        # Simulate the worker consuming immediately, before Session commits its
+        # accepted-message transcript block on the UI owner loop.
+        h.app.submit_message("queued-msg")
+        assert h.app._pending_input_display() == ["queued-msg"]
+
+        # Dequeue publication may already be empty before the Session callback
+        # runs; optimistic queue chrome must still bridge that frame.
+        h.runner._on_user_message_get(
+            "queued-msg",
+            generation=h.runner._binding_generation,
+            user_messages=h.runner._user_messages,
+            previous=None,
+        )
+        assert h.runner.state.pending_inputs == ()
+        assert h.app._pending_input_display() == ["queued-msg"]
+
+        h.app.complete_pending_input_handoff("queued-msg")
+        assert h.app._pending_input_display() == []
+
+
+async def test_submission_exception_retires_only_new_handoff(monkeypatch):
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("trigger")
+        await h.wait_for(lambda: h.app.is_thinking())
+        assert [item.text for item in h.app._pending_input_handoff] == ["trigger"]
+
+        def fail_submit(_text: str) -> bool:
+            raise RuntimeError("agent transition")
+
+        monkeypatch.setattr(h.app._agent_controller, "submit", fail_submit)
+        h.app.submit_message("rejected")
+
+        assert [item.text for item in h.app._pending_input_handoff] == ["trigger"]
+        await h.wait_output_contains("Message rejected.")
+
+
+async def test_coalesced_accepted_echo_retires_all_submission_handoffs():
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("trigger")
+        await h.wait_for(lambda: h.app.is_thinking())
+
+        h.app.complete_pending_input_handoff("trigger")
+        h.app.submit_message("one")
+        h.app.submit_message("two")
+        h.app.submit_message("one\ntwo")
+
+        # FIFO completion must retire the first two submissions, not the later
+        # literal multiline duplicate.
+        h.app.complete_pending_input_handoff("one\ntwo")
+        assert [item.text for item in h.app._pending_input_handoff] == ["one\ntwo"]
+        h.app.complete_pending_input_handoff("one\ntwo")
+        assert h.app._pending_input_handoff == []
+
+
+async def test_withdrawing_coalesced_input_retires_queue_handoff():
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("trigger")
+        await h.wait_for(lambda: h.app.is_thinking())
+        h.app.complete_pending_input_handoff("trigger")
+        await h.submit_async("one")
+        await h.submit_async("two")
+        await h.wait_for(lambda: h.app._pending_input_display() == ["one", "two"])
+
+        await h.press("up")
+        await h.wait_input_equals("one\ntwo")
+        assert h.app._pending_input_display() == []
+
+
 async def test_queue_multiple_enters_merge_into_one_item():
     """Successive Enters typed while the agent is working compose one
     queued message joined with newlines so the agent isn't asked to

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -803,6 +803,22 @@ async def test_coalesced_accepted_echo_retires_all_submission_handoffs():
         assert h.app._pending_input_handoff == []
 
 
+@pytest.mark.parametrize("echo", ["two", "runtime-prefix\ntwo"])
+async def test_out_of_order_echo_retires_only_matching_handoff(echo: str) -> None:
+    from nooa_cli.tui.tui_application import TUIApplication, _PendingInputHandoff
+
+    app = TUIApplication(display_mode="fullscreen")
+    app._pending_input_handoff = [
+        _PendingInputHandoff("one"),
+        _PendingInputHandoff("two"),
+        _PendingInputHandoff("three"),
+    ]
+
+    app.complete_pending_input_handoff(echo)
+
+    assert [item.text for item in app._pending_input_handoff] == ["one", "three"]
+
+
 async def test_coalesced_echo_with_runtime_prefix_retires_tui_handoffs():
     agent = _blocking_agent()
     async with TUIHarness(agent=agent) as h:

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -165,6 +165,48 @@ async def test_observation_close_failure_does_not_skip_app_teardown(
     assert app._loop is None
 
 
+@pytest.mark.parametrize("task_name", ["_clipboard_task", "_link_task"])
+async def test_failed_auxiliary_task_does_not_skip_app_teardown(
+    monkeypatch: pytest.MonkeyPatch, task_name: str
+) -> None:
+    from nooa_cli.tui.host_services import TUIHostServices
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    phases: list[str] = []
+
+    async def quiesce() -> None:
+        phases.append("quiesce")
+
+    async def fail_after_cancellation() -> None:
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError as exc:
+            raise RuntimeError("task teardown failed") from exc
+
+    app = TUIApplication(
+        host_services=TUIHostServices(before_output_drain=quiesce),
+        display_mode="native-replay",
+    )
+
+    async def exit_immediately(*_args, **_kwargs) -> None:
+        setattr(app, task_name, asyncio.create_task(fail_after_cancellation()))
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(app._app, "run_async", exit_immediately)
+    monkeypatch.setattr(
+        "nooa_cli.tui.stream_forwarder.install_stray_stream_capture",
+        lambda *_args, **_kwargs: lambda: phases.append("streams restored"),
+    )
+
+    await app.run_async()
+
+    assert phases == ["streams restored", "quiesce"]
+    assert getattr(app, task_name) is None
+    assert app._block_queue is None
+    assert app._consumer_task is None
+    assert app._loop is None
+
+
 async def test_pre_run_emit_uses_the_same_normalized_block_as_replay(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes two critical fullscreen TUI interaction regressions found after #176:

1. **Fullscreen links were not clickable.** Renderer-owned mouse selection swallowed ordinary clicks on OSC-8 hyperlinks.
2. **Submitted text could temporarily disappear while an agent was working.** A fast dequeue could remove queue chrome before the accepted-message transcript callback committed the user message.

### Fullscreen links

- Preserve OSC-8 metadata through fullscreen projection and hit-test links by screen cell.
- Open links only for click-without-drag, retaining drag-to-copy behavior.
- Validate HTTP(S) targets, handle wrapping/Unicode/blank rows, and suppress duplicate launches.
- Use cancellable local opener subprocesses; under SSH, copy the URL instead of launching a browser on the remote host.

### Queued input visibility

- Keep admitted text visible through the queue-to-transcript handoff.
- Retire the fallback only after the accepted user transcript block is committed.
- Serialize pending-input state publication against dequeue to prevent stale snapshots.
- Handle coalesced multiline messages, duplicate text, withdrawal back into the composer, and rejected/exceptional submissions.

### Scope

This PR targets `dev/tui` and now contains only `packages/nooa-cli` TUI/runtime-adapter changes. Agent-facing Python diagnostic improvements were extracted to #189, targeting `main`.

### Validation

- Combined focused TUI/runtime suites: **292 passed**
- Ruff: passed
- Scoped Pyright: **0 errors, 0 warnings**
- `git diff --check`: passed

Signed-off-by: Paul Furgale <pfurgale@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clickable HTTP(S) hyperlinks in fullscreen transcripts, with clipboard fallback.
  - Added configurable trailing blank-row visibility and improved scrolling, selection, and transcript layout.
  - Added responsive splash-screen rendering for fullscreen and standard terminal modes.
  - Improved formatting for live and resumed user messages, including wrapped and wide-character text.

- **Bug Fixes**
  - Improved hyperlink safety, wrapping, hit testing, and rendering.
  - Prevented pending input from disappearing or becoming inconsistent during rapid submissions.
  - Improved session-swap cleanup, stale callback handling, click-versus-drag behavior, and shutdown reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->