### PR TITLE
feat(tui): improve fullscreen follow behavior

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/agent_event_renderer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/agent_event_renderer.py
@@ -203,7 +203,7 @@ class AgentEventRenderer:
                 Rule(Text("OO ", style=self._colors["mauve"]), style="dim", align="left"),
                 **emit_kwargs,
             )
-        self._emit_text(Markdown(str(text)), **emit_kwargs)
+        self._emit_text(Markdown(str(text)), agent_message=True, **emit_kwargs)
 
     # ── agent event handlers ───────────────────────────────────────────
 

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -359,9 +359,15 @@ class TerminalFrontend:
         self._console.print_help(output.commands)
 
     def _render_agent_message(self, output: AgentMessage) -> None:
-        self._console.print_agent(
-            output.content, show_rule=output.show_rule, soft_wrap=output.soft_wrap
-        )
+        from contextlib import nullcontext
+
+        stream = getattr(self._console.console, "file", None)
+        agent_message = getattr(stream, "agent_message", None)
+        scope = agent_message() if callable(agent_message) else nullcontext()
+        with scope:
+            self._console.print_agent(
+                output.content, show_rule=output.show_rule, soft_wrap=output.soft_wrap
+            )
 
     def _render_clear(self, _output: ClearScreen) -> None:
         stream = getattr(self._console.console, "file", None)

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -131,10 +131,13 @@ class _EmitStream:
         self._clear = clear
         self._buf: list[str] = []
         self._held = 0
+        self._agent_message_depth = 0
+        self._buffer_has_agent_message = False
 
     def write(self, text: str) -> int:
         if text:
             self._buf.append(text)
+            self._buffer_has_agent_message |= self._agent_message_depth > 0
         return len(text)
 
     def flush(self) -> None:
@@ -142,15 +145,23 @@ class _EmitStream:
             # Defer until the hold span releases — keep the buffer intact so
             # subsequent renders append to the same block.
             return
+        self._emit_buffer()
+
+    def _emit_buffer(self) -> None:
         if not self._buf:
             return
         chunk = "".join(self._buf)
         self._buf.clear()
-        if chunk:
+        agent_message = self._buffer_has_agent_message
+        self._buffer_has_agent_message = False
+        if agent_message:
+            self._emit(chunk, agent_message=True)
+        else:
             self._emit(chunk)
 
     def clear_transcript(self) -> None:
         self._buf.clear()
+        self._buffer_has_agent_message = False
         if self._clear is not None:
             self._clear()
 
@@ -179,15 +190,21 @@ class _EmitStream:
         code_copy_actions: dict[str, str] | None = None,
     ) -> None:
         if self._buf:
-            chunk = "".join(self._buf)
-            self._buf.clear()
-            if chunk:
-                self._emit(chunk)
+            self._emit_buffer()
         if text:
             kwargs: dict[str, Any] = {"replay": replay}
             if code_copy_actions:
                 kwargs["code_copy_actions"] = code_copy_actions
             self._emit(text, **kwargs)
+
+    @contextmanager
+    def agent_message(self):
+        """Mark blocks flushed in this span as semantic agent prose."""
+        self._agent_message_depth += 1
+        try:
+            yield
+        finally:
+            self._agent_message_depth -= 1
 
     @contextmanager
     def hold(self):
@@ -1005,6 +1022,7 @@ class Session:
         event_id: str | None = None,
         tags: set[str] | frozenset[str] | None = None,
         keep: bool = False,
+        agent_message: bool = False,
     ) -> None:
         """Render a Rich renderable → ANSI → enqueue to the block queue.
 
@@ -1036,7 +1054,13 @@ class Session:
             dict(renderable.copy_actions) if isinstance(renderable, CopyableMarkdown) else None
         )
         if replay is None:
-            self._app.emit_block(rendered, event_id=event_id, tags=tags, keep=keep)
+            self._app.emit_block(
+                rendered,
+                event_id=event_id,
+                tags=tags,
+                keep=keep,
+                agent_message=agent_message,
+            )
         else:
             self._app.emit_block(
                 rendered,
@@ -1045,6 +1069,7 @@ class Session:
                 tags=tags,
                 keep=keep,
                 code_copy_actions=code_copy_actions,
+                agent_message=agent_message,
             )
 
     def _get_command_runner(self):

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -34,6 +34,7 @@ from prompt_toolkit.document import Document
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.formatted_text import ANSI, AnyFormattedText
 from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
+from prompt_toolkit.key_binding.bindings.scroll import scroll_page_down, scroll_page_up
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.layout import (
     ConditionalContainer,
@@ -609,6 +610,88 @@ class _FullscreenDragBoundaryControl(_TranscriptGestureControlMixin, FormattedTe
         return super().mouse_handler(mouse_event)
 
 
+class _ComposerWindow(Window):
+    """Input window whose wheel viewport can detach from the edit cursor."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._manual_wheel_scroll = False
+        self.always_hide_cursor = Condition(self.manual_cursor_is_offscreen)
+
+    def reset_manual_wheel_scroll(self) -> None:
+        """Resume prompt_toolkit's normal keep-the-cursor-visible behavior."""
+        self._manual_wheel_scroll = False
+
+    def scroll_without_moving_cursor(self, delta: int) -> None:
+        """Move the wrapped viewport by visual rows, leaving the buffer cursor alone."""
+        info = self.render_info
+        if info is None or not delta:
+            return
+        self._manual_wheel_scroll = True
+        step = 1 if delta > 0 else -1
+        for _ in range(abs(delta)):
+            if step < 0:
+                if self.vertical_scroll_2 > 0:
+                    self.vertical_scroll_2 -= 1
+                elif self.vertical_scroll > 0:
+                    self.vertical_scroll -= 1
+                    self.vertical_scroll_2 = info.get_height_for_line(self.vertical_scroll) - 1
+            elif self._manual_rows_below(info) > info.window_height:
+                line_height = info.get_height_for_line(self.vertical_scroll)
+                if self.vertical_scroll_2 + 1 < line_height:
+                    self.vertical_scroll_2 += 1
+                elif self.vertical_scroll + 1 < info.content_height:
+                    self.vertical_scroll += 1
+                    self.vertical_scroll_2 = 0
+
+    def _manual_rows_below(self, info: Any) -> int:
+        """Return visual rows from the current manual viewport through EOF."""
+        return (
+            info.get_height_for_line(self.vertical_scroll)
+            - self.vertical_scroll_2
+            + sum(
+                info.get_height_for_line(line_number)
+                for line_number in range(self.vertical_scroll + 1, info.content_height)
+            )
+        )
+
+    def _scroll(self, ui_content: UIContent, width: int, height: int) -> None:
+        if not self._manual_wheel_scroll:
+            super()._scroll(ui_content, width, height)
+            return
+        self.vertical_scroll = min(max(0, self.vertical_scroll), max(0, ui_content.line_count - 1))
+        line_height = ui_content.get_height_for_line(
+            self.vertical_scroll, width, self.get_line_prefix
+        )
+        self.vertical_scroll_2 = min(max(0, self.vertical_scroll_2), line_height - 1)
+
+    def manual_cursor_is_offscreen(self) -> bool:
+        """Return whether detached wheel scrolling currently hides the edit cursor."""
+        info = self.render_info
+        if not self._manual_wheel_scroll or info is None:
+            return False
+        cursor = info.ui_content.cursor_position
+        rows_before_cursor = sum(
+            info.get_height_for_line(line_number) for line_number in range(cursor.y)
+        )
+        cursor_rows_in_line = info.ui_content.get_height_for_line(
+            cursor.y,
+            info.window_width,
+            self.get_line_prefix,
+            slice_stop=cursor.x,
+        )
+        cursor_visual_row = rows_before_cursor + max(0, cursor_rows_in_line - 1)
+        rows_before_viewport = (
+            sum(
+                info.get_height_for_line(line_number) for line_number in range(self.vertical_scroll)
+            )
+            + self.vertical_scroll_2
+        )
+        return not (
+            rows_before_viewport <= cursor_visual_row < rows_before_viewport + info.window_height
+        )
+
+
 class _NativeSelectionBufferControl(_TranscriptGestureControlMixin, BufferControl):
     """Composer control that hands transcript-wide pointer gestures to their owner."""
 
@@ -688,15 +771,25 @@ class _ReturnToTailControl(_TranscriptGestureControlMixin, FormattedTextControl)
         self,
         callback: Callable[[], None],
         *,
+        has_new_agent_message: Callable[[], bool] = lambda: False,
         transcript_drag_callback: Callable[[MouseEvent], bool] | None = None,
         transcript_scroll_callback: Callable[[int], None] | None = None,
         render_counter: Callable[[], int] = lambda: 0,
     ) -> None:
-        super().__init__(
-            lambda: _native_hyperlink_boundary(
-                [("class:return-to-tail", " ↓ Return to bottom (Ctrl+End)")],
+        def _formatted_text() -> list[tuple[str, str]]:
+            notice_visible = has_new_agent_message()
+            notice = " New agent message   " if notice_visible else " " * 21
+            fragments = [
+                ("class:return-to-tail" if notice_visible else "", notice),
+                ("class:return-to-tail", "↓ Return to bottom (Ctrl+End)"),
+            ]
+            return _native_hyperlink_boundary(
+                fragments,
                 render_counter=render_counter(),
-            ),
+            )
+
+        super().__init__(
+            _formatted_text,
             focusable=False,
             show_cursor=False,
             transcript_drag_callback=transcript_drag_callback,
@@ -824,6 +917,7 @@ class TranscriptBlock:
     replay_cache: dict[int, str] = field(default_factory=dict)
     fullscreen_rendered: str | None = None
     code_copy_actions: dict[str, str] = field(default_factory=dict)
+    agent_message: bool = False
 
 
 @dataclass(frozen=True)
@@ -1002,6 +1096,7 @@ class TUIApplication:
         # Option/Alt-drag can bypass reporting in supporting terminals; F6 is
         # the reliable escape hatch that disables application mouse handling.
         self._fullscreen_mouse_navigation = self._is_fullscreen
+        self._has_unseen_agent_message = False
         # Retained transcript replay units. On resize we intentionally clear
         # the visible screen + terminal scrollback, then rewrite these blocks.
         self._transcript_blocks: list[TranscriptBlock] = []
@@ -1030,6 +1125,7 @@ class TUIApplication:
             accept_handler=self._accept_handler,
         )
         self.input_buffer.on_text_changed += self._on_input_text_changed
+        self.input_buffer.on_cursor_position_changed += self._on_input_cursor_position_changed
 
         # History — a plain list of submitted strings and a cursor that
         # tracks Up/Down navigation. Simpler than prompt_toolkit's async
@@ -1178,7 +1274,7 @@ class TUIApplication:
         )
 
         input_style = "class:input-area"
-        input_window = Window(
+        input_window = _ComposerWindow(
             _NativeSelectionBufferControl(
                 self.input_buffer,
                 input_processors=[self._prompt_processor],
@@ -1186,14 +1282,14 @@ class TUIApplication:
                     self._handle_fullscreen_drag_over_bottom_chrome if self._is_fullscreen else None
                 ),
                 transcript_scroll_callback=(
-                    self._scroll_fullscreen_transcript if self._is_fullscreen else None
+                    self._scroll_fullscreen_input_or_transcript if self._is_fullscreen else None
                 ),
                 selection_copy_callback=(
                     self._copy_input_selection if self._is_fullscreen else None
                 ),
             ),
             wrap_lines=True,
-            height=Dimension(min=1),
+            height=(Dimension(min=1, max=10) if self._is_fullscreen else Dimension(min=1)),
             dont_extend_height=True,
             style=input_style,
         )
@@ -1288,6 +1384,7 @@ class TUIApplication:
 
         self._return_to_tail_control = _ReturnToTailControl(
             self._jump_fullscreen_to_tail,
+            has_new_agent_message=lambda: self._has_unseen_agent_message,
             transcript_drag_callback=self._handle_fullscreen_drag_over_bottom_chrome,
             transcript_scroll_callback=self._scroll_fullscreen_transcript,
             render_counter=lambda: self._app.render_counter,
@@ -1842,11 +1939,34 @@ class TUIApplication:
         except Exception:
             return terminal_cols(minimum=1), 18
 
+    def _fullscreen_input_overflows(self) -> bool:
+        """Return whether the capped composer currently has hidden visual rows."""
+        if not self._is_fullscreen:
+            return False
+        info = self._input_window.render_info
+        if info is None or info.window_height <= 0:
+            return False
+        return (
+            sum(info.get_height_for_line(line_number) for line_number in range(info.content_height))
+            > info.window_height
+        )
+
+    def _scroll_fullscreen_input_or_transcript(self, delta: int) -> None:
+        """Wheel the capped composer when overflowing, otherwise the transcript."""
+        if not self._fullscreen_input_overflows():
+            self._scroll_fullscreen_transcript(delta)
+            return
+        self._input_window.scroll_without_moving_cursor(delta)
+        if self._app.is_running:
+            self._app.invalidate()
+
     def _scroll_fullscreen_transcript(self, delta: int) -> None:
         if not self._is_fullscreen:
             return
         width, height = self._transcript_viewport_size()
         self._fullscreen_transcript.scroll_visual_lines(delta, width=width, height=height)
+        if self._fullscreen_transcript.viewport.follows_tail:
+            self._has_unseen_agent_message = False
         if self._app.is_running:
             self._app.invalidate()
 
@@ -1855,6 +1975,7 @@ class TUIApplication:
         if not self._is_fullscreen:
             return
         self._fullscreen_transcript.jump_to_tail()
+        self._has_unseen_agent_message = False
         if self._app.is_running:
             self._app.invalidate()
 
@@ -2077,13 +2198,21 @@ class TUIApplication:
 
         @kb.add("pageup", filter=fullscreen_transcript, eager=True)
         def _(event):
-            _, height = self._transcript_viewport_size()
-            self._scroll_fullscreen_transcript(-height)
+            if self._fullscreen_input_overflows():
+                self._input_window.reset_manual_wheel_scroll()
+                scroll_page_up(event)
+            else:
+                _, height = self._transcript_viewport_size()
+                self._scroll_fullscreen_transcript(-height)
 
         @kb.add("pagedown", filter=fullscreen_transcript, eager=True)
         def _(event):
-            _, height = self._transcript_viewport_size()
-            self._scroll_fullscreen_transcript(height)
+            if self._fullscreen_input_overflows():
+                self._input_window.reset_manual_wheel_scroll()
+                scroll_page_down(event)
+            else:
+                _, height = self._transcript_viewport_size()
+                self._scroll_fullscreen_transcript(height)
 
         @kb.add(Keys.ControlHome, filter=fullscreen_transcript, eager=True)
         def _(event):
@@ -2352,6 +2481,7 @@ class TUIApplication:
         text = buffer.text
         if not text.strip():
             return False
+        self._jump_fullscreen_to_tail()
         if not self._history or self._history[-1] != text:
             self._history.append(text)
         self._history_cursor = None
@@ -2615,9 +2745,20 @@ class TUIApplication:
             self._on_agent_activity()
         return accepted
 
+    def _resume_input_cursor_following(self) -> None:
+        """End a mouse-wheel viewport lease after the user edits or moves."""
+        input_window = getattr(self, "_input_window", None)
+        if isinstance(input_window, _ComposerWindow):
+            input_window.reset_manual_wheel_scroll()
+
     def _on_input_text_changed(self, _buffer: Buffer) -> None:
-        """Typing after an exit warning cancels the double-Ctrl-C gesture."""
+        """Resume cursor following and cancel any pending double-Ctrl-C gesture."""
+        self._resume_input_cursor_following()
         self._clear_ctrl_c_exit()
+
+    def _on_input_cursor_position_changed(self, _buffer: Buffer) -> None:
+        """Bring the edit cursor back onscreen after keyboard or pointer movement."""
+        self._resume_input_cursor_following()
 
     def request_command_cancel(self) -> bool:
         """Ask the host to cancel its active slash command, if any."""
@@ -2703,6 +2844,7 @@ class TUIApplication:
         self._fullscreen_semantic_replay_count = 0
         if self._is_fullscreen:
             self._fullscreen_transcript.clear()
+            self._has_unseen_agent_message = False
             self._app.invalidate()
             return
         self.output_buffer.set_document(Document(""), bypass_readonly=True)
@@ -2727,6 +2869,7 @@ class TUIApplication:
         tags: set[str] | frozenset[str] | None = None,
         keep: bool = False,
         code_copy_actions: dict[str, str] | None = None,
+        agent_message: bool = False,
     ) -> None:
         """Enqueue one ANSI-bearing block for the transcript.
 
@@ -2750,6 +2893,7 @@ class TUIApplication:
             tags=frozenset(str(t) for t in (tags or ())),
             keep=keep,
             code_copy_actions=dict(code_copy_actions or {}),
+            agent_message=agent_message,
         )
 
         # Before the consumer is up (pre-run_async) we're single-threaded
@@ -2766,6 +2910,7 @@ class TUIApplication:
                     copy_actions=block.code_copy_actions,
                 )
                 self._fullscreen_transcript.evict_prefix(evicted)
+                self._note_unseen_agent_message(block)
                 self._app.invalidate()
                 return
             self._append_stripped_to_buffer(rendered)
@@ -2903,6 +3048,7 @@ class TUIApplication:
                 copy_actions=block.code_copy_actions,
             )
             self._fullscreen_transcript.evict_prefix(evicted)
+            self._note_unseen_agent_message(block)
             self._app.invalidate()
             return
         self._append_stripped_to_buffer(rendered)
@@ -2922,6 +3068,13 @@ class TUIApplication:
                 out.flush()
             except Exception:
                 pass
+
+    def _note_unseen_agent_message(self, block: TranscriptBlock) -> None:
+        """Show a notice when agent prose arrives outside the anchored viewport."""
+        if self._fullscreen_transcript.viewport.follows_tail:
+            self._has_unseen_agent_message = False
+        elif block.agent_message:
+            self._has_unseen_agent_message = True
 
     def _append_stripped_to_buffer(self, text: str) -> None:
         """Append the ANSI-stripped transcript text to ``output_buffer``.

--- a/packages/nooa-cli/tests/tui/test_agent_event_renderer.py
+++ b/packages/nooa-cli/tests/tui/test_agent_event_renderer.py
@@ -72,9 +72,13 @@ def _mk(
     agent = _FakeAgent()
     emitted: list[Any] = []
     pending_code: dict[str, str] = {}
+
+    def emit_text(renderable: Any, **_kwargs: Any) -> None:
+        emitted.append(renderable)
+
     r = AgentEventRenderer(
         agent=agent,  # type: ignore[arg-type]
-        emit_text=emitted.append,
+        emit_text=emit_text,
         show_python=lambda: show_python,
         show_diffs=lambda: show_diffs,
         pending_code=pending_code,
@@ -176,6 +180,29 @@ def test_message_emits_inline_not_buffered() -> None:
     _fire_python_output(agent.event_manager, stderr="warn")
     markdowns_after = [e for e in emitted if isinstance(e, Markdown)]
     assert len(markdowns_after) == 1
+
+
+def test_message_marks_only_agent_prose_for_unseen_notification() -> None:
+    agent = _FakeAgent()
+    calls: list[tuple[Any, dict[str, Any]]] = []
+    renderer = AgentEventRenderer(
+        agent=agent,  # type: ignore[arg-type]
+        emit_text=lambda renderable, **kwargs: calls.append((renderable, kwargs)),
+        show_python=lambda: False,
+        show_diffs=lambda: True,
+        pending_code={},
+        colors=COLORS,
+    )
+    renderer.attach()
+
+    assert agent._render_message is not None
+    agent._render_message("new reply")
+
+    rule, message = calls
+    assert isinstance(rule[0], Rule)
+    assert "agent_message" not in rule[1]
+    assert isinstance(message[0], Markdown)
+    assert message[1]["agent_message"] is True
 
 
 def test_message_between_preview_and_cell_output_preserves_natural_order() -> None:

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -79,6 +79,76 @@ def test_fullscreen_copy_and_return_actions_share_status_region() -> None:
     assert bool(app._return_to_tail_container.filter())
 
 
+def test_fullscreen_agent_message_notice_appears_only_while_scrolled_up() -> None:
+    from prompt_toolkit.formatted_text import fragment_list_to_text, to_formatted_text
+
+    app = _make_fullscreen_app()
+    app.emit_block("".join(f"line {index}\n" for index in range(30)))
+    app._transcript_viewport_size = lambda: (20, 4)
+    app._scroll_fullscreen_transcript(-4)
+
+    app.emit_block("tool activity\n")
+    text = fragment_list_to_text(to_formatted_text(app._return_to_tail_control.text()))
+    assert "New agent message" not in text
+    return_position = text.index("Return to bottom")
+
+    app.emit_block("agent reply\n", agent_message=True)
+    fragments = to_formatted_text(app._return_to_tail_control.text())
+    text = fragment_list_to_text(fragments)
+    assert text.index("New agent message") < text.index("Return to bottom")
+    assert text.index("Return to bottom") == return_position
+    notice_style = next(style for style, value, *_ in fragments if "New agent message" in value)
+    return_style = next(style for style, value, *_ in fragments if "Return to bottom" in value)
+    assert notice_style == return_style
+    assert app._has_unseen_agent_message
+
+    app._jump_fullscreen_to_tail()
+    assert not app._has_unseen_agent_message
+    assert not bool(app._return_to_tail_container.filter())
+
+
+def test_fullscreen_clear_removes_unseen_agent_message_notice() -> None:
+    app = _make_fullscreen_app()
+    app.emit_block("".join(f"line {index}\n" for index in range(30)))
+    app._transcript_viewport_size = lambda: (20, 4)
+    app._scroll_fullscreen_transcript(-4)
+    app.emit_block("agent reply\n", agent_message=True)
+    assert app._has_unseen_agent_message
+
+    app.clear_transcript()
+
+    assert not app._has_unseen_agent_message
+    assert app._fullscreen_transcript.viewport.follows_tail
+
+
+def test_fullscreen_agent_message_at_tail_does_not_create_notice() -> None:
+    from prompt_toolkit.formatted_text import fragment_list_to_text, to_formatted_text
+
+    app = _make_fullscreen_app()
+    app.emit_block("agent reply\n", agent_message=True)
+
+    assert app._fullscreen_transcript.viewport.follows_tail
+    assert not app._has_unseen_agent_message
+    assert "New agent message" not in fragment_list_to_text(
+        to_formatted_text(app._return_to_tail_control.text())
+    )
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_input_composer_is_capped_at_ten_rows() -> None:
+    from prompt_toolkit.application.current import set_app
+
+    app = _make_fullscreen_app()
+    app.input_buffer.text = "\n".join(f"line {index}" for index in range(20))
+
+    with set_app(app._app):
+        dimension = app._input_window.preferred_height(80, 100)
+
+    assert dimension.min == 1
+    assert dimension.max == 10
+    assert dimension.preferred == 10
+
+
 def test_fullscreen_status_removes_visual_transcript_gap() -> None:
     from prompt_toolkit.formatted_text import fragment_list_to_text, to_formatted_text
 
@@ -1642,7 +1712,7 @@ def test_fullscreen_wheel_is_guarded_by_explicit_mouse_navigation_policy() -> No
     assert app._fullscreen_transcript.viewport.follows_tail
 
 
-def test_fullscreen_wheel_over_composer_scrolls_transcript_not_input() -> None:
+def test_fullscreen_wheel_over_short_composer_scrolls_transcript() -> None:
     from prompt_toolkit.mouse_events import MouseEventType
 
     app = _make_fullscreen_app()
@@ -1808,6 +1878,128 @@ def test_transcript_control_uses_current_frame_height_before_formatting() -> Non
 
 
 @pytest.mark.asyncio
+async def test_fullscreen_wheel_scrolls_overflowing_composer_instead_of_transcript() -> None:
+    from prompt_toolkit.mouse_events import MouseEventType
+
+    async with TUIHarness(display_mode=DisplayMode.FULLSCREEN) as harness:
+        app = harness.app
+        assert app is not None
+        app.emit_block("".join(f"transcript {index}\n" for index in range(30)))
+        app.input_buffer.text = "\n".join(f"draft {index}" for index in range(20))
+        app.input_buffer.cursor_position = len(app.input_buffer.text)
+        app._app.invalidate()
+        await harness.wait_for(
+            lambda: (
+                app._input_window.render_info is not None
+                and app._input_window.render_info.window_height == 10
+                and app._input_window.vertical_scroll > 0
+            )
+        )
+        before_scroll = app._input_window.vertical_scroll
+        before_cursor_row = app.input_buffer.document.cursor_position_row
+
+        result = app._input_window.content.mouse_handler(
+            _mouse_event(MouseEventType.SCROLL_UP, button=None)
+        )
+        assert app._input_window.vertical_scroll < before_scroll
+
+        assert result is None
+        assert app._fullscreen_transcript.viewport.follows_tail
+        assert app.input_buffer.document.cursor_position_row == before_cursor_row
+        assert app._input_window.manual_cursor_is_offscreen()
+        after_up_scroll = app._input_window.vertical_scroll
+
+        result = app._input_window.content.mouse_handler(
+            _mouse_event(MouseEventType.SCROLL_DOWN, button=None)
+        )
+        assert app._input_window.vertical_scroll > after_up_scroll
+
+        assert result is None
+        assert app._fullscreen_transcript.viewport.follows_tail
+        assert app.input_buffer.document.cursor_position_row == before_cursor_row
+
+        app._input_window.content.mouse_handler(_mouse_event(MouseEventType.SCROLL_UP, button=None))
+        assert app._input_window.manual_cursor_is_offscreen()
+        await harness.type_keys("!")
+        await harness.wait_for(lambda: not app._input_window._manual_wheel_scroll)
+        await harness.wait_for(lambda: app._input_window.vertical_scroll == before_scroll)
+
+        assert app.input_buffer.document.cursor_position_row == before_cursor_row
+        assert not app._input_window.manual_cursor_is_offscreen()
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_wheel_scrolls_wrapped_draft_without_moving_cursor() -> None:
+    from prompt_toolkit.mouse_events import MouseEventType
+
+    async with TUIHarness(display_mode=DisplayMode.FULLSCREEN) as harness:
+        app = harness.app
+        assert app is not None
+        app.input_buffer.text = "wrapped " * 300
+        app.input_buffer.cursor_position = len(app.input_buffer.text)
+        app._app.invalidate()
+        await harness.wait_for(
+            lambda: (
+                app._input_window.render_info is not None
+                and app._input_window.render_info.window_height == 10
+                and app._input_window.vertical_scroll_2 > 0
+            )
+        )
+        before_cursor = app.input_buffer.cursor_position
+        before_scroll = app._input_window.vertical_scroll_2
+
+        app._input_window.content.mouse_handler(_mouse_event(MouseEventType.SCROLL_UP, button=None))
+
+        assert app.input_buffer.cursor_position == before_cursor
+        assert app._input_window.vertical_scroll_2 < before_scroll
+        assert app._input_window.manual_cursor_is_offscreen()
+
+        await harness.type_keys("!")
+        await harness.wait_for(lambda: not app._input_window._manual_wheel_scroll)
+
+        assert app.input_buffer.cursor_position == before_cursor + 1
+        assert not app._input_window.manual_cursor_is_offscreen()
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_page_keys_scroll_overflowing_composer_instead_of_transcript() -> None:
+    async with TUIHarness(display_mode=DisplayMode.FULLSCREEN) as harness:
+        app = harness.app
+        assert app is not None
+        app.emit_block("".join(f"transcript {index}\n" for index in range(30)))
+        app.input_buffer.text = "\n".join(f"draft {index}" for index in range(20))
+        app.input_buffer.cursor_position = len(app.input_buffer.text)
+        app._app.invalidate()
+        await harness.wait_for(
+            lambda: (
+                app._input_window.render_info is not None
+                and app._input_window.render_info.window_height == 10
+            )
+        )
+        before_cursor_row = app.input_buffer.document.cursor_position_row
+
+        await harness.press("pageup")
+        await harness.wait_for(
+            lambda: app.input_buffer.document.cursor_position_row < before_cursor_row
+        )
+
+        assert app._fullscreen_transcript.viewport.follows_tail
+        assert app._input_window.vertical_scroll < 10
+        after_up_cursor_row = app.input_buffer.document.cursor_position_row
+
+        after_up_scroll = app._input_window.vertical_scroll
+        await harness.press("pagedown")
+        await harness.wait_for(
+            lambda: (
+                app.input_buffer.document.cursor_position_row > after_up_cursor_row
+                or app._input_window.vertical_scroll > after_up_scroll
+            )
+        )
+
+        assert app._fullscreen_transcript.viewport.follows_tail
+
+
+@pytest.mark.asyncio
 async def test_fullscreen_navigation_preserves_composer_draft_focus_and_mouse_policy() -> None:
     async with TUIHarness(display_mode=DisplayMode.FULLSCREEN) as harness:
         app = harness.app
@@ -1833,6 +2025,25 @@ async def test_fullscreen_navigation_preserves_composer_draft_focus_and_mouse_po
         await harness.wait_for(lambda: app._fullscreen_transcript.viewport.follows_tail)
         assert harness.capture_input() == "draft text"
         assert app._app.layout.current_buffer is app.input_buffer
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_enter_submission_returns_scrolled_transcript_to_tail() -> None:
+    async with TUIHarness(display_mode=DisplayMode.FULLSCREEN) as harness:
+        app = harness.app
+        assert app is not None
+        app.emit_block("".join(f"line {index}\n" for index in range(80)))
+        await harness.press("pageup")
+        await harness.wait_for(lambda: not app._fullscreen_transcript.viewport.follows_tail)
+        app.emit_block("agent reply\n", agent_message=True)
+        assert app._has_unseen_agent_message
+
+        await harness.type_keys("follow up")
+        await harness.press("enter")
+        await harness.wait_for(lambda: harness.agent.messages_received == ["follow up"])
+
+        assert app._fullscreen_transcript.viewport.follows_tail
+        assert not app._has_unseen_agent_message
 
 
 @pytest.mark.asyncio

--- a/packages/nooa-cli/tests/tui/test_session_plumbing.py
+++ b/packages/nooa-cli/tests/tui/test_session_plumbing.py
@@ -170,6 +170,40 @@ def test_emit_stream_coalesces_one_print_into_one_emit_call() -> None:
     assert "a" in calls[0] and "b" in calls[0]
 
 
+def test_emit_stream_marks_agent_message_scope_without_changing_other_emits() -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def emit(text: str, **kwargs: object) -> None:
+        calls.append((text, kwargs))
+
+    stream = _EmitStream(emit)
+    stream.write("activity")
+    stream.flush()
+    with stream.agent_message():
+        stream.write("agent reply")
+        stream.flush()
+
+    assert calls == [
+        ("activity", {}),
+        ("agent reply", {"agent_message": True}),
+    ]
+
+
+def test_emit_stream_preserves_agent_message_marker_across_held_flush() -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def emit(text: str, **kwargs: object) -> None:
+        calls.append((text, kwargs))
+
+    stream = _EmitStream(emit)
+    with stream.hold():
+        with stream.agent_message():
+            stream.write("agent reply")
+            stream.flush()
+
+    assert calls == [("agent reply", {"agent_message": True})]
+
+
 def test_emit_stream_empty_flush_is_noop() -> None:
     """Flushing an empty buffer doesn't emit a stray empty block."""
     calls: list[str] = []
@@ -186,6 +220,33 @@ def test_emit_stream_multiple_prints_produce_multiple_emits() -> None:
     c.print("first")
     c.print("second")
     assert len(calls) == 2
+
+
+def test_terminal_frontend_marks_agent_message_blocks() -> None:
+    from types import SimpleNamespace
+
+    from nooa_cli.tui.frontend import TerminalFrontend
+    from nooa_cli.tui.output import AgentMessage
+
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def emit(text: str, **kwargs: object) -> None:
+        calls.append((text, kwargs))
+
+    frontend = TerminalFrontend(SimpleNamespace(tui=SimpleNamespace(vi_mode=False)))
+    frontend.console.replace_console(
+        Console(
+            file=_EmitStream(emit),
+            force_terminal=True,
+            color_system="256",
+            width=80,
+        )
+    )
+
+    frontend._render_agent_message(AgentMessage("hello", show_rule=False))
+
+    assert len(calls) == 1
+    assert calls[0][1] == {"agent_message": True}
 
 
 def test_tui_console_replace_console_swaps_underlying_console() -> None:


### PR DESCRIPTION
## Summary
- return the fullscreen transcript to the live tail whenever non-empty input is submitted
- show a semantic **New agent message** notice beside **Return to bottom** when agent prose arrives while the viewport is anchored
- cap the fullscreen input composer at 10 rows and route navigation to it while it overflows

## Implementation
- carry an explicit `agent_message` marker through both direct agent-event rendering and structured `AgentMessage` frontend rendering
- keep unseen-message state UI-owned and clear it when the user returns to the tail or clears the transcript
- leave activity/tool output unmarked so it does not trigger the notice
- while the capped composer has hidden rows, mouse-wheel gestures over it move a detached viewport without moving the edit cursor; typing or cursor movement resumes cursor following
- Page Up/Page Down intentionally move the composer cursor; short drafts retain transcript navigation

## Validation
- `uv run pytest -q packages/nooa-cli/tests/tui/test_fullscreen_transcript.py` — 177 passed
- `uv run pytest -q packages/nooa-cli/tests/tui` — 1204 passed, 2 pre-existing macOS `/var` vs `/private/var` path failures
- Ruff check and format pass on changed files
- Pyright passes on changed source and test files
- `git diff --check` passes

## Review
Two independent focused reviews were run. One identified missing semantic propagation through `TerminalFrontend`; that path is now covered. Final review reported no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved fullscreen composer scrolling for long drafts, including mouse-wheel and page-key navigation.
  - Limited the composer viewport to prevent it from overwhelming the transcript.
  - Added notifications when new agent messages arrive while viewing older transcript content.
  - Returning to the latest transcript or clearing it removes the notification.
- **Bug Fixes**
  - Restored cursor-following behavior after editing or moving through the composer.
  - Returning to the transcript tail after submitting a message now behaves consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->