### PR TITLE
fix(tui): make interrupt keys unambiguous

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/agent_event_renderer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/agent_event_renderer.py
@@ -37,12 +37,12 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, Protocol
 
-from rich.markdown import Markdown
 from rich.rule import Rule
 from rich.syntax import Syntax
 from rich.text import Text
 
 from .code_preview import _code_preview
+from .copyable_markdown import TerminalMarkdown
 
 
 class _ReasoningEvent(Protocol):
@@ -203,7 +203,7 @@ class AgentEventRenderer:
                 Rule(Text("OO ", style=self._colors["mauve"]), style="dim", align="left"),
                 **emit_kwargs,
             )
-        self._emit_text(Markdown(str(text)), agent_message=True, **emit_kwargs)
+        self._emit_text(TerminalMarkdown(str(text)), agent_message=True, **emit_kwargs)
 
     # ── agent event handlers ───────────────────────────────────────────
 

--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -1030,6 +1030,7 @@ class ThemeCommand(Command):
 
         name = args[0].lower()
         theme_module.set_theme(name)
+        self.config.theme = name
 
         # Replace the base theme in Rich Console's ThemeStack
         # We can't just push - we need to replace the base entry
@@ -1051,7 +1052,17 @@ class ThemeCommand(Command):
         if callable(refresh_app_style):
             refresh_app_style()
 
-        return CommandResult.ok(TextOutput(f"Switched to {name} theme", "success"))
+        try:
+            path = self._persist_tui_setting("theme", name)
+        except Exception as exc:
+            return CommandResult.ok(
+                TextOutput(f"Switched to {name} theme", "success"),
+                TextOutput(f"Could not save the theme preference: {exc}", "warning"),
+            )
+        return CommandResult.ok(
+            TextOutput(f"Switched to {name} theme", "success"),
+            TextOutput(f"Saved in {path}", "status"),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nooa-cli/src/nooa_cli/tui/config.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/config.py
@@ -104,6 +104,9 @@ class TUIConfig(BaseModel):
     # Trace output directory (None = OTLP auto-probe only; --trace writes files)
     trace_dir: Path | None = None
 
+    # Color theme selected by ``/theme`` and restored on the next launch.
+    theme: Literal["mocha", "latte", "vsdark", "vslight"] = "mocha"
+
     # Vi keybindings in prompt_toolkit input
     vi_mode: bool = False
 

--- a/packages/nooa-cli/src/nooa_cli/tui/console.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/console.py
@@ -7,12 +7,12 @@ Uses Catppuccin Mocha theme from https://catppuccin.com/palette/
 
 from rich.console import Console
 from rich.live import Live
-from rich.markdown import Markdown
 from rich.rule import Rule
 from rich.spinner import Spinner
 from rich.table import Table
 from rich.text import Text
 
+from .copyable_markdown import TerminalMarkdown
 from .theme import CATPPUCCIN_THEME, COLORS
 
 
@@ -91,7 +91,7 @@ class TUIConsole:
             self.console.print(
                 Rule(title="[agent]OO[/agent]", style=COLORS["surface2"], align="left")
             )
-        self.console.print(Markdown(cleaned), soft_wrap=soft_wrap)
+        self.console.print(TerminalMarkdown(cleaned), soft_wrap=soft_wrap)
 
     def print_error(self, message: str) -> None:
         """Print an error message."""

--- a/packages/nooa-cli/src/nooa_cli/tui/console.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/console.py
@@ -13,14 +13,14 @@ from rich.table import Table
 from rich.text import Text
 
 from .copyable_markdown import TerminalMarkdown
-from .theme import CATPPUCCIN_THEME, COLORS
+from .theme import COLORS, create_theme
 
 
 class TUIConsole:
     """Rich console wrapper with Catppuccin styling for the NOOA TUI."""
 
     def __init__(self) -> None:
-        self.console = Console(theme=CATPPUCCIN_THEME)
+        self.console = Console(theme=create_theme())
         self._live_spinner: Live | None = None
         self._spinner: Spinner | None = None
 

--- a/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
@@ -26,7 +26,7 @@ class TerminalMarkdown(Markdown):
 
     def __init__(self, markup: str, **kwargs: Any) -> None:
         super().__init__(markup, **kwargs)
-        if "file://" not in markup.lower():
+        if "file:" not in markup.lower():
             return
         parser = MarkdownIt().enable("strikethrough").enable("table")
         default_validate = parser.validateLink

--- a/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import secrets
 from typing import Any
 
+from rich.cells import split_graphemes
 from rich.console import Console, ConsoleOptions, RenderResult
 from rich.markdown import CodeBlock, ListItem, Markdown
 from rich.segment import Segment
@@ -15,6 +16,48 @@ from rich.text import Text
 
 _COPY_URI_PREFIX = "nooa-copy://"
 _CODE_SOURCE_URI_PREFIX = "nooa-code-source://"
+
+
+def visible_code_line(source: str) -> tuple[str, tuple[tuple[int, int], ...]]:
+    """Expose terminal controls and map each rendered code point to source."""
+    rendered: list[str] = []
+    source_map: list[tuple[int, int]] = []
+    column = 0
+    cursor = 0
+    while cursor < len(source):
+        control = ord(source[cursor]) < 0x20 or ord(source[cursor]) == 0x7F or 0x80 <= ord(
+            source[cursor]
+        ) <= 0x9F
+        if control:
+            stop = cursor + 1
+            codepoint = ord(source[cursor])
+            if source[cursor] == "\t":
+                visible = " " * (4 - (column % 4))
+            elif source[cursor] == "\r":
+                visible = r"\r"
+            else:
+                width = 2 if codepoint <= 0xFF else 4
+                prefix = "x" if width == 2 else "u"
+                visible = f"\\{prefix}{codepoint:0{width}x}"
+            spans = ((cursor, stop, visible),)
+        else:
+            run_stop = cursor + 1
+            while run_stop < len(source):
+                codepoint = ord(source[run_stop])
+                if codepoint < 0x20 or codepoint == 0x7F or 0x80 <= codepoint <= 0x9F:
+                    break
+                run_stop += 1
+            graphemes, _ = split_graphemes(source[cursor:run_stop])
+            spans = tuple(
+                (cursor + start, cursor + stop, source[cursor + start : cursor + stop])
+                for start, stop, _cells in graphemes
+            )
+        for start, stop, visible in spans:
+            rendered.append(visible)
+            source_map.extend((start, stop) for _ in visible)
+            column += len(visible)
+            cursor = stop
+    return "".join(rendered), tuple(source_map)
 
 
 class _CopyableCodeBlock(CodeBlock):
@@ -38,14 +81,22 @@ class _CopyableCodeBlock(CodeBlock):
             # Replace Syntax's top padding row with a full-width, same-background
             # control row so the language and Copy action sit inside the panel.
             header = Text(style=Syntax.get_theme(self.theme).get_background_style())
-            if self.lexer_name != "text":
-                header.append(f"{self.lexer_name} · ", style="dim")
+            width = max(1, options.max_width)
+            copy_width = min(width, len("Copy"))
+            trailing_space = width > copy_width
+            available = width - copy_width - int(trailing_space)
+            if self.lexer_name != "text" and available >= 4:
+                language = Text(self.lexer_name, style="dim")
+                language.truncate(available - 3, overflow="ellipsis")
+                header.append_text(language)
+                header.append(" · ", style="dim")
             header.append(
-                "Copy",
+                "Copy"[-copy_width:],
                 style=f"bold underline link {_COPY_URI_PREFIX}{self.action_id}",
             )
-            header.append(" ")
-            header.align("right", options.max_width)
+            if trailing_space:
+                header.append(" ")
+            header.align("right", width)
             yield header
         # Drop only Markdown's structural newline. Source trailing spaces and
         # blank lines are real clipboard content and must remain addressable.
@@ -55,7 +106,9 @@ class _CopyableCodeBlock(CodeBlock):
         # line. A single styled space occupies an already-painted code cell and
         # gives semantic selection a stable anchor for that source newline.
         rendered_code = (
-            "\n".join(line or " " for line in source_lines) if self.action_id is not None else code
+            "\n".join(visible_code_line(line)[0] or " " for line in source_lines)
+            if self.action_id is not None
+            else code
         )
         syntax = Syntax(
             rendered_code,
@@ -67,7 +120,7 @@ class _CopyableCodeBlock(CodeBlock):
         )
         if self.action_id is not None:
             for line_number, line in enumerate(source_lines, 1):
-                rendered_length = len(line.expandtabs(4)) or 1
+                rendered_length = len(visible_code_line(line)[0]) or 1
                 syntax.stylize_range(
                     f"link {_CODE_SOURCE_URI_PREFIX}{self.action_id}/{line_number - 1}",
                     (line_number, 0),

--- a/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
@@ -7,15 +7,46 @@ from __future__ import annotations
 import secrets
 from typing import Any
 
-from rich.cells import split_graphemes
+from markdown_it import MarkdownIt
+from rich.cells import cell_len, split_graphemes
 from rich.console import Console, ConsoleOptions, RenderResult
 from rich.markdown import CodeBlock, ListItem, Markdown
 from rich.segment import Segment
 from rich.syntax import Syntax
 from rich.text import Text
 
+from .terminal_safety import safe_hyperlink_target
+
 _COPY_URI_PREFIX = "nooa-copy://"
 _CODE_SOURCE_URI_PREFIX = "nooa-code-source://"
+
+
+class TerminalMarkdown(Markdown):
+    """Rich Markdown whose parser also permits validated ``file://`` links."""
+
+    def __init__(self, markup: str, **kwargs: Any) -> None:
+        super().__init__(markup, **kwargs)
+        if "file://" not in markup.lower():
+            return
+        parser = MarkdownIt().enable("strikethrough").enable("table")
+        default_validate = parser.validateLink
+
+        def validate_link(target: str) -> bool:
+            validated = safe_hyperlink_target(target)
+            return default_validate(target) or (
+                validated is not None and validated.lower().startswith("file://")
+            )
+
+        parser.validateLink = validate_link
+        self.parsed = parser.parse(markup)
+        for token in self.parsed:
+            for child in token.children or ():
+                if child.type != "link_open":
+                    continue
+                target = child.attrGet("href")
+                normalized = safe_hyperlink_target(target)
+                if normalized is not None and target != normalized:
+                    child.attrSet("href", normalized)
 
 
 def visible_code_line(source: str) -> tuple[str, tuple[tuple[int, int], ...]]:
@@ -55,7 +86,7 @@ def visible_code_line(source: str) -> tuple[str, tuple[tuple[int, int], ...]]:
         for start, stop, visible in spans:
             rendered.append(visible)
             source_map.extend((start, stop) for _ in visible)
-            column += len(visible)
+            column += cell_len(visible)
             cursor = stop
     return "".join(rendered), tuple(source_map)
 
@@ -172,7 +203,7 @@ class _SemanticListItem(ListItem):
             yield Segment.line()
 
 
-class CopyableMarkdown(Markdown):
+class CopyableMarkdown(TerminalMarkdown):
     """Rich Markdown that exposes exact fenced-code payloads by stable action ID."""
 
     elements = {

--- a/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
@@ -34,6 +34,19 @@ class _CopyableCodeBlock(CodeBlock):
         self.action_id = action_id
 
     def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        if self.action_id is not None:
+            # Replace Syntax's top padding row with a full-width, same-background
+            # control row so the language and Copy action sit inside the panel.
+            header = Text(style=Syntax.get_theme(self.theme).get_background_style())
+            if self.lexer_name != "text":
+                header.append(f"{self.lexer_name} · ", style="dim")
+            header.append(
+                "Copy",
+                style=f"bold underline link {_COPY_URI_PREFIX}{self.action_id}",
+            )
+            header.append(" ")
+            header.align("right", options.max_width)
+            yield header
         # Drop only Markdown's structural newline. Source trailing spaces and
         # blank lines are real clipboard content and must remain addressable.
         code = str(self.text).removesuffix("\n")
@@ -49,8 +62,8 @@ class _CopyableCodeBlock(CodeBlock):
             self.lexer_name,
             theme=self.theme,
             word_wrap=True,
-            # The footer below occupies the existing bottom padding row.
-            padding=(1, 1, 0, 1) if self.action_id is not None else 1,
+            # The header above occupies the existing top padding row.
+            padding=(0, 1, 1, 1) if self.action_id is not None else 1,
         )
         if self.action_id is not None:
             for line_number, line in enumerate(source_lines, 1):
@@ -65,19 +78,6 @@ class _CopyableCodeBlock(CodeBlock):
         # Override that option locally so long source lines still wrap rather
         # than being cropped from the transcript.
         yield from console.render(syntax, options.update(no_wrap=False, overflow="fold"))
-        if self.action_id is not None:
-            # Keep the language and action inside the code panel by painting the
-            # former bottom padding row with Syntax's own background style.
-            footer = Text(style=Syntax.get_theme(self.theme).get_background_style())
-            if self.lexer_name != "text":
-                footer.append(f"{self.lexer_name} · ", style="dim")
-            footer.append(
-                "Copy",
-                style=f"bold underline link {_COPY_URI_PREFIX}{self.action_id}",
-            )
-            footer.append(" ")
-            footer.align("right", options.max_width)
-            yield footer
 
 
 class _SemanticListItem(ListItem):

--- a/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
@@ -34,15 +34,6 @@ class _CopyableCodeBlock(CodeBlock):
         self.action_id = action_id
 
     def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
-        if self.action_id is not None:
-            header = Text(justify="right")
-            if self.lexer_name != "text":
-                header.append(f"{self.lexer_name} · ", style="dim")
-            header.append(
-                "Copy",
-                style=f"bold underline link {_COPY_URI_PREFIX}{self.action_id}",
-            )
-            yield header
         # Drop only Markdown's structural newline. Source trailing spaces and
         # blank lines are real clipboard content and must remain addressable.
         code = str(self.text).removesuffix("\n")
@@ -58,7 +49,8 @@ class _CopyableCodeBlock(CodeBlock):
             self.lexer_name,
             theme=self.theme,
             word_wrap=True,
-            padding=1,
+            # The footer below occupies the existing bottom padding row.
+            padding=(1, 1, 0, 1) if self.action_id is not None else 1,
         )
         if self.action_id is not None:
             for line_number, line in enumerate(source_lines, 1):
@@ -73,6 +65,19 @@ class _CopyableCodeBlock(CodeBlock):
         # Override that option locally so long source lines still wrap rather
         # than being cropped from the transcript.
         yield from console.render(syntax, options.update(no_wrap=False, overflow="fold"))
+        if self.action_id is not None:
+            # Keep the language and action inside the code panel by painting the
+            # former bottom padding row with Syntax's own background style.
+            footer = Text(style=Syntax.get_theme(self.theme).get_background_style())
+            if self.lexer_name != "text":
+                footer.append(f"{self.lexer_name} · ", style="dim")
+            footer.append(
+                "Copy",
+                style=f"bold underline link {_COPY_URI_PREFIX}{self.action_id}",
+            )
+            footer.append(" ")
+            footer.align("right", options.max_width)
+            yield footer
 
 
 class _SemanticListItem(ListItem):

--- a/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
@@ -108,7 +108,8 @@ class _CopyableCodeBlock(CodeBlock):
         self.action_id = action_id
 
     def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
-        if self.action_id is not None and options.max_width >= len("Copy"):
+        show_header = self.action_id is not None and options.max_width >= len("Copy")
+        if show_header:
             # Replace Syntax's top padding row with a full-width, same-background
             # control row so the language and Copy action sit inside the panel.
             # At widths below the full label, omit the action rather than expose
@@ -149,7 +150,7 @@ class _CopyableCodeBlock(CodeBlock):
             theme=self.theme,
             word_wrap=True,
             # The header above occupies the existing top padding row.
-            padding=(0, 1, 1, 1) if self.action_id is not None else 1,
+            padding=(0, 1, 1, 1) if show_header else 1,
         )
         if self.action_id is not None:
             for line_number, line in enumerate(source_lines, 1):

--- a/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
@@ -108,12 +108,14 @@ class _CopyableCodeBlock(CodeBlock):
         self.action_id = action_id
 
     def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
-        if self.action_id is not None:
+        if self.action_id is not None and options.max_width >= len("Copy"):
             # Replace Syntax's top padding row with a full-width, same-background
             # control row so the language and Copy action sit inside the panel.
+            # At widths below the full label, omit the action rather than expose
+            # an ambiguous linked suffix such as "y" or "py".
             header = Text(style=Syntax.get_theme(self.theme).get_background_style())
-            width = max(1, options.max_width)
-            copy_width = min(width, len("Copy"))
+            width = options.max_width
+            copy_width = len("Copy")
             trailing_space = width > copy_width
             available = width - copy_width - int(trailing_space)
             if self.lexer_name != "text" and available >= 4:
@@ -122,7 +124,7 @@ class _CopyableCodeBlock(CodeBlock):
                 header.append_text(language)
                 header.append(" · ", style="dim")
             header.append(
-                "Copy"[-copy_width:],
+                "Copy",
                 style=f"bold underline link {_COPY_URI_PREFIX}{self.action_id}",
             )
             if trailing_space:

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -45,14 +45,9 @@ class _HistoryReplayRenderer:
     """Width-aware history renderer retaining source metadata across replay."""
 
     def __init__(self, output: HistoryReplay, *, copyable: bool = False) -> None:
-        from rich.markdown import Markdown
+        from .copyable_markdown import CopyableMarkdown, TerminalMarkdown
 
-        if copyable:
-            from .copyable_markdown import CopyableMarkdown
-
-            markdown_type = CopyableMarkdown
-        else:
-            markdown_type = Markdown
+        markdown_type = CopyableMarkdown if copyable else TerminalMarkdown
         self.output = output
         self.agent_markdown = [
             markdown_type(turn.content) for turn in output.turns if turn.role == "agent"
@@ -73,7 +68,7 @@ class _HistoryReplayRenderer:
         from rich.rule import Rule
         from rich.text import Text
 
-        from .theme import CATPPUCCIN_THEME
+        from .theme import create_theme
 
         dim = COLORS["overlay1"]
         render_width = max(int(width), 1)
@@ -87,7 +82,7 @@ class _HistoryReplayRenderer:
             highlight=False,
             force_terminal=True,
             color_system="256",
-            theme=CATPPUCCIN_THEME,
+            theme=create_theme(),
             _environ={"COLUMNS": str(render_width), "LINES": "25"},
         )
 
@@ -115,7 +110,7 @@ class _HistoryReplayRenderer:
                 # current viewport; Rich hard wrapping would add copied whitespace.
                 console.print(self.agent_markdown[agent_index], style=dim, soft_wrap=True)
                 agent_index += 1
-            console.print()
+                console.print()
         if self.output.show_footer:
             console.print(Rule(style=COLORS["surface1"]))
         return buf.getvalue()

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -230,6 +230,12 @@ class TerminalFrontend:
     """
 
     def __init__(self, config: "Config") -> None:
+        from .theme import set_theme
+
+        # Apply the persisted palette before constructing any Rich or
+        # prompt-toolkit rendering surfaces.
+        set_theme(getattr(config.tui, "theme", "mocha"))
+
         from .console import TUIConsole
 
         self._config = config

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -679,7 +679,7 @@ class TerminalFrontend:
 
         keybinds = ("vi mode  " if info.vi_mode else "") + (
             "Tab: complete  |  ↑↓: history  |  Ctrl+U: clear  |  Shift+Enter: newline  |  "
-            "Esc: interrupt  |  Ctrl+C ×2: exit"
+            "Esc: interrupt  |  Ctrl+C: clear / interrupt / exit"
         )
         table.add_row("keys", f"[{overlay}]{keybinds}[/]")
         table.add_row(

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -499,17 +499,17 @@ class FullscreenTranscriptModel:
             if not mappings:
                 continue
 
-            # Syntax contributes one top padding row, while the generated
-            # Copy link lives in the bottom padding row after the source. Keep
-            # both decorations inside the semantic region so dragging across
-            # the complete panel still projects to exact source text.
-            first_code_line = plain.rfind("\n", 0, mappings[0].display_start) + 1
-            if first_code_line > 0:
-                display_start = plain.rfind("\n", 0, first_code_line - 1) + 1
+            # The generated Copy link occupies Syntax's top padding row;
+            # Syntax retains one bottom padding row after the source. Keep both
+            # decorations inside the semantic region so dragging across the
+            # complete panel still projects to exact source text.
+            display_start = plain.rfind("\n", 0, label_ranges[0][0]) + 1
+            last_line_end = plain.find("\n", mappings[-1].display_stop)
+            if last_line_end < 0:
+                display_stop = len(plain)
             else:
-                display_start = 0
-            footer_end = plain.find("\n", label_ranges[-1][1])
-            display_stop = len(plain) if footer_end < 0 else footer_end + 1
+                bottom_end = plain.find("\n", last_line_end + 1)
+                display_stop = len(plain) if bottom_end < 0 else bottom_end + 1
             regions.append(
                 _CodeSelectionRegion(display_start, display_stop, payload, tuple(mappings))
             )

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -499,15 +499,19 @@ class FullscreenTranscriptModel:
             if not mappings:
                 continue
 
-            header_start = plain.rfind("\n", 0, label_ranges[0][0]) + 1
-            last_line_end = plain.find("\n", mappings[-1].display_stop)
-            if last_line_end < 0:
-                display_stop = len(plain)
+            # Syntax contributes one top padding row, while the generated
+            # Copy link lives in the bottom padding row after the source. Keep
+            # both decorations inside the semantic region so dragging across
+            # the complete panel still projects to exact source text.
+            first_code_line = plain.rfind("\n", 0, mappings[0].display_start) + 1
+            if first_code_line > 0:
+                display_start = plain.rfind("\n", 0, first_code_line - 1) + 1
             else:
-                bottom_end = plain.find("\n", last_line_end + 1)
-                display_stop = len(plain) if bottom_end < 0 else bottom_end + 1
+                display_start = 0
+            footer_end = plain.find("\n", label_ranges[-1][1])
+            display_stop = len(plain) if footer_end < 0 else footer_end + 1
             regions.append(
-                _CodeSelectionRegion(header_start, display_stop, payload, tuple(mappings))
+                _CodeSelectionRegion(display_start, display_stop, payload, tuple(mappings))
             )
         return tuple(sorted(regions, key=lambda region: region.display_start))
 

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -16,6 +16,7 @@ from prompt_toolkit.formatted_text import ANSI, FormattedText, to_formatted_text
 from rich.cells import split_graphemes
 from wcwidth import wcswidth
 
+from .copyable_markdown import visible_code_line
 from .terminal_safety import (
     _hyperlink_spans_from_safe_ansi,
     project_prompt_toolkit_ansi,
@@ -443,30 +444,8 @@ class FullscreenTranscriptModel:
                 if line_number >= len(payload_lines):
                     continue
                 source_line = payload_lines[line_number]
-                expanded_to_source: list[tuple[int, int]] = []
-                column = 0
-                source_index = 0
-                source_parts = source_line.split("\t")
-                for part_index, part in enumerate(source_parts):
-                    grapheme_spans, _ = split_graphemes(part)
-                    for start, stop, _cells in grapheme_spans:
-                        source_start = source_index + start
-                        source_stop = source_index + stop
-                        # Syntax expands tabs by Python string columns before
-                        # rendering. Map each rendered code point back to the
-                        # complete source grapheme; projection handles cell width.
-                        expanded_to_source.extend(
-                            (source_start, source_stop) for _ in range(stop - start)
-                        )
-                        column += stop - start
-                    source_index += len(part)
-                    if part_index + 1 < len(source_parts):
-                        width = 4 - (column % 4)
-                        expanded_to_source.extend(
-                            (source_index, source_index + 1) for _ in range(width)
-                        )
-                        source_index += 1
-                        column += width
+                _rendered_line, source_map = visible_code_line(source_line)
+                expanded_to_source = list(source_map)
                 if not source_line:
                     # CopyableMarkdown paints one linked placeholder cell for
                     # an otherwise unstyleable empty source row. It represents

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -982,7 +982,7 @@ class Session:
 
     def _render_to_ansi(self, renderable: Any) -> str:
         """Render a Rich renderable using the current terminal width."""
-        from .theme import CATPPUCCIN_THEME
+        from .theme import create_theme
         from .tui_application import terminal_cols
 
         try:
@@ -1002,7 +1002,7 @@ class Session:
             # height is explicit too. Rendering is unpaged, so its value is
             # immaterial; fixing it keeps wrapping tied to transcript width.
             height=1,
-            theme=CATPPUCCIN_THEME,
+            theme=create_theme(),
         )
         # Markdown prose must retain semantic line boundaries. Rich's default
         # width wrapping pads every visual row and inserts hard newlines, which
@@ -1032,13 +1032,13 @@ class Session:
         assert self._app is not None
 
         from .config import DisplayMode
-        from .copyable_markdown import CopyableMarkdown
+        from .copyable_markdown import CopyableMarkdown, TerminalMarkdown
 
         full_screen = getattr(self._app, "display_mode", None) is DisplayMode.FULLSCREEN
         if full_screen:
             from rich.markdown import Markdown
 
-            if type(renderable) is Markdown:
+            if type(renderable) in {Markdown, TerminalMarkdown}:
                 renderable = CopyableMarkdown(
                     renderable.markup,
                     code_theme=renderable.code_theme,

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -404,7 +404,7 @@ class Session:
         from .agent_event_renderer import AgentEventRenderer
         from .input_handler import SlashCommandCompleter
         from .output import TextOutput
-        from .theme import CATPPUCCIN_THEME
+        from .theme import create_theme
         from .tui_application import TUIApplication
 
         # Save terminal attributes so we can restore them on exit, even
@@ -660,7 +660,7 @@ class Session:
                     force_terminal=True,
                     color_system="256",
                     width=120,
-                    theme=CATPPUCCIN_THEME,
+                    theme=create_theme(),
                 )
             )
 

--- a/packages/nooa-cli/src/nooa_cli/tui/settings.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/settings.py
@@ -51,6 +51,7 @@ SETTINGS_ENV_VAR = "NEMO_OO_SETTINGS"
 # coerced here. Dotted path (section.field) → callable; unlisted = set as-is.
 _COERCE: dict[str, Any] = {
     "tui.display_mode": lambda v: _coerce_display_mode(v),
+    "tui.theme": lambda v: _coerce_theme(v),
     "tui.mcp_file": lambda v: Path(v),
     "tui.trace_dir": lambda v: Path(v) if v is not None else None,
     "tui.additional_skills_dirs": lambda v: [Path(item) for item in (v or [])],
@@ -65,6 +66,15 @@ def _coerce_display_mode(value: Any) -> Any:
     from .config import DisplayMode
 
     return DisplayMode(value)
+
+
+def _coerce_theme(value: Any) -> str:
+    from .theme import THEMES
+
+    name = str(value).lower()
+    if name not in THEMES:
+        raise ValueError(f"Unknown theme {value!r}. Choose from: {', '.join(THEMES)}")
+    return name
 
 
 # Fields that are computed / runtime-only and must NOT be persisted or
@@ -270,6 +280,9 @@ SETTINGS_TEMPLATE = """\
 tui:
   # LLM model alias (from the unifiedllm registry) or a litellm model name.
   # default_model: {default_model}
+
+  # Color palette. Prefer /theme <name> so the choice is applied and saved.
+  # theme: mocha               # mocha | latte | vsdark | vslight
 
   # Show the agent's Python execution panels.
   # show_python: false

--- a/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/terminal_safety.py
@@ -13,13 +13,13 @@ from __future__ import annotations
 
 import re
 import shutil
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit, urlunsplit
 
 from rich.cells import split_graphemes
 
 _ESC = "\x1b"
 
-_MAX_SAFE_HTTP_URL_LENGTH = 2_048
+_MAX_SAFE_HYPERLINK_LENGTH = 2_048
 
 # This expression is used only after ``sanitize_transcript_ansi`` has reduced
 # the language to SGR and OSC-8.  It deliberately recognizes both OSC
@@ -138,11 +138,11 @@ def sanitize_transcript_ansi(value: str) -> str:
     return "".join(output)
 
 
-def safe_http_url(value: str | None) -> str | None:
-    """Return a control-free HTTP(S) URL suitable for an explicit browser launch."""
+def safe_hyperlink_target(value: str | None) -> str | None:
+    """Return a control-free HTTP(S) or absolute file URL for explicit opening."""
     if (
         not value
-        or len(value) > _MAX_SAFE_HTTP_URL_LENGTH
+        or len(value) > _MAX_SAFE_HYPERLINK_LENGTH
         or any(
             character.isspace() or ord(character) < 0x20 or 0x7F <= ord(character) <= 0x9F
             for character in value
@@ -153,9 +153,41 @@ def safe_http_url(value: str | None) -> str | None:
         parsed = urlsplit(value)
     except ValueError:
         return None
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+    if parsed.scheme in {"http", "https"}:
+        return value if parsed.netloc else None
+    if parsed.scheme == "file":
+        if not parsed.path.startswith("/"):
+            return None
+        local_path = parsed.path
+        authority = parsed.netloc
+        if authority and authority.lower() != "localhost":
+            # Users commonly spell a local path as ``file://path/to/file``.
+            # Interpret its authority as the first path segment rather than as
+            # a remote host, which could trigger network authentication.
+            local_path = f"/{authority}{parsed.path}"
+            authority = ""
+        # Reject UNC/device-like paths after combining and decoding every path
+        # component; encoded separators in the apparent authority must not
+        # evade the local-only policy.
+        decoded_path = unquote(local_path)
+        if (
+            decoded_path.startswith("//")
+            or "\\" in decoded_path
+            or any(
+                ord(char) < 0x20 or 0x7F <= ord(char) <= 0x9F for char in decoded_path
+            )
+        ):
+            return None
+        return urlunsplit(("file", authority, local_path, parsed.query, parsed.fragment))
+    return None
+
+
+def safe_http_url(value: str | None) -> str | None:
+    """Return a control-free HTTP(S) URL suitable for an explicit browser launch."""
+    target = safe_hyperlink_target(value)
+    if target is None:
         return None
-    return value
+    return target if urlsplit(target).scheme in {"http", "https"} else None
 
 
 def hyperlink_at_plain_offset(value: str, offset: int) -> str | None:
@@ -190,7 +222,7 @@ def _hyperlink_spans_from_safe_ansi(
                     spans.append((active[0], plain_offset, active[1]))
                 payload = sequence[4:-1] if sequence.endswith("\x07") else sequence[4:-2]
                 _parameters, _separator, target = payload.partition(";")
-                url = safe_http_url(target)
+                url = safe_hyperlink_target(target)
                 active = (plain_offset, url) if url is not None else None
             index = match.end()
             continue

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1069,6 +1069,7 @@ class TUIApplication:
         self._ctrl_c_exit_armed = False
         self._ctrl_c_exit_timer: asyncio.TimerHandle | None = None
         self._exit_hint_text = ""
+        self._interrupting_agent_turn = False
         self._transient_status_text = ""
         self._transient_status_style = "class:status"
         self._transient_status_timer: asyncio.TimerHandle | None = None
@@ -2712,7 +2713,9 @@ class TUIApplication:
         else:
             loop.call_soon_threadsafe(callback)
 
-    def _on_agent_change(self, _state: Any) -> None:
+    def _on_agent_change(self, state: Any) -> None:
+        if state is None or state.workspace.cancellation is not CancellationState.REQUESTED:
+            self._interrupting_agent_turn = False
         app = getattr(self, "_app", None)
         if app is not None and app.is_running:
             app.invalidate()
@@ -2736,7 +2739,8 @@ class TUIApplication:
         self._ensure_spinner_task()
 
     def runtime_cancelled(self) -> None:
-        """Render the existing interruption marker for a cancelled local turn."""
+        """Acknowledge completed cancellation and render its transcript marker."""
+        self._interrupting_agent_turn = False
         self.emit_block("\x1b[33m✗ Interrupted agent turn.\x1b[0m\n")
 
     def invalidate(self) -> None:
@@ -2759,8 +2763,14 @@ class TUIApplication:
         if self._agent_controller.state is None:
             return False
         accepted = self._agent_controller.interrupt()
-        if accepted and self._on_agent_activity is not None:
-            self._on_agent_activity()
+        if accepted:
+            # The runtime observation callback may arrive on another loop. Paint
+            # acknowledgement immediately so the key press never appears lost.
+            self._interrupting_agent_turn = True
+            if self._app.is_running:
+                self._app.invalidate()
+            if self._on_agent_activity is not None:
+                self._on_agent_activity()
         return accepted
 
     def _resume_input_cursor_following(self) -> None:
@@ -4012,8 +4022,10 @@ class TUIApplication:
         state = self._agent_controller.state
         if self._agent_controller.failure is not None:
             rows.append([("class:status", "Agent observation disconnected.")])
-        if state is not None and state.workspace.cancellation is CancellationState.REQUESTED:
-            rows.append([("class:status", f"{self._spinner_frame} cancelling agent turn...")])
+        if self._interrupting_agent_turn or (
+            state is not None and state.workspace.cancellation is CancellationState.REQUESTED
+        ):
+            rows.append([("class:status", "Interrupting agent turn")])
         elif self.is_thinking():
             rows.append([("class:status", f"{self._spinner_frame} thinking...")])
         if self._llm_probe_status_text:

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1582,6 +1582,12 @@ class TUIApplication:
             defer_resize_redraw=self._defer_prompt_toolkit_resize_redraw,
             resize_redraw_is_deferred=self._prompt_toolkit_resize_redraw_is_deferred,
         )
+        # Bare Escape passes through both the VT100 prefix parser and the key
+        # binding prefix matcher. Their one-second defaults make interruption
+        # feel broken; terminal-generated Meta sequences arrive as one read, so
+        # a short ambiguity window preserves them without delaying Esc.
+        self._app.ttimeoutlen = 0.05
+        self._app.timeoutlen = 0.05
 
     def observe_agent(self) -> None:
         """Observe the configured agent for this application run.

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1021,7 +1021,7 @@ class TUIApplication:
                 runs.
             on_cancel_command: Synchronously request cancellation of the
                 active slash command. Returns whether a command accepted the
-                request. Esc falls back to interrupting the agent when false.
+                request. Bare Esc falls back to interrupting the agent when false.
             on_bang: Called with the bang body (e.g. ``"echo hi"`` for
                 ``!echo hi``). Session wires this to run_in_terminal +
                 bash. If omitted, bang commands are only recorded in
@@ -2369,15 +2369,6 @@ class TUIApplication:
         def _(event):
             _extend_input_selection(event, event.current_buffer.cursor_down)
 
-        @kb.add("c-c", filter=input_selection_active, eager=True)
-        def _(event):
-            # Copy composer selection without turning Ctrl-C into cancellation.
-            # Keep the selection visible so repeated copy is harmless.
-            _document, clipboard_data = self.input_buffer.document.cut_selection()
-            if clipboard_data.text:
-                event.app.clipboard.set_data(clipboard_data)
-                self._start_fullscreen_selection_copy(clipboard_data.text)
-
         @kb.add("c-x", filter=input_selection_active, eager=True)
         def _(event):
             # Retain the text in prompt_toolkit's clipboard before deleting it.
@@ -2388,24 +2379,33 @@ class TUIApplication:
                 self._start_fullscreen_selection_copy(clipboard_data.text)
                 self.input_buffer.cut_selection()
 
-        @kb.add("c-c", filter=subview_inactive)
+        @kb.add("c-c", filter=subview_inactive, eager=True)
         def _(event):
-            # The second C-c in the confirmation window exits through the
-            # normal Application path; Session.run() then performs its full
-            # snapshot/close/terminal-restoration cleanup in ``finally``.
+            # Ctrl-C advances one destructive step per press: discard a draft,
+            # then interrupt active work, then confirm exit. Never combine a
+            # composer clear with cancellation, so a draft is recoverably cheap
+            # to abandon even while an agent is running.
+            if event.current_buffer.text:
+                event.current_buffer.reset()
+                self._history_cursor = None
+                self._clear_ctrl_c_exit()
+                return
+
+            # After the clear/interrupt step, an armed press exits even if
+            # cancellation cleanup has not acknowledged yet.
             if self._ctrl_c_exit_armed:
                 self._clear_ctrl_c_exit()
                 event.app.exit()
                 return
 
-            # The first C-c always clears the composer. While an agent is
-            # running it also requests cancellation; at an idle prompt it arms
-            # the existing second-C-c-to-exit confirmation.
-            event.current_buffer.reset()
-            self._history_cursor = None
-            if self.request_agent_cancel(source="ctrl-c"):
+            # A slash command owns its cancellation independently of the agent
+            # turn. Treat either accepted cancellation as the interrupt step.
+            if self.request_command_cancel() or self.request_agent_cancel(source="ctrl-c"):
                 self._arm_ctrl_c_exit()
                 return
+
+            # At an idle prompt, retain the established double-Ctrl-C safety
+            # gesture.
             self._arm_ctrl_c_exit()
 
         @kb.add("c-d", filter=subview_inactive)
@@ -2457,9 +2457,19 @@ class TUIApplication:
         def _(event):
             self._history_navigate(+1)
 
-        # Esc: soft-cancel the agent while preserving the queue. Any
-        # messages already submitted during the turn are delivered as
-        # the next respond() via the done-callback.
+        # Absorb escape-prefixed Meta/Option input as one non-interrupting
+        # gesture. prompt_toolkit otherwise falls back from an unmatched pair
+        # such as Option-[ (ESC + "[") to the bare-Escape binding below, which
+        # accidentally cancels the active turn. More-specific bindings (for
+        # example Alt+Enter and Emacs Meta navigation) still win.
+        @kb.add("escape", Keys.Any, filter=subview_inactive)
+        def _(event):
+            data = event.data
+            if data and data != "\x1b":
+                event.current_buffer.insert_text(data)
+
+        # A standalone Esc is emitted only after prompt_toolkit's VT parser has
+        # allowed time for a possible escape-prefixed key to arrive.
         @kb.add("escape", filter=subview_inactive)
         def _(event):
             if self.request_command_cancel():

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2405,9 +2405,12 @@ class TUIApplication:
                 event.app.exit()
                 return
 
-            # A slash command owns its cancellation independently of the agent
-            # turn. Treat either accepted cancellation as the interrupt step.
-            if self.request_command_cancel() or self.request_agent_cancel(source="ctrl-c"):
+            # Slash commands and agent work can overlap. Attempt both instead
+            # of short-circuiting so one Ctrl-C interrupts every active turn
+            # owner before the next press becomes the exit step.
+            command_cancelled = self.request_command_cancel()
+            agent_cancelled = self.request_agent_cancel(source="ctrl-c")
+            if command_cancelled or agent_cancelled:
                 self._arm_ctrl_c_exit()
                 return
 
@@ -2720,7 +2723,10 @@ class TUIApplication:
             loop.call_soon_threadsafe(callback)
 
     def _on_agent_change(self, state: Any) -> None:
-        if state is None or state.workspace.cancellation is not CancellationState.REQUESTED:
+        # A pre-interrupt observation may already be queued when cancellation is
+        # admitted. Only teardown may clear the optimistic acknowledgement;
+        # normal completion clears it through ``runtime_cancelled``.
+        if state is None:
             self._interrupting_agent_turn = False
         app = getattr(self, "_app", None)
         if app is not None and app.is_running:

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1156,6 +1156,8 @@ class TUIApplication:
         self._session_label: str = ""
         self._spinner_frame: str = "⠋"
         self._spinner_frames = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+        self._pulse_frame: str = "·"
+        self._pulse_frames = "·•"
         self._spinner_task: asyncio.Task | None = None
         self._command_status_text: str = ""
         self._command_queue_texts: list[str] = []
@@ -2597,8 +2599,16 @@ class TUIApplication:
         async def _animate() -> None:
             i = 0
             try:
-                while self.is_thinking() or self._llm_probe_status_text:
+                while (
+                    self.is_thinking()
+                    or self._interrupting_agent_turn
+                    or self._llm_probe_status_text
+                ):
                     self._spinner_frame = self._spinner_frames[i % len(self._spinner_frames)]
+                    # Match the command runner's calm half-second dot pulse
+                    # while retaining the thinking spinner's smoother cadence.
+                    pulse_index = int((i * 0.08) / 0.5)
+                    self._pulse_frame = self._pulse_frames[pulse_index % len(self._pulse_frames)]
                     if self._app.is_running:
                         self._app.invalidate()
                     i += 1
@@ -2862,8 +2872,10 @@ class TUIApplication:
             self._interrupt_status_acknowledged = False
             self._interrupt_completion_pending = False
             self._interrupt_status_started_at = time.monotonic()
+            self._pulse_frame = self._pulse_frames[0]
             if self._app.is_running:
                 self._app.invalidate()
+            self._ensure_spinner_task()
             if self._on_agent_activity is not None:
                 self._on_agent_activity()
         return accepted
@@ -4127,7 +4139,7 @@ class TUIApplication:
         if self._interrupting_agent_turn or (
             state is not None and state.workspace.cancellation is CancellationState.REQUESTED
         ):
-            rows.append([("class:status", "Interrupting agent turn")])
+            rows.append([("class:status", f"{self._pulse_frame} Interrupting agent turn")])
         elif self.is_thinking():
             rows.append([("class:status", f"{self._spinner_frame} thinking...")])
         if self._llm_probe_status_text:

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1073,6 +1073,7 @@ class TUIApplication:
         self._exit_hint_text = ""
         self._interrupting_agent_turn = False
         self._interrupt_status_acknowledged = False
+        self._interrupt_completion_pending = False
         self._interrupt_status_started_at: float | None = None
         self._interrupt_status_clear_timer: asyncio.TimerHandle | None = None
         self._transient_status_text = ""
@@ -2754,8 +2755,6 @@ class TUIApplication:
         # before prompt_toolkit can paint even one frame.
         if state is None:
             self._acknowledge_agent_interrupt()
-        elif state is not None:
-            self._retire_acknowledged_interrupt_for_new_turn(state)
         app = getattr(self, "_app", None)
         if app is not None and app.is_running:
             app.invalidate()
@@ -2763,6 +2762,10 @@ class TUIApplication:
 
     def runtime_notification_received(self) -> None:
         """Refresh native chrome after the host dequeues runtime work."""
+        if self._interrupt_completion_pending:
+            # A replacement turn is beginning. Retire the completed turn's
+            # optimistic label before rendering any chrome for the new work.
+            self._clear_agent_interrupt_status()
         self._on_dispatcher_dequeued()
 
     def runtime_state_changed(self) -> None:
@@ -2774,32 +2777,20 @@ class TUIApplication:
             self._refresh_runner_state()
 
     def _refresh_runner_state(self) -> None:
-        # This hook runs at the runtime transition site, while observation
-        # delivery may still be coalesced behind other UI work. Read the
-        # immutable source snapshot so a queued replacement turn cannot inherit
-        # the prior turn's delayed interrupt label even for one frame.
-        agent = self._agent
-        if agent is not None:
-            self._retire_acknowledged_interrupt_for_new_turn(agent.state)
         if self._app.is_running:
             self._app.invalidate()
         self._ensure_spinner_task()
 
-    def _retire_acknowledged_interrupt_for_new_turn(self, state: Any) -> None:
-        if (
-            self._interrupting_agent_turn
-            and self._interrupt_status_acknowledged
-            and state.lifecycle in {AgentLifecycle.THINKING, AgentLifecycle.WAITING}
-            and state.workspace.cancellation is CancellationState.NONE
-        ):
-            # A queued message has started a new turn. Never let the previous
-            # turn's minimum display interval label this fresh work as stopping.
-            self._clear_agent_interrupt_status()
-
     def runtime_cancelled(self) -> None:
-        """Acknowledge completed cancellation and render its transcript marker."""
-        self._schedule_agent_callback(self._acknowledge_agent_interrupt)
-        self.emit_block("\x1b[33m✗ Interrupted agent turn.\x1b[0m\n")
+        """Replace optimistic feedback with the completed-cancellation marker."""
+        self._schedule_agent_callback(self._complete_agent_interrupt)
+
+    def _complete_agent_interrupt(self) -> None:
+        if not self._interrupting_agent_turn:
+            self.emit_block("\x1b[33m✗ Interrupted agent turn.\x1b[0m\n")
+            return
+        self._interrupt_completion_pending = True
+        self._acknowledge_agent_interrupt()
 
     def _acknowledge_agent_interrupt(self) -> None:
         """Clear interrupt feedback only after it had time to reach a frame."""
@@ -2827,12 +2818,19 @@ class TUIApplication:
             )
 
     def _clear_agent_interrupt_status(self) -> None:
+        timer = self._interrupt_status_clear_timer
         self._interrupt_status_clear_timer = None
+        if timer is not None:
+            timer.cancel()
+        emit_completion = self._interrupt_completion_pending
+        self._interrupt_completion_pending = False
         self._interrupt_status_started_at = None
         self._interrupt_status_acknowledged = False
         self._interrupting_agent_turn = False
         if self._app.is_running:
             self._app.invalidate()
+        if emit_completion:
+            self.emit_block("\x1b[33m✗ Interrupted agent turn.\x1b[0m\n")
 
     def invalidate(self) -> None:
         """Thread-safe repaint hook for composition-root-owned policies."""
@@ -2862,6 +2860,7 @@ class TUIApplication:
                 self._interrupt_status_clear_timer = None
             self._interrupting_agent_turn = True
             self._interrupt_status_acknowledged = False
+            self._interrupt_completion_pending = False
             self._interrupt_status_started_at = time.monotonic()
             if self._app.is_running:
                 self._app.invalidate()
@@ -3264,6 +3263,7 @@ class TUIApplication:
                 self._interrupt_status_clear_timer = None
             self._interrupting_agent_turn = False
             self._interrupt_status_acknowledged = False
+            self._interrupt_completion_pending = False
             self._interrupt_status_started_at = None
             if self._transient_status_timer is not None:
                 self._transient_status_timer.cancel()

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -23,6 +23,7 @@ import os
 import re
 import shutil
 import subprocess
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
@@ -899,6 +900,7 @@ def format_session_rule(cols: int, label: str = "") -> list[tuple[str, str]]:
 
 PROMPT_MARKER = "❯ "
 _CTRL_C_EXIT_WINDOW_SECONDS = 2.0
+_MIN_INTERRUPT_STATUS_SECONDS = 0.75
 _TRANSCRIPT_CLEAR_SEQUENCE = "\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H"
 _FULLSCREEN_TRANSCRIPT_MAX_RECORDS = 10_000
 _FULLSCREEN_TRANSCRIPT_MAX_BYTES = 16 * 1024 * 1024
@@ -1070,6 +1072,8 @@ class TUIApplication:
         self._ctrl_c_exit_timer: asyncio.TimerHandle | None = None
         self._exit_hint_text = ""
         self._interrupting_agent_turn = False
+        self._interrupt_status_started_at: float | None = None
+        self._interrupt_status_clear_timer: asyncio.TimerHandle | None = None
         self._transient_status_text = ""
         self._transient_status_style = "class:status"
         self._transient_status_timer: asyncio.TimerHandle | None = None
@@ -2731,10 +2735,11 @@ class TUIApplication:
 
     def _on_agent_change(self, state: Any) -> None:
         # A pre-interrupt observation may already be queued when cancellation is
-        # admitted. Only teardown may clear the optimistic acknowledgement;
-        # normal completion clears it through ``runtime_cancelled``.
+        # admitted. Only teardown may acknowledge the optimistic status; the
+        # minimum display interval keeps a fast cancellation from clearing it
+        # before prompt_toolkit can paint even one frame.
         if state is None:
-            self._interrupting_agent_turn = False
+            self._acknowledge_agent_interrupt()
         app = getattr(self, "_app", None)
         if app is not None and app.is_running:
             app.invalidate()
@@ -2759,8 +2764,39 @@ class TUIApplication:
 
     def runtime_cancelled(self) -> None:
         """Acknowledge completed cancellation and render its transcript marker."""
-        self._interrupting_agent_turn = False
+        self._schedule_agent_callback(self._acknowledge_agent_interrupt)
         self.emit_block("\x1b[33m✗ Interrupted agent turn.\x1b[0m\n")
+
+    def _acknowledge_agent_interrupt(self) -> None:
+        """Clear interrupt feedback only after it had time to reach a frame."""
+        if not self._interrupting_agent_turn:
+            return
+        started_at = self._interrupt_status_started_at
+        remaining = (
+            0.0
+            if started_at is None
+            else _MIN_INTERRUPT_STATUS_SECONDS - (time.monotonic() - started_at)
+        )
+        if remaining <= 0:
+            self._clear_agent_interrupt_status()
+        elif self._interrupt_status_clear_timer is None:
+            loop = self._loop
+            if loop is None or not loop.is_running():
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    self._clear_agent_interrupt_status()
+                    return
+            self._interrupt_status_clear_timer = loop.call_later(
+                remaining, self._clear_agent_interrupt_status
+            )
+
+    def _clear_agent_interrupt_status(self) -> None:
+        self._interrupt_status_clear_timer = None
+        self._interrupt_status_started_at = None
+        self._interrupting_agent_turn = False
+        if self._app.is_running:
+            self._app.invalidate()
 
     def invalidate(self) -> None:
         """Thread-safe repaint hook for composition-root-owned policies."""
@@ -2785,7 +2821,11 @@ class TUIApplication:
         if accepted:
             # The runtime observation callback may arrive on another loop. Paint
             # acknowledgement immediately so the key press never appears lost.
+            if self._interrupt_status_clear_timer is not None:
+                self._interrupt_status_clear_timer.cancel()
+                self._interrupt_status_clear_timer = None
             self._interrupting_agent_turn = True
+            self._interrupt_status_started_at = time.monotonic()
             if self._app.is_running:
                 self._app.invalidate()
             if self._on_agent_activity is not None:
@@ -3182,6 +3222,11 @@ class TUIApplication:
             self._resize_replays_enabled = False
             self._cancel_resize_replay_work()
             self._clear_ctrl_c_exit()
+            if self._interrupt_status_clear_timer is not None:
+                self._interrupt_status_clear_timer.cancel()
+                self._interrupt_status_clear_timer = None
+            self._interrupting_agent_turn = False
+            self._interrupt_status_started_at = None
             if self._transient_status_timer is not None:
                 self._transient_status_timer.cancel()
                 self._transient_status_timer = None

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1072,6 +1072,7 @@ class TUIApplication:
         self._ctrl_c_exit_timer: asyncio.TimerHandle | None = None
         self._exit_hint_text = ""
         self._interrupting_agent_turn = False
+        self._interrupt_status_acknowledged = False
         self._interrupt_status_started_at: float | None = None
         self._interrupt_status_clear_timer: asyncio.TimerHandle | None = None
         self._transient_status_text = ""
@@ -2734,12 +2735,27 @@ class TUIApplication:
             loop.call_soon_threadsafe(callback)
 
     def _on_agent_change(self, state: Any) -> None:
+        # Agent implementations may publish from worker threads. Keep timer and
+        # prompt-toolkit mutations on the Application's owner loop even if a
+        # caller bypasses the controller's normal scheduler boundary.
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            try:
+                on_ui_loop = asyncio.get_running_loop() is loop
+            except RuntimeError:
+                on_ui_loop = False
+            if not on_ui_loop:
+                loop.call_soon_threadsafe(self._on_agent_change, state)
+                return
+
         # A pre-interrupt observation may already be queued when cancellation is
         # admitted. Only teardown may acknowledge the optimistic status; the
         # minimum display interval keeps a fast cancellation from clearing it
         # before prompt_toolkit can paint even one frame.
         if state is None:
             self._acknowledge_agent_interrupt()
+        elif state is not None:
+            self._retire_acknowledged_interrupt_for_new_turn(state)
         app = getattr(self, "_app", None)
         if app is not None and app.is_running:
             app.invalidate()
@@ -2758,9 +2774,27 @@ class TUIApplication:
             self._refresh_runner_state()
 
     def _refresh_runner_state(self) -> None:
+        # This hook runs at the runtime transition site, while observation
+        # delivery may still be coalesced behind other UI work. Read the
+        # immutable source snapshot so a queued replacement turn cannot inherit
+        # the prior turn's delayed interrupt label even for one frame.
+        agent = self._agent
+        if agent is not None:
+            self._retire_acknowledged_interrupt_for_new_turn(agent.state)
         if self._app.is_running:
             self._app.invalidate()
         self._ensure_spinner_task()
+
+    def _retire_acknowledged_interrupt_for_new_turn(self, state: Any) -> None:
+        if (
+            self._interrupting_agent_turn
+            and self._interrupt_status_acknowledged
+            and state.lifecycle in {AgentLifecycle.THINKING, AgentLifecycle.WAITING}
+            and state.workspace.cancellation is CancellationState.NONE
+        ):
+            # A queued message has started a new turn. Never let the previous
+            # turn's minimum display interval label this fresh work as stopping.
+            self._clear_agent_interrupt_status()
 
     def runtime_cancelled(self) -> None:
         """Acknowledge completed cancellation and render its transcript marker."""
@@ -2771,6 +2805,7 @@ class TUIApplication:
         """Clear interrupt feedback only after it had time to reach a frame."""
         if not self._interrupting_agent_turn:
             return
+        self._interrupt_status_acknowledged = True
         started_at = self._interrupt_status_started_at
         remaining = (
             0.0
@@ -2794,6 +2829,7 @@ class TUIApplication:
     def _clear_agent_interrupt_status(self) -> None:
         self._interrupt_status_clear_timer = None
         self._interrupt_status_started_at = None
+        self._interrupt_status_acknowledged = False
         self._interrupting_agent_turn = False
         if self._app.is_running:
             self._app.invalidate()
@@ -2825,6 +2861,7 @@ class TUIApplication:
                 self._interrupt_status_clear_timer.cancel()
                 self._interrupt_status_clear_timer = None
             self._interrupting_agent_turn = True
+            self._interrupt_status_acknowledged = False
             self._interrupt_status_started_at = time.monotonic()
             if self._app.is_running:
                 self._app.invalidate()
@@ -3226,6 +3263,7 @@ class TUIApplication:
                 self._interrupt_status_clear_timer.cancel()
                 self._interrupt_status_clear_timer = None
             self._interrupting_agent_turn = False
+            self._interrupt_status_acknowledged = False
             self._interrupt_status_started_at = None
             if self._transient_status_timer is not None:
                 self._transient_status_timer.cancel()

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1600,9 +1600,16 @@ class TUIApplication:
             self._agent_controller.observe(self._agent)
 
     def refresh_style(self) -> None:
-        """Apply the current TUI palette to the live prompt-toolkit app."""
+        """Apply the current palette to chrome and retained fullscreen output."""
         self._app.style = create_prompt_style()
-        self._app.invalidate()
+        if self._is_fullscreen and self._fullscreen_semantic_replay_count:
+            # Width caches also contain resolved theme colors. Theme changes
+            # must force each semantic callback to render again at this width.
+            for block in self._transcript_blocks:
+                block.replay_cache.clear()
+            self._rebuild_fullscreen_transcript()
+        else:
+            self._app.invalidate()
 
     async def open_event_explorer(self, event_manager: Any) -> None:
         """Open the event explorer as an in-app subview."""
@@ -2002,7 +2009,7 @@ class TUIApplication:
         return control.handle_external_mouse(mouse_event, below=True)
 
     def _open_fullscreen_link_at(self, x: int, y: int) -> bool:
-        """Open the safe HTTP(S) hyperlink under a click without affecting drag-copy."""
+        """Open a safe hyperlink under a click without affecting drag-copy."""
         if not self._is_fullscreen:
             return False
         width, height = self._transcript_viewport_size()

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2759,12 +2759,10 @@ class TUIApplication:
                 loop.call_soon_threadsafe(self._on_agent_change, state)
                 return
 
-        # A pre-interrupt observation may already be queued when cancellation is
-        # admitted. Only teardown may acknowledge the optimistic status; the
-        # minimum display interval keeps a fast cancellation from clearing it
-        # before prompt_toolkit can paint even one frame.
-        if state is None:
-            self._acknowledge_agent_interrupt()
+        # Observation teardown is independent from runtime turn cancellation.
+        # Only runtime_cancelled() may acknowledge interrupt feedback; otherwise
+        # a delayed observation-close callback could retire a newer turn's
+        # status.
         app = getattr(self, "_app", None)
         if app is not None and app.is_running:
             app.invalidate()

--- a/packages/nooa-cli/src/nooa_cli/tui/user_message.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/user_message.py
@@ -23,20 +23,26 @@ def _hex_to_ansi256(hex_color: str) -> int:
 
 
 def render_user_bar(text: str, cols: int, colors: dict[str, str]) -> str:
-    """Render one live or resumed user message as full-width highlighted rows."""
+    """Render one live or resumed user message with highlighted breathing room."""
     width = max(int(cols), 1)
     foreground = _hex_to_ansi256(colors["text"])
     background = _hex_to_ansi256(colors["surface2"])
     style_on = f"\x1b[38;5;{foreground};48;5;{background}m"
     style_off = "\x1b[0m"
 
-    rows: list[str] = []
+    def styled_row(content: str = "") -> str:
+        return f"{style_on}{set_cell_size(content, width)}{style_off}"
+
+    # Keep one full-width, same-background blank row above and below every
+    # accepted message so the padding survives both live output and replay.
+    rows: list[str] = [styled_row()]
     for index, line in enumerate(sanitize_live_text(text).split("\n")):
         shown = f" ❯ {line} " if index == 0 else f" {line} "
         # Rich's cell helpers preserve grapheme clusters and measure wide
         # glyphs correctly. Every row is exactly the safe content width.
         chunks = chop_cells(shown, width) or [""]
-        rows.extend(f"{style_on}{set_cell_size(chunk, width)}{style_off}" for chunk in chunks)
+        rows.extend(styled_row(chunk) for chunk in chunks)
+    rows.append(styled_row())
     return "\n".join(rows) + "\n"
 
 

--- a/packages/nooa-cli/tests/tui/test_agent_event_renderer.py
+++ b/packages/nooa-cli/tests/tui/test_agent_event_renderer.py
@@ -236,6 +236,22 @@ def test_message_parses_safe_file_link_as_markdown() -> None:
     )
 
 
+def test_message_parses_single_slash_absolute_file_link() -> None:
+    from nooa_cli.tui.copyable_markdown import TerminalMarkdown
+
+    markdown = TerminalMarkdown("Open [the file](file:/tmp/example.py).")
+    tokens = [
+        child
+        for token in markdown.parsed
+        for child in (token.children or [])
+    ]
+
+    assert any(
+        token.type == "link_open" and token.attrGet("href") == "file:///tmp/example.py"
+        for token in tokens
+    )
+
+
 def test_message_between_preview_and_cell_output_preserves_natural_order() -> None:
     """``self.message()`` is called *inside* the cell body, so the
     ``∴`` code preview (fired on the enclosing ``ToolCallEvent``)

--- a/packages/nooa-cli/tests/tui/test_agent_event_renderer.py
+++ b/packages/nooa-cli/tests/tui/test_agent_event_renderer.py
@@ -205,6 +205,37 @@ def test_message_marks_only_agent_prose_for_unseen_notification() -> None:
     assert message[1]["agent_message"] is True
 
 
+def test_message_parses_safe_file_link_as_markdown() -> None:
+    from nooa_cli.tui.copyable_markdown import TerminalMarkdown
+
+    agent = _FakeAgent()
+    calls: list[tuple[Any, dict[str, Any]]] = []
+    renderer = AgentEventRenderer(
+        agent=agent,  # type: ignore[arg-type]
+        emit_text=lambda renderable, **kwargs: calls.append((renderable, kwargs)),
+        show_python=lambda: False,
+        show_diffs=lambda: True,
+        pending_code={},
+        colors=COLORS,
+    )
+    renderer.attach()
+
+    assert agent._render_message is not None
+    agent._render_message("Open [the file](file://path/to/file).")
+
+    markdown = next(renderable for renderable, _kwargs in calls if isinstance(renderable, Markdown))
+    assert isinstance(markdown, TerminalMarkdown)
+    tokens = [
+        child
+        for token in markdown.parsed
+        for child in (token.children or [])
+    ]
+    assert any(
+        token.type == "link_open" and token.attrGet("href") == "file:///path/to/file"
+        for token in tokens
+    )
+
+
 def test_message_between_preview_and_cell_output_preserves_natural_order() -> None:
     """``self.message()`` is called *inside* the cell body, so the
     ``∴`` code preview (fired on the enclosing ``ToolCallEvent``)

--- a/packages/nooa-cli/tests/tui/test_bootstrap_scaffold.py
+++ b/packages/nooa-cli/tests/tui/test_bootstrap_scaffold.py
@@ -40,6 +40,7 @@ def test_scaffold_writes_settings_with_model_and_preserves_literal_braces(tmp_pa
     # The {default_model} placeholder is substituted...
     assert "nvidia/llama-3.3" in written
     assert "{default_model}" not in written
+    assert "# theme: mocha" in written
     # ...while literal braces from the inline-MCP example survive verbatim.
     assert "${MAAS_API_KEY}" in written
 

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -3552,6 +3552,27 @@ def test_copyable_markdown_preserves_long_list_item_for_fullscreen_reflow() -> N
     assert any(row.endswith(" ") for row in rows[:-1])
 
 
+def test_copyable_markdown_preserves_safe_markdown_links() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+    from nooa_cli.tui.terminal_safety import safe_hyperlink_spans, strip_safe_ansi
+
+    _renderable, ansi = _copyable_markdown_ansi(
+        "Read the [documentation](https://example.test/docs) for details.", width=60
+    )
+
+    plain = strip_safe_ansi(ansi)
+    label_start = plain.index("documentation")
+    assert safe_hyperlink_spans(ansi) == (
+        (label_start, label_start + len("documentation"), "https://example.test/docs"),
+    )
+
+    model = FullscreenTranscriptModel()
+    model.append(ansi)
+    assert model.hyperlink_at(x=label_start, y=0, width=60, height=2) == (
+        "https://example.test/docs"
+    )
+
+
 def test_copyable_markdown_preserves_nested_and_multiline_list_structure() -> None:
     from nooa_cli.tui.terminal_safety import strip_safe_ansi
 
@@ -3617,6 +3638,23 @@ def test_copyable_markdown_places_copy_action_in_top_code_padding() -> None:
         style for style, text, *_rest in fragments if text == "p" and "bg:" in style
     )
     assert copy_style.split("bg:", 1)[1].split()[0] == code_style.split("bg:", 1)[1].split()[0]
+
+
+@pytest.mark.parametrize(
+    ("markdown", "width"),
+    [
+        ("```python\nx\n```", 8),
+        ("```averyverylonglexername\nx\n```", 12),
+    ],
+)
+def test_copyable_markdown_keeps_complete_copy_label_at_narrow_width(
+    markdown: str, width: int
+) -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+
+    _renderable, ansi = _copyable_markdown_ansi(markdown, width=width)
+
+    assert "Copy" in strip_safe_ansi(ansi).splitlines()[0]
 
 
 def test_copyable_markdown_does_not_offer_copy_for_empty_fence() -> None:
@@ -3688,6 +3726,30 @@ def test_fullscreen_drag_copy_projects_decorated_code_to_exact_source() -> None:
     # full-width background fill, and blank padding rows.
     model.begin_selection(x=0, y=header_y, width=60, height=20)
     model.update_selection(x=59, y=after_y - 1, width=60, height=20)
+
+    assert model.selected_text() == source
+
+
+def test_fullscreen_code_selection_exposes_controls_but_copies_original_source() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+    from nooa_cli.tui.terminal_safety import safe_hyperlink_spans, strip_safe_ansi
+
+    source = "a\x1b[31mb\x1b]8;;https://evil.test\x1b\\c"
+    renderable, ansi = _copyable_markdown_ansi(f"```text\n{source}\n```", width=160)
+    plain = strip_safe_ansi(ansi)
+
+    assert r"a\x1b[31mb\x1b]8;;https://evil.test\x1b\c" in plain
+    assert safe_hyperlink_spans(ansi) == ()
+
+    model = FullscreenTranscriptModel()
+    model.append(ansi, copy_actions=renderable.copy_actions)
+    lines = "".join(
+        fragment[1] for fragment in model.formatted_text(width=160, height=20)
+    ).splitlines()
+    header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+    last_panel_y = max(index for index, line in enumerate(lines) if line and not line.isspace()) + 1
+    model.begin_selection(x=0, y=header_y, width=160, height=20)
+    model.update_selection(x=159, y=last_panel_y, width=160, height=20)
 
     assert model.selected_text() == source
 

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -3597,7 +3597,7 @@ def test_copyable_markdown_exposes_exact_fenced_code_payloads() -> None:
     assert list(renderable.copy_actions.values()) == ["print('one')", "  exact spacing  "]
 
 
-def test_copyable_markdown_places_copy_action_in_bottom_code_padding() -> None:
+def test_copyable_markdown_places_copy_action_in_top_code_padding() -> None:
     from nooa_cli.tui.terminal_safety import sanitize_transcript_ansi, strip_safe_ansi
     from prompt_toolkit.formatted_text import ANSI, to_formatted_text
 
@@ -3605,9 +3605,9 @@ def test_copyable_markdown_places_copy_action_in_bottom_code_padding() -> None:
     lines = strip_safe_ansi(ansi).splitlines()
 
     assert lines == [
-        " " * 30,
-        " print('one')".ljust(30),
         "python · Copy ".rjust(30),
+        " print('one')".ljust(30),
+        " " * 30,
     ]
     fragments = to_formatted_text(ANSI(sanitize_transcript_ansi(ansi)))
     copy_style = next(
@@ -3616,7 +3616,6 @@ def test_copyable_markdown_places_copy_action_in_bottom_code_padding() -> None:
     code_style = next(
         style for style, text, *_rest in fragments if text == "p" and "bg:" in style
     )
-    assert "bg:" in copy_style
     assert copy_style.split("bg:", 1)[1].split()[0] == code_style.split("bg:", 1)[1].split()[0]
 
 
@@ -3682,13 +3681,13 @@ def test_fullscreen_drag_copy_projects_decorated_code_to_exact_source() -> None:
     lines = "".join(
         fragment[1] for fragment in model.formatted_text(width=60, height=20)
     ).splitlines()
-    footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
-    first_code_y = next(index for index, line in enumerate(lines) if "if ready:" in line)
+    header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+    after_y = next(index for index, line in enumerate(lines) if "After" in line)
 
-    # Drag over the complete visual panel, including its top padding, gutter,
-    # full-width background fill, and Copy footer.
-    model.begin_selection(x=0, y=first_code_y - 1, width=60, height=20)
-    model.update_selection(x=59, y=footer_y, width=60, height=20)
+    # Drag over the complete visual panel, including its Copy header, gutter,
+    # full-width background fill, and blank padding rows.
+    model.begin_selection(x=0, y=header_y, width=60, height=20)
+    model.update_selection(x=59, y=after_y - 1, width=60, height=20)
 
     assert model.selected_text() == source
 
@@ -3707,10 +3706,10 @@ def test_copyable_markdown_wraps_long_code_without_clipping() -> None:
     lines = "".join(
         fragment[1] for fragment in model.formatted_text(width=32, height=20)
     ).splitlines()
-    first_code_y = next(index for index, line in enumerate(lines) if "x" in line)
-    footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
-    model.begin_selection(x=0, y=first_code_y - 1, width=32, height=20)
-    model.update_selection(x=31, y=footer_y, width=32, height=20)
+    header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+    last_panel_y = max(index for index, line in enumerate(lines) if "x" in line) + 1
+    model.begin_selection(x=0, y=header_y, width=32, height=20)
+    model.update_selection(x=31, y=last_panel_y, width=32, height=20)
 
     assert model.selected_text() == source
 
@@ -3755,11 +3754,11 @@ def test_fullscreen_code_selection_preserves_trailing_blank_lines() -> None:
     lines = "".join(
         fragment[1] for fragment in model.formatted_text(width=30, height=20)
     ).splitlines()
-    first_source_y = next(index for index, line in enumerate(lines) if "abc" in line)
-    footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+    header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+    last_source_y = max(index for index, line in enumerate(lines) if index > header_y) - 1
 
-    model.begin_selection(x=0, y=first_source_y, width=30, height=20)
-    model.update_selection(x=29, y=footer_y, width=30, height=20)
+    model.begin_selection(x=0, y=header_y, width=30, height=20)
+    model.update_selection(x=1, y=last_source_y, width=30, height=20)
 
     assert model.selected_text() == source
 
@@ -3817,11 +3816,11 @@ def test_fullscreen_drag_copy_source_mapping_survives_resize_replay() -> None:
     lines = "".join(
         fragment[1] for fragment in model.formatted_text(width=32, height=20)
     ).splitlines()
-    first_source_y = next(index for index, line in enumerate(lines) if "first_call" in line)
-    footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+    header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+    last_panel_y = max(index for index, line in enumerate(lines) if line and not line.isspace()) + 1
 
-    model.begin_selection(x=0, y=first_source_y - 1, width=32, height=20)
-    model.update_selection(x=31, y=footer_y, width=32, height=20)
+    model.begin_selection(x=0, y=header_y, width=32, height=20)
+    model.update_selection(x=31, y=last_panel_y, width=32, height=20)
 
     assert model.selected_text() == source
 
@@ -3914,12 +3913,12 @@ def test_fullscreen_drag_over_decorated_code_copies_exact_source(
     lines = "".join(
         fragment[1] for fragment in app._fullscreen_transcript.formatted_text(width=60, height=20)
     ).splitlines()
-    first_code_y = next(index for index, line in enumerate(lines) if "if ready:" in line)
-    footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+    header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+    last_panel_y = max(index for index, line in enumerate(lines) if line and not line.isspace()) + 1
 
-    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_DOWN, x=0, y=first_code_y - 1))
-    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_MOVE, x=59, y=footer_y))
-    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_UP, x=59, y=footer_y))
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_DOWN, x=0, y=header_y))
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_MOVE, x=59, y=last_panel_y))
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_UP, x=59, y=last_panel_y))
 
     assert copied == [source]
 

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -872,7 +872,9 @@ def test_fullscreen_session_production_rendering_reprojects_narrow_then_wide(
     wide = app._fullscreen_transcript.text
     assert app.output_buffer.text == ""
     assert expected_wide != expected_narrow
-    expected_visible = "abcdefgh\n" if producer == "rich" else " ❯ abcdefgh  \n"
+    expected_visible = (
+        "abcdefgh\n" if producer == "rich" else " " * 13 + "\n ❯ abcdefgh  \n" + " " * 13 + "\n"
+    )
     assert wide == expected_visible
     assert wide != narrow
 
@@ -3182,7 +3184,7 @@ def test_fullscreen_composer_mouse_selection_is_mirrored_non_destructively(monke
 
 
 @pytest.mark.asyncio
-async def test_fullscreen_input_selection_can_be_copied_and_cut(monkeypatch) -> None:
+async def test_fullscreen_input_selection_ctrl_c_clears_and_ctrl_x_cuts(monkeypatch) -> None:
     from nooa_cli.tui.tui_application import _ClipboardResult
     from prompt_toolkit.selection import SelectionState
 
@@ -3200,22 +3202,21 @@ async def test_fullscreen_input_selection_can_be_copied_and_cut(monkeypatch) -> 
         app.input_buffer.cursor_position = 4
         app.input_buffer.selection_state = SelectionState(original_cursor_position=0)
         await harness.press("c-c")
-        await harness.wait_for(lambda: copied == ["copy"])
-        if app._clipboard_task is not None:
-            await app._clipboard_task
+        await harness.wait_input_equals("")
 
-        assert copied == ["copy"]
-        assert app.input_buffer.text == "copy and cut"
-        assert app.input_buffer.selection_state is not None
+        assert copied == []
+        assert app.input_buffer.selection_state is None
+        assert app._ctrl_c_exit_armed is False
 
+        app.input_buffer.text = "copy and cut"
         app.input_buffer.cursor_position = 12
         app.input_buffer.selection_state = SelectionState(original_cursor_position=9)
         await harness.press("c-x")
-        await harness.wait_for(lambda: copied == ["copy", "cut"])
+        await harness.wait_for(lambda: copied == ["cut"])
         if app._clipboard_task is not None:
             await app._clipboard_task
 
-        assert copied == ["copy", "cut"]
+        assert copied == ["cut"]
         assert app.input_buffer.text == "copy and "
         assert app.input_buffer.selection_state is None
         assert app._app.clipboard.get_data().text == "cut"
@@ -3223,7 +3224,7 @@ async def test_fullscreen_input_selection_can_be_copied_and_cut(monkeypatch) -> 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("display_mode", [DisplayMode.NATIVE, DisplayMode.NATIVE_REPLAY])
-async def test_native_input_selection_copy_does_not_cancel_or_clear(
+async def test_native_input_selection_ctrl_c_clears_without_copying(
     monkeypatch, display_mode: DisplayMode
 ) -> None:
     from nooa_cli.tui.tui_application import _ClipboardResult
@@ -3243,12 +3244,10 @@ async def test_native_input_selection_copy_does_not_cancel_or_clear(
         app.input_buffer.cursor_position = 4
         app.input_buffer.selection_state = SelectionState(original_cursor_position=0)
         await harness.press("c-c")
-        await harness.wait_for(lambda: copied == ["copy"])
-        if app._clipboard_task is not None:
-            await app._clipboard_task
+        await harness.wait_input_equals("")
 
-        assert app.input_buffer.text == "copy safely"
-        assert app.input_buffer.selection_state is not None
+        assert copied == []
+        assert app.input_buffer.selection_state is None
         assert app._ctrl_c_exit_armed is False
 
 

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -3728,6 +3728,26 @@ def test_copyable_markdown_keeps_complete_copy_label_at_narrow_width(
     assert "Copy" in strip_safe_ansi(ansi).splitlines()[0]
 
 
+@pytest.mark.parametrize("width", [1, 2, 3])
+def test_copyable_markdown_omits_ambiguous_copy_suffix_at_tiny_width(width: int) -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+
+    _renderable, ansi = _copyable_markdown_ansi("```text\nx\n```", width=width)
+    first_line = strip_safe_ansi(ansi).splitlines()[0]
+
+    assert not any(label in first_line for label in ("y", "py", "opy"))
+    assert "nooa-copy://" not in ansi
+
+
+def test_copyable_markdown_keeps_full_copy_label_at_minimum_action_width() -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+
+    _renderable, ansi = _copyable_markdown_ansi("```text\nx\n```", width=4)
+
+    assert strip_safe_ansi(ansi).splitlines()[0] == "Copy"
+    assert "nooa-copy://" in ansi
+
+
 def test_copyable_markdown_does_not_offer_copy_for_empty_fence() -> None:
     renderable, ansi = _copyable_markdown_ansi("```python\n```")
 

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -517,6 +517,33 @@ async def test_fullscreen_transient_sigwinches_publish_only_final_frame() -> Non
         assert app._fullscreen_rebuild_timer is None
 
 
+def test_fullscreen_theme_refresh_recolors_retained_semantic_scrollback() -> None:
+    from nooa_cli.tui import theme
+    from nooa_cli.tui.session import Session
+    from rich.text import Text
+
+    original_theme = theme.get_theme()
+    try:
+        theme.set_theme("mocha")
+        app = _make_fullscreen_app()
+        session = Session.__new__(Session)
+        session._app = app
+        session._emit_text(Text("hello", style="agent.response"))
+        before = app._transcript_blocks[0].fullscreen_rendered
+        assert before is not None
+
+        theme.set_theme("latte")
+        app.refresh_style()
+        after = app._transcript_blocks[0].fullscreen_rendered
+
+        assert after is not None
+        assert after != before
+        assert app._transcript_blocks[0].replay_cache
+        assert app._fullscreen_transcript.text.count("hello") == 1
+    finally:
+        theme.set_theme(original_theme)
+
+
 def test_fullscreen_resize_preserves_history_beyond_native_replay_tail() -> None:
     app = _make_fullscreen_app()
     for index in range(app._untagged_replay_tail + 7):
@@ -667,7 +694,7 @@ def test_fullscreen_does_not_emit_native_metadata_for_unsafe_link_target() -> No
     from prompt_toolkit.formatted_text import to_formatted_text
 
     app = _make_fullscreen_app()
-    app.emit_block("\x1b]8;;file:///tmp/secret\x1b\\label\x1b]8;;\x1b\\")
+    app.emit_block("\x1b]8;;javascript:alert(1)\x1b\\label\x1b]8;;\x1b\\")
 
     fragments = to_formatted_text(app._fullscreen_transcript.formatted_text())
 
@@ -2560,6 +2587,28 @@ async def test_fullscreen_link_click_opens_safe_http_url(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_fullscreen_file_link_click_uses_platform_opener(monkeypatch) -> None:
+    app = _make_fullscreen_app()
+    url = "file:///path/to/file"
+    app.emit_block(f"\x1b]8;;{url}\x1b\\link\x1b]8;;\x1b\\")
+    app._transcript_viewport_size = lambda: (20, 2)
+    calls: list[str] = []
+
+    async def open_file(target: str) -> bool:
+        calls.append(target)
+        return True
+
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
+    monkeypatch.delenv("SSH_TTY", raising=False)
+    monkeypatch.setattr(app, "_open_local_url", open_file)
+
+    assert app._open_fullscreen_link_at(1, 0) is True
+    assert app._link_task is not None
+    await app._link_task
+    assert calls == [url]
+
+
+@pytest.mark.asyncio
 async def test_fullscreen_link_open_failure_copies_url(monkeypatch) -> None:
     app = _make_fullscreen_app()
     url = "https://example.test/docs"
@@ -3570,6 +3619,28 @@ def test_copyable_markdown_preserves_safe_markdown_links() -> None:
     model.append(ansi)
     assert model.hyperlink_at(x=label_start, y=0, width=60, height=2) == (
         "https://example.test/docs"
+    )
+
+
+def test_copyable_markdown_renders_and_hit_tests_file_links() -> None:
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+    from nooa_cli.tui.terminal_safety import safe_hyperlink_spans, strip_safe_ansi
+
+    _renderable, ansi = _copyable_markdown_ansi(
+        "Open [the file](file://path/to/file) locally.", width=60
+    )
+
+    plain = strip_safe_ansi(ansi)
+    assert "[the file](file://path/to/file)" not in plain
+    label_start = plain.index("the file")
+    assert safe_hyperlink_spans(ansi) == (
+        (label_start, label_start + len("the file"), "file:///path/to/file"),
+    )
+
+    model = FullscreenTranscriptModel()
+    model.append(ansi)
+    assert model.hyperlink_at(x=label_start, y=0, width=60, height=2) == (
+        "file:///path/to/file"
     )
 
 

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -3597,6 +3597,29 @@ def test_copyable_markdown_exposes_exact_fenced_code_payloads() -> None:
     assert list(renderable.copy_actions.values()) == ["print('one')", "  exact spacing  "]
 
 
+def test_copyable_markdown_places_copy_action_in_bottom_code_padding() -> None:
+    from nooa_cli.tui.terminal_safety import sanitize_transcript_ansi, strip_safe_ansi
+    from prompt_toolkit.formatted_text import ANSI, to_formatted_text
+
+    _renderable, ansi = _copyable_markdown_ansi("```python\nprint('one')\n```", width=30)
+    lines = strip_safe_ansi(ansi).splitlines()
+
+    assert lines == [
+        " " * 30,
+        " print('one')".ljust(30),
+        "python · Copy ".rjust(30),
+    ]
+    fragments = to_formatted_text(ANSI(sanitize_transcript_ansi(ansi)))
+    copy_style = next(
+        style for style, text, *_rest in fragments if text == "C" and "bg:" in style
+    )
+    code_style = next(
+        style for style, text, *_rest in fragments if text == "p" and "bg:" in style
+    )
+    assert "bg:" in copy_style
+    assert copy_style.split("bg:", 1)[1].split()[0] == code_style.split("bg:", 1)[1].split()[0]
+
+
 def test_copyable_markdown_does_not_offer_copy_for_empty_fence() -> None:
     renderable, ansi = _copyable_markdown_ansi("```python\n```")
 
@@ -3659,13 +3682,13 @@ def test_fullscreen_drag_copy_projects_decorated_code_to_exact_source() -> None:
     lines = "".join(
         fragment[1] for fragment in model.formatted_text(width=60, height=20)
     ).splitlines()
-    header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
-    after_y = next(index for index, line in enumerate(lines) if "After" in line)
+    footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+    first_code_y = next(index for index, line in enumerate(lines) if "if ready:" in line)
 
-    # Drag over the complete visual panel, including its Copy header, gutter,
-    # full-width background fill, and blank padding rows.
-    model.begin_selection(x=0, y=header_y, width=60, height=20)
-    model.update_selection(x=59, y=after_y - 1, width=60, height=20)
+    # Drag over the complete visual panel, including its top padding, gutter,
+    # full-width background fill, and Copy footer.
+    model.begin_selection(x=0, y=first_code_y - 1, width=60, height=20)
+    model.update_selection(x=59, y=footer_y, width=60, height=20)
 
     assert model.selected_text() == source
 
@@ -3684,10 +3707,10 @@ def test_copyable_markdown_wraps_long_code_without_clipping() -> None:
     lines = "".join(
         fragment[1] for fragment in model.formatted_text(width=32, height=20)
     ).splitlines()
-    header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
-    last_panel_y = max(index for index, line in enumerate(lines) if "x" in line) + 1
-    model.begin_selection(x=0, y=header_y, width=32, height=20)
-    model.update_selection(x=31, y=last_panel_y, width=32, height=20)
+    first_code_y = next(index for index, line in enumerate(lines) if "x" in line)
+    footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+    model.begin_selection(x=0, y=first_code_y - 1, width=32, height=20)
+    model.update_selection(x=31, y=footer_y, width=32, height=20)
 
     assert model.selected_text() == source
 
@@ -3732,11 +3755,11 @@ def test_fullscreen_code_selection_preserves_trailing_blank_lines() -> None:
     lines = "".join(
         fragment[1] for fragment in model.formatted_text(width=30, height=20)
     ).splitlines()
-    header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
-    last_source_y = max(index for index, line in enumerate(lines) if index > header_y) - 1
+    first_source_y = next(index for index, line in enumerate(lines) if "abc" in line)
+    footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
 
-    model.begin_selection(x=0, y=header_y, width=30, height=20)
-    model.update_selection(x=1, y=last_source_y, width=30, height=20)
+    model.begin_selection(x=0, y=first_source_y, width=30, height=20)
+    model.update_selection(x=29, y=footer_y, width=30, height=20)
 
     assert model.selected_text() == source
 
@@ -3794,11 +3817,11 @@ def test_fullscreen_drag_copy_source_mapping_survives_resize_replay() -> None:
     lines = "".join(
         fragment[1] for fragment in model.formatted_text(width=32, height=20)
     ).splitlines()
-    header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
-    last_panel_y = max(index for index, line in enumerate(lines) if line and not line.isspace()) + 1
+    first_source_y = next(index for index, line in enumerate(lines) if "first_call" in line)
+    footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
 
-    model.begin_selection(x=0, y=header_y, width=32, height=20)
-    model.update_selection(x=31, y=last_panel_y, width=32, height=20)
+    model.begin_selection(x=0, y=first_source_y - 1, width=32, height=20)
+    model.update_selection(x=31, y=footer_y, width=32, height=20)
 
     assert model.selected_text() == source
 
@@ -3891,12 +3914,12 @@ def test_fullscreen_drag_over_decorated_code_copies_exact_source(
     lines = "".join(
         fragment[1] for fragment in app._fullscreen_transcript.formatted_text(width=60, height=20)
     ).splitlines()
-    header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
-    last_panel_y = max(index for index, line in enumerate(lines) if line and not line.isspace()) + 1
+    first_code_y = next(index for index, line in enumerate(lines) if "if ready:" in line)
+    footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
 
-    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_DOWN, x=0, y=header_y))
-    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_MOVE, x=59, y=last_panel_y))
-    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_UP, x=59, y=last_panel_y))
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_DOWN, x=0, y=first_code_y - 1))
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_MOVE, x=59, y=footer_y))
+    control.mouse_handler(_mouse_event(MouseEventType.MOUSE_UP, x=59, y=footer_y))
 
     assert copied == [source]
 

--- a/packages/nooa-cli/tests/tui/test_input_style.py
+++ b/packages/nooa-cli/tests/tui/test_input_style.py
@@ -8,6 +8,8 @@ from types import SimpleNamespace
 
 from nooa_cli.tui import theme
 from nooa_cli.tui.commands import ThemeCommand
+from nooa_cli.tui.config import Config, TUIConfig
+from nooa_cli.tui.frontend import TerminalFrontend
 from nooa_cli.tui.tui_application import TUIApplication
 
 
@@ -30,19 +32,49 @@ def test_input_uses_terminal_background_across_themes() -> None:
         theme.set_theme(original_theme)
 
 
-async def test_theme_command_refreshes_live_composer_style() -> None:
+async def test_theme_command_refreshes_and_persists_selection(
+    tmp_path, monkeypatch
+) -> None:
+    import yaml
+
     class LiveApp:
         refreshed = False
 
         def refresh_style(self) -> None:
             self.refreshed = True
 
+    project_dir = tmp_path / ".nooa"
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project_dir))
     original_theme = theme.get_theme()
     app = LiveApp()
     frontend = SimpleNamespace(_app=app, _input_handler=None)
-    command = ThemeCommand(frontend, config=object(), agent=object())
+    config = TUIConfig()
+    command = ThemeCommand(frontend, config=config, agent=object())
     try:
-        await command.execute(["latte"])
+        result = await command.execute(["latte"])
+
+        assert result.success is True
         assert app.refreshed is True
+        assert config.theme == "latte"
+        saved = yaml.safe_load((project_dir / "settings.yaml").read_text())
+        assert saved["tui"]["theme"] == "latte"
+    finally:
+        theme.set_theme(original_theme)
+
+
+def test_terminal_frontend_restores_persisted_theme(tmp_path, monkeypatch) -> None:
+    project_dir = tmp_path / ".nooa"
+    project_dir.mkdir()
+    (project_dir / "settings.yaml").write_text("tui:\n  theme: vslight\n")
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project_dir))
+    original_theme = theme.get_theme()
+    try:
+        config = Config.load()
+        frontend = TerminalFrontend(config)
+
+        assert config.tui.theme == "vslight"
+        assert theme.get_theme() == "vslight"
+        assert frontend._console.console.get_style("agent").color is not None
+        assert frontend._console.console.get_style("agent").color.triplet == (111, 66, 193)
     finally:
         theme.set_theme(original_theme)

--- a/packages/nooa-cli/tests/tui/test_resume_replay.py
+++ b/packages/nooa-cli/tests/tui/test_resume_replay.py
@@ -325,10 +325,10 @@ class TestBatchRendering:
         lines = "".join(
             fragment[1] for fragment in model.formatted_text(width=60, height=30)
         ).splitlines()
-        first_code_y = next(index for index, line in enumerate(lines) if "if ready:" in line)
-        footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
-        model.begin_selection(x=0, y=first_code_y - 1, width=60, height=30)
-        model.update_selection(x=59, y=footer_y, width=60, height=30)
+        header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+        after_y = next(index for index, line in enumerate(lines) if "After" in line)
+        model.begin_selection(x=0, y=header_y, width=60, height=30)
+        model.update_selection(x=59, y=after_y - 1, width=60, height=30)
         assert model.selected_text() == source
 
         current_width = 42
@@ -338,10 +338,10 @@ class TestBatchRendering:
         lines = "".join(
             fragment[1] for fragment in resized.formatted_text(width=42, height=30)
         ).splitlines()
-        first_code_y = next(index for index, line in enumerate(lines) if "if ready:" in line)
-        footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
-        resized.begin_selection(x=0, y=first_code_y - 1, width=42, height=30)
-        resized.update_selection(x=41, y=footer_y, width=42, height=30)
+        header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+        after_y = next(index for index, line in enumerate(lines) if "After" in line)
+        resized.begin_selection(x=0, y=header_y, width=42, height=30)
+        resized.update_selection(x=41, y=after_y - 1, width=42, height=30)
         assert resized.selected_text() == source
 
     def test_fullscreen_resumed_code_uses_live_syntax_theme(self):

--- a/packages/nooa-cli/tests/tui/test_resume_replay.py
+++ b/packages/nooa-cli/tests/tui/test_resume_replay.py
@@ -325,10 +325,10 @@ class TestBatchRendering:
         lines = "".join(
             fragment[1] for fragment in model.formatted_text(width=60, height=30)
         ).splitlines()
-        header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
-        after_y = next(index for index, line in enumerate(lines) if "After" in line)
-        model.begin_selection(x=0, y=header_y, width=60, height=30)
-        model.update_selection(x=59, y=after_y - 1, width=60, height=30)
+        first_code_y = next(index for index, line in enumerate(lines) if "if ready:" in line)
+        footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+        model.begin_selection(x=0, y=first_code_y - 1, width=60, height=30)
+        model.update_selection(x=59, y=footer_y, width=60, height=30)
         assert model.selected_text() == source
 
         current_width = 42
@@ -338,10 +338,10 @@ class TestBatchRendering:
         lines = "".join(
             fragment[1] for fragment in resized.formatted_text(width=42, height=30)
         ).splitlines()
-        header_y = next(index for index, line in enumerate(lines) if "Copy" in line)
-        after_y = next(index for index, line in enumerate(lines) if "After" in line)
-        resized.begin_selection(x=0, y=header_y, width=42, height=30)
-        resized.update_selection(x=41, y=after_y - 1, width=42, height=30)
+        first_code_y = next(index for index, line in enumerate(lines) if "if ready:" in line)
+        footer_y = next(index for index, line in enumerate(lines) if "Copy" in line)
+        resized.begin_selection(x=0, y=first_code_y - 1, width=42, height=30)
+        resized.update_selection(x=41, y=footer_y, width=42, height=30)
         assert resized.selected_text() == source
 
     def test_fullscreen_resumed_code_uses_live_syntax_theme(self):

--- a/packages/nooa-cli/tests/tui/test_resume_replay.py
+++ b/packages/nooa-cli/tests/tui/test_resume_replay.py
@@ -200,6 +200,7 @@ class TestBatchRendering:
         assert all(
             "bg:" in style for style, text, *_ in to_formatted_text(ANSI(rendered)) if text != "\n"
         )
+        assert rendered == render_user_bar(replay.turns[0].content, 20, COLORS)
 
     def test_resumed_agent_prose_has_no_render_width_whitespace(self):
         from nooa_cli.tui.frontend import render_history_replay_to_ansi

--- a/packages/nooa-cli/tests/tui/test_settings.py
+++ b/packages/nooa-cli/tests/tui/test_settings.py
@@ -56,6 +56,7 @@ class TestRoundTrip:
         original = Config()
         original.tui.default_model = "my-model"
         original.tui.vi_mode = True
+        original.tui.theme = "vslight"
         original.tui.toolbar_items = ["model", "cwd", "session"]
         original.tui.active_skills = ["nvzurich.agent_mesh"]
         original.tui.inactive_skills = ["nemo.repo"]
@@ -65,6 +66,7 @@ class TestRoundTrip:
         loaded = load_settings(Config())
         assert loaded.tui.default_model == "my-model"
         assert loaded.tui.vi_mode is True
+        assert loaded.tui.theme == "vslight"
         assert loaded.tui.toolbar_items == ["model", "cwd", "session"]
         assert loaded.tui.active_skills == ["nvzurich.agent_mesh"]
         assert loaded.tui.inactive_skills == ["nemo.repo"]
@@ -100,6 +102,12 @@ class TestLayering:
         loaded = load_settings(Config())
         # null removed the key from the merged dict → field keeps its default.
         assert loaded.tui.agent_spec is None
+
+    def test_invalid_theme_fails_clearly(self, user_dir, project_dir):
+        (project_dir / "settings.yaml").write_text("tui:\n  theme: ultraviolet\n")
+
+        with pytest.raises(ValueError, match="ultraviolet"):
+            load_settings(Config())
 
     def test_path_coercion(self, user_dir, project_dir):
         (user_dir / "settings.yaml").write_text(

--- a/packages/nooa-cli/tests/tui/test_terminal_safety.py
+++ b/packages/nooa-cli/tests/tui/test_terminal_safety.py
@@ -9,10 +9,20 @@ from nooa_cli.tui.terminal_safety import (
     normalize_transcript_block,
     safe_http_url,
     safe_hyperlink_spans,
+    safe_hyperlink_target,
     sanitize_transcript_ansi,
     strip_safe_ansi,
 )
 from rich.cells import cell_len
+
+
+def test_visible_code_line_uses_terminal_cells_for_tab_stops() -> None:
+    from nooa_cli.tui.copyable_markdown import visible_code_line
+
+    rendered, source_map = visible_code_line("界\t")
+
+    assert rendered == "界  "
+    assert source_map == ((0, 1), (1, 2), (1, 2))
 
 
 def test_transcript_normalizer_allows_style_but_exposes_terminal_commands() -> None:
@@ -111,15 +121,34 @@ def test_safe_http_url_rejects_terminal_controls() -> None:
         assert safe_http_url(url) is None, f"accepted U+{codepoint:04X}"
 
 
+def test_safe_hyperlink_target_accepts_absolute_file_urls_only() -> None:
+    assert safe_hyperlink_target("file:///tmp/example.py") == "file:///tmp/example.py"
+    assert safe_hyperlink_target("file://path/to/file") == "file:///path/to/file"
+    assert safe_hyperlink_target("file://localhost/tmp/example.py") == (
+        "file://localhost/tmp/example.py"
+    )
+    assert safe_hyperlink_target("file:relative/path") is None
+    assert safe_hyperlink_target("file:////server/share") is None
+    assert safe_hyperlink_target("file://localhost//server/share") is None
+    assert safe_hyperlink_target("file:///%2Fserver/share") is None
+    assert safe_hyperlink_target("file://%2Fserver/share") is None
+    assert safe_hyperlink_target("file://%5C%5Cserver/share") is None
+    assert safe_hyperlink_target(r"file:///\\server\share") is None
+    assert safe_hyperlink_target("file:///tmp/%00unsafe") is None
+    assert safe_hyperlink_target("javascript:alert(1)") is None
+
+
 def test_safe_hyperlink_spans_reports_safe_label_bounds() -> None:
     linked = "before \x1b]8;id=7;https://example.test/path\x1b\\label\x1b]8;;\x1b\\ after"
-    unsafe = "\x1b]8;;file:///tmp/secret\x1b\\local\x1b]8;;\x1b\\"
+    local = "\x1b]8;;file:///tmp/example.py\x1b\\local\x1b]8;;\x1b\\"
+    unsafe = "\x1b]8;;javascript:alert(1)\x1b\\script\x1b]8;;\x1b\\"
 
     assert safe_hyperlink_spans(linked) == ((7, 12, "https://example.test/path"),)
+    assert safe_hyperlink_spans(local) == ((0, 5, "file:///tmp/example.py"),)
     assert safe_hyperlink_spans(unsafe) == ()
 
 
-def test_hyperlink_hit_testing_accepts_only_http_targets() -> None:
+def test_hyperlink_hit_testing_accepts_safe_browser_and_file_targets() -> None:
     linked = "before \x1b]8;id=7;https://example.test/path\x1b\\label\x1b]8;;\x1b\\ after"
 
     assert hyperlink_at_plain_offset(linked, 7) == "https://example.test/path"
@@ -127,5 +156,8 @@ def test_hyperlink_hit_testing_accepts_only_http_targets() -> None:
     assert hyperlink_at_plain_offset(linked, 6) is None
     assert hyperlink_at_plain_offset(linked, 12) is None
 
-    unsafe = "\x1b]8;;file:///tmp/secret\x1b\\local\x1b]8;;\x1b\\"
+    local = "\x1b]8;;file:///tmp/example.py\x1b\\local\x1b]8;;\x1b\\"
+    assert hyperlink_at_plain_offset(local, 0) == "file:///tmp/example.py"
+
+    unsafe = "\x1b]8;;javascript:alert(1)\x1b\\script\x1b]8;;\x1b\\"
     assert hyperlink_at_plain_offset(unsafe, 0) is None

--- a/packages/nooa-cli/tests/tui/test_terminal_safety.py
+++ b/packages/nooa-cli/tests/tui/test_terminal_safety.py
@@ -87,8 +87,14 @@ def test_user_bar_is_control_safe_cell_aware_and_reserves_final_column() -> None
 
     assert "\x1b[2J" not in bar
     visible_lines = strip_safe_ansi(sanitize_transcript_ansi(bar)).splitlines()
-    assert visible_lines
+    assert len(visible_lines) >= 3
+    assert visible_lines[0] == visible_lines[-1] == " " * 9
     assert all(cell_len(line) == 9 for line in visible_lines)
+
+    styled_lines = bar.splitlines()
+    assert styled_lines[0] == styled_lines[-1] == (
+        "\x1b[38;5;189;48;5;59m" + " " * 9 + "\x1b[0m"
+    )
 
 
 def test_hyperlink_target_length_is_bounded() -> None:

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -2431,6 +2431,22 @@ async def test_cancel_status_is_immediate_and_stays_until_agent_cleanup_ack() ->
         await h.wait_output_contains("Interrupted")
 
 
+async def test_fast_cancel_status_survives_runtime_ack_long_enough_to_render() -> None:
+    """A fast cancellation must not replace its acknowledgement before one frame."""
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+
+        await h.press("escape")
+        await h.wait_output_contains("Interrupted agent turn")
+
+        assert "Interrupting agent turn" in h.capture_status()
+        await asyncio.sleep(0.25)
+        assert "Interrupting agent turn" in h.capture_status()
+        await h.wait_for(lambda: "Interrupting agent turn" not in h.capture_status())
+
+
 async def test_cancel_status_ignores_stale_pre_interrupt_observation() -> None:
     agent = _blocking_agent()
     async with TUIHarness(agent=agent) as h:

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -2466,23 +2466,27 @@ async def test_cancel_status_ignores_stale_pre_interrupt_observation() -> None:
         await h.wait_for(lambda: not h.app.is_thinking())
 
 
-async def test_foreign_thread_interrupt_ack_runs_on_tui_owner_loop() -> None:
-    """Observation teardown must not mutate timers from its worker thread."""
-    agent = _blocking_agent()
+async def test_observation_teardown_does_not_acknowledge_active_interrupt() -> None:
+    """Closing an observation must not complete an unrelated active turn."""
+    agent = FakeAgent()
+    cleanup_started = ThreadGate()
+    release_cleanup = ThreadGate()
+
+    async def step(_self: FakeAgent, _msg: str) -> None:
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            await release_cleanup.wait()
+            raise
+
+    agent.queue(step)
     async with TUIHarness(agent=agent) as h:
         await h.submit_async("first")
         await h.wait_for(lambda: h.app.is_thinking())
         assert h.app.request_agent_cancel(source="escape") is True
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
 
-        owner_thread = threading.get_ident()
-        ack_threads: list[int] = []
-        original_ack = h.app._acknowledge_agent_interrupt
-
-        def record_ack() -> None:
-            ack_threads.append(threading.get_ident())
-            original_ack()
-
-        h.app._acknowledge_agent_interrupt = record_ack
         callback_errors: list[BaseException] = []
 
         def publish_teardown() -> None:
@@ -2497,8 +2501,10 @@ async def test_foreign_thread_interrupt_ack_runs_on_tui_owner_loop() -> None:
         assert not producer.is_alive()
         assert callback_errors == []
 
-        await h.wait_for(lambda: bool(ack_threads))
-        assert set(ack_threads) == {owner_thread}
+        await asyncio.sleep(0)
+        assert h.app._interrupt_status_acknowledged is False
+        assert h.capture_status().endswith("Interrupting agent turn")
+        release_cleanup.set()
 
 
 async def test_cancel_does_not_deliver_queued_message_until_cleanup_ack() -> None:

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -2442,6 +2442,7 @@ async def test_fast_cancel_status_survives_runtime_ack_long_enough_to_render() -
         await h.wait_output_contains("Interrupted agent turn")
 
         assert "Interrupting agent turn" in h.capture_status()
+        await h.wait_for(lambda: "Interrupting agent turn" in _last_screen_text(h.app))
         await asyncio.sleep(0.25)
         assert "Interrupting agent turn" in h.capture_status()
         await h.wait_for(lambda: "Interrupting agent turn" not in h.capture_status())
@@ -2460,6 +2461,41 @@ async def test_cancel_status_ignores_stale_pre_interrupt_observation() -> None:
 
         assert h.capture_status().startswith("Interrupting agent turn")
         await h.wait_for(lambda: not h.app.is_thinking())
+
+
+async def test_foreign_thread_interrupt_ack_runs_on_tui_owner_loop() -> None:
+    """Observation teardown must not mutate timers from its worker thread."""
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        assert h.app.request_agent_cancel(source="escape") is True
+
+        owner_thread = threading.get_ident()
+        ack_threads: list[int] = []
+        original_ack = h.app._acknowledge_agent_interrupt
+
+        def record_ack() -> None:
+            ack_threads.append(threading.get_ident())
+            original_ack()
+
+        h.app._acknowledge_agent_interrupt = record_ack
+        callback_errors: list[BaseException] = []
+
+        def publish_teardown() -> None:
+            try:
+                h.app._on_agent_change(None)
+            except BaseException as exc:
+                callback_errors.append(exc)
+
+        producer = threading.Thread(target=publish_teardown)
+        producer.start()
+        producer.join(timeout=1.0)
+        assert not producer.is_alive()
+        assert callback_errors == []
+
+        await h.wait_for(lambda: bool(ack_threads))
+        assert set(ack_threads) == {owner_thread}
 
 
 async def test_cancel_does_not_deliver_queued_message_until_cleanup_ack() -> None:
@@ -2494,6 +2530,9 @@ async def test_cancel_does_not_deliver_queued_message_until_cleanup_ack() -> Non
         release_cleanup.set()
         await asyncio.wait_for(cleanup_done.wait(), timeout=1.0)
         await h.wait_for(lambda: agent.messages_received == ["first", "queued"])
+        await h.wait_for(
+            lambda: "Interrupting agent turn" not in h.capture_status(), timeout=0.25
+        )
 
 
 async def test_escape_cancels_agent_turn_but_not_spawned_jobs() -> None:

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -984,7 +984,7 @@ async def test_option_brackets_do_not_interrupt_active_turn(key: str):
 
         assert h.app.is_thinking()
         assert h.capture_input() == key[-1]
-        assert "cancelling" not in h.capture_status()
+        assert "Interrupting agent turn" not in h.capture_status()
         agent.block.set()
 
 
@@ -2371,8 +2371,8 @@ async def test_non_fullscreen_keeps_native_scrollback_path() -> None:
         assert h.app._fullscreen_invalidate_count == 0
 
 
-async def test_cancel_status_stays_cancelling_until_agent_cleanup_ack() -> None:
-    """Esc keeps a visible cancelling state until the agent turn unwinds."""
+async def test_cancel_status_is_immediate_and_stays_until_agent_cleanup_ack() -> None:
+    """Esc immediately acknowledges interruption until the agent turn unwinds."""
     agent = FakeAgent()
     step_started = ThreadGate()
     cleanup_started = ThreadGate()
@@ -2395,13 +2395,18 @@ async def test_cancel_status_stays_cancelling_until_agent_cleanup_ack() -> None:
         await h.wait_for(lambda: h.app.is_thinking())
         await asyncio.wait_for(step_started.wait(), timeout=1.0)
         assert h.app.request_agent_cancel(source="escape") is True
+        # Acknowledge the accepted key press synchronously, before the agent
+        # loop has even entered cancellation cleanup.
+        assert h.capture_status().startswith("Interrupting agent turn")
+        assert cleanup_started.is_set() is False
         await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
-        assert "cancelling" in h.capture_status()
+        assert "Interrupting agent turn" in h.capture_status()
         assert h.app.is_thinking() is True
         assert cleanup_done.is_set() is False
         release_cleanup.set()
         await asyncio.wait_for(cleanup_done.wait(), timeout=1.0)
         await h.wait_for(lambda: not h.app.is_thinking())
+        await h.wait_for(lambda: "Interrupting agent turn" not in h.capture_status())
         await h.wait_output_contains("Interrupted")
 
 
@@ -2433,7 +2438,7 @@ async def test_cancel_does_not_deliver_queued_message_until_cleanup_ack() -> Non
         assert h.app.request_agent_cancel(source="escape") is True
         await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
         assert agent.messages_received == ["first"]
-        assert "cancelling" in h.capture_status()
+        assert "Interrupting agent turn" in h.capture_status()
         release_cleanup.set()
         await asyncio.wait_for(cleanup_done.wait(), timeout=1.0)
         await h.wait_for(lambda: agent.messages_received == ["first", "queued"])
@@ -2487,7 +2492,7 @@ async def test_repeated_ctrl_c_exits_while_cancel_is_pending() -> None:
         await asyncio.wait_for(step_started.wait(), timeout=1.0)
         await h.press("c-c")
         await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
-        assert "cancelling" in h.capture_status()
+        assert "Interrupting agent turn" in h.capture_status()
         assert "Press Ctrl+C again to exit" in h.capture_status()
         await h.press("c-c")
         await h.wait_for(lambda: not h.app.is_running)

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -960,6 +960,12 @@ async def test_interleaved_cmd_msg_msg_commands_fire_immediately():
         )
 
 
+async def test_escape_prefix_ambiguity_window_is_short():
+    async with TUIHarness() as h:
+        assert h.app._app.ttimeoutlen == pytest.approx(0.05)
+        assert h.app._app.timeoutlen == pytest.approx(0.05)
+
+
 async def test_bare_escape_interrupts_and_delivers_queued_input():
     agent = _blocking_agent()
     async with TUIHarness(agent=agent) as h:

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -1055,6 +1055,21 @@ async def test_ctrl_c_clears_draft_before_interrupting_active_turn():
         assert "Press Ctrl+C again to exit" in h.capture_status()
 
 
+async def test_ctrl_c_cancels_overlapping_command_and_agent_turn():
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        command_cancellations: list[bool] = []
+        h.app._on_cancel_command = lambda: command_cancellations.append(True) or True
+
+        await h.press("c-c")
+
+        await h.wait_for(lambda: not h.app.is_thinking())
+        assert command_cancellations == [True]
+        assert "Press Ctrl+C again to exit" in h.capture_status()
+
+
 async def test_ctrl_c_with_empty_composer_interrupts_active_turn():
     agent = _blocking_agent()
     async with TUIHarness(agent=agent) as h:
@@ -2414,6 +2429,21 @@ async def test_cancel_status_is_immediate_and_stays_until_agent_cleanup_ack() ->
         await h.wait_for(lambda: not h.app.is_thinking())
         await h.wait_for(lambda: "Interrupting agent turn" not in h.capture_status())
         await h.wait_output_contains("Interrupted")
+
+
+async def test_cancel_status_ignores_stale_pre_interrupt_observation() -> None:
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        stale_state = h.app._agent_controller.state
+        assert stale_state is not None
+
+        assert h.app.request_agent_cancel(source="escape") is True
+        h.app._on_agent_change(stale_state)
+
+        assert h.capture_status().startswith("Interrupting agent turn")
+        await h.wait_for(lambda: not h.app.is_thinking())
 
 
 async def test_cancel_does_not_deliver_queued_message_until_cleanup_ack() -> None:

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -2439,13 +2439,16 @@ async def test_fast_cancel_status_survives_runtime_ack_long_enough_to_render() -
         await h.wait_for(lambda: h.app.is_thinking())
 
         await h.press("escape")
-        await h.wait_output_contains("Interrupted agent turn")
 
-        assert "Interrupting agent turn" in h.capture_status()
+        await h.wait_for(lambda: "Interrupting agent turn" in h.capture_status())
         await h.wait_for(lambda: "Interrupting agent turn" in _last_screen_text(h.app))
         await asyncio.sleep(0.25)
         assert "Interrupting agent turn" in h.capture_status()
-        await h.wait_for(lambda: "Interrupting agent turn" not in h.capture_status())
+        assert "Interrupted agent turn" not in h.capture_output()
+
+        await h.wait_output_contains("Interrupted agent turn")
+        assert "Interrupting agent turn" not in h.capture_status()
+        await h.wait_for(lambda: "Interrupting agent turn" not in _last_screen_text(h.app))
 
 
 async def test_cancel_status_ignores_stale_pre_interrupt_observation() -> None:

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -354,12 +354,19 @@ async def test_baseline_ctrl_d_exits():
         await h.wait_for(lambda: not h.app.is_running)
 
 
-async def test_baseline_ctrl_c_clears_input_and_requires_confirmation():
+async def test_ctrl_c_clears_input_then_confirms_idle_exit():
     async with TUIHarness() as h:
         await h.type_keys("discard this command")
         await h.wait_input_equals("discard this command")
+
+        # Clearing a draft is its own step and never arms or exits.
         await h.press("c-c")
         await h.wait_input_equals("")
+        assert "Press Ctrl+C again to exit" not in h.capture_status()
+        assert h.app.is_running
+
+        # With no active turn, the next press arms the existing safe exit.
+        await h.press("c-c")
         await h.wait_for(lambda: "Press Ctrl+C again to exit" in h.capture_status())
         assert h.app.is_running
 
@@ -953,7 +960,7 @@ async def test_interleaved_cmd_msg_msg_commands_fire_immediately():
         )
 
 
-async def test_queue_esc_soft_cancels_and_delivers_queue():
+async def test_bare_escape_interrupts_and_delivers_queued_input():
     agent = _blocking_agent()
     async with TUIHarness(agent=agent) as h:
         await h.submit_async("first")
@@ -962,6 +969,23 @@ async def test_queue_esc_soft_cancels_and_delivers_queue():
         await h.press("enter")
         await h.press("escape")
         await h.wait_for(lambda: agent.messages_received == ["first", "queued"])
+
+
+@pytest.mark.parametrize("key", ["option-[", "option-]"])
+async def test_option_brackets_do_not_interrupt_active_turn(key: str):
+    """Raw ESC-prefixed bracket bytes are Meta input, not standalone Escape."""
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+
+        await h.press(key)
+        await h.wait_for(lambda: h.capture_input() in {"[", "]"})
+
+        assert h.app.is_thinking()
+        assert h.capture_input() == key[-1]
+        assert "cancelling" not in h.capture_status()
+        agent.block.set()
 
 
 async def test_esc_prefers_active_slash_command_over_agent_interrupt():
@@ -1006,18 +1030,52 @@ async def test_cancelled_agent_run_async_propagates_to_agent_loop():
 # ╚══════════════════════════════════════════════════════════════════════╝
 
 
-async def test_hard_ctrl_c_interrupts_and_clears_buffer():
-    """C-c while the agent is working cancels the agent and clears the buffer."""
+async def test_ctrl_c_clears_draft_before_interrupting_active_turn():
+    """Each Ctrl-C advances exactly one clear → interrupt → exit step."""
     agent = _blocking_agent()
     async with TUIHarness(agent=agent) as h:
         await h.submit_async("first")
         await h.wait_for(lambda: h.app.is_thinking())
         await h.type_keys("in-progress")
         await h.wait_input_equals("in-progress")
+
         await h.press("c-c")
-        # Agent gets cancelled and the in-progress input is discarded.
+        await h.wait_input_equals("")
+        assert h.app.is_thinking()
+        assert "Press Ctrl+C again to exit" not in h.capture_status()
+
+        await h.press("c-c")
+        await h.wait_for(lambda: not h.app.is_thinking())
+        assert "Press Ctrl+C again to exit" in h.capture_status()
+
+
+async def test_ctrl_c_with_empty_composer_interrupts_active_turn():
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+
+        await h.press("c-c")
+
         await h.wait_for(lambda: not h.app.is_thinking())
         assert h.capture_input() == ""
+        assert "Press Ctrl+C again to exit" in h.capture_status()
+
+
+async def test_ctrl_c_clears_keyboard_selection_before_interrupting():
+    agent = _blocking_agent()
+    async with TUIHarness(agent=agent) as h:
+        await h.submit_async("first")
+        await h.wait_for(lambda: h.app.is_thinking())
+        await h.type_keys("draft")
+        h.app.input_buffer.start_selection()
+        h.app.input_buffer.cursor_left(count=2)
+
+        await h.press("c-c")
+
+        await h.wait_input_equals("")
+        assert h.app.is_thinking()
+        assert "Press Ctrl+C again to exit" not in h.capture_status()
 
 
 async def test_hard_agent_error_shown_in_output():

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -2418,10 +2418,10 @@ async def test_cancel_status_is_immediate_and_stays_until_agent_cleanup_ack() ->
         assert h.app.request_agent_cancel(source="escape") is True
         # Acknowledge the accepted key press synchronously, before the agent
         # loop has even entered cancellation cleanup.
-        assert h.capture_status().startswith("Interrupting agent turn")
+        assert h.capture_status() == "· Interrupting agent turn"
         assert cleanup_started.is_set() is False
         await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
-        assert "Interrupting agent turn" in h.capture_status()
+        await h.wait_for(lambda: h.capture_status() == "• Interrupting agent turn")
         assert h.app.is_thinking() is True
         assert cleanup_done.is_set() is False
         release_cleanup.set()
@@ -2462,7 +2462,7 @@ async def test_cancel_status_ignores_stale_pre_interrupt_observation() -> None:
         assert h.app.request_agent_cancel(source="escape") is True
         h.app._on_agent_change(stale_state)
 
-        assert h.capture_status().startswith("Interrupting agent turn")
+        assert h.capture_status().endswith("Interrupting agent turn")
         await h.wait_for(lambda: not h.app.is_thinking())
 
 

--- a/packages/nooa-cli/tests/tui/tui_app_harness.py
+++ b/packages/nooa-cli/tests/tui/tui_app_harness.py
@@ -51,6 +51,8 @@ if TYPE_CHECKING:
 _KEY_SEQUENCES: dict[str, str] = {
     "enter": "\r",
     "escape": "\x1b",
+    "option-[": "\x1b[",
+    "option-]": "\x1b]",
     "q": "q",
     "tab": "\t",
     "backspace": "\x7f",


### PR DESCRIPTION
## Summary
- make Ctrl-C advance through clear composer, interrupt active work, then exit
- ensure only bare Escape interrupts while Meta/Option sequences such as Option-[ remain regular input
- show immediate pulsing `·` / `• Interrupting agent turn` feedback, then replace it with the completed interruption marker without leaking status into queued turns
- add one same-background blank row above and below accepted user transcript blocks in live and replay rendering
- add safe, validated HTTP(S) and absolute local `file:` links across live output, fullscreen scrollback, and resumed history
- improve fenced-code Copy affordances, exact source mapping, wide-character tab stops, and narrow-terminal behavior
- persist `/theme <name>` selections and refresh retained fullscreen history with the active palette

## Acceptance testing
Manually verified in the native TUI:
- code-block Copy copies exactly the fenced source
- HTTP and local-file links render and open correctly
- bare Escape cancels active work while leaving the TUI open
- pulsing interruption feedback is visible before `✗ Interrupted agent turn.`
- the interruption status disappears before queued work begins
- queued messages remain correctly ordered after cancellation

## Review follow-up
A three-perspective subagent review covered:
- cancellation concurrency, thread affinity, timers, teardown, and queued-turn ordering
- prompt-toolkit rendering, key decoding, status animation, Copy/selection, and terminal safety
- configuration persistence, compatibility, architecture, and test coverage

Fixes from that review:
- observation teardown no longer acknowledges an unrelated active turn; runtime cancellation is the authoritative completion signal
- code blocks narrower than `Copy` no longer expose ambiguous linked suffixes such as `y` or `py`
- added deterministic regressions for both cases

A post-fix adversarial review found no actionable findings. Residual risk is limited to platform-specific terminal/open behavior and unusual cancellation callback orderings beyond the covered runtime contract.

## Validation
- `uv run --frozen --project packages/nooa-cli ruff check packages/nooa-cli/src/nooa_cli/tui packages/nooa-cli/tests/tui`
- focused final-review regressions: 7 passed
- behavior + fullscreen suites: 317 passed
- full TUI suite: 1238 passed, with only two known unrelated macOS `/var` vs `/private/var` failures:
  - `test_get_bang_shell_syncs_cwd`
  - `test_connect_prompts_for_missing_secret_and_saves_it`
- DCO passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable, persisted themes, including Mocha, Latte, and VS Code styles.
  * Added support for safe local file links alongside secure web links.
  * Improved code copying and selection, including tabs, control characters, and narrow terminal widths.
* **Bug Fixes**
  * Refined Ctrl+C behavior to clear drafts, cancel active work, and exit predictably.
  * Improved Escape and Option-key handling.
  * Preserved styling and transcript content during replay, scrolling, and theme changes.
* **Documentation**
  * Updated startup guidance for Ctrl+C actions and theme configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->