### PR TITLE
fix(tui): avoid displayless clipboard helpers

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1458,12 +1458,24 @@ class TUIApplication:
 
     @staticmethod
     def _local_clipboard_command() -> tuple[str, ...] | None:
-        local_commands = (
+        # Graphical Linux clipboard clients can be installed even when their
+        # corresponding display is unavailable. In particular, displayless sbx
+        # environments expose an ``xclip`` compatibility shim that exits 0 for
+        # text without copying it. Do not treat that false success as a local
+        # clipboard write; fall through to OSC 52 instead.
+        local_commands = [
             ("pbcopy", ()),
-            ("wl-copy", ()),
-            ("xclip", ("-selection", "clipboard")),
-            ("xsel", ("--clipboard", "--input")),
-        )
+        ]
+        display_disabled = os.environ.get("SBX_NO_DISPLAY") == "1"
+        if not display_disabled and os.environ.get("WAYLAND_DISPLAY"):
+            local_commands.append(("wl-copy", ()))
+        if not display_disabled and os.environ.get("DISPLAY"):
+            local_commands.extend(
+                (
+                    ("xclip", ("-selection", "clipboard")),
+                    ("xsel", ("--clipboard", "--input")),
+                )
+            )
         for executable, arguments in local_commands:
             path = shutil.which(executable)
             if path is not None:

--- a/packages/nooa-cli/tests/tui/test_sensitive_prompt.py
+++ b/packages/nooa-cli/tests/tui/test_sensitive_prompt.py
@@ -218,6 +218,9 @@ def test_local_clipboard_prefers_platform_command_over_osc52(monkeypatch):
     app._app = SimpleNamespace(output=output)
     monkeypatch.delenv("SSH_CONNECTION", raising=False)
     monkeypatch.delenv("SSH_TTY", raising=False)
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("SBX_NO_DISPLAY", raising=False)
     monkeypatch.setattr(
         "nooa_cli.tui.tui_application.shutil.which",
         lambda name: "/usr/bin/wl-copy" if name == "wl-copy" else None,
@@ -233,3 +236,43 @@ def test_local_clipboard_prefers_platform_command_over_osc52(monkeypatch):
     assert run.call_args.args[0] == ["/usr/bin/wl-copy"]
     assert run.call_args.kwargs["input"] == b"local text"
     output.write_raw.assert_not_called()
+
+
+def test_displayless_sandbox_ignores_xclip_shim_and_uses_osc52(monkeypatch):
+    output = MagicMock()
+    app = TUIApplication.__new__(TUIApplication)
+    app._app = SimpleNamespace(output=output)
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
+    monkeypatch.delenv("SSH_TTY", raising=False)
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    monkeypatch.setenv("SBX_NO_DISPLAY", "1")
+    monkeypatch.setattr(
+        "nooa_cli.tui.tui_application.shutil.which",
+        lambda name: f"/usr/local/bin/{name}" if name in {"wl-copy", "xclip"} else None,
+    )
+    run = MagicMock()
+    monkeypatch.setattr("nooa_cli.tui.tui_application.subprocess.run", run)
+
+    result = app._copy_to_clipboard_result("sandbox text")
+
+    assert result.success is True
+    assert result.transport == "osc52"
+    run.assert_not_called()
+    assert "\x1b]52;c;" in output.write_raw.call_args.args[0]
+
+
+def test_xclip_is_available_with_x_display(monkeypatch):
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.delenv("SBX_NO_DISPLAY", raising=False)
+    monkeypatch.setattr(
+        "nooa_cli.tui.tui_application.shutil.which",
+        lambda name: "/usr/bin/xclip" if name == "xclip" else None,
+    )
+
+    assert TUIApplication._local_clipboard_command() == (
+        "/usr/bin/xclip",
+        "-selection",
+        "clipboard",
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes clipboard copy from the TUI in displayless `sbx` environments.

`sbx` removes the SSH markers used by the TUI's remote detection, exports `SBX_NO_DISPLAY=1`, and provides an `xclip` compatibility shim. For ordinary text that shim exits successfully without copying anything. The TUI therefore reported `Copied … characters` and never fell back to OSC 52.

This change:

- uses `wl-copy` only when Wayland is available;
- uses `xclip`/`xsel` only when X11 is available;
- honors `SBX_NO_DISPLAY=1` even if stale display variables remain;
- preserves `pbcopy` behavior on macOS;
- falls back to the existing OSC 52 path when no usable graphical clipboard is present.

The fix was verified live in the affected `ssh → tmux → sbx → nooa` setup. Copy now reaches the local clipboard. Claude and a direct OSC 52 command in the same sandbox were used to isolate the false-success `xclip` branch.

## Related issues

None.

## Validation

- `uv run pytest -q packages/nooa-cli/tests/tui/test_sensitive_prompt.py` — 23 passed
- `uv run pytest -q packages/nooa-cli/tests/tui/test_fullscreen_transcript.py -k 'clipboard or copy'` — 10 passed
- Full TUI suite — 1147 passed; 2 pre-existing macOS `/var` vs `/private/var` path-alias failures
- `uv run ruff check` — passed for changed files
- `uv run ruff format --check` — passed for changed files
- `uv run pyright` — 0 errors for changed files
- Live copy verification in `agent-garph` — passed

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass for changed files)
- [x] Tests added/updated and passing
- [x] Docs updated if behavior or public APIs changed (not applicable; no public API or documentation change)
- [x] New source files carry an SPDX license header (not applicable; no new files)
