### PR TITLE
Hide skill lifecycle hooks from agent docs

### DIFF
--- a/src/nooa/skill.py
+++ b/src/nooa/skill.py
@@ -302,6 +302,7 @@ class Skill:
             cls_name = name or "Skill"
             self.__class__ = type(cls_name, (Skill,), {"__doc__": content})  # pyright: ignore[reportAttributeAccessIssue]
 
+    @hidden
     def attach(self, agent: Any) -> None:
         """Called when this skill is installed on an agent.
 
@@ -309,6 +310,7 @@ class Skill:
         """
         self._agent = agent
 
+    @hidden
     def detach(self) -> None:
         """Called when this skill is removed from an agent."""
         self._agent = None

--- a/tests/agentdoc/test_skill_lifecycle_visibility.py
+++ b/tests/agentdoc/test_skill_lifecycle_visibility.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Skill lifecycle hooks are framework plumbing, not model-facing tools."""
+
+from nooa.agentdoc import doc
+from nooa.skill import Skill
+
+
+class ExampleSkill(Skill):
+    """A useful example skill."""
+
+    def useful(self, value: str) -> str:
+        """Return a useful value."""
+        return value
+
+
+def test_skill_lifecycle_hooks_are_hidden_from_docs():
+    rendered = doc(ExampleSkill)
+
+    assert "def useful(" in rendered
+    assert "def attach(" not in rendered
+    assert "def detach(" not in rendered


### PR DESCRIPTION
## Summary
- mark the base `Skill.attach()` and `Skill.detach()` lifecycle hooks with the existing `@hidden` decorator
- verify inherited lifecycle hooks stay out of model-facing agent docs
- avoid adding any new agentdoc visibility mechanism or changing `spec(..., hidden=False)` semantics

## Verification
- `uv run ruff check src/nooa/skill.py tests/agentdoc/test_skill_lifecycle_visibility.py`
- `uv run pytest tests/agentdoc -q` (687 passed)
