### PR TITLE
fix(agentdoc): include dynamic Pydantic-extra fields in doc(instance) 🤖🤖🤖

### DIFF
--- a/src/nooa/agentdoc/_pformat.py
+++ b/src/nooa/agentdoc/_pformat.py
@@ -1193,17 +1193,32 @@ def _extract_instance_values(obj: Any, type_info: TypeInfo) -> dict[str, Any]:
                 values[field.name] = class_val
 
     # Also include all __dict__ attributes (for instances without annotations)
-    if hasattr(obj, "__dict__"):
-        from nooa.agentdoc._visibility import is_hidden_field as _is_hidden_field
+    from nooa.agentdoc._visibility import is_hidden_field as _is_hidden_field
 
+    def _include_dynamic(name: str, value: Any) -> bool:
+        # Pass the instance (not obj_type) to is_hidden_field so per-instance
+        # spec(self, name, hidden=True) overrides are honored for dynamic fields.
+        return (
+            name not in values
+            and not name.startswith("_")
+            and not callable(value)
+            and not _is_hidden_field(obj, name)
+            and name not in _excluded_fields
+        )
+
+    if hasattr(obj, "__dict__"):
         for name, value in obj.__dict__.items():
-            if (
-                name not in values
-                and not name.startswith("_")
-                and not callable(value)
-                and not _is_hidden_field(obj_type, name)
-                and name not in _excluded_fields
-            ):
+            if _include_dynamic(name, value):
+                values[name] = value
+
+    # Pydantic models with `extra="allow"` store dynamically-assigned fields in
+    # `__pydantic_extra__`, not `__dict__`, so the sweep above misses them. Read
+    # the raw dict directly (never `model_extra`, which is a property that can
+    # trigger validator machinery) and apply the same visibility guards.
+    pydantic_extra = getattr(obj, "__pydantic_extra__", None)
+    if isinstance(pydantic_extra, dict):
+        for name, value in pydantic_extra.items():
+            if _include_dynamic(name, value):
                 values[name] = value
 
     return values

--- a/tests/agentdoc/test_doc_instance_dynamic_fields.py
+++ b/tests/agentdoc/test_doc_instance_dynamic_fields.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for doc(instance) including dynamically-attached instance fields.
+
+Issue #199: doc(instance) should match doc(type(instance)) and additionally
+surface fields attached dynamically to that specific instance.
+
+Plain classes and dataclasses store dynamic attributes in __dict__ (already
+rendered). Pydantic models declared with ``extra="allow"`` store dynamically
+assigned fields in ``__pydantic_extra__`` instead — these were previously
+dropped. All three are covered here.
+"""
+
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+from nooa.agentdoc import doc, pformat, spec
+
+
+class _Baz(BaseModel):
+    """A baz model that allows extra fields."""
+
+    model_config = {"extra": "allow"}
+
+    label: str = "x"
+
+    def greet(self, name: str) -> str:
+        """Say hi."""
+        return f"hi {name}"
+
+
+@dataclass
+class _Foo:
+    """A foo dataclass."""
+
+    label: str = "x"
+
+    def greet(self, name: str) -> str:
+        """Say hi."""
+        return f"hi {name}"
+
+
+class _Bar:
+    """A plain bar class."""
+
+    label: str = "x"
+
+    def greet(self, name: str) -> str:
+        """Say hi."""
+        return f"hi {name}"
+
+
+# ---------------------------------------------------------------------------
+# Pydantic extra="allow" — the fix
+# ---------------------------------------------------------------------------
+
+
+class TestPydanticExtraFields:
+    def test_instance_shows_dynamic_pydantic_extra(self):
+        z = _Baz()
+        z.dynamic_field = 123  # lands in __pydantic_extra__, not __dict__
+        z.tags = ["a", "b"]
+        out = doc(z)
+        assert "dynamic_field: int = 123" in out
+        assert "tags: list = ['a', 'b']" in out
+
+    def test_type_does_not_show_dynamic_fields(self):
+        # doc(type) is a class-only view: dynamic instance state must not leak in.
+        out = doc(_Baz)
+        assert "dynamic_field" not in out
+        assert "tags" not in out
+
+    def test_pformat_shows_dynamic_pydantic_extra(self):
+        z = _Baz()
+        z.dynamic_field = 123
+        out = pformat(z)  # repr-style path
+        assert "dynamic_field=123" in out
+        assert out.startswith("_Baz(")
+
+    def test_instance_hidden_extra_is_excluded(self):
+        # Per-instance spec(self, name, hidden=True) must hide a dynamic extra.
+        z = _Baz()
+        z.shown = 1
+        z.secret = 2
+        spec(z, "secret", hidden=True)
+        out = doc(z)
+        assert "shown" in out
+        assert "secret" not in out
+
+
+# ---------------------------------------------------------------------------
+# Plain class / dataclass — regression guards (already worked, keep working)
+# ---------------------------------------------------------------------------
+
+
+class TestDictBackedDynamicFields:
+    def test_plain_class_shows_dynamic_dict_field(self):
+        b = _Bar()
+        b.dynamic_field = 123
+        out = doc(b)
+        assert "dynamic_field: int = 123" in out
+
+    def test_dataclass_shows_dynamic_dict_field(self):
+        f = _Foo()
+        f.dynamic_field = 123
+        out = doc(f)
+        assert "dynamic_field: int = 123" in out
+
+
+# ---------------------------------------------------------------------------
+# Type-view parity — doc(instance) is a superset of doc(type)'s structure
+# ---------------------------------------------------------------------------
+
+
+class TestTypeViewParity:
+    def test_instance_doc_matches_type_structure(self):
+        z = _Baz()
+        z.dynamic_field = 123
+        type_out = doc(_Baz)
+        inst_out = doc(z)
+
+        # Class header, docstring, declared field, and method are all present in
+        # the instance view exactly as in the type view.
+        assert "class _Baz(BaseModel):" in type_out
+        assert "class _Baz(BaseModel):" in inst_out
+        assert '"""A baz model that allows extra fields."""' in inst_out
+        assert "label: str = 'x'" in inst_out
+        assert "def greet(self, name: str) -> str:" in inst_out
+        # ...and the instance view additionally carries the dynamic field.
+        assert "dynamic_field: int = 123" in inst_out


### PR DESCRIPTION
Closes #199

## What

`doc(instance)` should show everything `doc(type(instance))` shows, plus any fields attached to that specific instance at runtime.

This already worked for plain classes and dataclasses (their dynamic attributes live in `__dict__`). But for Pydantic models with `extra="allow"`, dynamically assigned fields go into `__pydantic_extra__`, not `__dict__` — and the value collector only looked at `__dict__`, so those fields were silently dropped.

## Example

```python
class Baz(BaseModel):
    model_config = {"extra": "allow"}
    label: str = "x"

z = Baz()
z.dynamic_field = 123
```

Before:
```
doc(z)      -> shows only `label`
pformat(z)  -> Baz(label='x')
```

After:
```
doc(z)      -> shows `label` and `dynamic_field: int = 123`
pformat(z)  -> Baz(label='x', dynamic_field=123)
```

`doc(Baz)` (the type view) correctly still does not show `dynamic_field`.

## The fix

In `_extract_instance_values` (`src/nooa/agentdoc/_pformat.py`):

- Added a sweep over `__pydantic_extra__` next to the existing `__dict__` sweep, sharing the same visibility guards. Both `doc()` and `pformat()` read from this collector, so one change fixes both.
- Read the raw `__pydantic_extra__` dict rather than the `model_extra` property, which can trigger validator machinery.
- Small correctness fix: the guard now passes the instance (not its class) to `is_hidden_field`, so a per-instance `spec(self, name, hidden=True)` is actually respected for dynamic fields. Previously the class was passed and instance-level hides were ignored.

## Tests

Added `tests/agentdoc/test_doc_instance_dynamic_fields.py`:
- Pydantic extra field shows up in `doc()` and `pformat()`, but not in `doc(type)`.
- A dynamic field hidden via `spec(self, name, hidden=True)` is excluded.
- Regression guards for plain class and dataclass dynamic fields.
- Type-view parity: instance doc contains the same class header, docstring, declared fields, and methods as the type doc.

## Verification

- `uv run pytest` — full suite green (6793 passed, 7 skipped, 3 xfailed)
- `uv run ruff check` — clean
- `uv run pyright` — 0 errors

🤖🤖🤖