### PR TITLE
perf(events): stream limited SQLite queries

### DIFF
--- a/src/nooa/runtime/event_backend.py
+++ b/src/nooa/runtime/event_backend.py
@@ -301,6 +301,15 @@ class InMemoryBackend:
     def all_events(self) -> Iterator[EventBase]:
         return iter(self._events)
 
+    def iter_events(
+        self,
+        *,
+        event_type: str | None = None,
+        newest_first: bool = False,
+    ) -> Iterator[EventBase]:
+        events = reversed(self._events) if newest_first else iter(self._events)
+        return (event for event in events if event_type is None or event.event_type == event_type)
+
     def find_tag(self, event: EventBase) -> str | None:
         for tag, e in self._tag_to_event.items():
             if e is event or e.id == event.id:

--- a/src/nooa/runtime/event_manager.py
+++ b/src/nooa/runtime/event_manager.py
@@ -14,8 +14,8 @@ import itertools
 import logging
 import re
 from collections import defaultdict
-from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any
+from collections.abc import Awaitable, Callable, Iterable, Iterator
+from typing import TYPE_CHECKING, Any, cast
 
 from nooa.context_blocks import EventStatus
 from nooa.context_blocks.models import Role
@@ -369,30 +369,44 @@ class EventManager:
         Returns:
             List of matching events.
         """
-        events = list(self._backend.all_events())
+        if limit is not None and limit <= 0:
+            return []
 
-        # Apply type filter
-        if type is not None:
-            events = [e for e in events if e.event_type == type]
+        newest_first = limit is not None
+        source: Iterable[EventBase]
+        iter_events = getattr(self._backend, "iter_events", None)
+        if newest_first and callable(iter_events):
+            optimized_iterator = cast(Callable[..., Iterator[EventBase]], iter_events)
+            source = optimized_iterator(event_type=type, newest_first=True)
+        else:
+            # ``iter_events`` is an optional optimization so existing custom
+            # EventBackend implementations remain compatible. Unlimited queries
+            # retain the backend's established snapshot behavior.
+            events = self._backend.all_events()
+            source = reversed(list(events)) if newest_first else events
+        matches: list[EventBase] = []
+        pattern = re.compile(query, re.IGNORECASE) if query is not None and regex else None
+        query_lower = query.lower() if query is not None and not regex else None
 
-        # Apply call_id filter
-        if call_id is not None:
-            events = [e for e in events if e.metadata.get("call_id") == call_id]
+        for event in source:
+            if type is not None and event.event_type != type:
+                continue
+            if call_id is not None and event.metadata.get("call_id") != call_id:
+                continue
+            if pattern is not None and not pattern.search(self._get_searchable_text(event)):
+                continue
+            if (
+                query_lower is not None
+                and query_lower not in self._get_searchable_text(event).lower()
+            ):
+                continue
+            matches.append(event)
+            if limit is not None and len(matches) >= limit:
+                break
 
-        # Apply text/regex filter
-        if query is not None:
-            if regex:
-                pattern = re.compile(query, re.IGNORECASE)
-                events = [e for e in events if pattern.search(self._get_searchable_text(e))]
-            else:
-                query_lower = query.lower()
-                events = [e for e in events if query_lower in self._get_searchable_text(e).lower()]
-
-        # Apply limit (from end = most recent)
-        if limit is not None and len(events) > limit:
-            events = events[-limit:]
-
-        return events
+        if newest_first:
+            matches.reverse()
+        return matches
 
     def _get_searchable_text(self, event: EventBase) -> str:
         """Extract searchable text from an event's public fields."""

--- a/src/nooa/storage/sqlite.py
+++ b/src/nooa/storage/sqlite.py
@@ -121,6 +121,15 @@ CREATE INDEX IF NOT EXISTS idx_events_event_id ON events(event_id);
 CREATE INDEX IF NOT EXISTS idx_events_insertion_order ON events(insertion_order);
 CREATE INDEX IF NOT EXISTS idx_events_type_order ON events(event_type, insertion_order);
 
+-- Database-owned monotonic ordering avoids collisions across backend instances
+-- and is intentionally not reset by clear().
+CREATE TABLE IF NOT EXISTS event_sequence (
+    singleton  INTEGER PRIMARY KEY CHECK (singleton = 1),
+    next_order INTEGER NOT NULL
+);
+INSERT OR IGNORE INTO event_sequence (singleton, next_order)
+SELECT 1, COALESCE(MAX(insertion_order), -1) + 1 FROM events;
+
 CREATE TABLE IF NOT EXISTS active_tags (
     position INTEGER NOT NULL,
     tag      TEXT NOT NULL UNIQUE
@@ -233,7 +242,8 @@ class SQLiteEventBackend:
     def __init__(self, conn: sqlite3.Connection, lock: threading.RLock | None = None) -> None:
         self._conn = conn
         self._lock = lock or threading.RLock()
-        self._insertion_counter = self._max_insertion_order() + 1
+        self._ensure_event_sequence()
+        self._insertion_counter = self._next_insertion_order()
         self._registry: dict[str, type[EventBase]] = dict(_CORE_TYPES)
         # Tag counter — eager-init from storage so a resumed DB picks
         # up at the right number. ``store()`` keeps it coherent when a
@@ -274,6 +284,53 @@ class SQLiteEventBackend:
             )
             return -1
         return row[0] if row[0] is not None else -1
+
+    def _ensure_event_sequence(self) -> None:
+        """Install the additive sequence table without owning the caller's transaction."""
+        savepoint = "nooa_event_sequence_init"
+        with self._lock:
+            self._conn.execute(f"SAVEPOINT {savepoint}")
+            try:
+                self._conn.execute(
+                    "CREATE TABLE IF NOT EXISTS event_sequence ("
+                    "singleton INTEGER PRIMARY KEY CHECK (singleton = 1), "
+                    "next_order INTEGER NOT NULL)"
+                )
+                try:
+                    self._conn.execute(
+                        "INSERT OR IGNORE INTO event_sequence (singleton, next_order) "
+                        "SELECT 1, COALESCE(MAX(insertion_order), -1) + 1 FROM events"
+                    )
+                except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:
+                    if not _is_corruption_error(exc):
+                        raise
+                    logger.warning(
+                        "_ensure_event_sequence(): events unreadable, starting at 0 (%s)",
+                        type(exc).__name__,
+                    )
+                    self._conn.execute(
+                        "INSERT OR IGNORE INTO event_sequence (singleton, next_order) VALUES (1, 0)"
+                    )
+                self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+            except Exception:
+                self._conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+                raise
+
+    def _next_insertion_order(self) -> int:
+        try:
+            row = self._conn.execute(
+                "SELECT next_order FROM event_sequence WHERE singleton = 1"
+            ).fetchone()
+        except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:
+            if not _is_corruption_error(exc):
+                raise
+            logger.warning(
+                "_next_insertion_order(): sequence unreadable, starting counter at 0: %s",
+                type(exc).__name__,
+            )
+            return 0
+        return row[0] if row is not None else self._max_insertion_order() + 1
 
     def _max_position(self) -> int:
         try:
@@ -319,29 +376,31 @@ class SQLiteEventBackend:
 
         with self._lock:
             data = self._serialize(event)
-            order = self._insertion_counter
-            self._insertion_counter += 1
             try:
-                self._do_store(tag, event, data, order)
-            except sqlite3.OperationalError as e:
-                if "disk I/O error" not in str(e) or self._on_io_error is None:
+                order = self._do_store(tag, event, data)
+            except sqlite3.OperationalError as exc:
+                if "disk I/O error" not in str(exc) or self._on_io_error is None:
                     raise
                 logger.warning("store(%s): disk I/O error, attempting reconnect + retry", tag)
                 self._on_io_error()
-                # Retry once after reconnect. If the original write partially
-                # committed before the I/O error, the retry hits IntegrityError
-                # on the UNIQUE constraint — that means the data IS stored, so
-                # we treat it as success.
+                # Retry once after reconnect. If the original write committed,
+                # the tag's UNIQUE constraint confirms that it is persisted.
                 try:
-                    self._do_store(tag, event, data, order)
-                except sqlite3.IntegrityError:
+                    order = self._do_store(tag, event, data)
+                except sqlite3.IntegrityError as retry_exc:
+                    row = self._conn.execute(
+                        "SELECT event_id, data, insertion_order FROM events WHERE tag = ?",
+                        (tag,),
+                    ).fetchone()
+                    if row is None or row[0] != event.id or row[1] != data:
+                        raise retry_exc
                     logger.info("store(%s): row already persisted before I/O error", tag)
+                    order = row[2]
                 except sqlite3.DatabaseError as retry_exc:
-                    # A double failure (I/O error then corruption on the
-                    # reconnected retry) must not escape unhandled either.
                     self._raise_for_db_error(tag, retry_exc)
-            except sqlite3.DatabaseError as e:
-                self._raise_for_db_error(tag, e)
+            except sqlite3.DatabaseError as exc:
+                self._raise_for_db_error(tag, exc)
+            self._insertion_counter = max(self._insertion_counter, order + 1)
             self._next_tag_num = max(self._next_tag_num, _tag_max_num(tag) + 1)
 
     def _raise_for_db_error(self, tag: str, exc: sqlite3.DatabaseError) -> typing.NoReturn:
@@ -356,8 +415,15 @@ class SQLiteEventBackend:
         logger.error("store(%s): database is corrupt — %s", tag, exc)
         raise CorruptDatabaseError(str(exc)) from exc
 
-    def _do_store(self, tag: str, event: EventBase, data: str, order: int) -> None:
+    def _do_store(self, tag: str, event: EventBase, data: str) -> int:
         with self._conn:
+            row = self._conn.execute(
+                "UPDATE event_sequence SET next_order = next_order + 1 "
+                "WHERE singleton = 1 RETURNING next_order - 1"
+            ).fetchone()
+            if row is None:
+                raise sqlite3.DatabaseError("event sequence is not initialized")
+            order = row[0]
             self._conn.execute(
                 "INSERT INTO events (tag, event_id, event_type, status, data, insertion_order) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
@@ -368,6 +434,7 @@ class SQLiteEventBackend:
                 "INSERT INTO active_tags (position, tag) VALUES (?, ?)",
                 (pos, tag),
             )
+        return order
 
     def _retry_on_io_error(self, fn: typing.Callable[[], typing.Any]) -> typing.Any:
         """Run *fn*; on disk I/O error, reconnect and retry once."""
@@ -515,7 +582,7 @@ class SQLiteEventBackend:
         with self._lock:
             try:
                 rows = self._conn.execute(
-                    "SELECT data FROM events ORDER BY insertion_order"
+                    "SELECT data FROM events ORDER BY insertion_order, rowid"
                 ).fetchall()
             except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
                 if not _is_corruption_error(e):
@@ -525,6 +592,54 @@ class SQLiteEventBackend:
         for (data,) in rows:
             if event := self._try_deserialize(data, context="all_events()"):
                 yield event
+
+    def iter_events(
+        self,
+        *,
+        event_type: str | None = None,
+        newest_first: bool = False,
+    ) -> Iterator[EventBase]:
+        """Stream a bounded snapshot using one-row keyset queries."""
+        order = "DESC" if newest_first else "ASC"
+        comparison = "<" if newest_first else ">"
+
+        try:
+            with self._lock:
+                row = self._conn.execute("SELECT MAX(insertion_order) FROM events").fetchone()
+            if row is None or row[0] is None:
+                return
+
+            upper_bound = row[0]
+            position = (upper_bound + 1, -1) if newest_first else (-1, -1)
+            batch_size = 128
+            while True:
+                sql = (
+                    "SELECT data, insertion_order, rowid FROM events "
+                    "WHERE insertion_order <= ? "
+                    f"AND (insertion_order, rowid) {comparison} (?, ?)"
+                )
+                params: tuple[int | str, ...] = (upper_bound, *position)
+                if event_type is not None:
+                    sql += " AND event_type = ?"
+                    params += (event_type,)
+                sql += f" ORDER BY insertion_order {order}, rowid {order} LIMIT ?"
+                params += (batch_size,)
+                with self._lock:
+                    rows = self._conn.execute(sql, params).fetchall()
+                if not rows:
+                    break
+                for data, insertion_order, rowid in rows:
+                    position = (insertion_order, rowid)
+                    event = self._try_deserialize(data, context="iter_events()")
+                    if event is not None:
+                        yield event
+        except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:
+            if not _is_corruption_error(exc):
+                raise
+            logger.error(
+                "iter_events(): query failed due to corruption (%s)",
+                type(exc).__name__,
+            )
 
     def find_tag(self, event: EventBase) -> str | None:
         with self._lock:
@@ -546,7 +661,6 @@ class SQLiteEventBackend:
             with self._conn:
                 self._conn.execute("DELETE FROM events")
                 self._conn.execute("DELETE FROM active_tags")
-            self._insertion_counter = 0
             self._next_tag_num = 1
 
     def allocate_next_tag(self) -> str:

--- a/tests/runtime/test_event_manager_events.py
+++ b/tests/runtime/test_event_manager_events.py
@@ -222,6 +222,32 @@ class TestEventManagerQuery:
         assert recent[0].prompt == "Message 2"
         assert recent[2].prompt == "Message 4"
 
+    def test_filter_nonpositive_limit_returns_no_events(self):
+        manager = EventManager()
+        manager.add(Task(prompt="one"))
+
+        assert manager.filter(limit=0) == []
+        assert manager.filter(limit=-1) == []
+
+    def test_filter_supports_backends_without_optional_iterator(self):
+        from nooa.runtime.event_backend import InMemoryBackend
+
+        class LegacyBackend:
+            def __init__(self) -> None:
+                self._delegate = InMemoryBackend()
+
+            def __getattr__(self, name):
+                if name == "iter_events":
+                    raise AttributeError(name)
+                return getattr(self._delegate, name)
+
+        manager = EventManager(backend=LegacyBackend())
+        manager.add(Task(prompt="old"))
+        manager.add(LLMOutput(content="middle"))
+        manager.add(Task(prompt="new"))
+
+        assert [event.prompt for event in manager.filter(type="Task", limit=1)] == ["new"]
+
     def test_filter_returns_all_if_less_than_limit(self):
         """filter(limit=n) should return all if fewer than n events."""
         manager = EventManager()

--- a/tests/test_event_backend_protocol.py
+++ b/tests/test_event_backend_protocol.py
@@ -399,3 +399,45 @@ def test_archived_status_preserved_after_roundtrip(backend):
     result = backend.get("1")
     assert type(result) is UserEvent
     assert result.status == EventStatus.ARCHIVED
+
+
+def test_iter_events_filters_type_and_can_reverse(backend):
+    backend.store("1", Task(prompt="old"))
+    backend.store(
+        "2",
+        ToolCallEvent(
+            tool_call_id="call-1",
+            name="tool",
+            arguments={},
+        ),
+    )
+    backend.store("3", Task(prompt="new"))
+
+    tasks = list(backend.iter_events(event_type="Task", newest_first=True))
+
+    assert [event.prompt for event in tasks] == ["new", "old"]
+
+
+def test_sqlite_iter_events_excludes_rows_appended_after_iteration_starts(sqlite_conn):
+    backend = SQLiteEventBackend(sqlite_conn)
+    backend.store("1", Task(prompt="old"))
+    backend.store("2", Task(prompt="current"))
+    events = backend.iter_events(event_type="Task")
+
+    assert next(events).prompt == "old"
+    backend.store("3", Task(prompt="later"))
+
+    assert [event.prompt for event in events] == ["current"]
+
+
+def test_sqlite_iter_events_excludes_rows_inserted_after_clear(sqlite_conn):
+    backend = SQLiteEventBackend(sqlite_conn)
+    backend.store("1", Task(prompt="old"))
+    backend.store("2", Task(prompt="current"))
+    events = backend.iter_events(event_type="Task")
+
+    assert next(events).prompt == "old"
+    backend.clear()
+    backend.store("1", Task(prompt="new"))
+
+    assert [event.prompt for event in events] == ["current"]

--- a/tests/test_sqlite_reconnect.py
+++ b/tests/test_sqlite_reconnect.py
@@ -55,12 +55,12 @@ class TestReconnect:
         call_count = 0
         original_do_store = storage._backend._do_store
 
-        def failing_store(tag, event, data, order):
+        def failing_store(tag, event, data):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
                 raise sqlite3.OperationalError("disk I/O error")
-            return original_do_store(tag, event, data, order)
+            return original_do_store(tag, event, data)
 
         storage._backend._do_store = failing_store
         event = _make_event("2")
@@ -74,7 +74,7 @@ class TestReconnect:
     def test_store_raises_on_non_io_error(self, storage):
         """store() should NOT retry on non-I/O OperationalErrors."""
 
-        def always_fail(tag, event, data, order):
+        def always_fail(tag, event, data):
             raise sqlite3.OperationalError("database is locked")
 
         storage._backend._do_store = always_fail
@@ -85,7 +85,7 @@ class TestReconnect:
     def test_store_raises_if_retry_also_fails(self, storage):
         """If reconnect doesn't help, the second failure should propagate."""
 
-        def always_fail(tag, event, data, order):
+        def always_fail(tag, event, data):
             raise sqlite3.OperationalError("disk I/O error")
 
         storage._backend._do_store = always_fail
@@ -98,13 +98,13 @@ class TestReconnect:
         call_count = [0]
         original_do_store = storage._backend._do_store
 
-        def commit_then_ioerr(tag, event, data, order):
+        def commit_then_ioerr(tag, event, data):
             call_count[0] += 1
             if call_count[0] == 1:
                 # Data commits, then I/O error on return path
-                original_do_store(tag, event, data, order)
+                original_do_store(tag, event, data)
                 raise sqlite3.OperationalError("disk I/O error")
-            return original_do_store(tag, event, data, order)
+            return original_do_store(tag, event, data)
 
         storage._backend._do_store = commit_then_ioerr
         event = _make_event("integrity")
@@ -118,7 +118,7 @@ class TestReconnect:
         sm = SQLiteStorageManager(tmp_db)
         sm._backend._on_io_error = None  # Explicitly clear
 
-        def always_fail(tag, event, data, order):
+        def always_fail(tag, event, data):
             raise sqlite3.OperationalError("disk I/O error")
 
         sm._backend._do_store = always_fail
@@ -126,6 +126,26 @@ class TestReconnect:
         with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
             sm._backend.store("5", event)
         sm.close()
+
+    def test_store_retry_does_not_mask_unrelated_integrity_error(self, storage):
+        """A retry collision is success only when the same event was persisted."""
+        call_count = 0
+        original_do_store = storage._backend._do_store
+        existing = _make_event("duplicate")
+        storage._backend.store("duplicate", existing)
+
+        def io_then_collision(tag, event, data):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise sqlite3.OperationalError("disk I/O error")
+            return original_do_store(tag, event, data)
+
+        storage._backend._do_store = io_then_collision
+        storage._backend._on_io_error = lambda: None
+
+        with pytest.raises(sqlite3.IntegrityError):
+            storage._backend.store("duplicate", _make_event("duplicate"))
 
 
 class TestBusyTimeout:

--- a/tests/test_sqlite_specific.py
+++ b/tests/test_sqlite_specific.py
@@ -10,11 +10,12 @@ These tests cover behavior that only applies to SQLiteEventBackend:
 """
 
 import logging
+import sqlite3
 from typing import Literal
 
 from nooa.context_blocks import EventBase, Metadata
 from nooa.context_blocks.events import AssistantEvent, ToolCallEvent, UserEvent
-from nooa.storage.sqlite import _CONTEXT_BLOCKS_TYPES, SQLiteEventBackend
+from nooa.storage.sqlite import _CONTEXT_BLOCKS_TYPES, SQLiteEventBackend, _ensure_schema
 
 # ---------------------------------------------------------------------------
 # _CONTEXT_BLOCKS_TYPES sanity
@@ -151,3 +152,105 @@ def test_register_event_type_overwrite_logs_warning(sqlite_conn, caplog):
     assert any("versioned_evt" in r.message for r in caplog.records), (
         "Expected a warning when overwriting an existing event_type key in the registry"
     )
+
+
+# ---------------------------------------------------------------------------
+# Streaming iteration
+# ---------------------------------------------------------------------------
+
+
+def test_iter_events_does_not_hold_read_lock_between_yields(tmp_path):
+    database = tmp_path / "events.db"
+    first_conn = sqlite3.connect(database, timeout=0.1, check_same_thread=False)
+    second_conn = sqlite3.connect(database, timeout=0.1, check_same_thread=False)
+    try:
+        first_conn.execute("PRAGMA journal_mode=DELETE")
+        second_conn.execute("PRAGMA journal_mode=DELETE")
+        _ensure_schema(first_conn)
+        first = SQLiteEventBackend(first_conn)
+        first.store("1", UserEvent(content="old"))
+        first.store("2", UserEvent(content="current"))
+        second = SQLiteEventBackend(second_conn)
+
+        events = first.iter_events(event_type="UserEvent")
+        assert next(events).content == "old"
+        second.store("3", UserEvent(content="later"))
+
+        assert [event.content for event in events] == ["current"]
+    finally:
+        first_conn.close()
+        second_conn.close()
+
+
+def test_iter_events_handles_writes_from_preinitialized_backends(tmp_path):
+    database = tmp_path / "events.db"
+    first_conn = sqlite3.connect(database, timeout=0.1, check_same_thread=False)
+    second_conn = sqlite3.connect(database, timeout=0.1, check_same_thread=False)
+    try:
+        _ensure_schema(first_conn)
+        first = SQLiteEventBackend(first_conn)
+        second = SQLiteEventBackend(second_conn)
+
+        first.store("1", UserEvent(content="one"))
+        second.store("2", UserEvent(content="two"))
+
+        rows = first_conn.execute(
+            "SELECT insertion_order FROM events ORDER BY insertion_order"
+        ).fetchall()
+        assert rows == [(0,), (1,)]
+        assert [event.content for event in first.iter_events(event_type="UserEvent")] == [
+            "one",
+            "two",
+        ]
+    finally:
+        first_conn.close()
+        second_conn.close()
+
+
+def test_iter_events_handles_legacy_duplicate_insertion_orders(sqlite_conn):
+    first = UserEvent(content="one")
+    second = UserEvent(content="two")
+    for tag, event in (("1", first), ("2", second)):
+        sqlite_conn.execute(
+            "INSERT INTO events "
+            "(tag, event_id, event_type, status, data, insertion_order) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                tag,
+                event.id,
+                event.event_type,
+                event.status.value,
+                event.model_dump_json(),
+                0,
+            ),
+        )
+    sqlite_conn.commit()
+    backend = SQLiteEventBackend(sqlite_conn)
+
+    assert [event.content for event in backend.all_events()] == ["one", "two"]
+    assert [event.content for event in backend.iter_events(event_type="UserEvent")] == [
+        "one",
+        "two",
+    ]
+    assert [
+        event.content for event in backend.iter_events(event_type="UserEvent", newest_first=True)
+    ] == ["two", "one"]
+
+
+def test_backend_init_preserves_callers_active_transaction(tmp_path):
+    database = tmp_path / "events.db"
+    conn = sqlite3.connect(database)
+    try:
+        _ensure_schema(conn)
+        conn.execute("CREATE TABLE unrelated (value TEXT)")
+        conn.commit()
+        conn.execute("INSERT INTO unrelated VALUES ('pending')")
+        assert conn.in_transaction
+
+        SQLiteEventBackend(conn)
+
+        assert conn.in_transaction
+        conn.rollback()
+        assert conn.execute("SELECT * FROM unrelated").fetchall() == []
+    finally:
+        conn.close()

--- a/tests/unit/test_util_and_sqlite.py
+++ b/tests/unit/test_util_and_sqlite.py
@@ -515,14 +515,15 @@ class TestSQLiteEventBackendClear:
         assert len(backend) == 0
         assert backend.active_tags() == []
 
-    def test_clear_resets_insertion_counter(self):
+    def test_clear_preserves_monotonic_insertion_counter(self):
         from nooa.events import Message
 
         backend, _ = _make_backend()
         backend.store("t1", Message(content="a"))
+        next_order = backend._insertion_counter
         backend.clear()
-        # After clear, insertion counter resets to 0
-        assert backend._insertion_counter == 0
+
+        assert backend._insertion_counter == next_order
 
 
 class TestSQLiteEventBackendDeserialization:


### PR DESCRIPTION
## Summary

- add optional reverse/type-filtered event iteration for backends
- make limited event queries stop after enough matching events instead of materializing full history
- use bounded SQLite keyset batches without holding a read cursor across yields
- allocate monotonic insertion order safely across SQLite connections and legacy databases
- harden disk-I/O retry handling against unrelated uniqueness failures

## Motivation

This was extracted from #189 after review identified that `events.query(..., limit=1)` could scan and materialize a long event history. It is intentionally separate from the Python error-context changes.

## Validation

- `uv run ruff check src/nooa/runtime/event_backend.py src/nooa/runtime/event_manager.py src/nooa/storage/sqlite.py tests/runtime/test_event_manager_events.py tests/test_event_backend_protocol.py tests/test_sqlite_reconnect.py tests/test_sqlite_specific.py tests/unit/test_util_and_sqlite.py`
- `uv run pytest -q tests/runtime/test_event_manager_events.py tests/test_event_backend_protocol.py tests/test_sqlite_reconnect.py tests/test_sqlite_specific.py tests/unit/test_util_and_sqlite.py` (188 passed)
- `git diff --check`
