### PR TITLE
fix(sandbox): restore traceback frame context in agent-facing errors

### DIFF
--- a/src/nooa/errors/formatting.py
+++ b/src/nooa/errors/formatting.py
@@ -362,11 +362,16 @@ class IPythonErrorFormatter:
                     ~~^~~
             ZeroDivisionError: division by zero
         """
-        if not error.__traceback__:
-            return f"{type(error).__name__}: {error}"
+        # Frames come either from a live traceback (in-process) or, when the cell
+        # ran in the sandbox worker, from frames marshaled across the process
+        # boundary — a reconstructed exception has no live ``__traceback__``.
+        if error.__traceback__:
+            extracted = traceback.extract_tb(error.__traceback__)
+        else:
+            extracted = list(getattr(error, "worker_frames", ()))
 
-        # Extract all frames as FrameSummary objects (filterable)
-        extracted = traceback.extract_tb(error.__traceback__)
+        if not extracted:
+            return f"{type(error).__name__}: {error}"
 
         # Filter to user code frames only
         user_frames = [frame for frame in extracted if _is_user_code_frame(frame.filename)]

--- a/src/nooa/runtime/sandbox/serialization.py
+++ b/src/nooa/runtime/sandbox/serialization.py
@@ -39,6 +39,7 @@ class ErrorDTO:
     type_name: str
     message: str
     traceback: str
+    frames: list[tuple[str, int, str, str]] = field(default_factory=list)
 
 
 @dataclass
@@ -109,6 +110,10 @@ def result_to_dto(result: Any) -> ResultDTO:
             type_name=type(err).__name__,
             message=message,
             traceback="".join(tb.format_exception(type(err), err, err.__traceback__)),
+            frames=[
+                (f.filename, f.lineno or 0, f.name, f.line or "")
+                for f in tb.extract_tb(err.__traceback__)
+            ],
         )
         return dto
 
@@ -182,8 +187,15 @@ def _reconstruct_error(err: ErrorDTO) -> Exception:
                 exc = _SurrogateCellError(err)
         else:
             exc = _SurrogateCellError(err)
+
     if err.traceback:
         exc.worker_traceback = err.traceback  # type: ignore[attr-defined]
+    if err.frames:
+        import traceback as _tb
+
+        exc.worker_frames = [  # type: ignore[attr-defined]
+            _tb.FrameSummary(fn, ln, nm, line=src) for fn, ln, nm, src in err.frames
+        ]
     return exc
 
 

--- a/tests/runtime/sandbox/test_error_traceback_parity.py
+++ b/tests/runtime/sandbox/test_error_traceback_parity.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Error-rendering parity between the in-process and sandbox execution backends.
+
+The sandbox backend marshals exceptions across a process boundary, so the live
+``__traceback__`` cannot survive. These tests pin the requirement that the
+agent-facing error text stays equivalent regardless of backend.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nooa import Agent
+from nooa.errors.formatting import format_error_for_llm
+from nooa.runtime.sandbox.config import SandboxConfig
+from nooa.runtime.sandbox.executor import SandboxedExecutor
+from nooa.unifiedllm import FakeLLMClient
+
+pytestmark = pytest.mark.sandbox
+
+_SANDBOX = SandboxConfig(require=False, network=True, filesystem=False)
+
+# Error on line 6 so an off-by-one in offset handling is visible.
+_CODE = "a = 1\nb = 2\nc = 3\nd = 4\ne = 5\nboom = None.strip()\n"
+
+
+def _agent() -> Agent:
+    class _T(Agent, llm=FakeLLMClient()):
+        pass
+
+    return _T()
+
+
+async def _render(*, sandboxed: bool) -> str:
+    """Run _CODE on one backend and return the error text shown to the LLM."""
+    agent = _agent()
+    executor = None
+    kwargs = {}
+    if sandboxed:
+        executor = SandboxedExecutor(agent, _SANDBOX, cell_timeout=15.0)
+        kwargs["sandbox_executor"] = executor
+    try:
+        result = await agent.runtime.execute_code(
+            _CODE, execution_count=1, wrap_in_function=True, **kwargs
+        )
+        assert result.error is not None, "expected the cell to raise"
+        return format_error_for_llm(result.error, _CODE, line_offset=result.wrapper_line_offset)
+    finally:
+        if executor is not None:
+            await executor.aclose()
+
+
+async def test_inprocess_renders_frame_context() -> None:
+    """Baseline: the in-process backend already reports location."""
+    rendered = await _render(sandboxed=False)
+    assert "Cell In[1], line 6" in rendered
+    assert "None.strip()" in rendered
+    assert "AttributeError" in rendered
+
+
+async def test_sandbox_renders_frame_context() -> None:
+    """The sandbox backend must report the same location, not a bare message."""
+    rendered = await _render(sandboxed=True)
+    assert "Cell In[1], line 6" in rendered
+    assert "None.strip()" in rendered
+    assert "AttributeError" in rendered
+
+
+async def test_backends_render_identical_frame_lines() -> None:
+    """Frame location and source text match across backends.
+
+    Caret columns are deliberately out of scope: they are computed in wrapper
+    coordinates and the two backends anchor them differently. Restoring frame
+    context is separable from making carets column-accurate.
+    """
+    inproc = await _render(sandboxed=False)
+    sandboxed = await _render(sandboxed=True)
+
+    assert "Cell In[1], line 6" in inproc
+    assert "Cell In[1], line 6" in sandboxed
+    assert inproc.splitlines()[-1] == sandboxed.splitlines()[-1]


### PR DESCRIPTION
Fixes #191.

### Problem

Errors raised inside a sandboxed cell reach the LLM as a bare `Type: message` line, with no frame, line number, or source text. The in-process backend renders full IPython-style context for identical code.

Before:

    --- execution_backend=inprocess ---
      Cell In[1], line 6, in <module>
        boom = None.strip()
               ^^^^^^^^^^
    AttributeError: 'NoneType' object has no attribute 'strip'

    --- execution_backend=sandbox ---
    AttributeError: 'NoneType' object has no attribute 'strip'

Agents running the sandbox backend get error feedback with no location information, weakening the error-recovery loop precisely in the configuration intended for untrusted code.

### Cause

`serialization.py` already captured the worker traceback and attached it to the reconstructed exception as `worker_traceback` — but that attribute had two write sites and no read sites. `_format_runtime_error` derives frames solely from `error.__traceback__`, which is empty on a parent-side surrogate because tracebacks aren't picklable. It therefore returned at the early guard before any rendering ran.

### Approach

Marshal structured frames rather than relying on the formatted string.

`extract_tb` resolves source text eagerly, and it runs inside the worker where the cell is registered with `linecache`, so `(filename, lineno, name, line)` tuples carry everything the renderer needs across the boundary. `FrameSummary` objects are rebuilt on the parent and the existing filter/format pipeline runs unchanged — cell filenames already pass `_is_user_code_frame`, and `__repl_wrapper__` is the wrapper name on both paths.

I considered instead teaching the formatter to consume the `worker_traceback` string, but that would mean re-parsing formatted text to redo framework-frame filtering that already works on structured data.

The in-process branch is untouched; the fallback engages only when `__traceback__` is absent.

### Scope

Caret columns are deliberately excluded. They're computed in wrapper coordinates and the two backends anchor them differently, which is a separable concern from restoring frame context. The parity test asserts frame location and source text, and documents why it stops short of byte-identity. Happy to take that on in a follow-up if you'd like it.

### Tests

Adds `tests/runtime/sandbox/test_error_traceback_parity.py` with three cases: an in-process baseline guard (so a regression there isn't misread as a sandbox fault), the sandbox requirement, and cross-backend parity of frame lines. The error sits mid-file at line 6 so an off-by-one in offset handling would be caught.

- `uv run pytest -m sandbox -q` — 51 passed, 1 skipped (48 before this change)
- `uv run pytest -q` — 6641 passed, 152 skipped, 3 xfailed
- `uv run ruff format` / `ruff check` — clean

Verified on commit 97f52de, Python 3.12.3, Ubuntu.

### Note on #187

This surfaced while prototyping the shared conformance fixture that #187 asks for. The open CI question there still stands — `addopts` deselects the `sandbox` marker, so these tests don't run in the default suite. Happy to follow up once you've weighed in on whether that should be a separate job or a default-run subset.