### PR TITLE
fix(cli): make trace imports reliable under viewer backpressure

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
@@ -61,9 +61,19 @@ def inject_resource_attrs(
     Existing keys are preserved unless ``overwrite`` is true. Values are typed:
     str → stringValue, bool → boolValue, int → intValue.
     """
-    for rs in body.get("resourceSpans", []):
+    resource_spans = body.get("resourceSpans")
+    if not isinstance(resource_spans, list):
+        return body
+
+    for rs in resource_spans:
+        if not isinstance(rs, dict):
+            continue
         resource = rs.setdefault("resource", {})
+        if not isinstance(resource, dict):
+            continue
         existing = resource.setdefault("attributes", [])
+        if not isinstance(existing, list):
+            continue
         existing_by_key = {
             attribute["key"]: attribute
             for attribute in existing

--- a/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
@@ -3,6 +3,8 @@
 """Shared utilities for OTLP trace import commands."""
 
 import json
+import time
+import urllib.error
 import urllib.parse
 import urllib.request
 
@@ -11,6 +13,24 @@ import click
 JOURNAL_ENVELOPE_KEY = "nooaJournal"
 JOURNAL_FORMAT = "nooa.message_journal"
 JOURNAL_VERSION = 1
+RETRYABLE_HTTP_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+class OtlpRequestError(RuntimeError):
+    """An OTLP viewer request failed with details suitable for CLI output."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        retryable: bool = False,
+        retry_after: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.retryable = retryable
+        self.retry_after = retry_after
 
 
 def validate_endpoint(endpoint: str) -> None:
@@ -44,12 +64,29 @@ def inject_resource_attrs(body: dict, attrs: dict[str, str | bool | int]) -> dic
     return body
 
 
-def post_trace(endpoint: str, body: dict, timeout: float = 30) -> bool:
-    """POST a single OTLP trace body to the viewer endpoint.
+def _http_error_body(error: urllib.error.HTTPError) -> str:
+    """Read a bounded, printable HTTP error response body."""
+    try:
+        body = error.read(2048).decode("utf-8", errors="replace").strip()
+    except Exception:
+        return ""
+    return body
 
-    ``timeout`` defaults to 30s so large batched bodies (see ``post_traces_batch``)
-    don't spuriously time out; per-line callers are unaffected.
-    """
+
+def _retry_after_seconds(error: urllib.error.HTTPError) -> float | None:
+    """Return a numeric Retry-After value when the server supplied one."""
+    value = error.headers.get("Retry-After") if error.headers else None
+    if value is None:
+        return None
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        return None
+
+
+def _post_trace_checked(endpoint: str, body: dict, timeout: float = 30) -> None:
+    """POST one OTLP body, raising a detailed error on failure."""
+
     url = f"{endpoint.rstrip('/')}/v1/traces"
     data = json.dumps(body, separators=(",", ":")).encode("utf-8")
     req = urllib.request.Request(
@@ -60,9 +97,71 @@ def post_trace(endpoint: str, body: dict, timeout: float = 30) -> bool:
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return resp.status < 300
-    except Exception:
+            if resp.status >= 300:
+                raise OtlpRequestError(
+                    f"HTTP {resp.status} from {url}",
+                    status_code=resp.status,
+                    retryable=resp.status in RETRYABLE_HTTP_STATUS_CODES,
+                )
+    except urllib.error.HTTPError as error:
+        response_body = _http_error_body(error)
+        detail = f": {response_body}" if response_body else ""
+        raise OtlpRequestError(
+            f"HTTP {error.code} {error.reason} from {url}{detail}",
+            status_code=error.code,
+            retryable=error.code in RETRYABLE_HTTP_STATUS_CODES,
+            retry_after=_retry_after_seconds(error),
+        ) from error
+    except (urllib.error.URLError, TimeoutError, OSError) as error:
+        reason = getattr(error, "reason", error)
+        raise OtlpRequestError(
+            f"request to {url} failed: {reason}",
+            retryable=True,
+        ) from error
+
+
+def post_trace(endpoint: str, body: dict, timeout: float = 30) -> bool:
+    """POST a single OTLP body, preserving the legacy boolean API."""
+    try:
+        _post_trace_checked(endpoint, body, timeout=timeout)
+    except OtlpRequestError:
         return False
+    return True
+
+
+def post_trace_with_retry(
+    endpoint: str,
+    body: dict,
+    *,
+    timeout: float = 30,
+    max_retries: int = 5,
+    initial_backoff: float = 0.25,
+    max_backoff: float = 5.0,
+) -> None:
+    """POST an OTLP body, retrying transient HTTP and transport failures.
+
+    Raises :class:`OtlpRequestError` with the HTTP status and response body when
+    all attempts fail. ``max_retries`` counts retries after the initial request.
+    """
+    for retry_index in range(max_retries + 1):
+        try:
+            _post_trace_checked(endpoint, body, timeout=timeout)
+            return
+        except OtlpRequestError as error:
+            if not error.retryable or retry_index >= max_retries:
+                attempts = retry_index + 1
+                raise OtlpRequestError(
+                    f"{error} (after {attempts} attempt{'s' if attempts != 1 else ''})",
+                    status_code=error.status_code,
+                    retryable=error.retryable,
+                    retry_after=error.retry_after,
+                ) from error
+            delay = (
+                min(error.retry_after, max_backoff)
+                if error.retry_after is not None
+                else min(initial_backoff * (2**retry_index), max_backoff)
+            )
+            time.sleep(delay)
 
 
 def post_traces_batch(endpoint: str, bodies: list[dict]) -> bool:
@@ -82,6 +181,48 @@ def post_traces_batch(endpoint: str, bodies: list[dict]) -> bool:
     if not merged["resourceSpans"]:
         return True
     return post_trace(endpoint, merged)
+
+
+def post_traces_batch_with_retry(
+    endpoint: str,
+    bodies: list[dict],
+    *,
+    max_retries: int = 5,
+) -> None:
+    """Merge and reliably POST a bounded batch of OTLP envelopes."""
+    merged: dict = {"resourceSpans": []}
+    for body in bodies:
+        spans = body.get("resourceSpans")
+        if isinstance(spans, list):
+            merged["resourceSpans"].extend(spans)
+    if not merged["resourceSpans"]:
+        return
+    post_trace_with_retry(endpoint, merged, max_retries=max_retries)
+
+
+def sync_ingest(endpoint: str, timeout: float = 35) -> None:
+    """Wait until the viewer has processed every accepted OTLP request."""
+    url = f"{endpoint.rstrip('/')}/v1/sync"
+    request = urllib.request.Request(url, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            if response.status >= 300:
+                raise OtlpRequestError(
+                    f"HTTP {response.status} from {url}",
+                    status_code=response.status,
+                    retryable=response.status in RETRYABLE_HTTP_STATUS_CODES,
+                )
+    except urllib.error.HTTPError as error:
+        response_body = _http_error_body(error)
+        detail = f": {response_body}" if response_body else ""
+        raise OtlpRequestError(
+            f"HTTP {error.code} {error.reason} from {url}{detail}",
+            status_code=error.code,
+            retryable=error.code in RETRYABLE_HTTP_STATUS_CODES,
+        ) from error
+    except (urllib.error.URLError, TimeoutError, OSError) as error:
+        reason = getattr(error, "reason", error)
+        raise OtlpRequestError(f"request to {url} failed: {reason}") from error
 
 
 def post_annotations(endpoint: str, annotations: list[dict]) -> int:

--- a/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
@@ -10,8 +10,6 @@ import urllib.request
 
 import click
 
-from nooa.tracing._viewer_auth import apply_viewer_auth
-
 JOURNAL_ENVELOPE_KEY = "nooaJournal"
 JOURNAL_FORMAT = "nooa.message_journal"
 JOURNAL_VERSION = 1
@@ -45,23 +43,43 @@ def validate_endpoint(endpoint: str) -> None:
         )
 
 
-def inject_resource_attrs(body: dict, attrs: dict[str, str | bool | int]) -> dict:
-    """Inject additional resource attributes into an OTLP body (skips existing keys).
+def _viewer_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Apply viewer authentication without slowing unrelated CLI commands."""
+    from nooa.tracing._viewer_auth import apply_viewer_auth
 
-    Values are typed: str → stringValue, bool → boolValue, int → intValue.
+    return apply_viewer_auth(headers)
+
+
+def inject_resource_attrs(
+    body: dict,
+    attrs: dict[str, str | bool | int],
+    *,
+    overwrite: bool = False,
+) -> dict:
+    """Inject additional resource attributes into an OTLP body.
+
+    Existing keys are preserved unless ``overwrite`` is true. Values are typed:
+    str → stringValue, bool → boolValue, int → intValue.
     """
     for rs in body.get("resourceSpans", []):
         resource = rs.setdefault("resource", {})
         existing = resource.setdefault("attributes", [])
-        existing_keys = {a["key"] for a in existing}
+        existing_by_key = {
+            attribute["key"]: attribute
+            for attribute in existing
+            if isinstance(attribute, dict) and isinstance(attribute.get("key"), str)
+        }
         for key, val in attrs.items():
-            if key not in existing_keys:
-                if isinstance(val, bool):
-                    otlp_val = {"boolValue": val}
-                elif isinstance(val, int):
-                    otlp_val = {"intValue": val}
-                else:
-                    otlp_val = {"stringValue": val}
+            if isinstance(val, bool):
+                otlp_val = {"boolValue": val}
+            elif isinstance(val, int):
+                otlp_val = {"intValue": val}
+            else:
+                otlp_val = {"stringValue": val}
+            if key in existing_by_key:
+                if overwrite:
+                    existing_by_key[key]["value"] = otlp_val
+            else:
                 existing.append({"key": key, "value": otlp_val})
     return body
 
@@ -94,7 +112,7 @@ def _post_trace_checked(endpoint: str, body: dict, timeout: float = 30) -> None:
     req = urllib.request.Request(
         url,
         data=data,
-        headers=apply_viewer_auth({"Content-Type": "application/json"}),
+        headers=_viewer_headers({"Content-Type": "application/json"}),
         method="POST",
     )
     try:
@@ -118,7 +136,6 @@ def _post_trace_checked(endpoint: str, body: dict, timeout: float = 30) -> None:
         reason = getattr(error, "reason", error)
         raise OtlpRequestError(
             f"request to {url} failed: {reason}",
-            retryable=True,
         ) from error
 
 
@@ -140,10 +157,12 @@ def post_trace_with_retry(
     initial_backoff: float = 0.25,
     max_backoff: float = 5.0,
 ) -> None:
-    """POST an OTLP body, retrying transient HTTP and transport failures.
+    """POST an OTLP body, retrying transient HTTP failures.
 
     Raises :class:`OtlpRequestError` with the HTTP status and response body when
     all attempts fail. ``max_retries`` counts retries after the initial request.
+    Transport failures are not replayed because the server may already have
+    accepted the request, and OTLP ingest is not idempotent.
     """
     for retry_index in range(max_retries + 1):
         try:
@@ -166,6 +185,16 @@ def post_trace_with_retry(
             time.sleep(delay)
 
 
+def _merge_resource_spans(bodies: list[dict]) -> dict:
+    """Merge valid ``resourceSpans`` arrays into one OTLP envelope."""
+    merged: dict = {"resourceSpans": []}
+    for body in bodies:
+        spans = body.get("resourceSpans")
+        if isinstance(spans, list):
+            merged["resourceSpans"].extend(spans)
+    return merged
+
+
 def post_traces_batch(endpoint: str, bodies: list[dict]) -> bool:
     """POST multiple OTLP bodies as one request by merging their ``resourceSpans``.
 
@@ -173,13 +202,7 @@ def post_traces_batch(endpoint: str, bodies: list[dict]) -> bool:
     and posts it once, drastically reducing HTTP round-trips for large imports.
     Returns True (a no-op success) when there are no spans to send.
     """
-    merged: dict = {"resourceSpans": []}
-    for body in bodies:
-        # Guard against malformed bodies whose ``resourceSpans`` is missing or
-        # not a list (e.g. None or a dict); skip rather than raise on extend.
-        spans = body.get("resourceSpans")
-        if isinstance(spans, list):
-            merged["resourceSpans"].extend(spans)
+    merged = _merge_resource_spans(bodies)
     if not merged["resourceSpans"]:
         return True
     return post_trace(endpoint, merged)
@@ -192,11 +215,7 @@ def post_traces_batch_with_retry(
     max_retries: int = 5,
 ) -> None:
     """Merge and reliably POST a bounded batch of OTLP envelopes."""
-    merged: dict = {"resourceSpans": []}
-    for body in bodies:
-        spans = body.get("resourceSpans")
-        if isinstance(spans, list):
-            merged["resourceSpans"].extend(spans)
+    merged = _merge_resource_spans(bodies)
     if not merged["resourceSpans"]:
         return
     post_trace_with_retry(endpoint, merged, max_retries=max_retries)
@@ -205,7 +224,7 @@ def post_traces_batch_with_retry(
 def sync_ingest(endpoint: str, timeout: float = 35) -> None:
     """Wait until the viewer has processed every accepted OTLP request."""
     url = f"{endpoint.rstrip('/')}/v1/sync"
-    request = urllib.request.Request(url, headers=apply_viewer_auth({}), method="POST")
+    request = urllib.request.Request(url, headers=_viewer_headers({}), method="POST")
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             if response.status >= 300:
@@ -237,7 +256,7 @@ def post_annotations(endpoint: str, annotations: list[dict]) -> int:
         req = urllib.request.Request(
             url,
             data=data,
-            headers=apply_viewer_auth({"Content-Type": "application/json"}),
+            headers=_viewer_headers({"Content-Type": "application/json"}),
             method="POST",
         )
         try:
@@ -290,7 +309,7 @@ def post_journal_record(endpoint: str, record: dict, session_id: str) -> bool:
     request = urllib.request.Request(
         f"{endpoint.rstrip('/')}{path}",
         data=data,
-        headers=apply_viewer_auth(headers),
+        headers=_viewer_headers(headers),
         method="POST",
     )
     try:
@@ -303,7 +322,7 @@ def post_journal_record(endpoint: str, record: dict, session_id: str) -> bool:
 def session_exists(endpoint: str, session_id: str) -> bool:
     """Check whether a session already exists in the viewer."""
     url = f"{endpoint.rstrip('/')}/api/trace-count?session_id={urllib.parse.quote(session_id)}"
-    req = urllib.request.Request(url, headers=apply_viewer_auth({}), method="GET")
+    req = urllib.request.Request(url, headers=_viewer_headers({}), method="GET")
     try:
         with urllib.request.urlopen(req, timeout=5) as resp:
             return resp.status == 200
@@ -312,14 +331,47 @@ def session_exists(endpoint: str, session_id: str) -> bool:
 
 
 def check_endpoint_reachable(endpoint: str) -> bool:
-    """Return True if the viewer API is reachable."""
+    """Return true when reachable, raising detailed HTTP response failures."""
     request = urllib.request.Request(
         f"{endpoint.rstrip('/')}/api/version",
-        headers=apply_viewer_auth({}),
+        headers=_viewer_headers({}),
         method="GET",
     )
     try:
         with urllib.request.urlopen(request, timeout=5):
             return True
-    except Exception:
+    except urllib.error.HTTPError as error:
+        response_body = _http_error_body(error)
+        detail = f": {response_body}" if response_body else ""
+        raise OtlpRequestError(
+            f"HTTP {error.code} {error.reason} from {request.full_url}{detail}",
+            status_code=error.code,
+        ) from error
+    except (urllib.error.URLError, TimeoutError, OSError):
         return False
+
+
+def get_session_span_count(endpoint: str, session_id: str) -> int:
+    """Return the viewer's stored span count for one session."""
+    url = f"{endpoint.rstrip('/')}/api/trace-count?session_id={urllib.parse.quote(session_id)}"
+    request = urllib.request.Request(url, headers=_viewer_headers({}), method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            payload = json.loads(response.read())
+    except urllib.error.HTTPError as error:
+        response_body = _http_error_body(error)
+        detail = f": {response_body}" if response_body else ""
+        raise OtlpRequestError(
+            f"HTTP {error.code} {error.reason} from {url}{detail}",
+            status_code=error.code,
+        ) from error
+    except (urllib.error.URLError, TimeoutError, OSError) as error:
+        reason = getattr(error, "reason", error)
+        raise OtlpRequestError(f"request to {url} failed: {reason}") from error
+    except (json.JSONDecodeError, TypeError, ValueError) as error:
+        raise OtlpRequestError(f"invalid trace-count response from {url}: {error}") from error
+
+    count = payload.get("event_count") if isinstance(payload, dict) else None
+    if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+        raise OtlpRequestError(f"invalid trace-count response from {url}: {payload!r}")
+    return count

--- a/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
@@ -10,6 +10,8 @@ import urllib.request
 
 import click
 
+from nooa.tracing._viewer_auth import apply_viewer_auth
+
 JOURNAL_ENVELOPE_KEY = "nooaJournal"
 JOURNAL_FORMAT = "nooa.message_journal"
 JOURNAL_VERSION = 1
@@ -92,7 +94,7 @@ def _post_trace_checked(endpoint: str, body: dict, timeout: float = 30) -> None:
     req = urllib.request.Request(
         url,
         data=data,
-        headers={"Content-Type": "application/json"},
+        headers=apply_viewer_auth({"Content-Type": "application/json"}),
         method="POST",
     )
     try:
@@ -203,7 +205,7 @@ def post_traces_batch_with_retry(
 def sync_ingest(endpoint: str, timeout: float = 35) -> None:
     """Wait until the viewer has processed every accepted OTLP request."""
     url = f"{endpoint.rstrip('/')}/v1/sync"
-    request = urllib.request.Request(url, method="POST")
+    request = urllib.request.Request(url, headers=apply_viewer_auth({}), method="POST")
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             if response.status >= 300:
@@ -235,7 +237,7 @@ def post_annotations(endpoint: str, annotations: list[dict]) -> int:
         req = urllib.request.Request(
             url,
             data=data,
-            headers={"Content-Type": "application/json"},
+            headers=apply_viewer_auth({"Content-Type": "application/json"}),
             method="POST",
         )
         try:
@@ -288,7 +290,7 @@ def post_journal_record(endpoint: str, record: dict, session_id: str) -> bool:
     request = urllib.request.Request(
         f"{endpoint.rstrip('/')}{path}",
         data=data,
-        headers=headers,
+        headers=apply_viewer_auth(headers),
         method="POST",
     )
     try:
@@ -301,7 +303,7 @@ def post_journal_record(endpoint: str, record: dict, session_id: str) -> bool:
 def session_exists(endpoint: str, session_id: str) -> bool:
     """Check whether a session already exists in the viewer."""
     url = f"{endpoint.rstrip('/')}/api/trace-count?session_id={urllib.parse.quote(session_id)}"
-    req = urllib.request.Request(url, method="GET")
+    req = urllib.request.Request(url, headers=apply_viewer_auth({}), method="GET")
     try:
         with urllib.request.urlopen(req, timeout=5) as resp:
             return resp.status == 200
@@ -311,8 +313,13 @@ def session_exists(endpoint: str, session_id: str) -> bool:
 
 def check_endpoint_reachable(endpoint: str) -> bool:
     """Return True if the viewer API is reachable."""
+    request = urllib.request.Request(
+        f"{endpoint.rstrip('/')}/api/version",
+        headers=apply_viewer_auth({}),
+        method="GET",
+    )
     try:
-        with urllib.request.urlopen(f"{endpoint.rstrip('/')}/api/version", timeout=5):
+        with urllib.request.urlopen(request, timeout=5):
             return True
     except Exception:
         return False

--- a/packages/nooa-cli/src/nooa_cli/commands/delete_traces.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/delete_traces.py
@@ -13,7 +13,7 @@ import urllib.request
 
 import click
 
-from nooa.tracing._viewer_auth import apply_viewer_auth
+from ._otlp_helpers import OtlpRequestError, _viewer_headers, check_endpoint_reachable
 
 NAME = "delete-traces"
 
@@ -44,21 +44,19 @@ def command(batch_id: str, endpoint: str):
     """Delete all traces belonging to a batch."""
     _validate_endpoint(endpoint)
 
-    # Verify endpoint is reachable
     try:
-        request = urllib.request.Request(
-            f"{endpoint.rstrip('/')}/api/version",
-            headers=apply_viewer_auth({}),
-            method="GET",
-        )
-        with urllib.request.urlopen(request, timeout=5):
-            pass
-    except Exception:
-        click.echo(f"Cannot reach viewer at {endpoint}. Is it running?")
+        reachable = check_endpoint_reachable(endpoint)
+    except OtlpRequestError as error:
+        click.echo(f"Viewer at {endpoint} rejected the request: {error}")
+        if error.status_code in (401, 403):
+            click.echo("Check NOOA_VIEWER_AUTH_TOKEN and try again.")
         raise SystemExit(1) from None
+    if not reachable:
+        click.echo(f"Cannot reach viewer at {endpoint}. Is it running?")
+        raise SystemExit(1)
 
     url = f"{endpoint.rstrip('/')}/api/traces?batch_id={urllib.parse.quote(batch_id, safe='')}"
-    req = urllib.request.Request(url, headers=apply_viewer_auth({}), method="DELETE")
+    req = urllib.request.Request(url, headers=_viewer_headers({}), method="DELETE")
 
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:

--- a/packages/nooa-cli/src/nooa_cli/commands/delete_traces.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/delete_traces.py
@@ -13,6 +13,8 @@ import urllib.request
 
 import click
 
+from nooa.tracing._viewer_auth import apply_viewer_auth
+
 NAME = "delete-traces"
 
 
@@ -44,14 +46,19 @@ def command(batch_id: str, endpoint: str):
 
     # Verify endpoint is reachable
     try:
-        with urllib.request.urlopen(f"{endpoint.rstrip('/')}/api/version", timeout=5):
+        request = urllib.request.Request(
+            f"{endpoint.rstrip('/')}/api/version",
+            headers=apply_viewer_auth({}),
+            method="GET",
+        )
+        with urllib.request.urlopen(request, timeout=5):
             pass
     except Exception:
         click.echo(f"Cannot reach viewer at {endpoint}. Is it running?")
         raise SystemExit(1) from None
 
     url = f"{endpoint.rstrip('/')}/api/traces?batch_id={urllib.parse.quote(batch_id, safe='')}"
-    req = urllib.request.Request(url, method="DELETE")
+    req = urllib.request.Request(url, headers=apply_viewer_auth({}), method="DELETE")
 
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:

--- a/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import click
 
 from ._otlp_helpers import (
+    OtlpRequestError,
     check_endpoint_reachable,
     get_journal_record,
     inject_resource_attrs,
@@ -437,7 +438,14 @@ def command(
 
     validate_endpoint(endpoint)
 
-    if not check_endpoint_reachable(endpoint):
+    try:
+        reachable = check_endpoint_reachable(endpoint)
+    except OtlpRequestError as error:
+        click.echo(f"Viewer at {endpoint} rejected the request: {error}")
+        if error.status_code in (401, 403):
+            click.echo("Check NOOA_VIEWER_AUTH_TOKEN and try again.")
+        raise SystemExit(1) from None
+    if not reachable:
         click.echo(f"Cannot reach viewer at {endpoint}. Is it running?")
         raise SystemExit(1)
 

--- a/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
@@ -24,6 +24,7 @@ import click
 
 from ._otlp_helpers import (
     OtlpRequestError,
+    _viewer_headers,
     check_endpoint_reachable,
     get_journal_record,
     inject_resource_attrs,
@@ -216,7 +217,7 @@ def _find_matching_live_session(endpoint: str, meta: dict, experiment: str) -> s
         }
         url = f"{endpoint.rstrip('/')}/api/eval/match-session?{urllib.parse.urlencode(query)}"
         try:
-            req = urllib.request.Request(url, method="GET")
+            req = urllib.request.Request(url, headers=_viewer_headers({}), method="GET")
             with urllib.request.urlopen(req, timeout=10) as resp:
                 if resp.status >= 300:
                     return None

--- a/packages/nooa-cli/src/nooa_cli/commands/import_traces.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/import_traces.py
@@ -11,6 +11,7 @@ Usage:
 import json
 import shlex
 import urllib.parse
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
@@ -21,6 +22,7 @@ from ._otlp_helpers import (
     OtlpRequestError,
     check_endpoint_reachable,
     get_journal_record,
+    get_session_span_count,
     inject_resource_attrs,
     post_annotations,
     post_journal_record,
@@ -71,6 +73,43 @@ def _session_id_from_filename(path: Path) -> str:
     return path.stem
 
 
+def _count_otlp_spans(body: dict) -> int:
+    """Count spans in a validated OTLP envelope."""
+    count = 0
+    for resource_spans in body.get("resourceSpans", []):
+        if not isinstance(resource_spans, dict):
+            continue
+        scope_spans = resource_spans.get("scopeSpans", [])
+        if not isinstance(scope_spans, list):
+            continue
+        for scope in scope_spans:
+            if not isinstance(scope, dict):
+                continue
+            spans = scope.get("spans", [])
+            if isinstance(spans, list):
+                count += len(spans)
+    return count
+
+
+@dataclass
+class _TraceBatch:
+    """Mutable state for one bounded OTLP request."""
+
+    bodies: list[dict] = field(default_factory=list)
+    input_bytes: int = 0
+    first_line: int = 0
+    last_line: int = 0
+    attempted: bool = False
+    accepted: bool = False
+
+    def clear(self) -> None:
+        """Reset buffered request data while preserving aggregate status."""
+        self.bodies = []
+        self.input_bytes = 0
+        self.first_line = 0
+        self.last_line = 0
+
+
 def _post_batch(
     endpoint: str,
     bodies: list[dict],
@@ -91,6 +130,31 @@ def _post_batch(
     except OtlpRequestError as error:
         return f"{file_name}:{line_range}: {error}"
     return None
+
+
+def _flush_batch(
+    endpoint: str,
+    state: _TraceBatch,
+    *,
+    max_retries: int,
+    file_name: str,
+) -> str | None:
+    """Post and clear buffered trace bodies, returning a user-facing error."""
+    if not state.bodies:
+        return None
+    state.attempted = True
+    error = _post_batch(
+        endpoint,
+        state.bodies,
+        max_retries=max_retries,
+        file_name=file_name,
+        first_line=state.first_line,
+        last_line=state.last_line,
+    )
+    state.clear()
+    if error is None:
+        state.accepted = True
+    return error
 
 
 @click.command()
@@ -148,8 +212,14 @@ def command(
     if batch_id is None:
         batch_id = f"import_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid4().hex[:6]}"
 
-    # Verify endpoint is reachable
-    if not check_endpoint_reachable(endpoint):
+    try:
+        reachable = check_endpoint_reachable(endpoint)
+    except OtlpRequestError as error:
+        click.echo(f"Viewer at {endpoint} rejected the request: {error}")
+        if error.status_code in (401, 403):
+            click.echo("Check NOOA_VIEWER_AUTH_TOKEN and try again.")
+        raise SystemExit(1) from None
+    if not reachable:
         click.echo(f"Cannot reach viewer at {endpoint}. Is it running?")
         raise SystemExit(1)
 
@@ -177,14 +247,11 @@ def command(
         inject_attrs = {"batch_id": batch_id, "session.id": session_id}
 
         file_errors: list[str] = []
-        trace_post_attempted = False
-        trace_batch_accepted = False
+        file_imported = False
+        expected_span_count = 0
         is_legacy = False
         deferred_annotations: list[dict] = []
-        batch: list[dict] = []
-        batch_input_bytes = 0
-        batch_first_line = 0
-        batch_last_line = 0
+        batch = _TraceBatch()
 
         with open(file) as f:
             for line_num, raw_line in enumerate(f, 1):
@@ -202,6 +269,8 @@ def command(
                 if journal_record is not None:
                     if not post_journal_record(endpoint, journal_record, session_id):
                         file_errors.append(f"{file.name}:{line_num}: failed to post journal record")
+                    else:
+                        file_imported = True
                     continue
 
                 # Handle annotation lines from exported traces
@@ -231,67 +300,82 @@ def command(
                 if not resource_spans:
                     continue
 
-                inject_resource_attrs(body, inject_attrs)
-                if not batch:
-                    batch_first_line = line_num
-                batch_last_line = line_num
-                batch.append(body)
-                batch_input_bytes += len(raw_line.encode("utf-8"))
-
-                if len(batch) >= batch_lines or batch_input_bytes >= batch_bytes:
-                    trace_post_attempted = True
-                    batch_error = _post_batch(
+                raw_line_bytes = len(raw_line.encode("utf-8"))
+                if batch.bodies and batch.input_bytes + raw_line_bytes > batch_bytes:
+                    batch_error = _flush_batch(
                         endpoint,
                         batch,
                         max_retries=max_retries,
                         file_name=file.name,
-                        first_line=batch_first_line,
-                        last_line=batch_last_line,
                     )
-                    batch = []
-                    batch_input_bytes = 0
                     if batch_error:
                         file_errors.append(batch_error)
                         break
-                    trace_batch_accepted = True
 
-            else:
-                if batch:
-                    trace_post_attempted = True
-                    batch_error = _post_batch(
+                inject_resource_attrs(body, inject_attrs, overwrite=True)
+                if not batch.bodies:
+                    batch.first_line = line_num
+                batch.last_line = line_num
+                batch.bodies.append(body)
+                batch.input_bytes += raw_line_bytes
+                expected_span_count += _count_otlp_spans(body)
+
+                if len(batch.bodies) >= batch_lines or batch.input_bytes >= batch_bytes:
+                    batch_error = _flush_batch(
                         endpoint,
                         batch,
                         max_retries=max_retries,
                         file_name=file.name,
-                        first_line=batch_first_line,
-                        last_line=batch_last_line,
                     )
                     if batch_error:
                         file_errors.append(batch_error)
-                    else:
-                        trace_batch_accepted = True
+                        break
+
+            else:
+                batch_error = _flush_batch(
+                    endpoint,
+                    batch,
+                    max_retries=max_retries,
+                    file_name=file.name,
+                )
+                if batch_error:
+                    file_errors.append(batch_error)
 
         # A 200 from /v1/traces only means queued. Wait for durable processing
         # before importing annotations or reporting success.
-        if trace_post_attempted:
+        if batch.attempted:
             try:
                 sync_ingest(endpoint)
             except OtlpRequestError as error:
                 file_errors.append(f"{file.name}: failed to sync viewer ingest: {error}")
 
-        if not file_errors and trace_batch_accepted:
-            if deferred_annotations:
-                count = post_annotations(endpoint, deferred_annotations)
-                annotations_imported += count
-                if count != len(deferred_annotations):
+        if not file_errors and batch.accepted:
+            try:
+                stored_span_count = get_session_span_count(endpoint, session_id)
+            except OtlpRequestError as error:
+                file_errors.append(f"{file.name}: failed to verify viewer ingest: {error}")
+            else:
+                if stored_span_count != expected_span_count:
                     file_errors.append(
-                        f"{file.name}: imported {count}/{len(deferred_annotations)} annotations"
+                        f"{file.name}: viewer stored {stored_span_count}/{expected_span_count} spans"
                     )
+                else:
+                    file_imported = True
+
+        if not file_errors and deferred_annotations:
+            count = post_annotations(endpoint, deferred_annotations)
+            annotations_imported += count
+            if count != len(deferred_annotations):
+                file_errors.append(
+                    f"{file.name}: imported {count}/{len(deferred_annotations)} annotations"
+                )
+            else:
+                file_imported = True
 
         if file_errors:
             failed += 1
             errors.extend(file_errors)
-        elif trace_batch_accepted:
+        elif file_imported:
             imported += 1
         elif not is_legacy:
             skipped += 1

--- a/packages/nooa-cli/src/nooa_cli/commands/import_traces.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/import_traces.py
@@ -9,6 +9,7 @@ Usage:
 """
 
 import json
+import shlex
 import urllib.parse
 from datetime import datetime
 from pathlib import Path
@@ -17,13 +18,15 @@ from uuid import uuid4
 import click
 
 from ._otlp_helpers import (
+    OtlpRequestError,
     check_endpoint_reachable,
     get_journal_record,
     inject_resource_attrs,
     post_annotations,
     post_journal_record,
-    post_trace,
+    post_traces_batch_with_retry,
     session_exists,
+    sync_ingest,
     validate_endpoint,
 )
 
@@ -68,6 +71,28 @@ def _session_id_from_filename(path: Path) -> str:
     return path.stem
 
 
+def _post_batch(
+    endpoint: str,
+    bodies: list[dict],
+    *,
+    max_retries: int,
+    file_name: str,
+    first_line: int,
+    last_line: int,
+) -> str | None:
+    """Post one trace batch and return a user-facing error, if any."""
+    line_range = str(first_line) if first_line == last_line else f"{first_line}-{last_line}"
+    try:
+        post_traces_batch_with_retry(
+            endpoint,
+            bodies,
+            max_retries=max_retries,
+        )
+    except OtlpRequestError as error:
+        return f"{file_name}:{line_range}: {error}"
+    return None
+
+
 @click.command()
 @click.argument("path", type=click.Path(exists=True))
 @click.option(
@@ -81,7 +106,35 @@ def _session_id_from_filename(path: Path) -> str:
     default=None,
     help="Batch ID for this import (default: auto-generated).",
 )
-def command(path: str, endpoint: str, batch_id: str | None):
+@click.option(
+    "--batch-lines",
+    default=1000,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Max OTLP lines combined into one request.",
+)
+@click.option(
+    "--batch-bytes",
+    default=4_000_000,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Max raw input bytes combined into one request.",
+)
+@click.option(
+    "--max-retries",
+    default=5,
+    show_default=True,
+    type=click.IntRange(min=0),
+    help="Retries for transient viewer errors such as HTTP 503.",
+)
+def command(
+    path: str,
+    endpoint: str,
+    batch_id: str | None,
+    batch_lines: int,
+    batch_bytes: int,
+    max_retries: int,
+):
     """Import OTLP and portable NOOA journal .jsonl files into the viewer."""
     target = Path(path)
     files = _find_trace_files(target)
@@ -104,9 +157,10 @@ def command(path: str, endpoint: str, batch_id: str | None):
 
     imported = 0
     skipped = 0
+    failed = 0
     already_exist = 0
     annotations_imported = 0
-    errors = []
+    errors: list[str] = []
 
     for file in files:
         session_id = _session_id_from_filename(file)
@@ -120,12 +174,17 @@ def command(path: str, endpoint: str, batch_id: str | None):
             already_exist += 1
             continue
 
-        inject_attrs = {"batch_id": batch_id}
+        inject_attrs = {"batch_id": batch_id, "session.id": session_id}
 
-        file_has_session = False
-        file_imported = False
+        file_errors: list[str] = []
+        trace_post_attempted = False
+        trace_batch_accepted = False
         is_legacy = False
         deferred_annotations: list[dict] = []
+        batch: list[dict] = []
+        batch_input_bytes = 0
+        batch_first_line = 0
+        batch_last_line = 0
 
         with open(file) as f:
             for line_num, raw_line in enumerate(f, 1):
@@ -135,13 +194,14 @@ def command(path: str, endpoint: str, batch_id: str | None):
 
                 try:
                     body = json.loads(raw_line)
-                except json.JSONDecodeError:
+                except json.JSONDecodeError as error:
+                    file_errors.append(f"{file.name}:{line_num}: invalid JSON: {error.msg}")
                     continue
 
                 journal_record = get_journal_record(body)
                 if journal_record is not None:
                     if not post_journal_record(endpoint, journal_record, session_id):
-                        errors.append(f"{file.name}:{line_num}: failed to post journal record")
+                        file_errors.append(f"{file.name}:{line_num}: failed to post journal record")
                     continue
 
                 # Handle annotation lines from exported traces
@@ -155,34 +215,90 @@ def command(path: str, endpoint: str, batch_id: str | None):
 
                 if fmt == "legacy":
                     if not is_legacy:
-                        errors.append(f"{file.name}: legacy format not supported, skipping")
+                        file_errors.append(f"{file.name}: legacy format not supported, skipping")
                         is_legacy = True
                     continue
 
                 if fmt != "otlp":
                     continue
 
-                if not file_has_session:
-                    inject_attrs["session.id"] = session_id
-                    file_has_session = True
+                resource_spans = body.get("resourceSpans")
+                if not isinstance(resource_spans, list):
+                    file_errors.append(
+                        f"{file.name}:{line_num}: resourceSpans must be a JSON array"
+                    )
+                    continue
+                if not resource_spans:
+                    continue
 
                 inject_resource_attrs(body, inject_attrs)
+                if not batch:
+                    batch_first_line = line_num
+                batch_last_line = line_num
+                batch.append(body)
+                batch_input_bytes += len(raw_line.encode("utf-8"))
 
-                if post_trace(endpoint, body):
-                    file_imported = True
-                else:
-                    errors.append(f"{file.name}:{line_num}: failed to post")
+                if len(batch) >= batch_lines or batch_input_bytes >= batch_bytes:
+                    trace_post_attempted = True
+                    batch_error = _post_batch(
+                        endpoint,
+                        batch,
+                        max_retries=max_retries,
+                        file_name=file.name,
+                        first_line=batch_first_line,
+                        last_line=batch_last_line,
+                    )
+                    batch = []
+                    batch_input_bytes = 0
+                    if batch_error:
+                        file_errors.append(batch_error)
+                        break
+                    trace_batch_accepted = True
 
-        if file_imported:
-            imported += 1
-            # Import annotations after spans so the session exists
+            else:
+                if batch:
+                    trace_post_attempted = True
+                    batch_error = _post_batch(
+                        endpoint,
+                        batch,
+                        max_retries=max_retries,
+                        file_name=file.name,
+                        first_line=batch_first_line,
+                        last_line=batch_last_line,
+                    )
+                    if batch_error:
+                        file_errors.append(batch_error)
+                    else:
+                        trace_batch_accepted = True
+
+        # A 200 from /v1/traces only means queued. Wait for durable processing
+        # before importing annotations or reporting success.
+        if trace_post_attempted:
+            try:
+                sync_ingest(endpoint)
+            except OtlpRequestError as error:
+                file_errors.append(f"{file.name}: failed to sync viewer ingest: {error}")
+
+        if not file_errors and trace_batch_accepted:
             if deferred_annotations:
                 count = post_annotations(endpoint, deferred_annotations)
                 annotations_imported += count
+                if count != len(deferred_annotations):
+                    file_errors.append(
+                        f"{file.name}: imported {count}/{len(deferred_annotations)} annotations"
+                    )
+
+        if file_errors:
+            failed += 1
+            errors.extend(file_errors)
+        elif trace_batch_accepted:
+            imported += 1
         elif not is_legacy:
             skipped += 1
 
     click.echo(f"  {imported} imported, {skipped} skipped")
+    if failed:
+        click.echo(f"  {failed} failed")
     if already_exist:
         click.echo(f"  {already_exist} skipped (already exist)")
     if annotations_imported:
@@ -194,4 +310,13 @@ def command(path: str, endpoint: str, batch_id: str | None):
             click.echo(f"  ... and {len(errors) - 10} more errors")
 
     encoded_batch = urllib.parse.quote(batch_id, safe="")
+    if errors:
+        click.echo(
+            f"\nImport incomplete. Partial data may exist in batch '{batch_id}'.\n"
+            f"Delete it before retrying:\n"
+            f"  nooa delete-traces --batch-id {shlex.quote(batch_id)} "
+            f"--endpoint {shlex.quote(endpoint)}"
+        )
+        raise SystemExit(1)
+
     click.echo(f"\nView at: {endpoint}/traces?batch_id={encoded_batch}")

--- a/packages/nooa-cli/tests/test_cli_smoke.py
+++ b/packages/nooa-cli/tests/test_cli_smoke.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Smoke test: verify the nooa CLI package is importable and the main entry point exists."""
 
+import subprocess
+import sys
+
 
 def test_cli_importable():
     from nooa_cli import main
@@ -18,3 +21,18 @@ def test_commands_discoverable():
     assert "start-dev" in names
     assert "eval" in names
     assert "config" in names
+
+
+def test_cli_discovery_does_not_import_tracing_runtime():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import nooa_cli; assert 'nooa.tracing' not in sys.modules",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/packages/nooa-cli/tests/test_import_traces.py
+++ b/packages/nooa-cli/tests/test_import_traces.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
-from nooa_cli.commands import _otlp_helpers, delete_traces, import_traces
+from nooa_cli.commands import _otlp_helpers, delete_traces, import_harbor, import_traces
 
 
 def _otlp_body(index: int) -> dict:
@@ -41,12 +41,21 @@ def _write_trace(path: Path, count: int, *extra_records: dict) -> None:
     path.write_text("\n".join(json.dumps(record) for record in records) + "\n")
 
 
-def _patch_viewer_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+def _patch_viewer_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stored_span_count: int = 1,
+) -> None:
     monkeypatch.setattr(import_traces, "check_endpoint_reachable", lambda _endpoint: True)
     monkeypatch.setattr(
         import_traces,
         "session_exists",
         lambda _endpoint, _session_id: False,
+    )
+    monkeypatch.setattr(
+        import_traces,
+        "get_session_span_count",
+        lambda _endpoint, _session_id: stored_span_count,
     )
 
 
@@ -115,6 +124,51 @@ def test_post_trace_exposes_http_status_and_response_body(monkeypatch: pytest.Mo
     assert "after 1 attempt" in message
 
 
+def test_post_trace_does_not_replay_ambiguous_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls = 0
+    sleeps: list[float] = []
+
+    def urlopen(_request, *, timeout):
+        nonlocal calls
+        calls += 1
+        raise urllib.error.URLError(TimeoutError("response lost"))
+
+    monkeypatch.setattr(_otlp_helpers.urllib.request, "urlopen", urlopen)
+    monkeypatch.setattr(_otlp_helpers.time, "sleep", sleeps.append)
+
+    with pytest.raises(_otlp_helpers.OtlpRequestError) as exc_info:
+        _otlp_helpers.post_trace_with_retry(
+            "http://viewer:5001",
+            _otlp_body(1),
+            max_retries=5,
+        )
+
+    assert calls == 1
+    assert sleeps == []
+    assert "after 1 attempt" in str(exc_info.value)
+
+
+def test_endpoint_probe_exposes_authentication_failure(monkeypatch: pytest.MonkeyPatch):
+    def urlopen(request, *, timeout):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            401,
+            "Unauthorized",
+            {},
+            io.BytesIO(b'{"detail":"viewer authorization required"}'),
+        )
+
+    monkeypatch.setattr(_otlp_helpers.urllib.request, "urlopen", urlopen)
+
+    with pytest.raises(_otlp_helpers.OtlpRequestError) as exc_info:
+        _otlp_helpers.check_endpoint_reachable("http://viewer:5001")
+
+    assert exc_info.value.status_code == 401
+    assert "viewer authorization required" in str(exc_info.value)
+
+
 def test_remote_import_requests_use_configured_viewer_auth(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -173,6 +227,51 @@ def test_remote_cleanup_requests_use_configured_viewer_auth(
     )
 
 
+def test_remote_cleanup_reports_authentication_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def fail_probe(_endpoint):
+        raise _otlp_helpers.OtlpRequestError(
+            "HTTP 401 Unauthorized",
+            status_code=401,
+        )
+
+    monkeypatch.setattr(delete_traces, "check_endpoint_reachable", fail_probe)
+
+    result = CliRunner().invoke(
+        delete_traces.command,
+        ["--batch-id", "batch-1", "--endpoint", "http://viewer:5001"],
+    )
+
+    assert result.exit_code == 1
+    assert "HTTP 401 Unauthorized" in result.output
+    assert "Check NOOA_VIEWER_AUTH_TOKEN" in result.output
+    assert "Is it running?" not in result.output
+
+
+def test_harbor_import_reports_authentication_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def fail_probe(_endpoint):
+        raise _otlp_helpers.OtlpRequestError(
+            "HTTP 403 Forbidden",
+            status_code=403,
+        )
+
+    monkeypatch.setattr(import_harbor, "check_endpoint_reachable", fail_probe)
+
+    result = CliRunner().invoke(
+        import_harbor.command,
+        [str(tmp_path), "--endpoint", "http://viewer:5001"],
+    )
+
+    assert result.exit_code == 1
+    assert "HTTP 403 Forbidden" in result.output
+    assert "Check NOOA_VIEWER_AUTH_TOKEN" in result.output
+    assert "Is it running?" not in result.output
+
+
 def test_import_batches_179_records_and_syncs_before_annotations(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -180,7 +279,7 @@ def test_import_batches_179_records_and_syncs_before_annotations(
     annotation_record = {"annotations": [{"session_id": "session", "label": "good"}]}
     trace_file = tmp_path / "session.jsonl"
     _write_trace(trace_file, 179, annotation_record)
-    _patch_viewer_preflight(monkeypatch)
+    _patch_viewer_preflight(monkeypatch, stored_span_count=179)
 
     batch_sizes: list[int] = []
     events: list[str] = []
@@ -227,7 +326,12 @@ def test_import_injects_batch_and_session_attributes(
     monkeypatch: pytest.MonkeyPatch,
 ):
     trace_file = tmp_path / "my-session.nooa.jsonl"
-    _write_trace(trace_file, 1)
+    body = _otlp_body(1)
+    body["resourceSpans"][0]["resource"]["attributes"] = [
+        {"key": "batch_id", "value": {"stringValue": "old-batch"}},
+        {"key": "session.id", "value": {"stringValue": "old-session"}},
+    ]
+    trace_file.write_text(json.dumps(body) + "\n")
     _patch_viewer_preflight(monkeypatch)
     posted: list[dict] = []
 
@@ -247,6 +351,121 @@ def test_import_injects_batch_and_session_attributes(
     values = {attribute["key"]: attribute["value"] for attribute in attributes}
     assert values["batch_id"] == {"stringValue": "batch-1"}
     assert values["session.id"] == {"stringValue": "my-session"}
+
+
+def test_import_flushes_before_crossing_batch_byte_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    records = [_otlp_body(1), _otlp_body(2)]
+    serialized = [json.dumps(record) for record in records]
+    trace_file = tmp_path / "session.jsonl"
+    trace_file.write_text("\n".join(serialized) + "\n")
+    _patch_viewer_preflight(monkeypatch, stored_span_count=2)
+    batch_sizes: list[int] = []
+
+    def post_batch(_endpoint, bodies, *, max_retries):
+        batch_sizes.append(len(bodies))
+
+    monkeypatch.setattr(import_traces, "post_traces_batch_with_retry", post_batch)
+    monkeypatch.setattr(import_traces, "sync_ingest", lambda _endpoint: None)
+
+    result = CliRunner().invoke(
+        import_traces.command,
+        [
+            str(trace_file),
+            "--batch-id",
+            "batch-1",
+            "--batch-bytes",
+            str(len(serialized[0].encode("utf-8")) + 1),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert batch_sizes == [1, 1]
+
+
+def test_import_exits_nonzero_when_stored_span_count_is_incomplete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    trace_file = tmp_path / "session.jsonl"
+    _write_trace(trace_file, 2)
+    _patch_viewer_preflight(monkeypatch, stored_span_count=1)
+    monkeypatch.setattr(
+        import_traces,
+        "post_traces_batch_with_retry",
+        lambda _endpoint, _bodies, *, max_retries: None,
+    )
+    monkeypatch.setattr(import_traces, "sync_ingest", lambda _endpoint: None)
+
+    result = CliRunner().invoke(
+        import_traces.command,
+        [str(trace_file), "--batch-id", "batch-1"],
+    )
+
+    assert result.exit_code == 1
+    assert "viewer stored 1/2 spans" in result.output
+    assert "Import incomplete" in result.output
+
+
+def test_annotation_only_file_is_imported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    trace_file = tmp_path / "session.jsonl"
+    trace_file.write_text(
+        json.dumps({"annotations": [{"session_id": "session", "name": "quality"}]}) + "\n"
+    )
+    _patch_viewer_preflight(monkeypatch)
+    monkeypatch.setattr(
+        import_traces,
+        "post_annotations",
+        lambda _endpoint, annotations: len(annotations),
+    )
+
+    result = CliRunner().invoke(
+        import_traces.command,
+        [str(trace_file), "--batch-id", "batch-1"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "1 imported, 0 skipped" in result.output
+    assert "1 annotation(s) imported" in result.output
+
+
+def test_journal_only_file_is_imported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    trace_file = tmp_path / "session.nooa.jsonl"
+    trace_file.write_text(
+        json.dumps(
+            {
+                "nooaJournal": {
+                    "format": "nooa.message_journal",
+                    "version": 1,
+                    "type": "blocks",
+                    "blocks": [],
+                }
+            }
+        )
+        + "\n"
+    )
+    _patch_viewer_preflight(monkeypatch)
+    monkeypatch.setattr(
+        import_traces,
+        "post_journal_record",
+        lambda _endpoint, _record, _session_id: True,
+    )
+
+    result = CliRunner().invoke(
+        import_traces.command,
+        [str(trace_file), "--batch-id", "batch-1"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "1 imported, 0 skipped" in result.output
 
 
 def test_import_exits_nonzero_and_prints_cleanup_on_batch_failure(

--- a/packages/nooa-cli/tests/test_import_traces.py
+++ b/packages/nooa-cli/tests/test_import_traces.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
-from nooa_cli.commands import _otlp_helpers, import_traces
+from nooa_cli.commands import _otlp_helpers, delete_traces, import_traces
 
 
 def _otlp_body(index: int) -> dict:
@@ -113,6 +113,64 @@ def test_post_trace_exposes_http_status_and_response_body(monkeypatch: pytest.Mo
     assert "HTTP 413 Content Too Large" in message
     assert "ingest body too large" in message
     assert "after 1 attempt" in message
+
+
+def test_remote_import_requests_use_configured_viewer_auth(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    requests: list[urllib.request.Request] = []
+
+    def urlopen(request, *, timeout):
+        requests.append(request)
+        return _Response()
+
+    monkeypatch.setenv("NOOA_VIEWER_AUTH_TOKEN", "test-viewer-token")
+    monkeypatch.setattr(_otlp_helpers.urllib.request, "urlopen", urlopen)
+
+    assert _otlp_helpers.check_endpoint_reachable("http://viewer:5001")
+    assert _otlp_helpers.session_exists("http://viewer:5001", "new-session")
+    _otlp_helpers.post_trace_with_retry("http://viewer:5001", _otlp_body(1))
+    _otlp_helpers.sync_ingest("http://viewer:5001")
+    assert _otlp_helpers.post_annotations("http://viewer:5001", [{"label": "good"}]) == 1
+    assert _otlp_helpers.post_journal_record(
+        "http://viewer:5001",
+        {"type": "blocks", "blocks": []},
+        "new-session",
+    )
+
+    assert len(requests) == 6
+    assert all(
+        request.get_header("Authorization") == "Bearer test-viewer-token" for request in requests
+    )
+
+
+def test_remote_cleanup_requests_use_configured_viewer_auth(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    requests: list[urllib.request.Request] = []
+
+    class DeleteResponse(_Response):
+        def read(self):
+            return b'{"deleted":1}'
+
+    def urlopen(request, *, timeout):
+        requests.append(request)
+        return DeleteResponse()
+
+    monkeypatch.setenv("NOOA_VIEWER_AUTH_TOKEN", "test-viewer-token")
+    monkeypatch.setattr(delete_traces.urllib.request, "urlopen", urlopen)
+
+    result = CliRunner().invoke(
+        delete_traces.command,
+        ["--batch-id", "batch-1", "--endpoint", "http://viewer:5001"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Deleted 1 trace(s)" in result.output
+    assert len(requests) == 2
+    assert all(
+        request.get_header("Authorization") == "Bearer test-viewer-token" for request in requests
+    )
 
 
 def test_import_batches_179_records_and_syncs_before_annotations(

--- a/packages/nooa-cli/tests/test_import_traces.py
+++ b/packages/nooa-cli/tests/test_import_traces.py
@@ -198,6 +198,49 @@ def test_remote_import_requests_use_configured_viewer_auth(
     )
 
 
+def test_resource_attribute_injection_skips_malformed_entries():
+    body = {
+        "resourceSpans": [
+            "not-an-object",
+            {"resource": "not-an-object"},
+            {"resource": {"attributes": {}}},
+            {"resource": {"attributes": []}},
+        ]
+    }
+
+    assert _otlp_helpers.inject_resource_attrs(body, {"session.id": "session-1"}) is body
+    assert body["resourceSpans"][3]["resource"]["attributes"] == [
+        {"key": "session.id", "value": {"stringValue": "session-1"}}
+    ]
+
+
+def test_harbor_live_session_lookup_uses_configured_viewer_auth(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    requests: list[urllib.request.Request] = []
+
+    class MatchResponse(_Response):
+        def read(self):
+            return b'{"match":{"session_id":"live-session"}}'
+
+    def urlopen(request, *, timeout):
+        requests.append(request)
+        return MatchResponse()
+
+    monkeypatch.setenv("NOOA_VIEWER_AUTH_TOKEN", "test-viewer-token")
+    monkeypatch.setattr(import_harbor.urllib.request, "urlopen", urlopen)
+
+    session_id = import_harbor._find_matching_live_session(
+        "http://viewer:5001",
+        {"task_name": "task-1", "model_name": "model-1"},
+        "experiment-1",
+    )
+
+    assert session_id == "live-session"
+    assert len(requests) == 1
+    assert requests[0].get_header("Authorization") == "Bearer test-viewer-token"
+
+
 def test_remote_cleanup_requests_use_configured_viewer_auth(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/packages/nooa-cli/tests/test_import_traces.py
+++ b/packages/nooa-cli/tests/test_import_traces.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for reliable ``nooa import-traces`` ingestion."""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from nooa_cli.commands import _otlp_helpers, import_traces
+
+
+def _otlp_body(index: int) -> dict:
+    return {
+        "resourceSpans": [
+            {
+                "resource": {"attributes": []},
+                "scopeSpans": [
+                    {
+                        "spans": [
+                            {
+                                "traceId": f"{index:032x}",
+                                "spanId": f"{index:016x}",
+                                "name": f"span-{index}",
+                            }
+                        ]
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _write_trace(path: Path, count: int, *extra_records: dict) -> None:
+    records = [_otlp_body(index) for index in range(count)]
+    records.extend(extra_records)
+    path.write_text("\n".join(json.dumps(record) for record in records) + "\n")
+
+
+def _patch_viewer_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(import_traces, "check_endpoint_reachable", lambda _endpoint: True)
+    monkeypatch.setattr(
+        import_traces,
+        "session_exists",
+        lambda _endpoint, _session_id: False,
+    )
+
+
+class _Response:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+def test_post_trace_retries_503_with_exponential_backoff(monkeypatch: pytest.MonkeyPatch):
+    calls = 0
+    sleeps: list[float] = []
+
+    def urlopen(request, *, timeout):
+        nonlocal calls
+        calls += 1
+        if calls <= 2:
+            raise urllib.error.HTTPError(
+                request.full_url,
+                503,
+                "Service Unavailable",
+                {},
+                io.BytesIO(b'{"error":"ingest queue is full"}'),
+            )
+        return _Response()
+
+    monkeypatch.setattr(_otlp_helpers.urllib.request, "urlopen", urlopen)
+    monkeypatch.setattr(_otlp_helpers.time, "sleep", sleeps.append)
+
+    _otlp_helpers.post_trace_with_retry(
+        "http://viewer:5001",
+        _otlp_body(1),
+        max_retries=2,
+        initial_backoff=0.1,
+    )
+
+    assert calls == 3
+    assert sleeps == [0.1, 0.2]
+
+
+def test_post_trace_exposes_http_status_and_response_body(monkeypatch: pytest.MonkeyPatch):
+    def urlopen(request, *, timeout):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            413,
+            "Content Too Large",
+            {},
+            io.BytesIO(b'{"detail":"ingest body too large"}'),
+        )
+
+    monkeypatch.setattr(_otlp_helpers.urllib.request, "urlopen", urlopen)
+
+    with pytest.raises(_otlp_helpers.OtlpRequestError) as exc_info:
+        _otlp_helpers.post_trace_with_retry(
+            "http://viewer:5001",
+            _otlp_body(1),
+        )
+
+    message = str(exc_info.value)
+    assert "HTTP 413 Content Too Large" in message
+    assert "ingest body too large" in message
+    assert "after 1 attempt" in message
+
+
+def test_import_batches_179_records_and_syncs_before_annotations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    annotation_record = {"annotations": [{"session_id": "session", "label": "good"}]}
+    trace_file = tmp_path / "session.jsonl"
+    _write_trace(trace_file, 179, annotation_record)
+    _patch_viewer_preflight(monkeypatch)
+
+    batch_sizes: list[int] = []
+    events: list[str] = []
+
+    def post_batch(_endpoint, bodies, *, max_retries):
+        assert max_retries == 5
+        batch_sizes.append(len(bodies))
+        events.append("post")
+
+    def sync(_endpoint):
+        events.append("sync")
+
+    def post_annotations(_endpoint, annotations):
+        events.append("annotations")
+        return len(annotations)
+
+    monkeypatch.setattr(import_traces, "post_traces_batch_with_retry", post_batch)
+    monkeypatch.setattr(import_traces, "sync_ingest", sync)
+    monkeypatch.setattr(import_traces, "post_annotations", post_annotations)
+
+    result = CliRunner().invoke(
+        import_traces.command,
+        [
+            str(trace_file),
+            "--endpoint",
+            "http://viewer:5001",
+            "--batch-id",
+            "batch-1",
+            "--batch-lines",
+            "50",
+            "--batch-bytes",
+            "10000000",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert batch_sizes == [50, 50, 50, 29]
+    assert events == ["post", "post", "post", "post", "sync", "annotations"]
+    assert "1 imported, 0 skipped" in result.output
+
+
+def test_import_injects_batch_and_session_attributes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    trace_file = tmp_path / "my-session.nooa.jsonl"
+    _write_trace(trace_file, 1)
+    _patch_viewer_preflight(monkeypatch)
+    posted: list[dict] = []
+
+    def post_batch(_endpoint, bodies, *, max_retries):
+        posted.extend(bodies)
+
+    monkeypatch.setattr(import_traces, "post_traces_batch_with_retry", post_batch)
+    monkeypatch.setattr(import_traces, "sync_ingest", lambda _endpoint: None)
+
+    result = CliRunner().invoke(
+        import_traces.command,
+        [str(trace_file), "--batch-id", "batch-1"],
+    )
+
+    assert result.exit_code == 0, result.output
+    attributes = posted[0]["resourceSpans"][0]["resource"]["attributes"]
+    values = {attribute["key"]: attribute["value"] for attribute in attributes}
+    assert values["batch_id"] == {"stringValue": "batch-1"}
+    assert values["session.id"] == {"stringValue": "my-session"}
+
+
+def test_import_exits_nonzero_and_prints_cleanup_on_batch_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    trace_file = tmp_path / "session.jsonl"
+    _write_trace(trace_file, 2)
+    _patch_viewer_preflight(monkeypatch)
+    sync_calls: list[str] = []
+
+    def fail_batch(_endpoint, _bodies, *, max_retries):
+        raise _otlp_helpers.OtlpRequestError(
+            'HTTP 503 Service Unavailable: {"error":"ingest queue is full"}',
+            status_code=503,
+            retryable=True,
+        )
+
+    monkeypatch.setattr(import_traces, "post_traces_batch_with_retry", fail_batch)
+    monkeypatch.setattr(import_traces, "sync_ingest", sync_calls.append)
+
+    result = CliRunner().invoke(
+        import_traces.command,
+        [str(trace_file), "--endpoint", "http://viewer:5001", "--batch-id", "batch-1"],
+    )
+
+    assert result.exit_code == 1
+    assert sync_calls == ["http://viewer:5001"]
+    assert "HTTP 503 Service Unavailable" in result.output
+    assert "1 failed" in result.output
+    assert "Import incomplete" in result.output
+    assert "nooa delete-traces --batch-id batch-1" in result.output
+
+
+def test_import_exits_nonzero_when_sync_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    trace_file = tmp_path / "session.jsonl"
+    _write_trace(trace_file, 1)
+    _patch_viewer_preflight(monkeypatch)
+
+    monkeypatch.setattr(
+        import_traces,
+        "post_traces_batch_with_retry",
+        lambda _endpoint, _bodies, *, max_retries: None,
+    )
+
+    def fail_sync(_endpoint):
+        raise _otlp_helpers.OtlpRequestError(
+            'HTTP 503 Service Unavailable: {"error":"timeout waiting for queue drain"}',
+            status_code=503,
+            retryable=True,
+        )
+
+    monkeypatch.setattr(import_traces, "sync_ingest", fail_sync)
+
+    result = CliRunner().invoke(
+        import_traces.command,
+        [str(trace_file), "--batch-id", "batch-1"],
+    )
+
+    assert result.exit_code == 1
+    assert "failed to sync viewer ingest" in result.output
+    assert "timeout waiting for queue drain" in result.output

--- a/tests/integration/test_import_roundtrip.py
+++ b/tests/integration/test_import_roundtrip.py
@@ -56,6 +56,60 @@ def fresh_viewer():
         backend.stop()
 
 
+def _otlp_body(index: int) -> dict:
+    """Build one minimal OTLP envelope containing exactly one span."""
+    return {
+        "resourceSpans": [
+            {
+                "resource": {"attributes": []},
+                "scopeSpans": [
+                    {
+                        "scope": {"name": "import-backpressure-test"},
+                        "spans": [
+                            {
+                                "traceId": f"{index:032x}",
+                                "spanId": f"{index:016x}",
+                                "name": f"span-{index}",
+                                "startTimeUnixNano": str(1_000_000_000 + index),
+                                "endTimeUnixNano": str(1_000_000_001 + index),
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_import_179_records_stores_every_span(fresh_viewer, tmp_path):
+    """A file larger than the viewer queue is batched, synced, and complete."""
+    from click.testing import CliRunner
+    from nooa_cli.commands.import_traces import command
+
+    session_id = "large-import"
+    trace_file = tmp_path / f"{session_id}.jsonl"
+    trace_file.write_text("\n".join(json.dumps(_otlp_body(index)) for index in range(179)) + "\n")
+
+    result = CliRunner().invoke(
+        command,
+        [
+            str(trace_file),
+            "--endpoint",
+            fresh_viewer,
+            "--batch-id",
+            "backpressure-regression",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    with urllib.request.urlopen(
+        f"{fresh_viewer}/api/trace-count?session_id={session_id}",
+        timeout=10,
+    ) as response:
+        trace_count = json.loads(response.read())
+    assert trace_count["event_count"] == 179
+
+
 @pytest.mark.asyncio
 async def test_save_then_import_then_download_preserves_messages(fresh_viewer):
     """A JSONL written by the file exporter, then re-imported into a fresh

--- a/tests/integration/test_import_roundtrip.py
+++ b/tests/integration/test_import_roundtrip.py
@@ -110,6 +110,35 @@ def test_import_179_records_stores_every_span(fresh_viewer, tmp_path):
     assert trace_count["event_count"] == 179
 
 
+def test_import_reports_viewer_ingest_failure(fresh_viewer, tmp_path):
+    """Queue drain is not success when the viewer rejected the queued payload."""
+    from click.testing import CliRunner
+    from nooa_cli.commands.import_traces import command
+
+    good_body = _otlp_body(1)
+    malformed_body = _otlp_body(2)
+    malformed_body["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["startTimeUnixNano"] = (
+        "not-an-integer"
+    )
+    trace_file = tmp_path / "failed-ingest.jsonl"
+    trace_file.write_text(f"{json.dumps(good_body)}\n{json.dumps(malformed_body)}\n")
+
+    result = CliRunner().invoke(
+        command,
+        [
+            str(trace_file),
+            "--endpoint",
+            fresh_viewer,
+            "--batch-id",
+            "failed-ingest-regression",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "failed to verify viewer ingest" in result.output
+    assert "Import incomplete" in result.output
+
+
 @pytest.mark.asyncio
 async def test_save_then_import_then_download_preserves_messages(fresh_viewer):
     """A JSONL written by the file exporter, then re-imported into a fresh


### PR DESCRIPTION
## Summary

- batch bounded groups of OTLP records instead of posting every JSONL line independently
- retry transient HTTP and transport failures with exponential backoff
- wait for viewer ingestion via `/v1/sync` before reporting success
- expose HTTP status and response details, exit nonzero on incomplete imports, and print a cleanup command
- authenticate remote import and cleanup requests with the existing viewer bearer-token configuration

## Validation

- imported the original `20260824_074819_450ed39b.jsonl` reproduction into the configured remote viewer: 280 valid OTLP records accepted and 280 spans independently confirmed stored
- `uv run pytest packages/nooa-cli/tests -q`: 76 passed
- full repository test suite for the backpressure changes: 6,879 passed, 4 skipped, 3 xfailed, 236 deselected
- Ruff lint and formatting checks passed
- targeted Pyright: 0 errors, 0 warnings
- SPDX header check passed for all 922 Python files
- commit pre-commit hooks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated requests for trace import, deletion, and live-session matching.
  * Added configurable batching, byte limits, retries, ingestion synchronization, and span-count verification.
  * Added automatic session metadata and improved resource-attribute handling.
  * Added clearer per-file error reporting and retry guidance.

* **Bug Fixes**
  * Improved handling of malformed trace data, invalid responses, and incomplete imports.
  * Added clearer authentication guidance for rejected requests.
  * Ensured large imports reliably preserve all records.
  * Improved endpoint failure reporting and cleanup after unsuccessful imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->