### PR TITLE
fix(agentdoc): preserve type docs for instances

### DIFF
--- a/src/nooa/agentdoc/__init__.py
+++ b/src/nooa/agentdoc/__init__.py
@@ -42,6 +42,8 @@ from nooa.agentdoc.core import doc
 from nooa.agentdoc.doc_config import DocConfig
 
 __submodules__ = ["ext", "introspect", "visibility", "adapters"]
+# Keep doc(agentdoc) as a capability map; individual callables provide details on demand.
+__agentdoc_concise_members__ = True
 
 
 def truncating_pformat(

--- a/src/nooa/agentdoc/__init__.py
+++ b/src/nooa/agentdoc/__init__.py
@@ -16,9 +16,14 @@ Quick start:
         label: Annotated[str, spec(description="Display name")] = "agent"
 
     agent = MyAgent()
-    doc(MyAgent)   # → API contract (type view)
-    doc(agent)     # → API contract with current values substituted
-    pformat(agent) # → compact repr: MyAgent(label='agent')
+    agent.region = "us-east"
+    doc(MyAgent)   # → API contract with declared defaults
+    doc(agent)     # → same contract + current values and public runtime fields
+    pformat(agent) # → compact value representation: MyAgent(label='agent', region='us-east')
+
+Unlike pformat(), doc(instance) documents the type structure even when the
+instance defines a custom __repr__. It preserves declared fields, methods,
+properties, docstrings, and referenced types; properties are not evaluated.
 """
 
 import io

--- a/src/nooa/agentdoc/__init__.py
+++ b/src/nooa/agentdoc/__init__.py
@@ -1,29 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""agentdoc — runtime Python documentation for Python objects.
+"""Turn live Python objects into prompt-ready API documentation.
 
-Two-step mental model:
+Show an agent what an object can do—not just what it contains::
 
-  1. spec() — specify how the type renders: descriptions, visibility, hints.
-  2. doc()  — get the documentation: the API contract, ready for a prompt.
+    from typing import Annotated
 
-Quick start:
+    from nooa.agentdoc import doc, hidden, pformat, spec
 
-    from nooa.agentdoc import spec, hidden, doc, pformat, truncating_pformat
+    class Assistant:
+        api_key: Annotated[str, hidden] = ""
+        name: Annotated[str, spec(description="Display name")] = "Ada"
 
-    class MyAgent:
-        api_key: Annotated[str, hidden] = ""          # excluded from documentation
-        label: Annotated[str, spec(description="Display name")] = "agent"
+        def greet(self, person: str) -> str:
+            \"""Greet a person by name.\"""
 
-    agent = MyAgent()
-    agent.region = "us-east"
-    doc(MyAgent)   # → API contract with declared defaults
-    doc(agent)     # → same contract + current values and public runtime fields
-    pformat(agent) # → compact value representation: MyAgent(label='agent', region='us-east')
+    assistant = Assistant()
+    assistant.locale = "en-US"
 
-Unlike pformat(), doc(instance) documents the type structure even when the
-instance defines a custom __repr__. It preserves declared fields, methods,
-properties, docstrings, and referenced types; properties are not evaluated.
+    doc(Assistant)      # declared API and defaults
+    doc(assistant)      # the same API, enriched with live state
+    pformat(assistant)  # compact value view
+
+Use ``spec()`` and ``hidden`` to shape the contract, ``doc()`` to reveal it,
+and ``pformat()`` when values alone are enough.
 """
 
 import io
@@ -52,15 +52,9 @@ def truncating_pformat(
     ] = None,
     **kwargs: Any,
 ) -> str:
-    """Format *obj* as a string. Strings pass through verbatim; non-strings go
-    through :func:`pformat` with the supplied structural kwargs.
+    """Format a value, with a hard total-size cap for non-string objects.
 
-    Per-value bounds (``max_string``, ``max_length``, ``max_depth``) come from
-    ``kwargs``.  ``max_chars`` is an independent hard cap on the total rendered
-    output for non-string objects via :class:`TruncatingStringIO`.
-
-    Raises:
-        ValueError: if ``max_chars`` is set and <= 0.
+    Strings pass through unchanged. Other options are forwarded to ``pformat()``.
     """
     if max_chars is not None and max_chars <= 0:
         raise ValueError(f"truncating_pformat max_chars must be > 0 or None, got {max_chars}")
@@ -93,16 +87,10 @@ def pformat(
     ] = "repr",
     unquote_strings: Annotated[bool, "Untruncated strings rendered verbatim"] = False,
 ) -> str:
-    """Format an object as a string with smart truncation.
+    """Render a compact, value-focused representation.
 
-    Drop-in replacement for ``rich.pretty.pformat()``.
-    For user-defined instances, ``hidden`` fields are automatically excluded.
-    Respects ``@spec(expand=False)`` on field types — shown as ``ClassName()`` rather than expanded.
-
-    ``console`` and ``indent_guides`` are accepted for Rich API compatibility but have no effect.
-
-    To cap total output size (preventing OOM on huge objects), use :func:`truncating_pformat`
-    which applies a hard ``max_chars`` limit via :class:`TruncatingStringIO`.
+    Hidden fields are omitted and custom ``__repr__`` methods are honored. Use
+    ``doc()`` for an object's API, or ``truncating_pformat()`` for a hard size cap.
     """
     # console and indent_guides are intentionally ignored for Rich compatibility
     del console, indent_guides
@@ -151,14 +139,7 @@ def pprint(
         str, "Instance format: 'repr' for repr-style, 'type' for type structure"
     ] = "repr",
 ) -> None:
-    """Pretty-print an object with smart truncation. Prints to stdout.
-
-    Drop-in replacement for ``rich.pretty.pprint()``.
-    Writes directly to ``sys.stdout`` via stream-based formatting so that
-    stdout capture (via ``ContextVarStream``) bounds output during formatting.
-
-    ``console`` and ``indent_guides`` are accepted for Rich API compatibility but have no effect.
-    """
+    """Print the compact, value-focused representation produced by ``pformat()``."""
     # console and indent_guides are intentionally ignored for Rich compatibility
     del console, indent_guides
 

--- a/src/nooa/agentdoc/_discover.py
+++ b/src/nooa/agentdoc/_discover.py
@@ -54,6 +54,7 @@ def discover_referenced_types(
     obj: type | Any,
     *,
     seen: set[type] | None = None,
+    field_names: set[str] | None = None,
 ) -> list[type]:
     """Discover all custom types referenced in a class or callable's interface.
 
@@ -70,6 +71,8 @@ def discover_referenced_types(
         seen: Optional set of already-seen types to exclude from results.
             Used for deduplication when documenting multiple types together.
             Types in this set will not be included in the returned list.
+        field_names: Optional names of visible fields to scan. Methods are
+            always scanned. ``None`` scans every extracted field.
 
     Returns:
         List of unique custom type objects not in `seen`, sorted by name
@@ -86,21 +89,63 @@ def discover_referenced_types(
         ]
         return sorted(custom_types, key=lambda t: t.__name__)
 
-    # Handle class type
-    if not isinstance(obj, type):
-        return []  # Not a class or callable
+    # Instances use their type-level contract, with per-instance visibility.
+    # Built-in values are not documentable API objects.
+    visibility_obj = None
+    if isinstance(obj, type):
+        type_obj = obj
+    else:
+        type_obj = type(obj)
+        if type_obj.__module__ == "builtins":
+            return []
+        visibility_obj = obj
 
-    type_obj = obj
-
-    # 1. Discover from ALL fields (class-level annotations, __init__, non-annotated attrs)
+    # 1. Discover from visible fields (class-level annotations, __init__,
+    # non-annotated attrs).
     # Use the same extraction that extract_type_info uses for consistency
     from nooa.agentdoc._structured import extract_type_info
 
     type_info = extract_type_info(type_obj)
+    if visibility_obj is not None:
+        from nooa.agentdoc._visibility import is_hidden_field
+
     for field in type_info.fields:
+        if field_names is not None and field.name not in field_names:
+            continue
+        if visibility_obj is not None and is_hidden_field(visibility_obj, field.name):
+            continue
         # Parse the type string back to extract types
         # For fields, we need to look at the original type hints where possible
         _extract_types_from_field(type_obj, field.name, field.type, discovered)
+
+    # Instance-only public fields can introduce referenced types that are not
+    # present in the class contract. Read storage directly so discovery does
+    # not invoke arbitrary descriptors or __getattr__ hooks.
+    if visibility_obj is not None:
+        try:
+            obj_dict = object.__getattribute__(visibility_obj, "__dict__")
+        except AttributeError:
+            obj_dict = None
+        runtime_values = dict(obj_dict or {})
+        if hasattr(type_obj, "model_fields"):
+            try:
+                pydantic_extra = object.__getattribute__(visibility_obj, "__pydantic_extra__")
+            except AttributeError:
+                pydantic_extra = None
+            if isinstance(pydantic_extra, dict):
+                runtime_values.update(pydantic_extra)
+
+        declared_names = {field.name for field in type_info.fields}
+        for name, value in runtime_values.items():
+            if (
+                name in declared_names
+                or name.startswith("_")
+                or is_hidden_field(visibility_obj, name)
+            ):
+                continue
+            if callable(value) and not isinstance(value, type):
+                continue
+            _extract_types_from_hint(value if isinstance(value, type) else type(value), discovered)
 
     # 2. Discover from method signatures
     for method_info in type_info.methods:

--- a/src/nooa/agentdoc/_docs.py
+++ b/src/nooa/agentdoc/_docs.py
@@ -93,36 +93,17 @@ class SpecAnnotation:
 
 
 class Spec:
-    """The ``spec`` singleton — step 1: specify how a type renders.
+    """Shape how objects appear in ``doc()`` and ``pformat()``.
 
-    Attach visibility rules, descriptions, and rendering hints to fields,
-    methods, or whole types; ``doc()`` and ``pformat()`` pick them up
-    automatically.
+    Use it as metadata, a decorator, or an imperative override::
 
-    **Default visibility rules:**
+        name: Annotated[str, spec(description="Display name")]
+        @spec(hidden=True)
+        def internal(self): ...
+        spec(ThirdParty, "verbose", hidden=True)
 
-    - Public names (no leading underscore) are **visible** by default.
-    - ``_private`` names (single or double leading underscore) are **hidden**
-      by default.  Use ``spec(hidden=False)`` or ``@spec(hidden=False)`` to
-      opt a private name back in.
-
-    Which form to use:
-
-    - **Annotated marker** — for fields in types you own::
-
-          api_key: Annotated[str, spec(hidden=True)] = ""
-
-    - **Decorator** — for methods or classes you own::
-
-          @spec(hidden=True)
-          def _internal(self): ...
-
-          @spec(hidden=False)       # opt a _private method back in
-          def _shown_helper(self): ...
-
-    - **Imperative** — for types you don't own::
-
-          spec(ThirdPartyClass, "verbose_field", hidden=True)
+    Public names are visible by default; private names are hidden unless
+    explicitly shown with ``spec(hidden=False)``.
     """
 
     def __call__(

--- a/src/nooa/agentdoc/_metadata.py
+++ b/src/nooa/agentdoc/_metadata.py
@@ -18,6 +18,14 @@ _DOCS_ATTR = "_agentdoc_docs"
 _FIELDS_ATTR = "_agentdoc_fields_docs"
 
 
+def _object_namespace(obj: Any) -> Any:
+    """Return ``obj.__dict__`` without invoking an instance ``__getattr__``."""
+    try:
+        return object.__getattribute__(obj, "__dict__")
+    except (AttributeError, TypeError):
+        return {}
+
+
 def get_docs_metadata(obj: Any) -> dict[str, Any]:
     """Return the spec() metadata dict for obj (never None)."""
     return getattr(obj, _DOCS_ATTR, None) or {}
@@ -33,20 +41,14 @@ def set_docs_metadata(obj: Any, **kwargs: Any) -> None:
 
 def get_field_metadata(obj: Any, field: str) -> dict[str, Any]:
     """Return per-field spec() metadata for obj's own declarations only (never None)."""
-    try:
-        fields_meta = vars(obj).get(_FIELDS_ATTR) or {}
-    except TypeError:
-        fields_meta = {}
+    fields_meta = _object_namespace(obj).get(_FIELDS_ATTR) or {}
     return fields_meta.get(field) or {}
 
 
 def set_field_metadata(obj: Any, field: str, **kwargs: Any) -> None:
     """Merge kwargs into the per-field spec() metadata on obj."""
     with contextlib.suppress(AttributeError, TypeError):
-        try:
-            fields_meta = vars(obj).get(_FIELDS_ATTR)
-        except TypeError:
-            fields_meta = None
+        fields_meta = _object_namespace(obj).get(_FIELDS_ATTR)
         if fields_meta is None:
             fields_meta = {}
             setattr(obj, _FIELDS_ATTR, fields_meta)

--- a/src/nooa/agentdoc/_pformat.py
+++ b/src/nooa/agentdoc/_pformat.py
@@ -227,19 +227,21 @@ def _pformat(
                     context_obj=_object,  # Pass the function/method for type discovery
                 )
             )
-        case _ if _is_structured_instance(_object):
-            # Instance of a structured type
+        case _ if _is_structured_instance(_object, respect_custom_repr=instance_mode != "type"):
+            # Instance of a structured type. doc() deliberately ignores a custom
+            # __repr__: documentation must retain the type's API contract.
             if instance_mode == "type":
                 # Show type structure with runtime values (for doc())
                 from nooa.agentdoc._structured import extract_type_info
                 from nooa.agentdoc._visibility import is_hidden_field
-                from nooa.agentdoc.protocols import SupportsInstanceValues
                 from nooa.agentdoc.registry import get_type_info_extractor
 
                 obj_type = type(_object)
                 # Check if instance has spec() overrides that could unhide class-hidden fields.
                 # spec(self, "field", hidden=False) in __init__ → per-instance opt-in.
-                _instance_fields_meta = vars(_object).get("_agentdoc_fields_docs") or {}
+                _instance_fields_meta = (_instance_dict(_object) or {}).get(
+                    "_agentdoc_fields_docs"
+                ) or {}
                 _has_instance_overrides = any(
                     meta.get("hidden") is False for meta in _instance_fields_meta.values()
                 )
@@ -300,6 +302,17 @@ def _pformat(
                         type_info = extract_type_info(obj_type)
                     values = _extract_instance_values(_object, type_info)
 
+                # Apply per-instance visibility in every extraction branch.
+                # This handles both hidden=False opt-ins and hidden=True overrides
+                # on fields already present in the type-level contract.
+                type_info = TypeInfo(
+                    name=type_info.name,
+                    base=type_info.base,
+                    fields=[f for f in type_info.fields if not is_hidden_field(_object, f.name)],
+                    methods=type_info.methods,
+                    docstring=type_info.docstring,
+                )
+
                 _stream.write(
                     _format_type_info(
                         type_info,
@@ -309,6 +322,7 @@ def _pformat(
                         indent=_indent,
                         context_obj=obj_type,
                         instance_values=values,
+                        visibility_obj=_object,
                     )
                 )
             else:
@@ -367,7 +381,16 @@ def _pformat_to_str(
     return stream.getvalue()
 
 
-def _is_structured_instance(obj: Any) -> bool:
+def _instance_dict(obj: Any) -> dict[str, Any] | None:
+    """Return an instance ``__dict__`` without invoking ``__getattr__``."""
+    try:
+        value = object.__getattribute__(obj, "__dict__")
+    except AttributeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _is_structured_instance(obj: Any, *, respect_custom_repr: bool = True) -> bool:
     """Check if object is an instance that should be formatted with type info.
 
     Returns True for:
@@ -376,6 +399,11 @@ def _is_structured_instance(obj: Any) -> bool:
     - NamedTuples
     - attrs classes
     - Any custom class instance with __dict__ (not built-in types)
+
+    Args:
+        obj: Candidate instance.
+        respect_custom_repr: If true, plain classes with custom ``__repr__``
+            are treated as values. ``doc()`` disables this to retain type docs.
 
     Returns False for:
     - Types (classes themselves)
@@ -431,16 +459,21 @@ def _is_structured_instance(obj: Any) -> bool:
     if obj_type.__module__ == "builtins":
         return False
 
-    # If the class defines its own __repr__ (not inherited from object),
-    # trust the library author's representation over field extraction.
-    for klass in obj_type.__mro__:
-        if klass is object:
-            break
-        if "__repr__" in klass.__dict__:
-            return False
+    # pformat() respects a custom __repr__, while doc() always renders the
+    # type-level API contract and augments it with runtime instance fields.
+    if respect_custom_repr:
+        for klass in obj_type.__mro__:
+            if klass is object:
+                break
+            if "__repr__" in klass.__dict__:
+                return False
 
-    # __slots__-only classes have no __dict__ but do have public slots
-    if not hasattr(obj, "__dict__"):
+    # In doc mode, every non-builtin instance is documentable even when an
+    # empty/private-only __slots__ leaves it with no runtime values. pformat()
+    # still requires a public slot before choosing structured value rendering.
+    if _instance_dict(obj) is None:
+        if not respect_custom_repr:
+            return True
         return any(
             slot
             for klass in obj_type.__mro__
@@ -462,6 +495,7 @@ def _format_type_info(
     indent: int,
     context_obj: type | None = None,
     instance_values: dict[str, Any] | None = None,
+    visibility_obj: Any = None,
 ) -> str:
     """Format TypeInfo as Python class syntax.
 
@@ -482,6 +516,7 @@ def _format_type_info(
         instance_values: Runtime instance values to show instead of static defaults.
             When provided, field values come from this dict (current state)
             rather than from field.default (source code defaults).
+        visibility_obj: Instance whose field-level visibility overrides apply.
 
     Returns:
         Python-style class definition string
@@ -551,8 +586,6 @@ def _format_type_info(
         # Skip fields marked repr=False (Pydantic field parameter — intentionally hidden)
         if not field.repr:
             continue
-        if instance_values is not None and field.name not in instance_values:
-            continue
         line = f"{ind}    {field.name}: {field.type}"
         if instance_values is not None and field.name in instance_values:
             default_str = _format_value_to_str(
@@ -565,7 +598,7 @@ def _format_type_info(
                 indent=0,
             )
             line += f" = {default_str}"
-        elif instance_values is None and field.default is not ...:
+        elif field.default is not ...:
             default_str = _format_value_to_str(
                 field.default,
                 max_length=3,
@@ -596,7 +629,8 @@ def _format_type_info(
                 continue
             if name.startswith("_"):
                 continue
-            if context_obj is not None and _is_hidden_field(context_obj, name):
+            visibility_target = visibility_obj if visibility_obj is not None else context_obj
+            if visibility_target is not None and _is_hidden_field(visibility_target, name):
                 continue
             # Skip callables unless they're classes
             if callable(value) and not isinstance(value, type):
@@ -661,8 +695,14 @@ def _format_type_info(
         )
         from nooa.agentdoc._structured import extract_type_info
 
+        visible_field_names = {field.name for field in info.fields}
         seed_set: set[type] = {
-            t for t in discover_referenced_types(context_obj) if not is_expand_false(t)
+            t
+            for t in discover_referenced_types(
+                context_obj,
+                field_names=visible_field_names if visibility_obj is not None else None,
+            )
+            if not is_expand_false(t)
         }
 
         # Also discover types from extra instance attributes
@@ -671,6 +711,8 @@ def _format_type_info(
 
             for name, value in instance_values.items():
                 if name.startswith("_"):
+                    continue
+                if visibility_obj is not None and _is_hidden_field(visibility_obj, name):
                     continue
                 # Skip callables unless they're classes
                 if callable(value) and not isinstance(value, type):
@@ -1043,7 +1085,7 @@ def _format_instance_repr(
         if field.name in values:
             value = values[field.name]
         else:
-            _obj_dict = getattr(obj, "__dict__", None)
+            _obj_dict = _instance_dict(obj)
             if _obj_dict is not None and field.name in _obj_dict:
                 value = _obj_dict[field.name]
             else:
@@ -1077,7 +1119,7 @@ def _format_instance_repr(
         field_count += 1
 
     # Add non-field attributes from __dict__ (skip hidden so they are not re-added)
-    if hasattr(obj, "__dict__"):
+    if _instance_dict(obj) is not None:
         from nooa.agentdoc._visibility import is_hidden_field as _is_hidden_field
 
         for name, value in sorted(values.items()):
@@ -1154,7 +1196,7 @@ def _extract_instance_values(obj: Any, type_info: TypeInfo) -> dict[str, Any]:
             if getattr(field_info, "exclude", False)
         }
 
-    obj_dict = getattr(obj, "__dict__", None) or {}
+    obj_dict = _instance_dict(obj) or {}
 
     # Collect slot names for __slots__-based classes (no __dict__)
     _slots: set[str] = set()
@@ -1172,11 +1214,15 @@ def _extract_instance_values(obj: Any, type_info: TypeInfo) -> dict[str, Any]:
         if field.name in obj_dict:
             values[field.name] = obj_dict[field.name]
         elif field.name in _slots:
-            # __slots__ values are safe to read — they're data, not descriptors.
-            try:
-                values[field.name] = object.__getattribute__(obj, field.name)
-            except AttributeError:
-                pass
+            # A subclass may replace an inherited slot with an arbitrary
+            # descriptor. Only invoke the concrete member descriptor found by
+            # static lookup; properties and custom descriptors are not safe.
+            slot_descriptor = inspect.getattr_static(obj_type, field.name, _MISSING)
+            if inspect.ismemberdescriptor(slot_descriptor):
+                try:
+                    values[field.name] = slot_descriptor.__get__(obj, obj_type)
+                except AttributeError:
+                    pass
         elif isinstance(obj, dict) and field.name in obj:
             # TypedDict instances are dicts
             values[field.name] = obj[field.name]
@@ -1192,18 +1238,33 @@ def _extract_instance_values(obj: Any, type_info: TypeInfo) -> dict[str, Any]:
             ):
                 values[field.name] = class_val
 
-    # Also include all __dict__ attributes (for instances without annotations)
-    if hasattr(obj, "__dict__"):
-        from nooa.agentdoc._visibility import is_hidden_field as _is_hidden_field
+    # Also include runtime-only attributes that are not declared type fields.
+    # Most objects store them in __dict__; Pydantic models with extra="allow"
+    # store them separately in __pydantic_extra__.
+    from nooa.agentdoc._visibility import is_hidden_field as _is_hidden_field
 
-        for name, value in obj.__dict__.items():
-            if (
-                name not in values
-                and not name.startswith("_")
-                and not callable(value)
-                and not _is_hidden_field(obj_type, name)
-                and name not in _excluded_fields
-            ):
+    def _include_dynamic(name: str, value: Any) -> bool:
+        return (
+            name not in values
+            and not name.startswith("_")
+            and not callable(value)
+            and not _is_hidden_field(obj, name)
+            and name not in _excluded_fields
+        )
+
+    for name, value in obj_dict.items():
+        if _include_dynamic(name, value):
+            values[name] = value
+
+    pydantic_extra = None
+    if hasattr(obj_type, "model_fields"):
+        try:
+            pydantic_extra = object.__getattribute__(obj, "__pydantic_extra__")
+        except AttributeError:
+            pass
+    if isinstance(pydantic_extra, dict):
+        for name, value in pydantic_extra.items():
+            if _include_dynamic(name, value):
                 values[name] = value
 
     return values

--- a/src/nooa/agentdoc/_pformat.py
+++ b/src/nooa/agentdoc/_pformat.py
@@ -705,6 +705,7 @@ def _format_type_info(
             discover_referenced_types,
         )
         from nooa.agentdoc._structured import extract_type_info
+        from nooa.agentdoc._visibility import is_hidden_field as _is_hidden_field
 
         visible_field_names = {field.name for field in info.fields}
         seed_set: set[type] = {

--- a/src/nooa/agentdoc/_pformat.py
+++ b/src/nooa/agentdoc/_pformat.py
@@ -81,18 +81,16 @@ def _resolve_field_type_by_name(type_name: str, context_obj: type | None) -> typ
     return None
 
 
-def _collect_referenced_types_transitive(
+def _collect_referenced_types(
     seed_types: set[type],
+    *,
     exclude: type | None = None,
+    max_depth: int,
 ) -> list[type]:
-    """Collect all referenced types transitively via BFS, deduplicated and sorted.
+    """Collect referenced types with bounded breadth-first traversal.
 
-    Args:
-        seed_types: Initial set of types to start from (already filtered).
-        exclude: Primary type to exclude from results (avoid self-reference).
-
-    Returns:
-        Sorted list of all reachable custom types (no duplicates).
+    ``seed_types`` are the direct references (depth 1). Each subsequent level
+    follows references from the preceding level until ``max_depth`` is reached.
     """
     from nooa.agentdoc._discover import discover_referenced_types
 
@@ -101,15 +99,21 @@ def _collect_referenced_types_transitive(
     # own method signatures (common, e.g. DataFrame methods returning DataFrame) must
     # not list itself under "Referenced Types".
     frontier = {t for t in seed_types if t is not exclude}
-    while frontier:
+    for _ in range(max_depth):
+        if not frontier:
+            break
         all_types.update(frontier)
         next_frontier: set[type] = set()
-        for t in frontier:
-            for new_t in discover_referenced_types(t):
-                if new_t not in all_types and not is_expand_false(new_t) and new_t is not exclude:
-                    next_frontier.add(new_t)
+        for ref_type in frontier:
+            for new_type in discover_referenced_types(ref_type):
+                if (
+                    new_type not in all_types
+                    and not is_expand_false(new_type)
+                    and new_type is not exclude
+                ):
+                    next_frontier.add(new_type)
         frontier = next_frontier
-    return sorted(all_types, key=lambda t: t.__name__)
+    return sorted(all_types, key=lambda type_: type_.__name__)
 
 
 def _field_type_docstring(
@@ -739,8 +743,10 @@ def _format_type_info(
                 if _is_custom_type(extra_type) and not is_expand_false(extra_type):
                     seed_set.add(extra_type)
 
-        # Collect all referenced types transitively (BFS), render flat
-        referenced_types = _collect_referenced_types_transitive(seed_set, exclude=context_obj)
+        # Collect referenced types to the requested depth, then render them flat.
+        referenced_types = _collect_referenced_types(
+            seed_set, exclude=context_obj, max_depth=type_depth
+        )
         if referenced_types:
             lines.append(f"{ind}## Referenced Types")
 
@@ -826,7 +832,9 @@ def _format_callable_info(
         from nooa.agentdoc._structured import extract_type_info
 
         seed_set = {t for t in discover_referenced_types(context_obj) if not is_expand_false(t)}
-        referenced_types = _collect_referenced_types_transitive(seed_set, exclude=context_obj)
+        referenced_types = _collect_referenced_types(
+            seed_set, exclude=context_obj, max_depth=type_depth
+        )
 
         if referenced_types:
             lines.append("")

--- a/src/nooa/agentdoc/_pformat.py
+++ b/src/nooa/agentdoc/_pformat.py
@@ -213,7 +213,14 @@ def _pformat(
                 from nooa.agentdoc._structured import extract_module_info
 
                 module_info = extract_module_info(_object)
-            _stream.write(_format_module_info(module_info, concise=concise, indent=_indent))
+            _stream.write(
+                _format_module_info(
+                    module_info,
+                    concise=concise,
+                    concise_members=bool(getattr(_object, "__agentdoc_concise_members__", False)),
+                    indent=_indent,
+                )
+            )
         case _ if inspect.isfunction(_object) or inspect.ismethod(_object):
             from nooa.agentdoc._structured import extract_callable_info
 
@@ -841,12 +848,19 @@ def _format_callable_info(
     return re.sub(r"\n{3,}", "\n\n", "\n".join(lines)).rstrip("\n")
 
 
-def _format_module_info(info: ModuleInfo, *, concise: bool, indent: int) -> str:
+def _format_module_info(
+    info: ModuleInfo,
+    *,
+    concise: bool,
+    concise_members: bool = False,
+    indent: int,
+) -> str:
     """Format ModuleInfo as Python module syntax.
 
     Args:
         info: ModuleInfo to format
-        concise: If True, show first-line docstrings only
+        concise: If True, show only the first line of every docstring
+        concise_members: If True, keep the module docstring but shorten member docs
         indent: Indentation level
 
     Returns:
@@ -913,7 +927,9 @@ def _format_module_info(info: ModuleInfo, *, concise: bool, indent: int) -> str:
                 lines.append("")
                 in_value_run = False
             func = func_map[sym_name]
-            func_lines = _format_callable_info(func, concise=concise, indent=indent)
+            func_lines = _format_callable_info(
+                func, concise=concise or concise_members, indent=indent
+            )
             lines.append(func_lines)
             lines.append("")
         elif sym_name in val_map:

--- a/src/nooa/agentdoc/_visibility.py
+++ b/src/nooa/agentdoc/_visibility.py
@@ -31,12 +31,9 @@ def _is_dunder(name: str) -> bool:
 
 
 class _Hidden:
-    """Exclude fields, methods, or imports from documentation.
+    """Hide a field, callable, or module-level name from documentation.
 
-    Works in three roles:
-    1. Decorator: @hidden on functions (module-level or methods)
-    2. Annotation marker: Annotated[T, hidden] on variables (module-level or fields)
-    3. Context manager: ``with hidden:`` — names defined in the block are hidden at module level
+    Use as ``@hidden``, ``Annotated[T, hidden]``, or ``with hidden:``.
     """
 
     def __init__(self):

--- a/src/nooa/agentdoc/core.py
+++ b/src/nooa/agentdoc/core.py
@@ -60,10 +60,12 @@ def doc(
 
         doc(MyAgent)          # label: str = "agent"
 
-    Passing an **instance** shows the current field values in place of defaults::
+    Passing an **instance** preserves the type-level documentation, replaces
+    defaults with available current values, and adds public runtime-only fields::
 
         agent = MyAgent(label="prod")
-        doc(agent)            # label: str = "prod"
+        agent.region = "us-east"
+        doc(agent)            # label: str = "prod"; region: str = "us-east"
 
     Respects ``@spec(expand=False)`` on field types — those are collapsed to a
     one-liner instead of being expanded inline.
@@ -130,10 +132,15 @@ def _doc_multiple(
     sections: list[str] = []
     seen_types: set[type] = set()
 
-    # Track which objects are types for deduplication
+    # Track primary contract types for deduplication. Instances document their
+    # type API, so their types must not reappear under Referenced Types.
     for obj in objs:
         if isinstance(obj, type):
             seen_types.add(obj)
+        elif not (inspect.isfunction(obj) or inspect.ismethod(obj) or inspect.ismodule(obj)):
+            obj_type = type(obj)
+            if obj_type.__module__ != "builtins":
+                seen_types.add(obj_type)
 
     # 1. Format each primary object (without their own referenced types section)
     for obj in objs:

--- a/src/nooa/agentdoc/core.py
+++ b/src/nooa/agentdoc/core.py
@@ -60,12 +60,18 @@ def doc(
 
         doc(MyAgent)          # label: str = "agent"
 
-    Passing an **instance** preserves the type-level documentation, replaces
-    defaults with available current values, and adds public runtime-only fields::
+    Passing an **instance** preserves declared fields, methods, properties,
+    docstrings, and referenced types. Available current values replace defaults,
+    and public runtime-only fields are added::
 
         agent = MyAgent(label="prod")
         agent.region = "us-east"
         doc(agent)            # label: str = "prod"; region: str = "us-east"
+
+    Instance visibility overrides from ``spec(instance, field, hidden=...)`` are
+    applied. Properties are documented without being evaluated. Unlike
+    ``pformat()``, instance documentation ignores a custom ``__repr__`` so that
+    the API contract remains visible.
 
     Respects ``@spec(expand=False)`` on field types — those are collapsed to a
     one-liner instead of being expanded inline.

--- a/src/nooa/agentdoc/core.py
+++ b/src/nooa/agentdoc/core.py
@@ -46,9 +46,9 @@ def doc(
     *objs: Any,
     concise: Annotated[bool, "Show first-line docstrings only"] = False,
     inline_depth: Annotated[
-        int | None,
-        "Levels of referenced types to expand inline; 0 = none, 1 = direct (default), 2+ = transitive; None = auto",
-    ] = None,
+        int,
+        "Levels of referenced types to expand inline; 0 = none, 1 = direct (default), 2+ = transitive",
+    ] = 1,
 ) -> str:
     """Render prompt-ready API documentation for one or more Python objects.
 
@@ -64,7 +64,8 @@ def doc(
             ``doc([A, B])``.
         concise: Show only the first line of each docstring.
         inline_depth: Referenced-type depth. ``0`` disables expansion, ``1``
-            includes direct references, and ``None`` chooses the default.
+            includes direct references (the default), and ``2+`` includes
+            transitive references to that depth.
 
     Returns:
         The formatted API documentation.
@@ -81,9 +82,10 @@ def doc(
     if not flat_objs:
         raise ValueError("doc() requires at least one object")
 
-    # Resolve inline_depth default based on concise
-    if inline_depth is None:
-        inline_depth = 0 if concise else 1
+    if not isinstance(inline_depth, int) or isinstance(inline_depth, bool):
+        raise TypeError("inline_depth must be a non-negative integer")
+    if inline_depth < 0:
+        raise ValueError("inline_depth must be a non-negative integer")
 
     # Single object: use optimized path
     if len(flat_objs) == 1:
@@ -367,7 +369,7 @@ def variables(
             # For classes, use doc(concise=True) to get a nice summary
             if inspect.isclass(attr):
                 class_name = attr.__name__
-                value_str = doc(attr, concise=True)
+                value_str = doc(attr, concise=True, inline_depth=0)
                 line = f"{name}: type[{class_name}] = {value_str}"
 
                 # Append hint within the existing comment if present

--- a/src/nooa/agentdoc/core.py
+++ b/src/nooa/agentdoc/core.py
@@ -50,40 +50,24 @@ def doc(
         "Levels of referenced types to expand inline; 0 = none, 1 = direct (default), 2+ = transitive; None = auto",
     ] = None,
 ) -> str:
-    """Get the documentation for one or more objects — step 2: render the API contract.
+    """Render prompt-ready API documentation for one or more Python objects.
 
-    Renders the API contract of a class, function, module, or instance as a
-    prompt-ready string. Referenced types are expanded inline and deduplicated
-    across all objects passed.
+    Types show their declared API and defaults. Instances show that same contract
+    enriched with current values and public runtime fields. Visibility rules are
+    honored, properties stay unevaluated, and custom ``__repr__`` methods never
+    hide the API.
 
-    Passing a **type** shows default field values::
-
-        doc(MyAgent)          # label: str = "agent"
-
-    Passing an **instance** preserves declared fields, methods, properties,
-    docstrings, and referenced types. Available current values replace defaults,
-    and public runtime-only fields are added::
-
-        agent = MyAgent(label="prod")
-        agent.region = "us-east"
-        doc(agent)            # label: str = "prod"; region: str = "us-east"
-
-    Instance visibility overrides from ``spec(instance, field, hidden=...)`` are
-    applied. Properties are documented without being evaluated. Unlike
-    ``pformat()``, instance documentation ignores a custom ``__repr__`` so that
-    the API contract remains visible.
-
-    Respects ``@spec(expand=False)`` on field types — those are collapsed to a
-    one-liner instead of being expanded inline.
+    Referenced types are expanded inline and deduplicated across the result.
 
     Args:
-        *objs: One or more objects: doc(MyClass), doc(Class, fn), doc([A, B])
-        concise: Show first-line docstrings only.
-        inline_depth: Levels of referenced types to expand inline (default 1).
-            0 = none, 1 = direct references, 2+ = transitive. None = auto.
+        *objs: Objects to document: ``doc(MyClass)``, ``doc(Class, fn)``, or
+            ``doc([A, B])``.
+        concise: Show only the first line of each docstring.
+        inline_depth: Referenced-type depth. ``0`` disables expansion, ``1``
+            includes direct references, and ``None`` chooses the default.
 
     Returns:
-        Formatted documentation string with each type appearing exactly once.
+        The formatted API documentation.
     """
     # Flatten input: handle lists/tuples passed as single argument
     # Only flatten if the list/tuple contains documentable objects (types, callables, modules)

--- a/src/nooa/agentdoc/protocols.py
+++ b/src/nooa/agentdoc/protocols.py
@@ -82,10 +82,12 @@ class SupportsCallableInfo(Protocol):
 
 @runtime_checkable
 class SupportsInstanceValues(Protocol):
-    """Protocol for instances that control their value extraction.
+    """Protocol for instances that control runtime value extraction.
 
-    Implement this to control which field values are shown when an instance
-    is documented (e.g., to hide internal state).
+    Implement this to control which current values are shown. In ``doc()``,
+    fields omitted from this mapping remain part of the type-level API contract;
+    use ``hidden`` or ``spec(..., hidden=True)`` to hide documented fields.
+    In ``pformat()``, omitted fields are excluded from the value representation.
 
     Example:
         class MyClass:
@@ -93,15 +95,15 @@ class SupportsInstanceValues(Protocol):
                 return {
                     "id": self.id,
                     "status": self.status,
-                    # Hide internal fields by not including them
                 }
     """
 
     def __instance_values__(self) -> dict[str, Any]:
-        """Return instance values for documentation.
+        """Return current instance values for documentation and formatting.
 
         Returns:
-            Dictionary mapping field names to their current values.
-            Fields not in the dict will use their default values.
+            Dictionary mapping field names to their current values. In
+            ``doc()``, omitted fields retain their type-level defaults; in
+            ``pformat()``, omitted fields are not rendered.
         """
         ...

--- a/src/nooa/errors/formatting.py
+++ b/src/nooa/errors/formatting.py
@@ -172,7 +172,7 @@ def _bad_call_agentdoc(error: Exception) -> str | None:
             return None
         from nooa.agentdoc import doc
 
-        rendered = doc(target, concise=True)
+        rendered = doc(target, concise=True, inline_depth=0)
         return str(rendered).strip() or None
     except Exception:
         return None

--- a/tests/agentdoc/test_annotated_params.py
+++ b/tests/agentdoc/test_annotated_params.py
@@ -210,6 +210,24 @@ class TestCallableInstanceAnnotatedParams:
         else:
             raise AssertionError("spec() function not found in doc(agentdoc)")
 
+    def test_agentdoc_module_documents_instance_contract(self):
+        """doc(agentdoc) explains the type-contract and value-view distinction."""
+        from nooa import agentdoc
+
+        result = doc(agentdoc)
+        assert "same contract + current values and public runtime fields" in result
+        assert "documents the type structure even when" in result
+        assert "properties are not evaluated" in result
+
+    def test_doc_documents_complete_instance_behavior(self):
+        """doc(doc) exposes the complete public contract for instance rendering."""
+        result = doc(doc)
+        assert "preserves declared fields, methods, properties" in result
+        assert "public runtime-only fields are added" in result
+        assert "spec(instance, field, hidden=...)" in result
+        assert "Properties are documented without being evaluated" in result
+        assert "ignores a custom ``__repr__``" in result
+
 
 # ---------------------------------------------------------------------------
 # _extract_dataclass_fields directly

--- a/tests/agentdoc/test_annotated_params.py
+++ b/tests/agentdoc/test_annotated_params.py
@@ -219,7 +219,7 @@ class TestCallableInstanceAnnotatedParams:
         assert "doc(Assistant)" in result
         assert "doc(assistant)" in result
         assert "pformat(assistant)" in result
-        assert len(result.splitlines()) <= 140
+        assert 40 <= len(result.splitlines()) <= 60
 
     def test_doc_explains_instance_contract(self):
         """doc(doc) captures the essential instance-rendering guarantees."""

--- a/tests/agentdoc/test_annotated_params.py
+++ b/tests/agentdoc/test_annotated_params.py
@@ -228,7 +228,10 @@ class TestCallableInstanceAnnotatedParams:
         assert "current values and public runtime fields" in result
         assert "properties stay unevaluated" in result
         assert "custom ``__repr__`` methods never" in result
-        assert len(result.splitlines()) <= 24
+        assert "inline_depth: int = 1" in result
+        assert "``2+`` includes" in result
+        assert "inline_depth: int | None" not in result
+        assert len(result.splitlines()) <= 25
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agentdoc/test_annotated_params.py
+++ b/tests/agentdoc/test_annotated_params.py
@@ -210,23 +210,25 @@ class TestCallableInstanceAnnotatedParams:
         else:
             raise AssertionError("spec() function not found in doc(agentdoc)")
 
-    def test_agentdoc_module_documents_instance_contract(self):
-        """doc(agentdoc) explains the type-contract and value-view distinction."""
+    def test_agentdoc_module_presents_type_and_value_views(self):
+        """doc(agentdoc) gives a concise, runnable mental model."""
         from nooa import agentdoc
 
         result = doc(agentdoc)
-        assert "same contract + current values and public runtime fields" in result
-        assert "documents the type structure even when" in result
-        assert "properties are not evaluated" in result
+        assert "Show an agent what an object can do" in result
+        assert "doc(Assistant)" in result
+        assert "doc(assistant)" in result
+        assert "pformat(assistant)" in result
+        assert len(result.splitlines()) <= 140
 
-    def test_doc_documents_complete_instance_behavior(self):
-        """doc(doc) exposes the complete public contract for instance rendering."""
+    def test_doc_explains_instance_contract(self):
+        """doc(doc) captures the essential instance-rendering guarantees."""
         result = doc(doc)
-        assert "preserves declared fields, methods, properties" in result
-        assert "public runtime-only fields are added" in result
-        assert "spec(instance, field, hidden=...)" in result
-        assert "Properties are documented without being evaluated" in result
-        assert "ignores a custom ``__repr__``" in result
+        assert "same contract" in result
+        assert "current values and public runtime fields" in result
+        assert "properties stay unevaluated" in result
+        assert "custom ``__repr__`` methods never" in result
+        assert len(result.splitlines()) <= 24
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agentdoc/test_contracts.py
+++ b/tests/agentdoc/test_contracts.py
@@ -9,9 +9,9 @@ writing the fix is the correct workflow.
 Contracts covered:
 - @hidden/@spec on @classmethod/@staticmethod works regardless of decorator order
 - _private methods are hidden by default; @spec(hidden=False) opts them back in
-- Fields absent from instance.__dict__ do not appear in doc(instance)
-- Properties that succeed on a live instance appear in doc(instance)
-- Properties that raise on access are silently omitted from doc(instance)
+- doc(instance) preserves type-level fields and augments them with runtime values
+- Properties appear in doc(instance) without being evaluated
+- Properties that raise on access remain documented without being evaluated
 - with hidden: raises RuntimeError when used inside a function or class body
 - Class annotation + @property on same name does not leak <property object at 0x...>
 - doc(instance) produces at most one blank line between docstring and first method
@@ -64,10 +64,10 @@ class TestHiddenOnProperty:
                 return "hi"
 
         assert "secret" not in doc(MyClass())
-        # Properties no longer show on instance formatting (only on Type).
-        # Instance formatting reads __dict__ only to avoid blocking I/O.
-        assert "visible" not in doc(MyClass())
-        # But properties DO show on the class (type introspection, no execution):
+        # Instance documentation retains type-level property metadata without
+        # invoking the descriptor.
+        assert "visible" in doc(MyClass())
+        # Properties also show on the class (type introspection, no execution):
         assert "visible" in doc(MyClass)
 
 
@@ -228,24 +228,21 @@ class TestPrivateMethodVisibility:
 
 
 # ---------------------------------------------------------------------------
-# 3. Instance fields: absent from __dict__ → absent from doc(instance)
+# 3. Instance fields: type declarations are preserved and runtime values augment them
 # ---------------------------------------------------------------------------
 
 
 class TestInstanceFieldAbsence:
-    """Fields not present in instance.__dict__ must not appear in doc(instance).
-    Showing them with no value would imply they are required/unset, which is wrong.
-    doc(Type) always shows class-level defaults regardless.
-    """
+    """doc(instance) retains type fields and overlays available runtime values."""
 
-    def test_absent_field_not_shown_in_instance_doc(self):
-        # Annotation-only (no class-level default) — getattr raises AttributeError
-        # on a bare __new__ instance, so it won't be in instance_values.
+    def test_absent_field_preserved_in_instance_doc(self):
+        # Annotation-only fields remain documented even when a bare instance
+        # has no corresponding runtime value.
         class MyClass:
             x: int  # no class-level default; only set in __init__
 
         inst = MyClass.__new__(MyClass)
-        assert "x" not in doc(inst)
+        assert "x: int" in doc(inst)
 
     def test_present_field_shown_in_instance_doc(self):
         class MyClass:
@@ -277,8 +274,8 @@ class TestInstanceFieldAbsence:
         assert "x" in out
         assert "y" in out
 
-    def test_partial_fields_shown(self):
-        """Only the fields actually accessible on the instance are shown."""
+    def test_partial_runtime_fields_preserve_type_contract(self):
+        """Missing runtime values do not remove declared type fields."""
 
         class MyClass:
             x: int  # annotation only — absent unless set
@@ -288,9 +285,9 @@ class TestInstanceFieldAbsence:
         inst = MyClass.__new__(MyClass)
         inst.y = 99
         out = doc(inst)
-        assert "x" not in out
-        assert "y" in out
-        assert "z" not in out
+        assert "x: int" in out
+        assert "y: int = 99" in out
+        assert "z: int" in out
 
 
 # ---------------------------------------------------------------------------
@@ -299,11 +296,9 @@ class TestInstanceFieldAbsence:
 
 
 class TestPropertyInInstanceDoc:
-    """Properties on live instances must appear in doc(instance).
-    Properties that raise on access must be silently omitted (not crash).
-    """
+    """Properties remain documented on instances without descriptor execution."""
 
-    def test_working_property_not_shown_on_instance(self):
+    def test_working_property_shown_without_evaluation(self):
         # Properties no longer execute on instance formatting (prevents blocking I/O).
         class MyClass:
             @property
@@ -312,11 +307,11 @@ class TestPropertyInInstanceDoc:
                 return "hello"
 
         out = doc(MyClass())
-        assert "value" not in out
-        # But they DO show on the type:
+        assert "value" in out
+        # The instance keeps the same property documentation as the type.
         assert "value" in doc(MyClass)
 
-    def test_property_value_not_included_on_instance(self):
+    def test_property_value_not_evaluated_on_instance(self):
         # Property values are not computed during instance formatting.
         class MyClass:
             @property
@@ -327,7 +322,7 @@ class TestPropertyInInstanceDoc:
         out = doc(MyClass())
         assert "42" not in out
 
-    def test_raising_property_silently_omitted(self):
+    def test_raising_property_remains_documented(self):
         class MyClass:
             @property
             def broken(self) -> str:
@@ -335,7 +330,7 @@ class TestPropertyInInstanceDoc:
                 raise RuntimeError("not initialised")
 
         out = doc(MyClass())
-        assert "broken" not in out
+        assert "broken" in out
 
     def test_raising_property_does_not_crash(self):
         class MyClass:
@@ -760,19 +755,19 @@ class TestPropertyContract:
         out = doc(PropClass)
         assert "hidden_inner" not in out
 
-    def test_doc_instance_omits_computed_property(self):
+    def test_doc_instance_documents_computed_property(self):
         """doc(instance): computed properties are not executed (prevents blocking I/O)."""
         PropClass = self._make_class()
         obj = PropClass(5)
         out = doc(obj)
-        assert "computed" not in out
+        assert "computed" in out
 
-    def test_doc_instance_omits_raising_property(self):
-        """doc(instance): raising property is silently omitted."""
+    def test_doc_instance_documents_raising_property(self):
+        """doc(instance): raising properties are documented without evaluation."""
         PropClass = self._make_class()
         obj = PropClass(5)
         out = doc(obj)
-        assert "raises_always" not in out
+        assert "raises_always" in out
 
     def test_doc_instance_hides_hidden_outer(self):
         """doc(instance): @hidden @property hides the property."""
@@ -815,12 +810,12 @@ class TestPropertyContract:
         out = doc(PropClass)
         assert "@property" not in out
 
-    def test_doc_instance_omits_property_docstring(self):
-        """doc(instance): properties are not shown (prevents blocking I/O)."""
+    def test_doc_instance_includes_property_docstring(self):
+        """doc(instance): property docs are shown without accessing the property."""
         PropClass = self._make_class()
         obj = PropClass(5)
         out = doc(obj)
-        assert "# A computed value." not in out
+        assert "# A computed value." in out
 
     def test_doc_instance_no_at_property_prefix(self):
         """doc(instance) must not prefix property descriptions with '@property —'."""
@@ -888,14 +883,14 @@ class TestCachedPropertyContract:
         out = doc(CP)
         assert "hidden_inner" not in out
 
-    def test_doc_instance_omits_uncached_property(self):
+    def test_doc_instance_documents_uncached_property(self):
         # cached_property only shows if already cached (in __dict__).
         # First access caches it; before that, it's a descriptor.
         CP = self._make_class()
         obj = CP(5)
-        # Before accessing .expensive, it's not in __dict__
+        # Before accessing .expensive, its type-level declaration is still shown.
         out = doc(obj)
-        assert "expensive" not in out
+        assert "expensive" in out
         # After access, it's cached in __dict__ and WILL show:
         _ = obj.expensive
         out2 = doc(obj)

--- a/tests/agentdoc/test_core.py
+++ b/tests/agentdoc/test_core.py
@@ -65,6 +65,138 @@ class TestDoc:
         assert "def " in result  # Methods shown as def statements
         assert "counter" in result  # Variables shown as attributes
 
+    def test_doc_instance_preserves_type_docs_and_adds_dynamic_fields(self):
+        """Issue #199: instance docs augment, rather than replace, type docs."""
+
+        class Documented:
+            """A documented class."""
+
+            required: int
+            configured: str = "default"
+
+            @property
+            def status(self) -> str:
+                """Current status."""
+                raise AssertionError("doc() must not evaluate properties")
+
+            def run(self, count: int) -> bool:
+                """Run the operation."""
+                return count > 0
+
+            def __repr__(self) -> str:
+                return "custom-repr"
+
+        instance = Documented.__new__(Documented)
+        instance.configured = "runtime"
+        instance.dynamic = 42
+
+        type_output = doc(Documented)
+        instance_output = doc(instance)
+
+        # Every type-level declaration remains represented on the instance.
+        for snippet in (
+            "class Documented:",
+            "A documented class.",
+            "required: int",
+            "status: str",
+            "def run(self, count: int) -> bool:",
+            "Run the operation.",
+        ):
+            assert snippet in type_output
+            assert snippet in instance_output
+
+        # Current declared values and instance-only state augment that contract.
+        assert "configured: str = 'runtime'" in instance_output
+        assert "dynamic: int = 42" in instance_output
+        assert "custom-repr" not in instance_output
+
+    def test_doc_instance_includes_pydantic_extra_fields(self):
+        """Pydantic extra fields are runtime-only state outside __dict__."""
+        from pydantic import BaseModel, ConfigDict
+
+        class Model(BaseModel):
+            model_config = ConfigDict(extra="allow")
+            label: str = "default"
+
+        instance = Model(label="runtime")
+        instance.dynamic = 42
+
+        output = doc(instance)
+        assert "label: str = 'runtime'" in output
+        assert "dynamic: int = 42" in output
+        assert "dynamic" not in doc(Model)
+
+    def test_doc_instance_preserves_pydantic_constraints(self):
+        """Pydantic constraints remain documented when rendering an instance."""
+        from typing import Annotated
+
+        from pydantic import BaseModel, Field
+
+        class Limits(BaseModel):
+            percentage: int = Field(default=50, gt=0, lt=100, description="Percentage")
+            count: int = Field(ge=1, le=10)
+            code: str = Field(min_length=2, max_length=5, pattern=r"^[A-Z]+$")
+            score: Annotated[float, Field(gt=0.0, le=1.0)] = 0.5
+
+        output = doc(Limits(count=2, code="OK"))
+
+        assert "percentage: int = 50  # Percentage [>0, <100]" in output
+        assert "count: int = 2  # [≥1, ≤10]" in output
+        assert "code: str = 'OK'  # [min_len=2, max_len=5, pattern='^[A-Z]+$']" in output
+        assert "score: float = 0.5  # [>0.0, ≤1.0]" in output
+
+    def test_doc_instance_respects_instance_hidden_dynamic_field(self):
+        """Instance-only fields hidden with spec() must not leak from doc()."""
+        from nooa.agentdoc import spec
+
+        class Documented:
+            pass
+
+        instance = Documented()
+        instance.public = "shown"
+        instance.secret = "SECRET"
+        spec(instance, "secret", hidden=True)
+
+        output = doc(instance)
+        assert "public: str = 'shown'" in output
+        assert "secret" not in output
+        assert "SECRET" not in output
+
+    def test_doc_instance_respects_instance_hidden_declared_field(self):
+        """Instance visibility overrides also apply to declared fields."""
+        from nooa.agentdoc import spec
+
+        class Documented:
+            visible: str = "class-secret"
+
+        instance = Documented()
+        instance.visible = "runtime-secret"
+        spec(instance, "visible", hidden=True)
+
+        output = doc(instance)
+        assert "visible" not in output
+        assert "runtime-secret" not in output
+        assert "class-secret" not in output
+
+    def test_doc_instance_does_not_invoke_descriptor_over_inherited_slot(self):
+        """Static slot extraction must not execute an overriding descriptor."""
+
+        class Base:
+            __slots__ = ("value",)
+
+        class Child(Base):
+            @property
+            def value(self) -> str:
+                raise AssertionError("doc() must not evaluate descriptors")
+
+            def __repr__(self) -> str:
+                return "custom-repr"
+
+        output = doc(Child())
+        assert "class Child:" in output
+        assert "value: str" in output
+        assert "custom-repr" not in output
+
     def test_doc_includes_methods(self):
         """Test doc() includes method signatures."""
         obj = SimpleClass()
@@ -853,8 +985,8 @@ class TestLargeValueTruncation:
         assert "data:" in result
         assert "str(len=100000," in result
 
-    def test_doc_on_class_with_repr_uses_repr(self):
-        """Classes with custom __repr__ should use repr(), not field extraction."""
+    def test_doc_on_class_with_repr_preserves_type_docs(self):
+        """doc(instance) ignores custom repr so it can preserve the type contract."""
 
         class WithRepr:
             def __init__(self):
@@ -864,11 +996,50 @@ class TestLargeValueTruncation:
                 return "custom_repr_sentinel"
 
         result = doc(WithRepr())
-        assert "custom_repr_sentinel" in result
-        assert "hidden" not in result
+        assert "class WithRepr:" in result
+        assert "hidden: str = 'not extracted'" in result
+        assert "custom_repr_sentinel" not in result
 
-    def test_slots_class_with_repr_uses_repr(self):
-        """__slots__-only classes with __repr__ should also trust repr()."""
+    def test_doc_empty_slots_class_with_repr_preserves_type_docs(self):
+        """doc() renders APIs for custom-repr classes with no public slots."""
+
+        class EmptySlots:
+            __slots__ = ()
+
+            def work(self, value: int) -> str:
+                """Do documented work."""
+                return str(value)
+
+            def __repr__(self) -> str:
+                return "EMPTY-SLOTS-REPR"
+
+        result = doc(EmptySlots())
+        assert "class EmptySlots:" in result
+        assert "def work(self, value: int) -> str:" in result
+        assert "Do documented work." in result
+        assert "EMPTY-SLOTS-REPR" not in result
+        assert pformat(EmptySlots()) == "EMPTY-SLOTS-REPR"
+
+    def test_doc_plain_class_does_not_probe_storage_via_getattr(self):
+        """Instance storage discovery must not invoke arbitrary __getattr__."""
+
+        class StrictLookup:
+            __slots__ = ()
+            value: int = 1
+
+            def __getattr__(self, name: str):
+                raise RuntimeError(f"unexpected storage probe: {name}")
+
+            def work(self) -> str:
+                """Documented API."""
+                return "done"
+
+        output = doc(StrictLookup())
+        assert "value: int = 1" in output
+        assert "def work(self) -> str:" in output
+
+    def test_doc_slots_class_with_repr_preserves_type_docs(self):
+        """doc(instance) supports slots-only classes and ignores custom repr."""
 
         class SlotsWithRepr:
             __slots__ = ("x", "y")
@@ -881,7 +1052,10 @@ class TestLargeValueTruncation:
                 return "SlotsWithRepr(custom)"
 
         result = doc(SlotsWithRepr())
-        assert "SlotsWithRepr(custom)" in result
+        assert "class SlotsWithRepr:" in result
+        assert "x: int = 1" in result
+        assert "y: int = 2" in result
+        assert "SlotsWithRepr(custom)" not in result
 
     def test_pydantic_still_uses_field_extraction_despite_repr(self):
         """Pydantic models define __repr__ but should still use field extraction."""

--- a/tests/agentdoc/test_multi_type_doc.py
+++ b/tests/agentdoc/test_multi_type_doc.py
@@ -213,10 +213,18 @@ class TestTypeDepthParameter:
         assert "class Address" in result
 
     def test_inline_depth_default_with_concise_true(self):
-        """Default inline_depth=0 when concise=True."""
+        """Default inline_depth=1 is independent of concise docstrings."""
         result = doc(Customer, concise=True)
 
-        assert "## Referenced Types" not in result
+        assert "## Referenced Types" in result
+        assert "class Address" in result
+
+    @pytest.mark.parametrize("invalid_depth", [None, -1, 1.5, "1", True])
+    def test_inline_depth_rejects_non_nonnegative_integers(self, invalid_depth):
+        """inline_depth accepts only non-negative integers."""
+        error = ValueError if invalid_depth == -1 else TypeError
+        with pytest.raises(error, match="inline_depth must be a non-negative integer"):
+            doc(Customer, inline_depth=invalid_depth)
 
     def test_inline_depth_override_with_concise_true(self):
         """Explicit inline_depth overrides concise=True default."""

--- a/tests/agentdoc/test_multi_type_doc.py
+++ b/tests/agentdoc/test_multi_type_doc.py
@@ -188,12 +188,14 @@ class TestTypeDepthParameter:
         assert "## Referenced Types" not in result
 
     def test_inline_depth_one_direct_references(self):
-        """inline_depth=1 shows direct referenced types."""
-        result = doc(Customer, inline_depth=1)
+        """inline_depth=1 includes direct references but not their references."""
+        # Order -> Customer -> Address
+        result = doc(Order, inline_depth=1)
 
-        assert "class Customer" in result
+        assert "class Order" in result
         assert "## Referenced Types" in result
-        assert "class Address" in result
+        assert "class Customer" in result
+        assert "class Address" not in result
 
     def test_inline_depth_two_transitive_references(self):
         """inline_depth=2 shows transitive referenced types."""
@@ -204,6 +206,15 @@ class TestTypeDepthParameter:
         assert "## Referenced Types" in result
         assert "class Customer" in result
         assert "class Address" in result  # Transitive through Customer
+
+    def test_inline_depth_bounds_multi_object_references(self):
+        """Multi-object docs use the same direct-versus-transitive semantics."""
+        direct = doc(Order, SimpleA, inline_depth=1)
+        transitive = doc(Order, SimpleA, inline_depth=2)
+
+        assert "class Customer" in direct
+        assert "class Address" not in direct
+        assert "class Address" in transitive
 
     def test_inline_depth_default_with_concise_false(self):
         """Default inline_depth=1 when concise=False."""

--- a/tests/agentdoc/test_multi_type_doc.py
+++ b/tests/agentdoc/test_multi_type_doc.py
@@ -95,6 +95,28 @@ class TestMultiTypeDoc:
         assert "value_a: str" in result
         assert "value_b: int" in result
 
+    def test_doc_multiple_instances_preserves_referenced_types(self):
+        """Multi-instance docs discover the same contract types as type docs."""
+
+        class Inner(BaseModel):
+            value: str
+
+        class Outer(BaseModel):
+            inner: Inner
+
+        class RuntimeDetail:
+            detail: str = "runtime"
+
+        outer = Outer(inner=Inner(value="x"))
+        outer.__pydantic_extra__ = {"detail": RuntimeDetail()}
+        result = doc(outer, SimpleA(value_a="a"), inline_depth=1)
+
+        assert "class Outer(BaseModel):" in result
+        assert "class SimpleA(BaseModel):" in result
+        assert "## Referenced Types" in result
+        assert result.count("class Inner(BaseModel):") == 1
+        assert result.count("class RuntimeDetail:") == 1
+
     def test_doc_multiple_types_list(self):
         """doc([Type1, Type2]) flattens and documents both."""
         result = doc([SimpleA, SimpleB])

--- a/tests/agentdoc/test_protocols.py
+++ b/tests/agentdoc/test_protocols.py
@@ -143,6 +143,39 @@ class TestCustomInstanceValues:
         # Should NOT show _internal (filtered by __instance_values__)
         assert "hidden" not in result
 
+    def test_instance_values_omission_only_hides_from_pformat(self):
+        """doc() keeps type fields while pformat() honors protocol omission."""
+
+        class SelectiveValues:
+            @classmethod
+            def __type_info__(cls) -> TypeInfo:
+                return TypeInfo(
+                    name="SelectiveValues",
+                    base=None,
+                    fields=[
+                        FieldInfo("required", "str", ...),
+                        FieldInfo("defaulted", "int", 7),
+                        FieldInfo("shown", "str", ...),
+                    ],
+                    methods=[],
+                    docstring=None,
+                )
+
+            def __instance_values__(self) -> dict:
+                return {"shown": "runtime"}
+
+        obj = SelectiveValues()
+
+        instance_doc = doc(obj)
+        assert "required: str" in instance_doc
+        assert "defaulted: int = 7" in instance_doc
+        assert "shown: str = 'runtime'" in instance_doc
+
+        instance_repr = pformat(obj)
+        assert "shown='runtime'" in instance_repr
+        assert "required" not in instance_repr
+        assert "defaulted" not in instance_repr
+
     def test_partial_custom_uses_automatic_values(self):
         """Test object with only __type_info__ uses automatic value extraction."""
         obj = PartialCustomClass()

--- a/tests/agentdoc/test_referenced_types.py
+++ b/tests/agentdoc/test_referenced_types.py
@@ -168,6 +168,31 @@ def test_doc_includes_referenced_types():
     assert main_class_pos < ref_section_pos
 
 
+def test_instance_hidden_field_type_not_in_referenced_types():
+    """Instance-hidden field types must not leak through referenced docs."""
+    from nooa.agentdoc import spec
+
+    class Secret:
+        def reveal(self) -> str:
+            """Sensitive API."""
+            return "secret"
+
+    class Holder:
+        secret: Secret
+
+        def __init__(self):
+            self.secret = Secret()
+
+    holder = Holder()
+    spec(holder, "secret", hidden=True)
+    output = doc(holder)
+
+    assert "secret" not in output.lower()
+    assert "class Secret" not in output
+    assert "reveal" not in output
+    assert "## Referenced Types" not in output
+
+
 def test_doc_no_referenced_types_if_none():
     """Test that Referenced Types section is omitted if no custom types."""
     output = doc(SimpleClass)

--- a/tests/agentdoc/test_referenced_types.py
+++ b/tests/agentdoc/test_referenced_types.py
@@ -280,8 +280,8 @@ def test_doc_callable_includes_referenced_types():
     assert "rows: list[dict]" in output
 
 
-def test_doc_callable_concise_no_referenced_types():
-    """doc(callable, concise=True) should NOT show referenced types."""
+def test_doc_callable_concise_uses_default_reference_depth():
+    """concise shortens docstrings without changing the default reference depth."""
     from pydantic import BaseModel
 
     class QueryRequest(BaseModel):
@@ -293,12 +293,13 @@ def test_doc_callable_concise_no_referenced_types():
 
     output = doc(query_function, concise=True)
 
-    # Should show the function signature with qualified name
     assert "query_function(request: QueryRequest) -> str" in output
+    assert "## Referenced Types" in output
+    assert "class QueryRequest(BaseModel):" in output
 
-    # Should NOT show Referenced Types section
-    assert "## Referenced Types" not in output
-    assert "### QueryRequest" not in output
+    without_references = doc(query_function, concise=True, inline_depth=0)
+    assert "## Referenced Types" not in without_references
+    assert "class QueryRequest(BaseModel):" not in without_references
 
 
 if __name__ == "__main__":

--- a/tests/test_pure_functions_gl105.py
+++ b/tests/test_pure_functions_gl105.py
@@ -190,7 +190,7 @@ def test_type_info_includes_classmethods():
 
 
 def test_instance_values_swallows_unexpected_exception():
-    """__instance_values__ swallows RuntimeError from a broken property."""
+    """doc() preserves property docs without propagating property errors."""
     from nooa.agentdoc import doc
 
     class BrokenAgent(Agent, llm=_TEST_LLM):
@@ -204,8 +204,8 @@ def test_instance_values_swallows_unexpected_exception():
     # doc() calls __instance_values__ internally; must not raise
     result = doc(agent)
     assert isinstance(result, str)
-    # The broken property should not appear in the output at all
-    assert "broken" not in result
+    # The type-level property remains documented, but is never evaluated.
+    assert "broken: str" in result
     assert "RuntimeError" not in result
 
 


### PR DESCRIPTION
## What does this PR do?

Makes `doc(instance)` preserve the complete type-level API contract from `doc(type(instance))`, then augment it with current values and public runtime-only fields.

Specifically, it:
- retains annotation-only fields, defaults, properties, methods, and docstrings in instance docs
- overlays current instance values and includes both `__dict__` and Pydantic `extra="allow"` fields
- documents plain classes with custom `__repr__` instead of replacing their API docs with repr output
- keeps `pformat()` repr semantics unchanged
- respects per-instance visibility overrides for both declared and dynamic fields
- preserves declared fields omitted by `SupportsInstanceValues` in `doc()`, while `pformat()` continues to omit them
- avoids executing arbitrary descriptors while reading inherited slots
- documents the resulting `SupportsInstanceValues` contract

## Rendered examples

Every output below was generated directly with this PR's committed code at `2da7420`.

### 1. Type parity, current values, dynamic fields, properties, and custom `__repr__`

```python
from nooa.agentdoc import doc, pformat

class Worker:
    """Runs queued work."""

    required_queue: str
    retries: int = 3

    @property
    def status(self) -> str:
        """Current worker status."""
        raise AssertionError("must not execute")

    def run(self, job_id: str) -> bool:
        """Run one job."""
        return True

    def __repr__(self) -> str:
        return "Worker(custom repr)"

worker = Worker()
worker.retries = 5
worker.region = "us-east"
```

`doc(Worker)`:

```python
class Worker:
    """Runs queued work."""

    required_queue: str
    retries: int = 3
    status: str  # Current worker status.

    def run(self, job_id: str) -> bool:
        """Run one job."""
```

`doc(worker)`:

```python
class Worker:
    """Runs queued work."""

    required_queue: str
    retries: int = 5
    status: str  # Current worker status.

    region: str = 'us-east'

    def run(self, job_id: str) -> bool:
        """Run one job."""
```

`pformat(worker)` still respects the author's representation:

```text
Worker(custom repr)
```

This demonstrates that instance docs retain the annotation-only field, property metadata, class/method docs, and method signature; overlay `retries`; add `region`; and never evaluate `status`.

### 2. Per-instance visibility for declared and dynamic fields

```python
from nooa.agentdoc import doc, spec

class Credentials:
    token: str = "class-token"

credentials = Credentials()
credentials.token = "runtime-token"
credentials.endpoint = "https://example.test"
credentials.session_key = "session-secret"
spec(credentials, "token", hidden=True)        # declared field
spec(credentials, "session_key", hidden=True)  # dynamic field

print(doc(credentials))
```

Rendered output:

```python
class Credentials:
    endpoint: str = 'https://example.test'
```

Both hidden values are absent; the visible runtime-only field remains.

### 3. Pydantic `extra="allow"` fields

```python
from pydantic import BaseModel, ConfigDict
from nooa.agentdoc import doc, pformat

class Request(BaseModel):
    """An API request."""

    model_config = ConfigDict(extra="allow")
    route: str = "/health"

request = Request()
request.trace_id = "abc-123"
```

`doc(Request)`:

```python
class Request(BaseModel):
    """An API request."""

    route: str = '/health'
```

`doc(request)`:

```python
class Request(BaseModel):
    """An API request."""

    route: str = '/health'

    trace_id: str = 'abc-123'
```

`pformat(request)`:

```text
Request(route='/health', trace_id='abc-123')
```

The extra field is instance-only and therefore does not leak into the type view.

### 4. `SupportsInstanceValues`: API docs versus value representation

```python
from nooa.agentdoc import doc, pformat
from nooa.agentdoc.ext import FieldInfo, TypeInfo

class SelectiveValues:
    @classmethod
    def __type_info__(cls) -> TypeInfo:
        return TypeInfo(
            name="SelectiveValues",
            base=None,
            fields=[
                FieldInfo("required", "str", ...),
                FieldInfo("defaulted", "int", 7),
                FieldInfo("shown", "str", ...),
            ],
            methods=[],
            docstring=None,
        )

    def __instance_values__(self) -> dict:
        return {"shown": "runtime"}

selective = SelectiveValues()
```

`doc(selective)` preserves the full declared contract and overlays the supplied runtime value:

```python
class SelectiveValues:
    required: str
    defaulted: int = 7
    shown: str = 'runtime'
```

`pformat(selective)` continues to use the protocol as a selective value representation:

```text
SelectiveValues(shown='runtime')
```

### 5. Inherited slot overridden by a descriptor

```python
from nooa.agentdoc import doc, pformat

class Base:
    __slots__ = ("value",)

class Child(Base):
    @property
    def value(self) -> str:
        """A descriptor that must not run during docs."""
        raise AssertionError("must not execute")

    def __repr__(self) -> str:
        return "Child(custom repr)"

child = Child()
```

`doc(child)` statically documents the descriptor without invoking it:

```python
class Child:
    value: str  # A descriptor that must not run during docs.
```

`pformat(child)` remains:

```text
Child(custom repr)
```

### 6. Pydantic validation constraints (`gt`, `lt`, `ge`, `le`, lengths, and patterns)

```python
from typing import Annotated

from pydantic import BaseModel, ConfigDict, Field
from nooa.agentdoc import doc

class Limits(BaseModel):
    """Validated limits."""

    model_config = ConfigDict(extra="allow")
    percentage: int = Field(default=50, gt=0, lt=100, description="Percentage")
    count: int = Field(ge=1, le=10, multiple_of=2)
    code: str = Field(min_length=2, max_length=5, pattern=r"^[A-Z]+$")
    score: Annotated[float, Field(gt=0.0, le=1.0)] = 0.5

limits = Limits(count=2, code="OK")
limits.dynamic = 7
```

`doc(Limits)`:

```python
class Limits(BaseModel):
    """Validated limits."""

    percentage: int = 50  # Percentage [>0, <100]
    count: int  # [≥1, ≤10]
    code: str  # [min_len=2, max_len=5, pattern='^[A-Z]+$']
    score: float = 0.5  # [>0.0, ≤1.0]
```

`doc(limits)` preserves all constraints while overlaying validated values and adding runtime state:

```python
class Limits(BaseModel):
    """Validated limits."""

    percentage: int = 50  # Percentage [>0, <100]
    count: int = 2  # [≥1, ≤10]
    code: str = 'OK'  # [min_len=2, max_len=5, pattern='^[A-Z]+$']
    score: float = 0.5  # [>0.0, ≤1.0]

    dynamic: int = 7
```

This covers strict and inclusive numeric bounds, string length bounds, regex patterns, descriptions combined with constraints, defaults, required validated values, `Annotated[..., Field(...)]`, and instance-only fields. Pydantic currently does not render `multiple_of` in agentdoc, so this example deliberately does not claim that it does; the existing behavior is unchanged by this PR.

## Public API documentation before and after

The outputs below were captured directly from the PR base (`c98bfb8`) and the current head (`0569cc9`) with the same four calls.

### `doc(agentdoc)`

<details>
<summary>Before this PR (<code>c98bfb8</code>) — 179 lines</summary>

```python
# nooa.agentdoc

"""
agentdoc — runtime Python documentation for Python objects.

Two-step mental model:

  1. spec() — specify how the type renders: descriptions, visibility, hints.
  2. doc()  — get the documentation: the API contract, ready for a prompt.

Quick start:

    from nooa.agentdoc import spec, hidden, doc, pformat, truncating_pformat

    class MyAgent:
        api_key: Annotated[str, hidden] = ""          # excluded from documentation
        label: Annotated[str, spec(description="Display name")] = "agent"

    agent = MyAgent()
    doc(MyAgent)   # → API contract (type view)
    doc(agent)     # → API contract with current values substituted
    pformat(agent) # → compact repr: MyAgent(label='agent')
"""

# Submodules:
#   nooa.agentdoc.ext — agentdoc.ext — Extension layer for custom extractors and library authors.
#   nooa.agentdoc.introspect — agentdoc.introspect — fine-grained introspection views.
#   nooa.agentdoc.visibility — agentdoc.visibility — inspect visibility decisions for framework authors.
#   nooa.agentdoc.adapters — agentdoc.adapters — doc() adapters for third-party libraries.

def spec(target: Any = ..., field: str | None = None, /, *, hidden: bool | None = None, description: str | None = None, expand: bool | None = None, max_length: int | None = ..., max_string: int | None = ..., max_depth: int | None = ...) -> SpecAnnotation | None:
    """
    The ``spec`` singleton — step 1: specify how a type renders.
    
    Attach visibility rules, descriptions, and rendering hints to fields,
    methods, or whole types; ``doc()`` and ``pformat()`` pick them up
    automatically.
    
    **Default visibility rules:**
    
    - Public names (no leading underscore) are **visible** by default.
    - ``_private`` names (single or double leading underscore) are **hidden**
      by default.  Use ``spec(hidden=False)`` or ``@spec(hidden=False)`` to
      opt a private name back in.
    
    Which form to use:
    
    - **Annotated marker** — for fields in types you own::
    
          api_key: Annotated[str, spec(hidden=True)] = ""
    
    - **Decorator** — for methods or classes you own::
    
          @spec(hidden=True)
          def _internal(self): ...
    
          @spec(hidden=False)       # opt a _private method back in
          def _shown_helper(self): ...
    
    - **Imperative** — for types you don't own::
    
          spec(ThirdPartyClass, "verbose_field", hidden=True)
    
    Args:
        field: Field or method name — second positional arg in imperative form: spec(MyClass, 'field_name', hidden=True)
        hidden: If True, exclude from documentation; False to force-show _-prefixed names
        description: Shown as inline # comment in doc() output
        expand: If False, collapse sub-type to a one-liner in doc()
        max_length: Override max items per container in pformat — parameter annotations only, e.g. Annotated[list, spec(max_length=20)] (not honored on class fields)
        max_string: Override max characters per string in pformat for this annotation (parameter annotation or class field)
        max_depth: Override max nesting depth in pformat — parameter annotations only (not honored on class fields)
    """

def hidden(func: Any) -> Any:
    """
    Exclude fields, methods, or imports from documentation.
    
    Works in three roles:
    1. Decorator: @hidden on functions (module-level or methods)
    2. Annotation marker: Annotated[T, hidden] on variables (module-level or fields)
    3. Context manager: ``with hidden:`` — names defined in the block are hidden at module level
    """

def doc(*objs: Any, concise: bool = False, inline_depth: int | None = None) -> str:
    """
    Get the documentation for one or more objects — step 2: render the API contract.
    
    Renders the API contract of a class, function, module, or instance as a
    prompt-ready string. Referenced types are expanded inline and deduplicated
    across all objects passed.
    
    Passing a **type** shows default field values::
    
        doc(MyAgent)          # label: str = "agent"
    
    Passing an **instance** shows the current field values in place of defaults::
    
        agent = MyAgent(label="prod")
        doc(agent)            # label: str = "prod"
    
    Respects ``@spec(expand=False)`` on field types — those are collapsed to a
    one-liner instead of being expanded inline.
    
    Args:
        *objs: One or more objects: doc(MyClass), doc(Class, fn), doc([A, B])
        concise: Show first-line docstrings only.
        inline_depth: Levels of referenced types to expand inline (default 1).
            0 = none, 1 = direct references, 2+ = transitive. None = auto.
    
    Returns:
        Formatted documentation string with each type appearing exactly once.
    """

class DocConfig:  # Configuration for documentation generation.

def pformat(obj: Any, *, console: Any = None, indent_guides: bool = True, max_length: int | None = None, max_string: int | None = None, max_depth: int | None = None, expand_all: bool = False, concise: bool = False, instance_mode: str = 'repr', unquote_strings: bool = False) -> str:
    """
    Format an object as a string with smart truncation.
    
    Drop-in replacement for ``rich.pretty.pformat()``.
    For user-defined instances, ``hidden`` fields are automatically excluded.
    Respects ``@spec(expand=False)`` on field types — shown as ``ClassName()`` rather than expanded.
    
    ``console`` and ``indent_guides`` are accepted for Rich API compatibility but have no effect.
    
    To cap total output size (preventing OOM on huge objects), use :func:`truncating_pformat`
    which applies a hard ``max_chars`` limit via :class:`TruncatingStringIO`.
    
    Args:
        obj: Object to format
        max_length: Max elements per container; None = unlimited
        max_string: Max string chars; None = unlimited
        max_depth: Max nesting depth; None = unlimited
        expand_all: Always expand containers to multiple lines
        concise: Show first-line docstrings only
        instance_mode: Instance format: 'repr' for repr-style, 'type' for type structure
        unquote_strings: Untruncated strings rendered verbatim
    """

def pprint(obj: Any, *, console: Any = None, indent_guides: bool = True, max_length: int | None = None, max_string: int | None = None, max_depth: int | None = None, expand_all: bool = False, concise: bool = False, instance_mode: str = 'repr') -> None:
    """
    Pretty-print an object with smart truncation. Prints to stdout.
    
    Drop-in replacement for ``rich.pretty.pprint()``.
    Writes directly to ``sys.stdout`` via stream-based formatting so that
    stdout capture (via ``ContextVarStream``) bounds output during formatting.
    
    ``console`` and ``indent_guides`` are accepted for Rich API compatibility but have no effect.
    
    Args:
        obj: Object to print
        max_length: Max elements per container; None = unlimited
        max_string: Max string chars; None = unlimited
        max_depth: Max nesting depth; None = unlimited
        expand_all: Always expand containers to multiple lines
        concise: Show first-line docstrings only
        instance_mode: Instance format: 'repr' for repr-style, 'type' for type structure
    """

def truncating_pformat(obj: Any, *, max_chars: int | None = None, **kwargs: Any) -> str:
    """
    Format *obj* as a string. Strings pass through verbatim; non-strings go
    through :func:`pformat` with the supplied structural kwargs.
    
    Per-value bounds (``max_string``, ``max_length``, ``max_depth``) come from
    ``kwargs``.  ``max_chars`` is an independent hard cap on the total rendered
    output for non-string objects via :class:`TruncatingStringIO`.
    
    Raises:
        ValueError: if ``max_chars`` is set and <= 0.
    
    Args:
        obj: Object to format
        max_chars: Hard char cap on non-string rendering via TruncatingStringIO
    """

class FileBackedTruncatingStringIO:  # TruncatingStringIO that also writes full output to a temp file.

class TruncatingStringIO:  # StringIO with hard character limit and head+tail truncation.
```
</details>

<details open>
<summary>After this PR (<code>0569cc9</code>) — 58 lines</summary>

```python
# nooa.agentdoc

"""
Turn live Python objects into prompt-ready API documentation.

Show an agent what an object can do—not just what it contains::

    from typing import Annotated

    from nooa.agentdoc import doc, hidden, pformat, spec

    class Assistant:
        api_key: Annotated[str, hidden] = ""
        name: Annotated[str, spec(description="Display name")] = "Ada"

        def greet(self, person: str) -> str:
            """Greet a person by name."""

    assistant = Assistant()
    assistant.locale = "en-US"

    doc(Assistant)      # declared API and defaults
    doc(assistant)      # the same API, enriched with live state
    pformat(assistant)  # compact value view

Use ``spec()`` and ``hidden`` to shape the contract, ``doc()`` to reveal it,
and ``pformat()`` when values alone are enough.
"""

# Submodules:
#   nooa.agentdoc.ext — agentdoc.ext — Extension layer for custom extractors and library authors.
#   nooa.agentdoc.introspect — agentdoc.introspect — fine-grained introspection views.
#   nooa.agentdoc.visibility — agentdoc.visibility — inspect visibility decisions for framework authors.
#   nooa.agentdoc.adapters — agentdoc.adapters — doc() adapters for third-party libraries.

def spec(target: Any = ..., field: str | None = None, /, *, hidden: bool | None = None, description: str | None = None, expand: bool | None = None, max_length: int | None = ..., max_string: int | None = ..., max_depth: int | None = ...) -> SpecAnnotation | None:
    """Shape how objects appear in ``doc()`` and ``pformat()``."""

def hidden(func: Any) -> Any:
    """Hide a field, callable, or module-level name from documentation."""

def doc(*objs: Any, concise: bool = False, inline_depth: int = 1) -> str:
    """Render prompt-ready API documentation for one or more Python objects."""

class DocConfig:  # Configuration for documentation generation.

def pformat(obj: Any, *, console: Any = None, indent_guides: bool = True, max_length: int | None = None, max_string: int | None = None, max_depth: int | None = None, expand_all: bool = False, concise: bool = False, instance_mode: str = 'repr', unquote_strings: bool = False) -> str:
    """Render a compact, value-focused representation."""

def pprint(obj: Any, *, console: Any = None, indent_guides: bool = True, max_length: int | None = None, max_string: int | None = None, max_depth: int | None = None, expand_all: bool = False, concise: bool = False, instance_mode: str = 'repr') -> None:
    """Print the compact, value-focused representation produced by ``pformat()``."""

def truncating_pformat(obj: Any, *, max_chars: int | None = None, **kwargs: Any) -> str:
    """Format a value, with a hard total-size cap for non-string objects."""

class FileBackedTruncatingStringIO:  # TruncatingStringIO that also writes full output to a temp file.

class TruncatingStringIO:  # StringIO with hard character limit and head+tail truncation.
```
</details>

### `doc(doc)`

<details>
<summary>Before this PR (<code>c98bfb8</code>) — 29 lines</summary>

```python
def doc(*objs: Any, concise: bool = False, inline_depth: int | None = None) -> str:
    """
    Get the documentation for one or more objects — step 2: render the API contract.
    
    Renders the API contract of a class, function, module, or instance as a
    prompt-ready string. Referenced types are expanded inline and deduplicated
    across all objects passed.
    
    Passing a **type** shows default field values::
    
        doc(MyAgent)          # label: str = "agent"
    
    Passing an **instance** shows the current field values in place of defaults::
    
        agent = MyAgent(label="prod")
        doc(agent)            # label: str = "prod"
    
    Respects ``@spec(expand=False)`` on field types — those are collapsed to a
    one-liner instead of being expanded inline.
    
    Args:
        *objs: One or more objects: doc(MyClass), doc(Class, fn), doc([A, B])
        concise: Show first-line docstrings only.
        inline_depth: Levels of referenced types to expand inline (default 1).
            0 = none, 1 = direct references, 2+ = transitive. None = auto.
    
    Returns:
        Formatted documentation string with each type appearing exactly once.
    """
```
</details>

<details open>
<summary>After this PR (<code>0569cc9</code>) — 22 lines</summary>

```python
def doc(*objs: Any, concise: bool = False, inline_depth: int = 1) -> str:
    """
    Render prompt-ready API documentation for one or more Python objects.
    
    Types show their declared API and defaults. Instances show that same contract
    enriched with current values and public runtime fields. Visibility rules are
    honored, properties stay unevaluated, and custom ``__repr__`` methods never
    hide the API.
    
    Referenced types are expanded inline and deduplicated across the result.
    
    Args:
        *objs: Objects to document: ``doc(MyClass)``, ``doc(Class, fn)``, or
            ``doc([A, B])``.
        concise: Show only the first line of each docstring.
        inline_depth: Referenced-type depth. ``0`` disables expansion, ``1``
            includes direct references (the default), and ``2+`` includes
            transitive references to that depth.
    
    Returns:
        The formatted API documentation.
    """
```
</details>

### `doc(pprint)`

<details>
<summary>Before this PR (<code>c98bfb8</code>) — 19 lines</summary>

```python
def pprint(obj: Any, *, console: Any = None, indent_guides: bool = True, max_length: int | None = None, max_string: int | None = None, max_depth: int | None = None, expand_all: bool = False, concise: bool = False, instance_mode: str = 'repr') -> None:
    """
    Pretty-print an object with smart truncation. Prints to stdout.
    
    Drop-in replacement for ``rich.pretty.pprint()``.
    Writes directly to ``sys.stdout`` via stream-based formatting so that
    stdout capture (via ``ContextVarStream``) bounds output during formatting.
    
    ``console`` and ``indent_guides`` are accepted for Rich API compatibility but have no effect.
    
    Args:
        obj: Object to print
        max_length: Max elements per container; None = unlimited
        max_string: Max string chars; None = unlimited
        max_depth: Max nesting depth; None = unlimited
        expand_all: Always expand containers to multiple lines
        concise: Show first-line docstrings only
        instance_mode: Instance format: 'repr' for repr-style, 'type' for type structure
    """
```
</details>

<details open>
<summary>After this PR (<code>0569cc9</code>) — 13 lines</summary>

```python
def pprint(obj: Any, *, console: Any = None, indent_guides: bool = True, max_length: int | None = None, max_string: int | None = None, max_depth: int | None = None, expand_all: bool = False, concise: bool = False, instance_mode: str = 'repr') -> None:
    """
    Print the compact, value-focused representation produced by ``pformat()``.
    
    Args:
        obj: Object to print
        max_length: Max elements per container; None = unlimited
        max_string: Max string chars; None = unlimited
        max_depth: Max nesting depth; None = unlimited
        expand_all: Always expand containers to multiple lines
        concise: Show first-line docstrings only
        instance_mode: Instance format: 'repr' for repr-style, 'type' for type structure
    """
```
</details>

### `doc(pformat)`

<details>
<summary>Before this PR (<code>c98bfb8</code>) — 23 lines</summary>

```python
def pformat(obj: Any, *, console: Any = None, indent_guides: bool = True, max_length: int | None = None, max_string: int | None = None, max_depth: int | None = None, expand_all: bool = False, concise: bool = False, instance_mode: str = 'repr', unquote_strings: bool = False) -> str:
    """
    Format an object as a string with smart truncation.
    
    Drop-in replacement for ``rich.pretty.pformat()``.
    For user-defined instances, ``hidden`` fields are automatically excluded.
    Respects ``@spec(expand=False)`` on field types — shown as ``ClassName()`` rather than expanded.
    
    ``console`` and ``indent_guides`` are accepted for Rich API compatibility but have no effect.
    
    To cap total output size (preventing OOM on huge objects), use :func:`truncating_pformat`
    which applies a hard ``max_chars`` limit via :class:`TruncatingStringIO`.
    
    Args:
        obj: Object to format
        max_length: Max elements per container; None = unlimited
        max_string: Max string chars; None = unlimited
        max_depth: Max nesting depth; None = unlimited
        expand_all: Always expand containers to multiple lines
        concise: Show first-line docstrings only
        instance_mode: Instance format: 'repr' for repr-style, 'type' for type structure
        unquote_strings: Untruncated strings rendered verbatim
    """
```
</details>

<details open>
<summary>After this PR (<code>0569cc9</code>) — 17 lines</summary>

```python
def pformat(obj: Any, *, console: Any = None, indent_guides: bool = True, max_length: int | None = None, max_string: int | None = None, max_depth: int | None = None, expand_all: bool = False, concise: bool = False, instance_mode: str = 'repr', unquote_strings: bool = False) -> str:
    """
    Render a compact, value-focused representation.
    
    Hidden fields are omitted and custom ``__repr__`` methods are honored. Use
    ``doc()`` for an object's API, or ``truncating_pformat()`` for a hard size cap.
    
    Args:
        obj: Object to format
        max_length: Max elements per container; None = unlimited
        max_string: Max string chars; None = unlimited
        max_depth: Max nesting depth; None = unlimited
        expand_all: Always expand containers to multiple lines
        concise: Show first-line docstrings only
        instance_mode: Instance format: 'repr' for repr-style, 'type' for type structure
        unquote_strings: Untruncated strings rendered verbatim
    """
```
</details>

## Related issues

Closes #199

This is broader than #202: that PR covers Pydantic extras, while this change also fixes type-view parity for annotation-only fields, properties, custom-`__repr__` instances, protocol-provided values, per-instance visibility, and descriptor safety.

## Verification

- `env -u VIRTUAL_ENV uv run pytest -q` — 6,805 passed, 7 skipped, 284 deselected, 3 xfailed
- focused agentdoc/error-formatting suite — 761 passed; focused depth regression suite — 145 passed
- focused Ruff check and format check — passed
- `git diff --check` — passed
- GitHub CI — DCO, build, frontend-build, lint, secret-scan, and test all passed

## Checklist

- [x] Code follows the project style (`uv run ruff check` and `uv run ruff format --check` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [x] Docs updated if behavior or public APIs changed
- [x] New source files carry an SPDX license header (no new source files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instance documentation to preserve declared fields, defaults, constraints, and property descriptions.
  * Runtime-only and supported extra fields are now included when appropriate.
  * Hidden fields remain excluded, while properties and descriptors are documented without being evaluated.
  * Custom `__repr__` output no longer overrides structured field rendering.

* **Documentation**
  * Clarified the differences between `doc()` and `pformat()` when displaying instance values and type information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



