### PR TITLE
fix(tools): send init_command through the same framing as user commands

### DIFF
--- a/src/nooa/tools/_bash_session.py
+++ b/src/nooa/tools/_bash_session.py
@@ -210,13 +210,17 @@ class BashSession:
             self._running_init = True
             try:
                 init_sentinel = f"__CTRL_{secrets.token_hex(8)}__"
-                init_script = (
-                    f"{self._init_command}\n_nemo_ec=$?\n"
-                    f"echo $_nemo_ec >&3\npwd >&3\necho {init_sentinel} >&3\n"
-                )
+                # Same framing as user commands: base64 keeps bash's parser away
+                # from the protocol lines, </dev/null keeps a stdin-reading init
+                # from consuming them.
+                init_script = self._build_script(self._init_command, init_sentinel)
                 ctrl_lines, _out, _err, _timed = await self._send_and_wait(
                     init_script, init_sentinel, timeout=60.0
                 )
+                if ctrl_lines:
+                    ec = ctrl_lines[0].strip()
+                    if ec.isdigit() and ec != "0":
+                        logger.warning("init_command %r exited %s", self._init_command, ec)
                 if len(ctrl_lines) >= 2 and ctrl_lines[1].strip().startswith("/"):
                     self._cwd = Path(ctrl_lines[1].strip())
             finally:

--- a/tests/tools/test_bash_session_framing.py
+++ b/tests/tools/test_bash_session_framing.py
@@ -154,3 +154,50 @@ class TestStreamingUsesTheSameFraming:
         ]
         assert "streamed" in "".join(chunks)
         assert session.cwd == sub
+
+
+class TestInitCommandUsesTheSameFraming:
+    """start() sends init_command through _build_script, so a malformed or
+    stdin-reading init cannot wedge the session for its whole 60s timeout."""
+
+    async def test_unbalanced_quote_in_init_does_not_wedge_start(self, tmp_path):
+        s = BashSession(cwd=tmp_path, init_command='echo "unclosed')
+        try:
+            await asyncio.wait_for(s.start(), timeout=10.0)
+            stdout, _stderr, code = await s.run("echo alive")
+            assert stdout == "alive"
+            assert code == 0
+        finally:
+            await s.close()
+
+    async def test_stdin_reading_init_does_not_consume_the_protocol(self, tmp_path):
+        s = BashSession(cwd=tmp_path, init_command="cat")
+        try:
+            await asyncio.wait_for(s.start(), timeout=10.0)
+            stdout, _stderr, code = await s.run("echo alive")
+            assert stdout == "alive"
+            assert code == 0
+        finally:
+            await s.close()
+
+    async def test_benign_init_still_applies_env_and_cwd(self, tmp_path):
+        sub = tmp_path / "initdir"
+        sub.mkdir()
+        s = BashSession(cwd=tmp_path, init_command=f"export NOOA_INIT_VAR=applied && cd {sub}")
+        try:
+            await asyncio.wait_for(s.start(), timeout=10.0)
+            assert s.cwd == sub
+            stdout, _stderr, _code = await s.run("echo $NOOA_INIT_VAR")
+            assert stdout == "applied"
+        finally:
+            await s.close()
+
+    async def test_failed_init_logs_a_warning(self, tmp_path, caplog):
+        s = BashSession(cwd=tmp_path, init_command="false")
+        try:
+            with caplog.at_level("WARNING", logger="nooa.tools._bash_session"):
+                await asyncio.wait_for(s.start(), timeout=10.0)
+            messages = [r.getMessage() for r in caplog.records]
+            assert any("init_command" in m and "exited 1" in m for m in messages)
+        finally:
+            await s.close()


### PR DESCRIPTION
## What does this PR do?

Routes the one-time `init_command` in `BashSession.start()` through `_build_script`, the same framing `run()` and `stream()` already use, and logs a warning when the init command exits nonzero.

On main, `start()` composes `init_script` as raw shell text with the control protocol lines appended (src/nooa/tools/_bash_session.py:213), while user commands go through `_build_script` (:289, :345), which base64-encodes the payload and redirects stdin from /dev/null. PR #149 introduced that framing to keep bash's parser away from the protocol, but the init path never got it. Two consequences:

- An `init_command` with an unbalanced quote (`echo "unclosed`) makes bash read the protocol lines as string content, so the sentinel never arrives and `start()` blocks for its full 60s timeout.
- An `init_command` that reads stdin (`cat`) consumes the protocol lines as its own input, same 60s wedge.

With the framing applied, both cases return promptly and the session stays usable. A nonzero init exit now also logs `init_command ... exited N` instead of passing silently.

Deliberately not changed: a failed init still does not abort `start()`, it only warns, matching how `run()` reports command failures in-band rather than raising. Whether a bad init should fail session creation is a design call for maintainers.

## Related issues

None on file. Sibling precedent: PR #149 (merged 2026-08-18), which fixed this same bug class for user commands.

## How tested

Four regression tests in `tests/tools/test_bash_session_framing.py::TestInitCommandUsesTheSameFraming`. With the source change reverted and the tests kept in place, the two wedge tests fail on timeout and the warning test fails on the missing log record (`3 failed, 19 passed`); the benign-init test passes both ways, since the old code handled well-formed inits. With the fix, `22 passed` in the framing file and `302 passed` across `tests/tools/`.

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [ ] Docs updated if behavior or public APIs changed (no public API change; the warning goes through the module logger)
- [x] New source files carry an SPDX license header (no new files)
