### PR TITLE
fix(tui): coalesce native resize redraw

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -730,6 +730,8 @@ def format_session_rule(cols: int, label: str = "") -> list[tuple[str, str]]:
 PROMPT_MARKER = "❯ "
 _CTRL_C_EXIT_WINDOW_SECONDS = 2.0
 _TRANSCRIPT_CLEAR_SEQUENCE = "\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H"
+_SYNCHRONIZED_OUTPUT_BEGIN = "\x1b[?2026h"
+_SYNCHRONIZED_OUTPUT_END = "\x1b[?2026l"
 _FULLSCREEN_TRANSCRIPT_MAX_RECORDS = 10_000
 _FULLSCREEN_TRANSCRIPT_MAX_BYTES = 16 * 1024 * 1024
 
@@ -3349,6 +3351,22 @@ class TUIApplication:
         except Exception:
             return False
 
+    def _set_synchronized_output(self, *, enabled: bool) -> None:
+        """Bracket a destructive replay in one terminal-visible update.
+
+        DEC private mode 2026 is understood by current terminals and tmux.
+        Terminals that do not implement it ignore the private mode sequence,
+        preserving the existing replay behavior. The disable marker is always
+        emitted from the replay ``finally`` path so cancellation cannot leave a
+        cooperative terminal holding subsequent output.
+        """
+        marker = _SYNCHRONIZED_OUTPUT_BEGIN if enabled else _SYNCHRONIZED_OUTPUT_END
+        try:
+            self._app.output.write_raw(marker)
+            self._app.output.flush()
+        except Exception:
+            logger.debug("failed to toggle synchronized terminal output", exc_info=True)
+
     async def _consume_resize_replay(self, item: _ResizeReplayQueueItem) -> None:
         schedule_latest_pending = False
         try:
@@ -3370,6 +3388,7 @@ class TUIApplication:
             from prompt_toolkit.application import run_in_terminal
 
             self._replay_columns_override = item.request.width
+            self._set_synchronized_output(enabled=True)
             try:
                 replayed = await run_in_terminal(lambda: self._replay_queue_item_if_current(item))
             except asyncio.CancelledError:
@@ -3377,6 +3396,10 @@ class TUIApplication:
             except Exception:
                 replayed = False
             finally:
+                # run_in_terminal flushes its final live-region redraw before
+                # returning. Reveal the erase, transcript replay, and redraw as
+                # one terminal update instead of two fast visible paints.
+                self._set_synchronized_output(enabled=False)
                 self._replay_columns_override = None
                 # If run_in_terminal failed before invoking the callback, its
                 # own final redraw was suppressed by the transaction guard.

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1046,9 +1046,8 @@ class TUIApplication:
         self._resize_replay_schedule_generation = 0
         self._queued_resize_replay_generation: int | None = None
         self._resize_replay_failure_generation: int | None = None
-        # Native replay suppresses prompt_toolkit's immediate width redraw so
-        # its live-region redraw and our semantic transcript replay become one
-        # settled visible transition.
+        # Resize-aware modes suppress prompt_toolkit's immediate SIGWINCH
+        # redraw so transient geometry collapses into one settled frame.
         self._resize_redraw_deferred = False
         # A real height shrink can compress the non-full-screen live region
         # below its preferred height.  prompt_toolkit erases using a cursor

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -103,7 +103,7 @@ class _ResizeAwareApplication(Application[Any]):
     def _on_resize(self) -> None:
         if self._defer_resize_redraw():
             return
-        super()._on_resize()
+        self._run_with_deferred_flush(super()._on_resize)
 
     def _redraw(self, render_as_done: bool = False) -> None:
         if not render_as_done and self._resize_redraw_is_deferred():
@@ -112,17 +112,10 @@ class _ResizeAwareApplication(Application[Any]):
 
     def redraw_after_deferred_resize(self) -> None:
         """Run prompt_toolkit's normal erase/redraw after resize settles."""
-        super()._on_resize()
+        self._run_with_deferred_flush(super()._on_resize)
 
-    def run_atomic_native_replay(self, replay: Callable[[Any], bool]) -> bool:
-        """Erase, replay, and redraw through one physical output flush.
-
-        ``run_in_terminal`` flushes its erase before invoking the callback. For
-        a semantic transcript replay that exposes an empty/intermediate frame
-        before the rebuilt transcript and live region. This transaction runs
-        synchronously on the UI loop and temporarily turns every renderer
-        flush into a no-op, then publishes the complete terminal update once.
-        """
+    def _run_with_deferred_flush(self, callback: Callable[[], Any]) -> Any:
+        """Buffer a prompt_toolkit terminal mutation and publish it once."""
         output = self.output
         physical_flush = output.flush
 
@@ -131,20 +124,34 @@ class _ResizeAwareApplication(Application[Any]):
 
         output.flush = defer_flush  # type: ignore[method-assign]
         try:
+            result = callback()
+        finally:
+            output.flush = physical_flush  # type: ignore[method-assign]
+        physical_flush()
+        return result
+
+    def run_atomic_native_replay(self, replay: Callable[[Any], bool]) -> bool:
+        """Erase, replay, and redraw through one physical output flush.
+
+        ``run_in_terminal`` flushes its erase before invoking the callback. For
+        a semantic transcript replay that exposes an empty/intermediate frame
+        before the rebuilt transcript and live region. This transaction runs
+        synchronously on the UI loop and buffers every renderer flush before
+        publishing the complete terminal update once.
+        """
+        output = self.output
+
+        def update() -> bool:
             self.renderer.erase()
             replayed = replay(output)
             self.renderer.reset()
             self._request_absolute_cursor_position()
             # Bypass this class's deferred-redraw guard: this is the one final
             # live-region frame belonging to the resize transaction.
-            super()._redraw()
-        finally:
-            output.flush = physical_flush  # type: ignore[method-assign]
+            super(_ResizeAwareApplication, self)._redraw()
+            return replayed
 
-        # Vt100_Output buffers all operations above. This is the transaction's
-        # only write to the underlying terminal.
-        physical_flush()
-        return replayed
+        return bool(self._run_with_deferred_flush(update))
 
 
 def _is_raw_mouse_report(data: str) -> bool:
@@ -3114,12 +3121,28 @@ class TUIApplication:
         changes can safely skip the first paint: the atomic native replay
         performs the final redraw. Row-only changes stay immediate.
         """
-        if not self.full_screen or not self._resize_replays_enabled:
+        if not self._resize_replays_enabled:
             return False
         current = self._read_terminal_size()
         if current is None:
             return False
         previous = self._resize_reflow.observed_size
+
+        if self._is_fullscreen:
+            # Alternate-screen mode owns every cell, so even a row-only resize
+            # can repaint the whole viewport. Hold SIGWINCH paints until the
+            # geometry settles rather than exposing each transient tmux size.
+            if previous == current:
+                return self._fullscreen_rebuild_timer is not None
+            self._resize_reflow.observe(current)
+            if previous is None or self._active_subview is not None:
+                return False
+            self._resize_redraw_deferred = True
+            self._schedule_fullscreen_rebuild()
+            return True
+
+        if not self.full_screen:
+            return False
         if previous == current:
             # Coalesce duplicate signals while a width transaction is pending.
             # Once settled, still let prompt_toolkit repaint its live region
@@ -3205,18 +3228,17 @@ class TUIApplication:
             self._schedule_resize_replay()
 
     def _schedule_fullscreen_rebuild(self) -> None:
-        """Coalesce semantic fullscreen re-rendering until resize input settles."""
-        # Static transcript blocks are projected by the model at any width and
-        # need no source rebuild. This makes the 10,000-record common case O(1)
-        # in the render callback.
-        if self._fullscreen_semantic_replay_count == 0:
-            self._cancel_fullscreen_drag()
-            self._fullscreen_invalidate_count += 1
-            self._app.invalidate()
-            return
+        """Coalesce fullscreen redraws until resize input settles."""
         loop = self._loop
         if loop is None or loop.is_closed():
-            self._rebuild_fullscreen_transcript()
+            if self._fullscreen_semantic_replay_count:
+                self._rebuild_fullscreen_transcript()
+            else:
+                # Static records project at render time; preserve the O(1)
+                # synchronous fallback used before the application loop starts.
+                self._cancel_fullscreen_drag()
+                self._fullscreen_invalidate_count += 1
+                self._app.invalidate()
             return
         if self._fullscreen_rebuild_timer is not None:
             self._fullscreen_rebuild_timer.cancel()
@@ -3234,7 +3256,21 @@ class TUIApplication:
         self._fullscreen_rebuild_timer = None
         if not self._resize_replays_enabled:
             return
-        self._rebuild_fullscreen_transcript()
+        if self._fullscreen_semantic_replay_count:
+            self._rebuild_fullscreen_transcript()
+        else:
+            # Static records are projected by the fullscreen model at render
+            # time, so only the settled prompt_toolkit frame is required.
+            self._cancel_fullscreen_drag()
+            self._fullscreen_invalidate_count += 1
+            self._finish_fullscreen_resize_redraw()
+
+    def _finish_fullscreen_resize_redraw(self) -> None:
+        if self._resize_redraw_deferred:
+            self._resize_redraw_deferred = False
+            self._app.redraw_after_deferred_resize()
+        else:
+            self._app.invalidate()
 
     def _rebuild_fullscreen_transcript(self) -> None:
         """Refresh width-sensitive semantic blocks from a one-width cache."""
@@ -3282,7 +3318,7 @@ class TUIApplication:
             ],
         )
         self._fullscreen_invalidate_count += 1
-        self._app.invalidate()
+        self._finish_fullscreen_resize_redraw()
 
     def _main_layout_is_compressed(self, size: tuple[int, int]) -> bool:
         """Return whether optional main-view rows cannot all fit."""

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -114,6 +114,38 @@ class _ResizeAwareApplication(Application[Any]):
         """Run prompt_toolkit's normal erase/redraw after resize settles."""
         super()._on_resize()
 
+    def run_atomic_native_replay(self, replay: Callable[[Any], bool]) -> bool:
+        """Erase, replay, and redraw through one physical output flush.
+
+        ``run_in_terminal`` flushes its erase before invoking the callback. For
+        a semantic transcript replay that exposes an empty/intermediate frame
+        before the rebuilt transcript and live region. This transaction runs
+        synchronously on the UI loop and temporarily turns every renderer
+        flush into a no-op, then publishes the complete terminal update once.
+        """
+        output = self.output
+        physical_flush = output.flush
+
+        def defer_flush() -> None:
+            return None
+
+        output.flush = defer_flush  # type: ignore[method-assign]
+        try:
+            self.renderer.erase()
+            replayed = replay(output)
+            self.renderer.reset()
+            self._request_absolute_cursor_position()
+            # Bypass this class's deferred-redraw guard: this is the one final
+            # live-region frame belonging to the resize transaction.
+            super()._redraw()
+        finally:
+            output.flush = physical_flush  # type: ignore[method-assign]
+
+        # Vt100_Output buffers all operations above. This is the transaction's
+        # only write to the underlying terminal.
+        physical_flush()
+        return replayed
+
 
 def _is_raw_mouse_report(data: str) -> bool:
     """Return whether raw input is a supported terminal mouse report."""
@@ -730,8 +762,6 @@ def format_session_rule(cols: int, label: str = "") -> list[tuple[str, str]]:
 PROMPT_MARKER = "❯ "
 _CTRL_C_EXIT_WINDOW_SECONDS = 2.0
 _TRANSCRIPT_CLEAR_SEQUENCE = "\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H"
-_SYNCHRONIZED_OUTPUT_BEGIN = "\x1b[?2026h"
-_SYNCHRONIZED_OUTPUT_END = "\x1b[?2026l"
 _FULLSCREEN_TRANSCRIPT_MAX_RECORDS = 10_000
 _FULLSCREEN_TRANSCRIPT_MAX_BYTES = 16 * 1024 * 1024
 
@@ -3081,8 +3111,8 @@ class TUIApplication:
         prompt_toolkit normally erases and redraws immediately on SIGWINCH. In
         native-replay mode that live-region paint is followed by our debounced
         clear, semantic transcript replay, and another live-region paint. Width
-        changes can safely skip the first paint: ``run_in_terminal`` performs
-        the final redraw after the replay. Row-only changes stay immediate.
+        changes can safely skip the first paint: the atomic native replay
+        performs the final redraw. Row-only changes stay immediate.
         """
         if not self.full_screen or not self._resize_replays_enabled:
             return False
@@ -3351,22 +3381,6 @@ class TUIApplication:
         except Exception:
             return False
 
-    def _set_synchronized_output(self, *, enabled: bool) -> None:
-        """Bracket a destructive replay in one terminal-visible update.
-
-        DEC private mode 2026 is understood by current terminals and tmux.
-        Terminals that do not implement it ignore the private mode sequence,
-        preserving the existing replay behavior. The disable marker is always
-        emitted from the replay ``finally`` path so cancellation cannot leave a
-        cooperative terminal holding subsequent output.
-        """
-        marker = _SYNCHRONIZED_OUTPUT_BEGIN if enabled else _SYNCHRONIZED_OUTPUT_END
-        try:
-            self._app.output.write_raw(marker)
-            self._app.output.flush()
-        except Exception:
-            logger.debug("failed to toggle synchronized terminal output", exc_info=True)
-
     async def _consume_resize_replay(self, item: _ResizeReplayQueueItem) -> None:
         schedule_latest_pending = False
         try:
@@ -3385,35 +3399,36 @@ class TUIApplication:
                 self._finish_deferred_resize_redraw()
                 return
 
-            from prompt_toolkit.application import run_in_terminal
-
             self._replay_columns_override = item.request.width
-            self._set_synchronized_output(enabled=True)
+            transaction_completed = False
             try:
-                replayed = await run_in_terminal(lambda: self._replay_queue_item_if_current(item))
+                replayed = self._app.run_atomic_native_replay(
+                    lambda output: self._replay_queue_item_if_current(item, output=output)
+                )
+                transaction_completed = True
             except asyncio.CancelledError:
                 raise
             except Exception:
                 replayed = False
             finally:
-                # run_in_terminal flushes its final live-region redraw before
-                # returning. Reveal the erase, transcript replay, and redraw as
-                # one terminal update instead of two fast visible paints.
-                self._set_synchronized_output(enabled=False)
                 self._replay_columns_override = None
-                # If run_in_terminal failed before invoking the callback, its
-                # own final redraw was suppressed by the transaction guard.
-                self._finish_deferred_resize_redraw()
+                if transaction_completed:
+                    self._resize_redraw_deferred = False
+                else:
+                    # Recover the live region if an output implementation
+                    # failed before the transaction's final flush.
+                    self._finish_deferred_resize_redraw()
 
-            # ``run_in_terminal`` always restores prompt_toolkit's live region
-            # before returning, so no separate resize redraw remains pending.
-            self._resize_redraw_deferred = False
             if replayed:
-                # The callback committed resize state before prompt_toolkit's
-                # final redraw, so before_render sees the rebuilt width.
-                # Verify geometry once afterward. A
-                # genuinely newer width starts its own transaction immediately;
-                # an unchanged final width does not arm another debounce timer.
+                # Commit only after the single physical flush succeeds. A
+                # failed flush therefore remains eligible for the bounded
+                # retry below instead of silently accepting a missing replay.
+                self._resize_reflow.mark_replayed(item.request)
+                self._resize_replay_failure_generation = None
+                self._height_compaction_needs_replay = False
+                self._fullscreen_invalidate_count += 1
+                # Verify geometry once afterward. A genuinely newer width
+                # starts its own transaction; an unchanged width is a no-op.
                 current = self._read_terminal_size()
                 if current is not None:
                     self._observe_terminal_size(current)
@@ -3438,11 +3453,9 @@ class TUIApplication:
             ):
                 self._schedule_resize_replay()
 
-    def _replay_queue_item_if_current(self, item: _ResizeReplayQueueItem) -> bool:
-        # run_in_terminal redraws immediately after this callback. Release the
-        # guard even when the queued replay went stale, so its erased live
-        # region is always restored.
-        self._resize_redraw_deferred = False
+    def _replay_queue_item_if_current(
+        self, item: _ResizeReplayQueueItem, *, output: Any | None = None
+    ) -> bool:
         if (
             not self._resize_replays_enabled
             or self._active_subview is not None
@@ -3451,7 +3464,7 @@ class TUIApplication:
             or not self._resize_output_width_is_current(item)
         ):
             return False
-        replayed = self._replay_fullscreen_transcript(
+        return self._replay_fullscreen_transcript(
             item.transcript_blocks,
             clear_even_if_empty=item.request.required,
             still_current=lambda: (
@@ -3461,14 +3474,10 @@ class TUIApplication:
                 and self._resize_reflow.is_current(item.request)
                 and self._resize_output_width_is_current(item)
             ),
+            output=output,
+            flush=False,
+            count_invalidation=False,
         )
-        if replayed:
-            # Commit before run_in_terminal performs its final prompt redraw.
-            # This keeps that frame from observing an apparently pending replay.
-            self._resize_reflow.mark_replayed(item.request)
-            self._resize_replay_failure_generation = None
-            self._height_compaction_needs_replay = False
-        return replayed
 
     def _resize_output_width_is_current(self, item: _ResizeReplayQueueItem) -> bool:
         current = self._read_terminal_size()
@@ -3547,13 +3556,17 @@ class TUIApplication:
         *,
         clear_even_if_empty: bool = False,
         still_current: Callable[[], bool] | None = None,
+        output: Any | None = None,
+        flush: bool = True,
+        count_invalidation: bool = True,
     ) -> bool:
         if not self.full_screen:
             return False
-        import sys as _sys
+        if output is None:
+            import sys as _sys
 
-        out = _sys.__stdout__
-        if out is None:
+            output = _sys.__stdout__
+        if output is None:
             return False
         if transcript_blocks is None:
             self._prune_transcript_blocks_for_active_events()
@@ -3576,11 +3589,16 @@ class TUIApplication:
         try:
             # Reset scroll region + style state before clearing. Homing again
             # after the purge gives prompt_toolkit a stable origin for its live
-            # input/status redraw when run_in_terminal returns.
-            out.write(_TRANSCRIPT_CLEAR_SEQUENCE)
-            out.write("".join(chunks))
-            out.flush()
-            self._fullscreen_invalidate_count += 1
+            # input/status redraw at the end of the atomic transaction.
+            write = getattr(output, "write_raw", None)
+            if write is None:
+                write = output.write
+            write(_TRANSCRIPT_CLEAR_SEQUENCE)
+            write("".join(chunks))
+            if flush:
+                output.flush()
+            if count_invalidation:
+                self._fullscreen_invalidate_count += 1
             return True
         except Exception:
             return False

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -86,6 +86,35 @@ from .terminal_safety import (
 logger = logging.getLogger(__name__)
 
 
+class _ResizeAwareApplication(Application[Any]):
+    """Let native replay fold SIGWINCH into its semantic resize transaction."""
+
+    def __init__(
+        self,
+        *args: Any,
+        defer_resize_redraw: Callable[[], bool],
+        resize_redraw_is_deferred: Callable[[], bool],
+        **kwargs: Any,
+    ) -> None:
+        self._defer_resize_redraw = defer_resize_redraw
+        self._resize_redraw_is_deferred = resize_redraw_is_deferred
+        super().__init__(*args, **kwargs)
+
+    def _on_resize(self) -> None:
+        if self._defer_resize_redraw():
+            return
+        super()._on_resize()
+
+    def _redraw(self, render_as_done: bool = False) -> None:
+        if not render_as_done and self._resize_redraw_is_deferred():
+            return
+        super()._redraw(render_as_done=render_as_done)
+
+    def redraw_after_deferred_resize(self) -> None:
+        """Run prompt_toolkit's normal erase/redraw after resize settles."""
+        super()._on_resize()
+
+
 def _is_raw_mouse_report(data: str) -> bool:
     """Return whether raw input is a supported terminal mouse report."""
     return (
@@ -978,6 +1007,10 @@ class TUIApplication:
         self._resize_replay_schedule_generation = 0
         self._queued_resize_replay_generation: int | None = None
         self._resize_replay_failure_generation: int | None = None
+        # Native replay suppresses prompt_toolkit's immediate width redraw so
+        # its live-region redraw and our semantic transcript replay become one
+        # settled visible transition.
+        self._resize_redraw_deferred = False
         # A real height shrink can compress the non-full-screen live region
         # below its preferred height.  prompt_toolkit erases using a cursor
         # offset captured before SIGWINCH, so one rebuild is required after the
@@ -1348,7 +1381,7 @@ class TUIApplication:
                 return False
             return bool(getattr(view, "mouse_support", True))
 
-        self._app = Application(
+        self._app = _ResizeAwareApplication(
             layout=Layout(
                 DynamicContainer(_root_container),
                 focused_element=input_window,
@@ -1369,6 +1402,10 @@ class TUIApplication:
             # delayed second redraw (~0.5–0.75s later), which is visible in
             # fullscreen subviews after terminal resize.
             terminal_size_polling_interval=None,
+            defer_resize_redraw=self._defer_prompt_toolkit_resize_redraw,
+            resize_redraw_is_deferred=lambda: (
+                self._resize_redraw_deferred and self._active_subview is None
+            ),
         )
 
     def observe_agent(self) -> None:
@@ -3036,6 +3073,41 @@ class TUIApplication:
         """Normalize source text at the native terminal's current safe width."""
         return normalize_transcript_block(source, columns=self.transcript_columns())
 
+    def _defer_prompt_toolkit_resize_redraw(self) -> bool:
+        """Fold native-replay width changes into the settled transcript replay.
+
+        prompt_toolkit normally erases and redraws immediately on SIGWINCH. In
+        native-replay mode that live-region paint is followed by our debounced
+        clear, semantic transcript replay, and another live-region paint. Width
+        changes can safely skip the first paint: ``run_in_terminal`` performs
+        the final redraw after the replay. Row-only changes stay immediate.
+        """
+        if not self.full_screen or not self._resize_replays_enabled:
+            return False
+        current = self._read_terminal_size()
+        if current is None:
+            return False
+        previous = self._resize_reflow.observed_size
+        if previous == current:
+            # Coalesce duplicate signals while a width transaction is pending.
+            # Once settled, still let prompt_toolkit repaint its live region
+            # when an unchanged pane is exposed again.
+            return self._resize_reflow.has_pending_replay
+
+        self._observe_terminal_size(current)
+        if previous is None or self._active_subview is not None:
+            return False
+        if previous[0] != current[0] or self._resize_reflow.has_pending_replay:
+            self._resize_redraw_deferred = True
+            return True
+        return False
+
+    def _finish_deferred_resize_redraw(self) -> None:
+        if not self._resize_redraw_deferred or not self._resize_replays_enabled:
+            return
+        self._resize_redraw_deferred = False
+        self._app.redraw_after_deferred_resize()
+
     def _before_render(self, _app) -> None:
         """Observe frame-local status and terminal geometry before rendering."""
         if self._is_fullscreen:
@@ -3218,8 +3290,9 @@ class TUIApplication:
             return
         current = self._read_terminal_size()
         if current is None:
-            # Keep the pending width. A later successful before_render sample
-            # will schedule it again without retrying a broken Output.
+            # Keep the pending width. Restore prompt_toolkit rendering so a
+            # later successful frame can observe and schedule it again.
+            self._finish_deferred_resize_redraw()
             return
         observation = self._resize_reflow.observe(current)
         if observation.should_debounce:
@@ -3231,6 +3304,7 @@ class TUIApplication:
 
         request = self._resize_reflow.prepare_replay()
         if request is None:
+            self._finish_deferred_resize_redraw()
             return
 
         queue = self._block_queue
@@ -3290,6 +3364,7 @@ class TUIApplication:
             if not item.transcript_blocks and not item.request.required:
                 self._resize_reflow.mark_replayed(item.request)
                 self._resize_replay_failure_generation = None
+                self._finish_deferred_resize_redraw()
                 return
 
             from prompt_toolkit.application import run_in_terminal
@@ -3303,14 +3378,22 @@ class TUIApplication:
                 replayed = False
             finally:
                 self._replay_columns_override = None
+                # If run_in_terminal failed before invoking the callback, its
+                # own final redraw was suppressed by the transaction guard.
+                self._finish_deferred_resize_redraw()
 
+            # ``run_in_terminal`` always restores prompt_toolkit's live region
+            # before returning, so no separate resize redraw remains pending.
+            self._resize_redraw_deferred = False
             if replayed:
-                self._resize_reflow.mark_replayed(item.request)
-                self._resize_replay_failure_generation = None
-                self._height_compaction_needs_replay = False
-                # Some terminal stacks report final geometry only after the
-                # replay-triggered prompt_toolkit redraw.
-                self._schedule_resize_replay()
+                # The callback committed resize state before prompt_toolkit's
+                # final redraw, so before_render sees the rebuilt width.
+                # Verify geometry once afterward. A
+                # genuinely newer width starts its own transaction immediately;
+                # an unchanged final width does not arm another debounce timer.
+                current = self._read_terminal_size()
+                if current is not None:
+                    self._observe_terminal_size(current)
             elif (
                 item.transcript_epoch != self._transcript_epoch
                 or not self._resize_reflow.is_current(item.request)
@@ -3333,6 +3416,10 @@ class TUIApplication:
                 self._schedule_resize_replay()
 
     def _replay_queue_item_if_current(self, item: _ResizeReplayQueueItem) -> bool:
+        # run_in_terminal redraws immediately after this callback. Release the
+        # guard even when the queued replay went stale, so its erased live
+        # region is always restored.
+        self._resize_redraw_deferred = False
         if (
             not self._resize_replays_enabled
             or self._active_subview is not None
@@ -3341,7 +3428,7 @@ class TUIApplication:
             or not self._resize_output_width_is_current(item)
         ):
             return False
-        return self._replay_fullscreen_transcript(
+        replayed = self._replay_fullscreen_transcript(
             item.transcript_blocks,
             clear_even_if_empty=item.request.required,
             still_current=lambda: (
@@ -3352,6 +3439,13 @@ class TUIApplication:
                 and self._resize_output_width_is_current(item)
             ),
         )
+        if replayed:
+            # Commit before run_in_terminal performs its final prompt redraw.
+            # This keeps that frame from observing an apparently pending replay.
+            self._resize_reflow.mark_replayed(item.request)
+            self._resize_replay_failure_generation = None
+            self._height_compaction_needs_replay = False
+        return replayed
 
     def _resize_output_width_is_current(self, item: _ResizeReplayQueueItem) -> bool:
         current = self._read_terminal_size()
@@ -3362,6 +3456,7 @@ class TUIApplication:
         if self._resize_replay_timer is not None:
             self._resize_replay_timer.cancel()
             self._resize_replay_timer = None
+        self._resize_redraw_deferred = False
         self._fullscreen_rebuild_generation += 1
         if self._fullscreen_rebuild_timer is not None:
             self._fullscreen_rebuild_timer.cancel()

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -125,8 +125,16 @@ class _ResizeAwareApplication(Application[Any]):
         output.flush = defer_flush  # type: ignore[method-assign]
         try:
             result = callback()
-        finally:
+        except BaseException:
             output.flush = physical_flush  # type: ignore[method-assign]
+            try:
+                physical_flush()
+            except Exception:
+                # Preserve the callback failure; callers cannot recover from a
+                # secondary flush error more usefully than from its root cause.
+                pass
+            raise
+        output.flush = physical_flush  # type: ignore[method-assign]
         physical_flush()
         return result
 
@@ -134,7 +142,7 @@ class _ResizeAwareApplication(Application[Any]):
         """Erase, replay, and redraw through one physical output flush.
 
         ``run_in_terminal`` flushes its erase before invoking the callback. For
-        a semantic transcript replay that exposes an empty/intermediate frame
+        a semantic transcript replay, this exposes an empty/intermediate frame
         before the rebuilt transcript and live region. This transaction runs
         synchronously on the UI loop and buffers every renderer flush before
         publishing the complete terminal update once.
@@ -1441,9 +1449,7 @@ class TUIApplication:
             # fullscreen subviews after terminal resize.
             terminal_size_polling_interval=None,
             defer_resize_redraw=self._defer_prompt_toolkit_resize_redraw,
-            resize_redraw_is_deferred=lambda: (
-                self._resize_redraw_deferred and self._active_subview is None
-            ),
+            resize_redraw_is_deferred=self._prompt_toolkit_resize_redraw_is_deferred,
         )
 
     def observe_agent(self) -> None:
@@ -1700,9 +1706,15 @@ class TUIApplication:
                 self._app.layout.focus(self._input_window)
             except Exception:
                 pass
+            if self._is_fullscreen and self._resize_reflow.has_pending_replay:
+                # The resize callback observes geometry while a modal subview is
+                # visible, but semantic transcript work stays deferred until the
+                # main view returns. Rebuild before invalidating so the first
+                # restored frame already has the settled projection.
+                self._rebuild_fullscreen_transcript()
             if self._app.is_running:
                 self._app.invalidate()
-            if self._resize_reflow.has_pending_replay:
+            if not self._is_fullscreen and self._resize_reflow.has_pending_replay:
                 self._schedule_resize_replay()
 
     def _prefill_input(self, text: str) -> None:
@@ -3142,6 +3154,15 @@ class TUIApplication:
 
         if not self.full_screen:
             return False
+        if self._app._running_in_terminal:
+            # Never let SIGWINCH erase an external editor/shell, including an
+            # unchanged duplicate signal. Observe changed geometry so a width
+            # replay remains pending; row-only changes use the handoff's final
+            # prompt_toolkit redraw after ownership returns.
+            if previous != current:
+                self._observe_terminal_size(current)
+            self._resize_redraw_deferred = True
+            return True
         if previous == current:
             # Coalesce duplicate signals while a width transaction is pending.
             # Once settled, still let prompt_toolkit repaint its live region
@@ -3155,6 +3176,28 @@ class TUIApplication:
             self._resize_redraw_deferred = True
             return True
         return False
+
+    def _prompt_toolkit_resize_redraw_is_deferred(self) -> bool:
+        """Keep a pending resize hidden until its terminal transaction can run."""
+        if not self._resize_redraw_deferred or self._active_subview is not None:
+            return False
+        if self.full_screen and self._resize_replays_enabled:
+            if self._resize_reflow.has_pending_replay:
+                if (
+                    self._resize_replay_timer is None
+                    and self._queued_resize_replay_generation is None
+                ):
+                    # ``run_in_terminal`` suppresses prompt_toolkit redraws while
+                    # an external program owns the terminal. Its final redraw
+                    # reaches this hook after ownership returns; resume the
+                    # deferred width replay then.
+                    self._schedule_resize_replay()
+                return True
+            # A row-only SIGWINCH needed no semantic replay. Let the handoff's
+            # own final redraw publish the new layout exactly once.
+            self._resize_redraw_deferred = False
+            return False
+        return True
 
     def _finish_deferred_resize_redraw(self) -> None:
         if not self._resize_redraw_deferred or not self._resize_replays_enabled:
@@ -3236,6 +3279,7 @@ class TUIApplication:
                 # Static records project at render time; preserve the O(1)
                 # synchronous fallback used before the application loop starts.
                 self._cancel_fullscreen_drag()
+                self._mark_fullscreen_resize_replayed()
                 self._fullscreen_invalidate_count += 1
                 self._app.invalidate()
             return
@@ -3261,8 +3305,14 @@ class TUIApplication:
             # Static records are projected by the fullscreen model at render
             # time, so only the settled prompt_toolkit frame is required.
             self._cancel_fullscreen_drag()
+            self._mark_fullscreen_resize_replayed()
             self._fullscreen_invalidate_count += 1
             self._finish_fullscreen_resize_redraw()
+
+    def _mark_fullscreen_resize_replayed(self) -> None:
+        request = self._resize_reflow.prepare_replay()
+        if request is not None and self._resize_reflow.is_current(request):
+            self._resize_reflow.mark_replayed(request)
 
     def _finish_fullscreen_resize_redraw(self) -> None:
         if self._resize_redraw_deferred:
@@ -3316,6 +3366,7 @@ class TUIApplication:
                 for index, block in enumerate(self._transcript_blocks)
             ],
         )
+        self._mark_fullscreen_resize_replayed()
         self._fullscreen_invalidate_count += 1
         self._finish_fullscreen_resize_redraw()
 
@@ -3354,6 +3405,11 @@ class TUIApplication:
             return
         self._resize_replay_timer = None
         if not self._resize_replays_enabled:
+            return
+        if self._app._running_in_terminal:
+            # An external editor/shell currently owns the terminal. Leave the
+            # request pending; prompt_toolkit's handoff redraw will schedule it
+            # through ``_prompt_toolkit_resize_redraw_is_deferred``.
             return
         current = self._read_terminal_size()
         if current is None:
@@ -3427,6 +3483,12 @@ class TUIApplication:
                 schedule_latest_pending = self._resize_reflow.has_pending_replay
                 return
             if self._active_subview is not None:
+                return
+            if self._app._running_in_terminal:
+                # A terminal handoff can begin after this barrier was queued.
+                # Never erase/replay over an external editor or shell; leave the
+                # request pending for prompt_toolkit's handoff redraw to resume.
+                schedule_latest_pending = self._resize_reflow.has_pending_replay
                 return
             if not item.transcript_blocks and not item.request.required:
                 self._resize_reflow.mark_replayed(item.request)

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -226,12 +226,43 @@ async def test_fullscreen_resize_reflows_without_destructive_replay(
         assert app is not None
         app.emit_block("abcdefghijklmnop\n")
         assert app._fullscreen_transcript.text == "abcdefghijklmnop\n"
+        output.events.clear()
+        render_count = app._app.render_counter
         await harness.resize_from_terminal(5, 20)
-        await asyncio.sleep(0)
+        assert app._app.render_counter == render_count
+        await harness.wait_for(lambda: app._fullscreen_invalidate_count == 1)
         assert app._fullscreen_transcript.text == "abcdefghijklmnop\n"
-        assert app._fullscreen_invalidate_count == 1
+        assert app._app.render_counter == render_count + 1
+        assert sum(event == ("flush",) for event in output.events) == 1
 
     assert stdout.getvalue() == ""
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_transient_sigwinches_publish_only_final_frame() -> None:
+    """A live resize burst must not expose prompt_toolkit's intermediate sizes."""
+    from .tui_app_harness import MutableRecordingOutput
+
+    output = MutableRecordingOutput(columns=80, rows=40)
+    async with TUIHarness(display_mode=DisplayMode.FULLSCREEN, output=output) as harness:
+        app = harness.app
+        assert app is not None
+        app.emit_block("stable transcript\n")
+        output.events.clear()
+        render_count = app._app.render_counter
+
+        output.set_size(70, 35)
+        app._app._on_resize()
+        output.set_size(60, 30)
+        app._app._on_resize()
+        app._app._on_resize()  # Duplicate final SIGWINCH from tmux exposure.
+
+        assert app._app.render_counter == render_count
+        await harness.wait_for(lambda: app._fullscreen_invalidate_count == 1)
+        assert app._resize_reflow.observed_size == (60, 30)
+        assert app._app.render_counter == render_count + 1
+        assert sum(event == ("flush",) for event in output.events) == 1
+        assert app._fullscreen_rebuild_timer is None
 
 
 def test_fullscreen_resize_preserves_history_beyond_native_replay_tail() -> None:

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -233,9 +233,164 @@ async def test_fullscreen_resize_reflows_without_destructive_replay(
         await harness.wait_for(lambda: app._fullscreen_invalidate_count == 1)
         assert app._fullscreen_transcript.text == "abcdefghijklmnop\n"
         assert app._app.render_counter == render_count + 1
-        assert sum(event == ("flush",) for event in output.events) == 1
+        flushes = [index for index, event in enumerate(output.events) if event == ("flush",)]
+        renderer_writes = [
+            index for index, event in enumerate(output.events) if event[0] == "write"
+        ]
+        assert len(flushes) == 1
+        assert renderer_writes
+        assert max(renderer_writes) < flushes[0]
 
     assert stdout.getvalue() == ""
+
+
+def test_resize_deferred_flush_restores_output_and_flushes_on_callback_error() -> None:
+    """A failed PTK mutation must not strand buffered terminal output."""
+    from .tui_app_harness import MutableRecordingOutput
+
+    output = MutableRecordingOutput()
+    with create_app_session(input=DummyInput(), output=output):
+        from nooa_cli.tui.tui_application import TUIApplication
+
+        app = TUIApplication(display_mode=DisplayMode.FULLSCREEN)
+
+    original_flush = output.flush
+    output.events.clear()
+
+    def failing_callback() -> None:
+        output.write_raw("partial mutation")
+        output.flush()
+        raise RuntimeError("render failed")
+
+    with pytest.raises(RuntimeError, match="render failed"):
+        app._app._run_with_deferred_flush(failing_callback)
+
+    assert output.flush == original_flush
+    assert output.events[-1] == ("flush",)
+    assert output.events.count(("flush",)) == 1
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_resize_while_subview_open_rebuilds_on_close() -> None:
+    """A modal view must defer, not consume, a semantic transcript resize."""
+    from .tui_app_harness import MutableRecordingOutput
+
+    class View:
+        mouse_support = True
+
+        def on_open(self) -> None:
+            pass
+
+        def on_close(self) -> None:
+            pass
+
+        def render(self, _width: int, _height: int) -> str:
+            return "temporary view"
+
+        def handle_key(self, key: str, _value: str | None = None) -> str:
+            return "close" if key == "quit" else "ignored"
+
+    output = MutableRecordingOutput(columns=10, rows=20)
+    async with TUIHarness(display_mode=DisplayMode.FULLSCREEN, output=output) as harness:
+        app = harness.app
+        assert app is not None
+        widths: list[int] = []
+
+        def semantic_projection() -> str:
+            width = app.transcript_columns()
+            widths.append(width)
+            return "wide transcript\n" if width >= 8 else "narrow\ntranscript\n"
+
+        app.emit_block(semantic_projection(), replay=semantic_projection)
+        opened = asyncio.create_task(app.open_subview(View()))  # type: ignore[arg-type]
+        await harness.wait_for(lambda: app.active_subview is not None)
+
+        output.set_size(6, 20)
+        app._app._on_resize()
+        await asyncio.sleep(0)
+
+        assert app._fullscreen_transcript.text == "wide transcript\n"
+        assert app._resize_reflow.has_pending_replay is True
+        assert app._fullscreen_invalidate_count == 0
+
+        await harness.press("q")
+        await asyncio.wait_for(opened, timeout=1)
+
+        assert app._fullscreen_transcript.text == "narrow\ntranscript\n"
+        assert widths == [9, 5]
+        assert app._resize_reflow.replayed_width == 6
+        assert app._resize_reflow.has_pending_replay is False
+        assert app._fullscreen_invalidate_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_row_only_resize_publishes_one_settled_frame() -> None:
+    from .tui_app_harness import MutableRecordingOutput
+
+    output = MutableRecordingOutput(columns=80, rows=40)
+    async with TUIHarness(display_mode=DisplayMode.FULLSCREEN, output=output) as harness:
+        app = harness.app
+        assert app is not None
+        output.events.clear()
+        render_count = app._app.render_counter
+
+        output.set_size(80, 30)
+        app._app._on_resize()
+
+        assert app._app.render_counter == render_count
+        await harness.wait_for(lambda: app._fullscreen_invalidate_count == 1)
+        assert app._app.render_counter == render_count + 1
+        assert sum(event == ("flush",) for event in output.events) == 1
+        assert app._resize_reflow.has_pending_replay is False
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_duplicate_sigwinch_after_settle_has_no_delayed_repaint() -> None:
+    """Re-exposing a settled tmux pane may repaint once, never again later."""
+    from .tui_app_harness import MutableRecordingOutput
+
+    output = MutableRecordingOutput(columns=80, rows=40)
+    async with TUIHarness(display_mode=DisplayMode.FULLSCREEN, output=output) as harness:
+        app = harness.app
+        assert app is not None
+
+        output.set_size(60, 30)
+        app._app._on_resize()
+        await harness.wait_for(lambda: app._fullscreen_invalidate_count == 1)
+        settled_render_count = app._app.render_counter
+        output.events.clear()
+
+        app._app._on_resize()
+        assert app._app.render_counter == settled_render_count + 1
+        assert app._fullscreen_rebuild_timer is None
+        await asyncio.sleep(0.1)
+
+        assert app._app.render_counter == settled_render_count + 1
+        assert app._fullscreen_invalidate_count == 1
+        assert app._fullscreen_rebuild_timer is None
+        assert sum(event == ("flush",) for event in output.events) == 1
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_unreadable_size_uses_prompt_toolkit_resize() -> None:
+    """A transient geometry read failure must not suppress PTK's safe fallback."""
+    from .tui_app_harness import MutableRecordingOutput
+
+    output = MutableRecordingOutput(columns=80, rows=40)
+    async with TUIHarness(display_mode=DisplayMode.FULLSCREEN, output=output) as harness:
+        app = harness.app
+        assert app is not None
+        render_count = app._app.render_counter
+        original_read_terminal_size = app._read_terminal_size
+        app._read_terminal_size = lambda: None  # type: ignore[method-assign]
+        try:
+            app._app._on_resize()
+        finally:
+            app._read_terminal_size = original_read_terminal_size  # type: ignore[method-assign]
+
+        assert app._app.render_counter == render_count + 1
+        assert app._fullscreen_rebuild_timer is None
+        assert app._resize_redraw_deferred is False
 
 
 @pytest.mark.asyncio

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -23,6 +23,33 @@ def _make_fullscreen_app():
         return TUIApplication(display_mode=DisplayMode.FULLSCREEN)
 
 
+def test_resize_application_prompt_toolkit_private_api_contract() -> None:
+    """Fail clearly if a prompt-toolkit upgrade changes private resize hooks."""
+    import inspect
+
+    from nooa_cli.tui.tui_application import _ResizeAwareApplication
+    from prompt_toolkit.application import Application
+
+    on_resize = inspect.signature(Application._on_resize)
+    assert tuple(on_resize.parameters) == ("self",)
+
+    redraw = inspect.signature(Application._redraw)
+    assert tuple(redraw.parameters) == ("self", "render_as_done")
+    assert redraw.parameters["render_as_done"].default is False
+
+    request_cursor = inspect.signature(Application._request_absolute_cursor_position)
+    assert tuple(request_cursor.parameters) == ("self",)
+
+    assert tuple(inspect.signature(_ResizeAwareApplication._on_resize).parameters) == ("self",)
+    assert tuple(inspect.signature(_ResizeAwareApplication._redraw).parameters) == (
+        "self",
+        "render_as_done",
+    )
+
+    app = _make_fullscreen_app()
+    assert isinstance(app._app._running_in_terminal, bool)
+
+
 def test_fullscreen_shell_owns_alternate_screen_and_transcript_window() -> None:
     app = _make_fullscreen_app()
 

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -2255,8 +2255,11 @@ async def test_atomic_resize_replay_rechecks_shutdown_before_clear(
     monkeypatch.setattr("sys.__stdout__", capture)
 
     async with TUIHarness(full_screen=True, output=output) as h:
+        callback_ran = False
 
         def replay_during_shutdown() -> str:
+            nonlocal callback_ran
+            callback_ran = True
             h.app._resize_replays_enabled = False
             return "must not be written\n"
 
@@ -2268,7 +2271,8 @@ async def test_atomic_resize_replay_rechecks_shutdown_before_clear(
         output.events.clear()
 
         await h.resize_from_terminal(60, 36)
-        await h.wait_for(lambda: h.app._queued_resize_replay_generation is None)
+        await h.wait_for(lambda: callback_ran and h.app._queued_resize_replay_generation is None)
+        await h.app._block_queue.join()
 
         assert h.app._fullscreen_invalidate_count == 0
         assert "\x1b[3J" not in capture.getvalue()

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -1264,6 +1264,128 @@ async def test_prompt_toolkit_resize_polling_disabled_to_avoid_delayed_double_re
         assert h.app._app.terminal_size_polling_interval is None
 
 
+async def test_native_replay_sigwinch_has_one_settled_visible_transition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A width SIGWINCH skips PTK's first paint and redraws after replay once."""
+    output = MutableRecordingOutput(columns=80, rows=40)
+    capture = io.StringIO()
+    monkeypatch.setattr("sys.__stdout__", capture)
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("stable transcript\n")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        capture.seek(0)
+        capture.truncate()
+        render_count = h.app._app.render_counter
+
+        output.set_size(60, 30)
+        h.app._app._on_resize()
+
+        # The native-replay handler observes the new width but does not paint
+        # prompt_toolkit's live region ahead of the semantic replay. Ordinary
+        # invalidations during the quiet period are folded into it as well.
+        assert h.app._app.render_counter == render_count
+        h.app._app.invalidate()
+        await asyncio.sleep(0)
+        assert h.app._app.render_counter == render_count
+        await h.wait_for(lambda: h.app._resize_reflow.replayed_width == 60)
+
+        physical = capture.getvalue()
+        assert physical.count("\x1b[3J") == 1
+        assert physical.count("stable transcript") == 1
+        assert h.app._app.render_counter == render_count + 1
+        assert h.app._fullscreen_invalidate_count == 1
+        assert h.app._resize_replay_timer is None
+        assert h.app._resize_reflow.has_pending_replay is False
+
+
+async def test_duplicate_sigwinch_after_hidden_window_resize_does_not_reflow_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Returning to a tmux window at its settled size is a no-op."""
+    output = MutableRecordingOutput(columns=80, rows=40)
+    capture = io.StringIO()
+    monkeypatch.setattr("sys.__stdout__", capture)
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("visible once\n")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        capture.seek(0)
+        capture.truncate()
+
+        # The first signal represents geometry observed while this tmux window
+        # is hidden. The duplicate represents exposing it at the same size.
+        output.set_size(60, 30)
+        h.app._app._on_resize()
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+        settled_render_count = h.app._app.render_counter
+        h.app._app._on_resize()
+        await asyncio.sleep(0)
+
+        physical = capture.getvalue()
+        assert physical.count("\x1b[3J") == 1
+        assert physical.count("visible once") == 1
+        # Exposing the pane may repaint prompt_toolkit's live region, but it
+        # must not schedule another delayed transcript transition.
+        assert h.app._app.render_counter == settled_render_count + 1
+        assert h.app._resize_replay_timer is None
+        assert h.app._queued_resize_replay_generation is None
+        assert h.app._resize_reflow.has_pending_replay is False
+
+
+async def test_sigwinch_row_only_change_keeps_prompt_toolkit_immediate_redraw() -> None:
+    output = MutableRecordingOutput(columns=80, rows=40)
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("stable transcript\n")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        render_count = h.app._app.render_counter
+
+        output.set_size(80, 30)
+        h.app._app._on_resize()
+
+        assert h.app._app.render_counter == render_count + 1
+        assert h.app._fullscreen_invalidate_count == 0
+        assert h.app._resize_replay_timer is None
+        assert h.app._resize_reflow.has_pending_replay is False
+
+
+async def test_sigwinch_transient_widths_collapse_to_one_final_transition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = MutableRecordingOutput(columns=80, rows=40)
+    capture = io.StringIO()
+    monkeypatch.setattr("sys.__stdout__", capture)
+    async with TUIHarness(full_screen=True, output=output) as h:
+        widths: list[int] = []
+
+        def replay() -> str:
+            widths.append(h.app.output_columns())
+            return "settled transcript\n"
+
+        h.app.emit_block("initial transcript\n", replay=replay)
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        capture.seek(0)
+        capture.truncate()
+        render_count = h.app._app.render_counter
+
+        output.set_size(70, 35)
+        h.app._app._on_resize()
+        output.set_size(60, 30)
+        h.app._app._on_resize()
+        # tmux can deliver the final SIGWINCH more than once while exposing a
+        # hidden pane. It belongs to the same pending width transaction.
+        h.app._app._on_resize()
+        assert h.app._app.render_counter == render_count
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+
+        assert widths == [60]
+        assert capture.getvalue().count("\x1b[3J") == 1
+        assert h.app._app.render_counter == render_count + 1
+
+
 async def test_row_only_resize_in_subview_needs_no_transcript_replay() -> None:
     output = MutableRecordingOutput()
     view = _DummySubview()

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -1277,6 +1277,7 @@ async def test_native_replay_sigwinch_has_one_settled_visible_transition(
         await h.app._block_queue.join()
         capture.seek(0)
         capture.truncate()
+        output.events.clear()
         render_count = h.app._app.render_counter
 
         output.set_size(60, 30)
@@ -1296,6 +1297,15 @@ async def test_native_replay_sigwinch_has_one_settled_visible_transition(
         assert physical.count("stable transcript") == 1
         assert h.app._app.render_counter == render_count + 1
         assert h.app._fullscreen_invalidate_count == 1
+        synchronized_markers = [event for event in output.events if event[0] == "write_raw"]
+        assert synchronized_markers == [
+            ("write_raw", "\x1b[?2026h"),
+            ("write_raw", "\x1b[?2026l"),
+        ]
+        begin = output.events.index(("write_raw", "\x1b[?2026h"))
+        erase = output.events.index(("erase_down",))
+        end = output.events.index(("write_raw", "\x1b[?2026l"))
+        assert begin < erase < end
         assert h.app._resize_replay_timer is None
         assert h.app._resize_reflow.has_pending_replay is False
 
@@ -2214,6 +2224,11 @@ async def test_inflight_resize_barrier_cannot_clear_after_app_exit(
     assert app is not None
     assert app._fullscreen_invalidate_count == 0
     assert "\x1b[3J" not in capture.getvalue()
+    synchronized_markers = [event for event in output.events if event[0] == "write_raw"]
+    assert synchronized_markers[-2:] == [
+        ("write_raw", "\x1b[?2026h"),
+        ("write_raw", "\x1b[?2026l"),
+    ]
 
 
 async def test_inflight_clear_cannot_purge_terminal_after_app_exit(

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -1435,6 +1435,63 @@ async def test_production_width_resize_waits_for_subview_to_close() -> None:
         assert h.app._resize_reflow.replayed_width == 60
 
 
+async def test_native_replay_resize_waits_for_external_terminal_handoff() -> None:
+    """Never erase/replay while ``run_in_terminal`` gives an editor ownership."""
+    output = MutableRecordingOutput(columns=80, rows=40)
+    async with TUIHarness(full_screen=True, output=output) as h:
+        h.app.emit_block("transcript behind editor\n")
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        output.events.clear()
+        h.app._app._running_in_terminal = True
+
+        output.set_size(60, 30)
+        h.app._app._on_resize()
+        await h.wait_for(lambda: h.app._resize_replay_timer is None)
+
+        assert h.app._resize_reflow.has_pending_replay is True
+        assert h.app._fullscreen_invalidate_count == 0
+        assert not any(event[0] == "write_raw" and "\x1b[3J" in event[1] for event in output.events)
+
+        # Mirrors prompt_toolkit's handoff-finally order: release ownership,
+        # then redraw. The guarded redraw resumes the pending resize transaction.
+        h.app._app._running_in_terminal = False
+        h.app._app._redraw()
+        await h.wait_for(lambda: h.app._fullscreen_invalidate_count == 1)
+
+        assert h.app._resize_reflow.replayed_width == 60
+        assert h.app._resize_reflow.has_pending_replay is False
+        assert (
+            sum(event[0] == "write_raw" and "\x1b[3J" in event[1] for event in output.events) == 1
+        )
+
+
+async def test_native_replay_row_resize_waits_for_external_terminal_handoff() -> None:
+    """A row-only SIGWINCH must not erase an editor-owned terminal."""
+    output = MutableRecordingOutput(columns=80, rows=40)
+    async with TUIHarness(full_screen=True, output=output) as h:
+        output.events.clear()
+        render_count = h.app._app.render_counter
+        h.app._app._running_in_terminal = True
+
+        output.set_size(80, 30)
+        h.app._app._on_resize()
+
+        assert h.app._resize_redraw_deferred is True
+        assert h.app._resize_reflow.has_pending_replay is False
+        assert h.app._app.render_counter == render_count
+        assert ("erase_down",) not in output.events
+
+        # prompt_toolkit releases ownership before its handoff-finally redraw.
+        h.app._app._running_in_terminal = False
+        h.app._app._redraw()
+
+        assert h.app._resize_redraw_deferred is False
+        assert h.app._app.render_counter == render_count + 1
+        assert h.app._fullscreen_invalidate_count == 0
+        assert h.app._resize_replay_timer is None
+
+
 async def test_fullscreen_mode_rewrites_scrollback_on_resize() -> None:
     """Fullscreen writes transcript once, then resize rewrites the whole scrollback."""
     agent = FakeAgent()

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -1297,15 +1297,16 @@ async def test_native_replay_sigwinch_has_one_settled_visible_transition(
         assert physical.count("stable transcript") == 1
         assert h.app._app.render_counter == render_count + 1
         assert h.app._fullscreen_invalidate_count == 1
-        synchronized_markers = [event for event in output.events if event[0] == "write_raw"]
-        assert synchronized_markers == [
-            ("write_raw", "\x1b[?2026h"),
-            ("write_raw", "\x1b[?2026l"),
+        raw_writes = [event for event in output.events if event[0] == "write_raw"]
+        assert raw_writes == [
+            ("write_raw", "\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H"),
+            ("write_raw", "stable transcript\n"),
         ]
-        begin = output.events.index(("write_raw", "\x1b[?2026h"))
         erase = output.events.index(("erase_down",))
-        end = output.events.index(("write_raw", "\x1b[?2026l"))
-        assert begin < erase < end
+        clear = output.events.index(raw_writes[0])
+        flushes = [index for index, event in enumerate(output.events) if event == ("flush",)]
+        assert len(flushes) == 1
+        assert erase < clear < flushes[0]
         assert h.app._resize_replay_timer is None
         assert h.app._resize_reflow.has_pending_replay is False
 
@@ -2188,47 +2189,35 @@ async def test_pending_resize_is_cancelled_before_terminal_teardown(
     assert "\x1b[3J" not in capture.getvalue()
 
 
-async def test_inflight_resize_barrier_cannot_clear_after_app_exit(
+async def test_atomic_resize_replay_rechecks_shutdown_before_clear(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A shutdown discovered during semantic rendering cannot purge scrollback."""
     output = MutableRecordingOutput()
-    replay_started = asyncio.Event()
-    release_replay = asyncio.Event()
     capture = io.StringIO()
     monkeypatch.setattr("sys.__stdout__", capture)
 
-    async def gated_run_in_terminal(callback):
-        replay_started.set()
-        await release_replay.wait()
-        return callback()
-
-    monkeypatch.setattr(
-        "prompt_toolkit.application.run_in_terminal",
-        gated_run_in_terminal,
-    )
-    app = None
     async with TUIHarness(full_screen=True, output=output) as h:
-        app = h.app
-        h.app.emit_block("stable transcript\n")
-        await asyncio.wait_for(replay_started.wait(), timeout=1)
-        release_replay.set()
+
+        def replay_during_shutdown() -> str:
+            h.app._resize_replays_enabled = False
+            return "must not be written\n"
+
+        h.app.emit_block("stable transcript\n", replay=replay_during_shutdown)
         assert h.app._block_queue is not None
         await h.app._block_queue.join()
+        capture.seek(0)
+        capture.truncate()
+        output.events.clear()
 
-        replay_started.clear()
-        release_replay.clear()
         await h.resize_from_terminal(60, 36)
-        await asyncio.wait_for(replay_started.wait(), timeout=1)
-        asyncio.get_running_loop().call_later(0.05, release_replay.set)
+        await h.wait_for(lambda: h.app._queued_resize_replay_generation is None)
 
-    assert app is not None
-    assert app._fullscreen_invalidate_count == 0
-    assert "\x1b[3J" not in capture.getvalue()
-    synchronized_markers = [event for event in output.events if event[0] == "write_raw"]
-    assert synchronized_markers[-2:] == [
-        ("write_raw", "\x1b[?2026h"),
-        ("write_raw", "\x1b[?2026l"),
-    ]
+        assert h.app._fullscreen_invalidate_count == 0
+        assert "\x1b[3J" not in capture.getvalue()
+        assert not any(
+            event[0] == "write_raw" and "must not be written" in event[1] for event in output.events
+        )
 
 
 async def test_inflight_clear_cannot_purge_terminal_after_app_exit(

--- a/packages/nooa-cli/tests/tui/tui_app_harness.py
+++ b/packages/nooa-cli/tests/tui/tui_app_harness.py
@@ -246,6 +246,9 @@ class MutableRecordingOutput(DummyOutput):
     def set_size(self, columns: int, rows: int) -> None:
         self._size = Size(rows=int(rows), columns=int(columns))
 
+    def write_raw(self, data: str) -> None:
+        self.events.append(("write_raw", data))
+
     def erase_down(self) -> None:
         self.events.append(("erase_down",))
 

--- a/packages/nooa-cli/tests/tui/tui_app_harness.py
+++ b/packages/nooa-cli/tests/tui/tui_app_harness.py
@@ -483,7 +483,7 @@ class TUIHarness(AbstractAsyncContextManager["TUIHarness"]):
         assert self.app is not None
         previous_size_reads = sum(event[0] == "get_size" for event in output.events)
         output.set_size(columns, rows)
-        self.app._app.invalidate()
+        self.app._app._on_resize()
         await self.wait_for(
             lambda: sum(event[0] == "get_size" for event in output.events) > previous_size_reads
         )

--- a/packages/nooa-cli/tests/tui/tui_app_harness.py
+++ b/packages/nooa-cli/tests/tui/tui_app_harness.py
@@ -247,6 +247,11 @@ class MutableRecordingOutput(DummyOutput):
     def set_size(self, columns: int, rows: int) -> None:
         self._size = Size(rows=int(rows), columns=int(columns))
 
+    def write(self, data: str) -> None:
+        self.events.append(("write", data))
+        if self._physical_replay_buffer is not None:
+            self._physical_replay_buffer.append(data)
+
     def write_raw(self, data: str) -> None:
         self.events.append(("write_raw", data))
         if "\x1b[3J" in data:

--- a/packages/nooa-cli/tests/tui/tui_app_harness.py
+++ b/packages/nooa-cli/tests/tui/tui_app_harness.py
@@ -235,6 +235,7 @@ class MutableRecordingOutput(DummyOutput):
         super().__init__()
         self._size = Size(rows=int(rows), columns=int(columns))
         self.events: list[tuple[Any, ...]] = []
+        self._physical_replay_buffer: list[str] | None = None
 
     def get_size(self) -> Size:
         self.events.append(("get_size", self._size.columns, self._size.rows))
@@ -248,6 +249,10 @@ class MutableRecordingOutput(DummyOutput):
 
     def write_raw(self, data: str) -> None:
         self.events.append(("write_raw", data))
+        if "\x1b[3J" in data:
+            self._physical_replay_buffer = []
+        if self._physical_replay_buffer is not None:
+            self._physical_replay_buffer.append(data)
 
     def erase_down(self) -> None:
         self.events.append(("erase_down",))
@@ -263,6 +268,15 @@ class MutableRecordingOutput(DummyOutput):
 
     def flush(self) -> None:
         self.events.append(("flush",))
+        if self._physical_replay_buffer is None:
+            return
+        data = "".join(self._physical_replay_buffer)
+        self._physical_replay_buffer = None
+        import sys
+
+        if sys.__stdout__ is not None:
+            sys.__stdout__.write(data)
+            sys.__stdout__.flush()
 
 
 def _wire_local_turn_policy(agent: Any, runner: Any, app: Any, config: Any) -> Any:


### PR DESCRIPTION
## Summary

- coalesce SIGWINCH-driven paints in both terminal ownership modes until geometry settles
- in native-replay mode, suppress prompt_toolkit's early paint and replace the two-flush `run_in_terminal()` replay path with one synchronous transaction containing erase, semantic transcript replay, and final live-region redraw
- in the default alternate-screen fullscreen mode, defer all transient resize paints (including row-only changes) and publish only the final settled prompt_toolkit frame
- preserve native terminal scrollback, FIFO ordering, stale-generation and width checks, semantic replay, bounded failure recovery, height recovery, subview behavior, and shutdown cancellation
- add deterministic coverage for one physical flush/render per settled resize, transient widths, duplicate final SIGWINCH signals, native replay clear/replay counts, row-only native behavior, and shutdown rechecks

## Root cause

There were two separate paths behind the reported behavior:

1. In `native-replay`, prompt_toolkit painted immediately on SIGWINCH, followed by Nooa's debounced transcript replay. Even after suppressing that early paint, `run_in_terminal()` flushed an erase separately from the replay/final redraw.
2. Manual testing used the default `fullscreen` mode, not `native-replay`. A timestamped recording from the exact live pane showed **no scrollback clear (`ED3`) at all** and multiple prompt_toolkit fullscreen repaint bursts for transient tmux geometries. The earlier fix was correct for native replay but did not govern this default path.

The final implementation makes resize painting mode-aware. Native replay buffers erase + replay + redraw through the same output object and physically flushes once. Fullscreen records each new geometry but suppresses its immediate SIGWINCH paint; the existing 75 ms settle timer is now used for static as well as semantic transcript content, and emits one final renderer-owned frame. Ordinary non-resize invalidations are folded into a pending resize transaction.

## Validation

- `uv run --project packages/nooa-cli pytest -q packages/nooa-cli/tests/tui/test_fullscreen_transcript.py packages/nooa-cli/tests/tui/test_tui_app_behavior.py` — 254 passed (before adding the final fullscreen transient-width regression; rerun included it in the full suite)
- `uv run --project packages/nooa-cli pytest -q packages/nooa-cli/tests/tui` — 1158 passed, 2 failed; both existing macOS `/var` vs `/private/var` path failures reproduced on untouched `origin/dev/tui`
- changed-file Ruff lint and format checks — passed
- changed-file Pyright — 0 errors
- `git diff --check` — passed

No tmuxmux change is included: the recorder showed normal transient SIGWINCH-driven fullscreen repaints emitted by the app, and the fix is at the application ownership boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal resizing for fullscreen views, including width-only, height-only, duplicate, and rapid successive resize events.
  * Prevented unnecessary redraws and terminal clearing during external editor or shell handoffs.
  * Ensured pending screen updates are flushed safely during errors and application shutdown.
  * Improved fallback behavior when terminal dimensions cannot be read.

* **Tests**
  * Expanded coverage for resize handling, redraw coalescing, external terminal ownership, and shutdown races.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->