### PR TITLE
fix(tui): preserve and word-wrap fullscreen prose

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
@@ -85,10 +85,18 @@ class _SemanticListItem(ListItem):
     owns visual wrapping at the current viewport width.
     """
 
+    def _semantic_lines(self, console: Console, options: ConsoleOptions) -> list[list[Segment]]:
+        """Render logical child lines without Rich's width-cropping pass."""
+        rendered = console.render(self.elements, options)
+        styled = Segment.apply_style(rendered, self.style)
+        return list(Segment.split_lines(styled)) or [[]]
+
     def render_bullet(self, console: Console, options: ConsoleOptions) -> RenderResult:
-        yield Segment(" • ", console.get_style("markdown.item.bullet", default="none"))
-        yield from console.render(self.elements, options)
-        yield Segment.line()
+        bullet_style = console.get_style("markdown.item.bullet", default="none")
+        for index, line in enumerate(self._semantic_lines(console, options)):
+            yield Segment(" • " if index == 0 else "   ", bullet_style)
+            yield from line
+            yield Segment.line()
 
     def render_number(
         self,
@@ -98,12 +106,12 @@ class _SemanticListItem(ListItem):
         last_number: int,
     ) -> RenderResult:
         number_width = len(str(last_number)) + 2
-        yield Segment(
-            f"{number}".rjust(number_width - 1) + " ",
-            console.get_style("markdown.item.number", default="none"),
-        )
-        yield from console.render(self.elements, options)
-        yield Segment.line()
+        number_style = console.get_style("markdown.item.number", default="none")
+        for index, line in enumerate(self._semantic_lines(console, options)):
+            prefix = f"{number}".rjust(number_width - 1) + " " if index == 0 else " " * number_width
+            yield Segment(prefix, number_style)
+            yield from line
+            yield Segment.line()
 
 
 class CopyableMarkdown(Markdown):

--- a/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
@@ -8,7 +8,8 @@ import secrets
 from typing import Any
 
 from rich.console import Console, ConsoleOptions, RenderResult
-from rich.markdown import CodeBlock, Markdown
+from rich.markdown import CodeBlock, ListItem, Markdown
+from rich.segment import Segment
 from rich.syntax import Syntax
 from rich.text import Text
 
@@ -74,6 +75,37 @@ class _CopyableCodeBlock(CodeBlock):
         yield from console.render(syntax, options.update(no_wrap=False, overflow="fold"))
 
 
+class _SemanticListItem(ListItem):
+    """Render complete list-item text for renderer-owned wrapping.
+
+    Rich's normal list renderer calls ``render_lines`` even under
+    ``soft_wrap=True``. That clips each list item to the Console width before
+    the fullscreen transcript can reflow it, permanently losing the suffix.
+    Emit the prefix and semantic child stream instead; the transcript model
+    owns visual wrapping at the current viewport width.
+    """
+
+    def render_bullet(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        yield Segment(" • ", console.get_style("markdown.item.bullet", default="none"))
+        yield from console.render(self.elements, options)
+        yield Segment.line()
+
+    def render_number(
+        self,
+        console: Console,
+        options: ConsoleOptions,
+        number: int,
+        last_number: int,
+    ) -> RenderResult:
+        number_width = len(str(last_number)) + 2
+        yield Segment(
+            f"{number}".rjust(number_width - 1) + " ",
+            console.get_style("markdown.item.number", default="none"),
+        )
+        yield from console.render(self.elements, options)
+        yield Segment.line()
+
+
 class CopyableMarkdown(Markdown):
     """Rich Markdown that exposes exact fenced-code payloads by stable action ID."""
 
@@ -81,6 +113,7 @@ class CopyableMarkdown(Markdown):
         **Markdown.elements,
         "fence": _CopyableCodeBlock,
         "code_block": _CopyableCodeBlock,
+        "list_item_open": _SemanticListItem,
     }
 
     def __init__(self, markup: str, **kwargs: Any) -> None:

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -866,29 +866,55 @@ class FullscreenTranscriptModel:
             styled_chars.extend((style, char) for char in text)
 
         rows: list[_ProjectedRow] = []
-        row: list[tuple[str, str]] = []
+        row: list[tuple[tuple[str, str], ...]] = []
         row_source_spans: list[tuple[int, int]] = []
+        row_widths: list[int] = []
         row_cells = 0
         source_offset = 0
         semantic_offset = 0
         row_source_offset = 0
         row_semantic_offset = 0
+
+        def emit_row(stop: int | None = None) -> None:
+            """Emit a row prefix and retain any suffix for the next row."""
+            nonlocal row, row_source_spans, row_widths, row_cells
+            nonlocal row_source_offset, row_semantic_offset
+            if stop is None:
+                stop = len(row_source_spans)
+            rows.append(
+                _ProjectedRow(
+                    ViewportAnchor(record.record_id, row_source_offset, row_semantic_offset),
+                    tuple(fragment for cluster in row[:stop] for fragment in cluster),
+                    tuple(row_source_spans[:stop]),
+                    record.hyperlinks,
+                )
+            )
+            emitted_spans = row_source_spans[:stop]
+            row_source_offset += len(emitted_spans)
+            row_semantic_offset += sum(
+                1 for start, stop_ in emitted_spans if not record.plain[start:stop_].isspace()
+            )
+            row = row[stop:]
+            row_source_spans = row_source_spans[stop:]
+            row_widths = row_widths[stop:]
+            row_cells = sum(row_widths)
+
+        def word_break() -> int | None:
+            """Return a natural break after the last whitespace in this row."""
+            for index in range(len(row) - 1, -1, -1):
+                if "".join(char for _style, char in row[index]).isspace():
+                    # Keep the delimiter in the preceding visual row. This
+                    # preserves exact copy semantics without indenting the
+                    # continuation by a source separator.
+                    return index + 1
+            return None
+
         for start, stop, cells in cls._grapheme_spans(styled_chars):
             cluster = styled_chars[start:stop]
             cluster_text = "".join(char for _, char in cluster)
             if cluster_text == "\n":
-                rows.append(
-                    _ProjectedRow(
-                        ViewportAnchor(record.record_id, row_source_offset, row_semantic_offset),
-                        tuple(row),
-                        tuple(row_source_spans),
-                        record.hyperlinks,
-                    )
-                )
+                emit_row()
                 source_offset += 1
-                row = []
-                row_source_spans = []
-                row_cells = 0
                 row_source_offset = source_offset
                 row_semantic_offset = semantic_offset
                 continue
@@ -903,54 +929,23 @@ class FullscreenTranscriptModel:
             if len(normalized) == 1:
                 cluster = [(cluster[0][0] if cluster else "", normalized)]
                 cluster_text = normalized
-            cells = max(cells, 0)
-            if cells > width:
-                # No terminal can faithfully fit this cluster in the viewport.
-                # Preserve the valid Unicode and clip only its layout footprint.
-                cells = width
-            if row and cells and row_cells + cells > width:
-                rows.append(
-                    _ProjectedRow(
-                        ViewportAnchor(record.record_id, row_source_offset, row_semantic_offset),
-                        tuple(row),
-                        tuple(row_source_spans),
-                        record.hyperlinks,
-                    )
-                )
-                row = []
-                row_source_spans = []
-                row_cells = 0
-                row_source_offset = source_offset
-                row_semantic_offset = semantic_offset
-            row.extend(cluster)
+            cells = min(max(cells, 0), width)
+
+            while row and cells and row_cells + cells > width:
+                # Prefer a semantic word boundary. If this row has no
+                # whitespace (a URL, identifier, or other long token), fold at
+                # the grapheme boundary as the lossless fallback.
+                natural_break = word_break()
+                emit_row(natural_break)
+            row.append(tuple(cluster))
             row_source_spans.append((start, stop))
+            row_widths.append(cells)
             row_cells += cells
             source_offset += 1
             if not cluster_text.isspace():
                 semantic_offset += 1
-            if row_cells >= width and stop < len(styled_chars) and styled_chars[stop][1] != "\n":
-                rows.append(
-                    _ProjectedRow(
-                        ViewportAnchor(record.record_id, row_source_offset, row_semantic_offset),
-                        tuple(row),
-                        tuple(row_source_spans),
-                        record.hyperlinks,
-                    )
-                )
-                row = []
-                row_source_spans = []
-                row_cells = 0
-                row_source_offset = source_offset
-                row_semantic_offset = semantic_offset
         if row or not rows or (styled_chars and styled_chars[-1][1] != "\n"):
-            rows.append(
-                _ProjectedRow(
-                    ViewportAnchor(record.record_id, row_source_offset, row_semantic_offset),
-                    tuple(row),
-                    tuple(row_source_spans),
-                    record.hyperlinks,
-                )
-            )
+            emit_row()
         return rows
 
     @staticmethod

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1932,7 +1932,15 @@ class TUIApplication:
         if isinstance(control, _FullscreenTranscriptControl):
             current = control.render_size
             if current is not None:
-                return current
+                # During a debounced resize this control can still expose the
+                # previous frame's width. Never project wider than the physical
+                # terminal or prompt_toolkit will clip the overflow before the
+                # next frame can update ``render_size``.
+                try:
+                    physical_width = max(1, int(self._app.output.get_size().columns))
+                except Exception:
+                    physical_width = current[0]
+                return min(current[0], physical_width), current[1]
         try:
             size = self._app.output.get_size()
             return max(1, int(size.columns)), max(1, int(size.rows) - 6)

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -3553,6 +3553,36 @@ def test_copyable_markdown_preserves_long_list_item_for_fullscreen_reflow() -> N
     assert any(row.endswith(" ") for row in rows[:-1])
 
 
+def test_copyable_markdown_preserves_nested_and_multiline_list_structure() -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+
+    _renderable, ansi = _copyable_markdown_ansi(
+        "- parent item\n"
+        "  - nested item one\n"
+        "  - nested item two\n"
+        "- first paragraph\n\n"
+        "  second paragraph in the same item\n\n"
+        "  > quoted child\n"
+        "98. ninety eight\n"
+        "99. ninety nine\n"
+        "100. one hundred",
+        width=30,
+    )
+
+    lines = [line.rstrip() for line in strip_safe_ansi(ansi).splitlines() if line.strip()]
+    assert lines == [
+        " • parent item",
+        "    • nested item one",
+        "    • nested item two",
+        " • first paragraph",
+        "   second paragraph in the same item",
+        "   ▌ quoted child",
+        "  98 ninety eight",
+        "  99 ninety nine",
+        " 100 one hundred",
+    ]
+
+
 def test_copyable_markdown_exposes_exact_fenced_code_payloads() -> None:
     from nooa_cli.tui.terminal_safety import strip_safe_ansi
 

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -598,12 +598,45 @@ def test_fullscreen_hyperlink_hit_testing_survives_projection_and_wrapping() -> 
 
     assert model.hyperlink_at(x=0, y=0, width=8, height=3) == "https://example.test/docs"
     assert model.hyperlink_at(x=1, y=1, width=8, height=3) == "https://example.test/docs"
-    assert model.hyperlink_at(x=2, y=1, width=8, height=3) is None
+    assert model.hyperlink_at(x=4, y=1, width=8, height=3) is None
 
     blank = FullscreenTranscriptModel()
     blank.append("\x1b]8;;https://example.test/docs\x1b\\foo\n\nbar\x1b]8;;\x1b\\")
     assert blank.hyperlink_at(x=0, y=1, width=20, height=3) is None
     assert blank.hyperlink_at(x=19, y=1, width=20, height=3) is None
+
+
+def test_fullscreen_projection_wraps_prose_at_word_boundaries() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+
+    model = FullscreenTranscriptModel()
+    model.append("alpha beta gamma-delta")
+
+    rows = _projected_row_texts(model, 11)
+
+    assert rows == ["alpha beta ", "gamma-delta"]
+    assert "".join(rows) == model.text
+
+
+def test_fullscreen_projection_keeps_an_exactly_full_row() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+
+    model = FullscreenTranscriptModel()
+    model.append("alpha beta next")
+
+    assert _projected_row_texts(model, 10) == ["alpha ", "beta next"]
+
+
+def test_fullscreen_projection_folds_one_long_word_without_losing_text() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+
+    model = FullscreenTranscriptModel()
+    model.append("supercalifragilistic")
+
+    rows = _projected_row_texts(model, 6)
+
+    assert rows == ["superc", "alifra", "gilist", "ic"]
+    assert "".join(rows) == model.text
 
 
 def test_fullscreen_hyperlink_hit_testing_matches_combining_grapheme_rendering() -> None:
@@ -677,6 +710,22 @@ async def test_fullscreen_edit_returns_command_error_without_terminal_handoff(
     assert result.success is False
     assert len(result.outputs) == 1
     assert "native or native-replay" in result.outputs[0].content
+
+
+def test_fullscreen_transcript_never_projects_past_physical_width() -> None:
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    from .tui_app_harness import MutableRecordingOutput
+
+    output = MutableRecordingOutput(columns=20, rows=12)
+    with create_app_session(input=DummyInput(), output=output):
+        app = TUIApplication(display_mode=DisplayMode.FULLSCREEN)
+
+    control = app._output_window.content
+    control._render_width = 80
+    control._render_height = 7
+
+    assert app._transcript_viewport_size() == (20, 7)
 
 
 def test_fullscreen_width_change_reprojects_semantic_blocks_and_unwraps() -> None:
@@ -1079,7 +1128,7 @@ def test_projection_cache_extends_incrementally_on_stream_append(
 
     assert calls == [1]
     assert extended[: len(first_projection) - 1] == first_projection[:-1]
-    assert _projected_row_texts(model, 8)[-3:] == ["stream d", "elta", ""]
+    assert _projected_row_texts(model, 8)[-3:] == ["stream ", "delta", ""]
 
 
 def test_adjacent_records_have_one_separator_without_blank_row() -> None:
@@ -1390,7 +1439,7 @@ def test_fullscreen_screen_preserves_native_osc8_metadata_across_wrapped_rows() 
     app.emit_block(
         "plain \x1b]8;id=docs;https://example.test/docs\x1b\\linked text\x1b]8;;\x1b\\ tail"
     )
-    app._transcript_viewport_size = lambda: (8, 3)
+    app._transcript_viewport_size = lambda: (8, 5)
     assert app._output_window is not None
     app._app.render_counter += 1
     screen = Screen()
@@ -1398,7 +1447,7 @@ def test_fullscreen_screen_preserves_native_osc8_metadata_across_wrapped_rows() 
         app._output_window.write_to_screen(
             screen,
             MouseHandlers(),
-            WritePosition(xpos=0, ypos=0, width=8, height=3),
+            WritePosition(xpos=0, ypos=0, width=8, height=5),
             parent_style="",
             erase_bg=False,
             z_index=None,
@@ -1406,9 +1455,9 @@ def test_fullscreen_screen_preserves_native_osc8_metadata_across_wrapped_rows() 
 
     target = "\x1b]8;;https://example.test/docs\x1b\\"
     close = "\x1b]8;;\x1b\\"
-    assert screen.zero_width_escapes[0][6] == target
     assert screen.zero_width_escapes[1][0] == target
-    assert screen.zero_width_escapes[1][3] == close
+    assert screen.zero_width_escapes[2][0] == target
+    assert screen.zero_width_escapes[2][4] == close
     assert all(
         "id=docs" not in sequence
         for row in screen.zero_width_escapes.values()
@@ -3479,6 +3528,29 @@ def _copy_label_position(model, *, width: int, height: int) -> tuple[int, int]:
         if "Copy" in line:
             return line.index("Copy"), y
     raise AssertionError("copy label was not rendered")
+
+
+def test_copyable_markdown_preserves_long_list_item_for_fullscreen_reflow() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+
+    suffix = "the complete suffix remains visible after an intelligent wrap"
+    markdown = (
+        "- **[#205 — Trace Explorer](https://example.test/issues/205)** — "
+        "a long explanation that reaches beyond the initial Rich console width; " + suffix
+    )
+    _renderable, ansi = _copyable_markdown_ansi(markdown, width=60)
+
+    plain = strip_safe_ansi(ansi)
+    assert suffix in plain
+
+    model = FullscreenTranscriptModel()
+    model.append(ansi)
+    rows = [row for row in _projected_row_texts(model, 40) if row]
+
+    assert "".join(rows) == plain.strip("\n")
+    assert all(not row.endswith(("explan", "intellig")) for row in rows[:-1])
+    assert any(row.endswith(" ") for row in rows[:-1])
 
 
 def test_copyable_markdown_exposes_exact_fenced_code_payloads() -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes fullscreen transcript prose that was clipped or split mid-word.

- preserves complete Markdown list-item content instead of letting Rich crop it at the initial console width
- wraps transcript prose at whitespace boundaries, with grapheme-safe folding for indivisible long tokens
- caps projection width to the current physical terminal during debounced resizes so stale render geometry cannot clip a frame
- adds regressions for long Markdown lists, semantic wrapping, long tokens, hyperlinks, and stale resize geometry

The live tmux capture showed list rows ending at the right edge with no continuation rows. Comparing the captured output with the persisted `AgentMessage` proved the missing suffixes were present in source and were being discarded by Rich `ListItem.render_lines()` before the fullscreen transcript received them.

## Related issues

Follow-up hotfix for the fullscreen transcript work in #198, #204, and #207.

## Validation

- `uv run --frozen pytest -q packages/nooa-cli/tests/tui/test_fullscreen_transcript.py` — 183 passed
- `uv run --frozen pytest -q packages/nooa-cli/tests/tui` — 1211 passed, 2 known unrelated macOS path failures reproduced on baseline
- changed-file Ruff lint/format — passed
- changed-file Pyright — passed
- `git diff --check` — passed

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass for changed files)
- [x] Tests added/updated and passing
- [x] Docs updated if behavior or public APIs changed (not applicable)
- [x] New source files carry an SPDX license header (no new source files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fullscreen transcript wrapping at word and character boundaries without losing content.
  * Preserved complete long Markdown list items when copying or viewing transcripts.
  * Prevented transcript content from exceeding the terminal’s current width during resizing.
  * Maintained hyperlink metadata correctly across wrapped transcript rows.
  * Improved rendering of nested and multiline Markdown lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->