### PR TITLE
perf(tui): defer optional datascience imports

### DIFF
--- a/packages/nooa-cli/tests/tui/test_startup_latency.py
+++ b/packages/nooa-cli/tests/tui/test_startup_latency.py
@@ -38,6 +38,23 @@ def test_tui_package_import_does_not_import_agent_stack() -> None:
     assert result.stdout.splitlines() == ["False", "False"]
 
 
+def test_interactive_import_defers_optional_datascience_stack() -> None:
+    code = (
+        "import sys\n"
+        "import nooa.interactive\n"
+        "print('numpy' in sys.modules)\n"
+        "print('pandas' in sys.modules)\n"
+        "print('plotly.express' in sys.modules)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.splitlines() == ["False", "False", "False"]
+
+
 @pytest.mark.asyncio
 async def test_pending_llm_health_does_not_emit_durable_startup_status(tmp_path, monkeypatch):
     from nooa_cli.tui.bootstrap import bootstrap

--- a/src/nooa/interactive.py
+++ b/src/nooa/interactive.py
@@ -33,6 +33,8 @@ from nooa.storage.markers import nosnapshot
 from nooa.storage.snapshot_vars import SnapshotVars
 
 with hidden:
+    import importlib
+    import importlib.util
     from collections.abc import Callable
 
     from nooa import Agent
@@ -57,33 +59,75 @@ from nooa.runtime.producers import after, cron, monitor, run_job, tail  # noqa: 
 with hidden:
     import os
 
-# Optional third-party libraries — visible in REPL (use np, pd, px, go directly)
-try:
-    import numpy as np  # noqa: F401  # type: ignore[import-untyped]
-except ImportError:
-    pass
+@hidden
+class _LazyOptionalImport:
+    """Proxy an optional REPL convenience import until generated code uses it."""
 
-try:
-    import pandas as pd  # noqa: F401  # type: ignore[import-untyped]
-except ImportError:
-    pass
+    def __init__(self, module_name: str, attr_name: str | None = None) -> None:
+        self._module_name = module_name
+        self._attr_name = attr_name
+        self._loaded: Any | None = None
 
-try:
-    import plotly.express as px  # noqa: F401  # type: ignore[import-untyped]
-    import plotly.graph_objects as go  # noqa: F401  # type: ignore[import-untyped]
-    from plotly.subplots import make_subplots  # noqa: F401  # type: ignore[import-untyped]
-except ImportError:
-    pass
+    def _load(self) -> Any:
+        if self._loaded is None:
+            module = importlib.import_module(self._module_name)
+            self._loaded = getattr(module, self._attr_name) if self._attr_name else module
+        return self._loaded
 
-try:
-    import scipy  # noqa: F401  # type: ignore[import-untyped]
-except ImportError:
-    pass
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._load(), name)
 
-try:
-    import sklearn  # noqa: F401  # type: ignore[import-untyped]
-except ImportError:
-    pass
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._load()(*args, **kwargs)
+
+    def __dir__(self) -> list[str]:
+        try:
+            return sorted(set(super().__dir__()) | set(dir(self._load())))
+        except ImportError:
+            return super().__dir__()
+
+    def __repr__(self) -> str:
+        target = f"{self._module_name}.{self._attr_name}" if self._attr_name else self._module_name
+        if self._loaded is None:
+            return f"<lazy import {target}>"
+        return repr(self._loaded)
+
+
+@hidden
+def _optional_import(module_name: str, attr_name: str | None = None) -> _LazyOptionalImport | None:
+    try:
+        if importlib.util.find_spec(module_name) is None:
+            return None
+    except (ImportError, ValueError):
+        return None
+    return _LazyOptionalImport(module_name, attr_name)
+
+
+# Optional third-party libraries — visible in REPL (use np, pd, px, go directly).
+# Keep the names available without charging import cost before the first prompt.
+with hidden:
+    _np = _optional_import("numpy")
+    _pd = _optional_import("pandas")
+    _px = _optional_import("plotly.express")
+    _go = _optional_import("plotly.graph_objects")
+    _make_subplots = _optional_import("plotly.subplots", "make_subplots")
+    _scipy = _optional_import("scipy")
+    _sklearn = _optional_import("sklearn")
+
+if _np is not None:
+    np = _np  # noqa: F401
+if _pd is not None:
+    pd = _pd  # noqa: F401
+if _px is not None:
+    px = _px  # noqa: F401
+if _go is not None:
+    go = _go  # noqa: F401
+if _make_subplots is not None:
+    make_subplots = _make_subplots  # noqa: F401
+if _scipy is not None:
+    scipy = _scipy  # noqa: F401
+if _sklearn is not None:
+    sklearn = _sklearn  # noqa: F401
 
 with hidden:
     from nooa.unifiedllm import UnifiedLLM


### PR DESCRIPTION
## Summary
- Defer optional data-science REPL imports in nooa.interactive until first use.
- Keep convenience globals like pd, np, px, go, scipy, and sklearn available to generated code through lazy proxies.
- Add a startup regression test that importing nooa.interactive does not eagerly import numpy, pandas, or plotly.express.

## Measurements
Measured against origin/dev/tui using the same .venv:
- TUI config + bootstrap agent path median: 2.075s -> 1.536s, about 0.538s saved.
- TUI config + bootstrap agent path mean: 2.223s -> 1.640s, about 0.582s saved.
- Fresh import nooa.interactive median: 1.659s -> 1.428s, about 0.231s saved.

This is a modest startup improvement. The main remaining startup bottleneck is still the core nooa/LiteLLM import path; this PR only removes eager optional data-science imports from startup.

## Testing
- uv run pytest packages/nooa-cli/tests/tui/test_startup_latency.py packages/nooa-cli/tests/tui/test_context_usage_display.py tests/test_interactive_agent.py tests/runtime/test_issue_144_pandas_scope.py tests/agentdoc/test_pandas_adapter.py
- uv run ruff check src/nooa/interactive.py packages/nooa-cli/tests/tui/test_startup_latency.py