### PR TITLE
Clarify MethodWriting strategy guidance

### DIFF
--- a/src/nooa/tools/method_writing_lib.py
+++ b/src/nooa/tools/method_writing_lib.py
@@ -1,62 +1,56 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""MethodWriting — opt-in capability for agents to define helper functions."""
+"""MethodWriting — guidance for defining helpers and LLM-powered sub-calls."""
 
 from nooa.skill import Skill
 
 
 class MethodWriting(Skill):
-    """Define helpers and LLM-powered sub-calls at the top of a REPL cell.
+    """Define local helpers and LLM-powered sub-calls at the top of a REPL cell.
 
-    ## Plain helper functions
-    For deterministic logic (math, filtering, formatting, data transformation).
-    Define at the top of the cell and call by name:
+    Choose the smallest mechanism that fits the work:
 
-        def celsius_to_fahrenheit(c):
-            return c * 9/5 + 32
-
-        converted = [celsius_to_fahrenheit(t) for t in temperatures]
-        return_result(converted)
-
-    ## @strategy(PredictStrategy()) — per-item generation with fan-out
-    For sub-tasks requiring language understanding (classification, extraction,
-    interpretation). These tasks need LLM reasoning. Decorate a standalone
-    async function with an ellipsis body. ``asyncio.gather`` runs the calls
-    in parallel.
+    - Use a normal ``def`` for deterministic computation such as filtering,
+      formatting, math, or parsing a known syntax.
+    - Use ``PredictStrategy`` for an independent, one-shot semantic task. Fan out
+      independent calls concurrently with ``asyncio.gather``.
+    - Use ``CodeActStrategy`` only when a subtask needs iterative execution or
+      tools. Prefer the current call for simple work; sub-calls add cost and context.
 
     Examples:
 
+    Deterministic helper:
+
+        def celsius_to_fahrenheit(value: float) -> float:
+            return value * 9 / 5 + 32
+
+        converted = [celsius_to_fahrenheit(value) for value in temperatures]
+
+    Example — concurrent one-shot semantic tasks:
+
         @strategy(PredictStrategy())
         async def detect_language(message: str) -> str:
-            \"\"\"Return the ISO 639-1 code for {{message}} (e.g. 'en', 'fr', 'ja').\"\"\"
+            '''Return the message's ISO 639-1 language code.'''
             ...
 
-        codes = await asyncio.gather(*(detect_language(m) for m in messages))
-        return_result(codes)
+        codes = await asyncio.gather(*(detect_language(message) for message in messages))
 
-    ## @strategy(CodeActStrategy()) — multi-step sub-calls
-    For sub-tasks needing both reasoning and multi-step computation:
+    Example — an iterative sub-call:
 
         @strategy(CodeActStrategy())
-        async def plan_itinerary(request: str) -> Itinerary:
-            \"\"\"Build a day-by-day travel itinerary from {{request}}.\"\"\"
+        async def investigate_failure(log_excerpt: str) -> str:
+            '''Investigate the failure and return the most likely root cause.'''
             ...
 
-        result = await plan_itinerary(payload)
+        diagnosis = await investigate_failure(log_text)
 
-    ## Rules
-    - Use ``...`` (ellipsis) as the body — the framework implements the call
-      via LLM. The docstring IS the prompt: use ``{{param}}`` placeholders to
-      interpolate argument values.
+    Define generated methods as standalone top-level ``async def`` functions with
+    an ellipsis body. Their docstring is the prompt. Arguments are passed and
+    rendered automatically, so do not interpolate parameter values into docstrings.
 
-    ## No heuristics for language understanding
-    Never use keyword matching, regex, or hand-written rules for tasks
-    requiring language understanding (classification, extraction,
-    interpretation). These tasks need LLM reasoning — delegate to a
-    ``@strategy(PredictStrategy())`` standalone function.
-
-    Load this skill:
-        doc(self.writing)
+    Do not replace semantic judgment with keyword matching, regex, or hand-written
+    scoring rules. Deterministic parsing of a known syntax is appropriate; semantic
+    classification, extraction, and interpretation belong in an LLM-powered call.
     """
 
     pass

--- a/tests/tools/test_builtin_libs.py
+++ b/tests/tools/test_builtin_libs.py
@@ -26,6 +26,15 @@ def test_events_api_has_library_docstring():
 
 def test_method_writing_lib_has_library_docstring():
     _check_library_docstring(MethodWriting)
+    docstring = MethodWriting.__doc__ or ""
+    assert "@strategy(PredictStrategy())" in docstring
+    assert "asyncio.gather" in docstring
+    assert "@strategy(CodeActStrategy())" in docstring
+    assert "Arguments are passed" in docstring
+    assert "rendered automatically" in docstring
+    assert "{{" not in docstring
+    assert "}}" not in docstring
+    assert "Never use" not in docstring
 
 
 def test_method_writing_lib_is_instantiable():


### PR DESCRIPTION
## Summary
- rewrite `MethodWriting` around a clear choice between deterministic helpers, one-shot `PredictStrategy` calls, and iterative `CodeActStrategy` calls
- remove unsafe/manual argument interpolation examples
- distinguish semantic judgment from valid deterministic parsing
- add regression assertions for the model-facing guidance

## Verification
- `uv run ruff check src/nooa/tools/method_writing_lib.py tests/tools/test_builtin_libs.py`
- `uv run pytest tests/tools/test_builtin_libs.py -q` (8 passed)
