### PR TITLE
refactor(agentdoc): unify document rendering paths

### DIFF
--- a/src/nooa/agentdoc/_discover.py
+++ b/src/nooa/agentdoc/_discover.py
@@ -10,6 +10,23 @@ import inspect
 import typing
 from typing import Any
 
+
+class _IdentityTypeSet:
+    """Minimal add/iteration collection that deduplicates types by identity."""
+
+    def __init__(self) -> None:
+        self._items: list[type] = []
+        self._ids: set[int] = set()
+
+    def add(self, item: type) -> None:
+        if id(item) not in self._ids:
+            self._ids.add(id(item))
+            self._items.append(item)
+
+    def __iter__(self):
+        return iter(self._items)
+
+
 # Builtins to exclude from referenced types
 BUILTIN_TYPE_NAMES = {
     "str",
@@ -50,11 +67,17 @@ STDLIB_MODULES = {
 }
 
 
+def _identity_contains(items: Any, candidate: type) -> bool:
+    """Return whether *items* contains candidate by identity, without hashing it."""
+    return items is not None and any(item is candidate for item in items)
+
+
 def discover_referenced_types(
     obj: type | Any,
     *,
     seen: set[type] | None = None,
     field_names: set[str] | None = None,
+    type_info: Any = None,
 ) -> list[type]:
     """Discover all custom types referenced in a class or callable's interface.
 
@@ -77,7 +100,7 @@ def discover_referenced_types(
     Returns:
         List of unique custom type objects not in `seen`, sorted by name
     """
-    discovered: set[type] = set()
+    discovered = _IdentityTypeSet()
 
     # Handle callable (function/method) directly
     if inspect.isfunction(obj) or inspect.ismethod(obj):
@@ -85,9 +108,9 @@ def discover_referenced_types(
 
         # Filter to only custom types, excluding already-seen types
         custom_types = [
-            t for t in discovered if _is_custom_type(t) and (seen is None or t not in seen)
+            t for t in discovered if _is_custom_type(t) and not _identity_contains(seen, t)
         ]
-        return sorted(custom_types, key=lambda t: t.__name__)
+        return sorted(custom_types, key=lambda t: (t.__name__, t.__module__, t.__qualname__))
 
     # Instances use their type-level contract, with per-instance visibility.
     # Built-in values are not documentable API objects.
@@ -104,10 +127,9 @@ def discover_referenced_types(
     # non-annotated attrs).
     # Use the same extraction that extract_type_info uses for consistency
     from nooa.agentdoc._structured import extract_type_info
+    from nooa.agentdoc._visibility import is_hidden_field
 
-    type_info = extract_type_info(type_obj)
-    if visibility_obj is not None:
-        from nooa.agentdoc._visibility import is_hidden_field
+    type_info = type_info or extract_type_info(type_obj)
 
     for field in type_info.fields:
         if field_names is not None and field.name not in field_names:
@@ -162,11 +184,11 @@ def discover_referenced_types(
         _extract_types_from_callable(attr, discovered)
 
     # Filter to only custom types, excluding already-seen types
-    custom_types = [t for t in discovered if _is_custom_type(t) and (seen is None or t not in seen)]
-    return sorted(custom_types, key=lambda t: t.__name__)
+    custom_types = [t for t in discovered if _is_custom_type(t) and not _identity_contains(seen, t)]
+    return sorted(custom_types, key=lambda t: (t.__name__, t.__module__, t.__qualname__))
 
 
-def _extract_types_from_callable(attr: Any, discovered: set[type]) -> None:
+def _extract_types_from_callable(attr: Any, discovered: Any) -> None:
     """Extract referenced types from a callable's parameter and return annotations.
 
     Handles ``from __future__ import annotations`` (PEP 563), where every annotation
@@ -229,7 +251,7 @@ def _extract_types_from_callable(attr: Any, discovered: set[type]) -> None:
 
 
 def _extract_types_from_field(
-    cls: type, field_name: str, field_type_str: str, discovered: set[type]
+    cls: type, field_name: str, field_type_str: str, discovered: Any
 ) -> None:
     """Extract types from a field, looking at class attributes and annotations.
 
@@ -274,7 +296,7 @@ def _extract_types_from_field(
         _extract_types_from_type_string(cls, field_type_str, discovered)
 
 
-def _extract_types_from_type_string(cls: type, type_str: str, discovered: set[type]) -> None:
+def _extract_types_from_type_string(cls: type, type_str: str, discovered: Any) -> None:
     """Try to evaluate a type string and extract types from it.
 
     This handles cases like "list[WorkerAgent]" where the type came from __init__.
@@ -305,7 +327,7 @@ def _extract_types_from_type_string(cls: type, type_str: str, discovered: set[ty
         pass  # Can't evaluate - might be a complex expression or unavailable type
 
 
-def _extract_types_from_hint(type_hint: Any, discovered: set[type]) -> None:
+def _extract_types_from_hint(type_hint: Any, discovered: Any) -> None:
     """Extract all type objects from a type hint, recursively.
 
     Handles:

--- a/src/nooa/agentdoc/_document.py
+++ b/src/nooa/agentdoc/_document.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Typed orchestration for complete agentdoc documents.
+
+Formatting lives in :mod:`_pformat`; this module owns object normalization and the
+identity-based reference graph shared by ``doc()`` and direct ``pformat()``.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from typing import Any
+
+from nooa.agentdoc._discover import (
+    _extract_types_from_hint,
+    _IdentityTypeSet,
+    _is_custom_type,
+    discover_referenced_types,
+)
+from nooa.agentdoc._info import CallableInfo, ModuleInfo, TypeInfo
+from nooa.agentdoc._introspection import (
+    _extract_instance_values,
+    _is_structured_instance,
+)
+from nooa.agentdoc._metadata import is_expand_false
+from nooa.agentdoc._structured import extract_callable_info, extract_module_info, extract_type_info
+from nooa.agentdoc._visibility import is_hidden_field
+from nooa.agentdoc.protocols import SupportsInstanceValues
+from nooa.agentdoc.registry import get_module_info_extractor, get_type_info_extractor
+
+StructuredInfo = TypeInfo | CallableInfo | ModuleInfo
+
+
+@dataclass
+class DocumentSubject:
+    """A primary object normalized once for formatting and graph discovery."""
+
+    obj: Any
+    info: StructuredInfo | None = None
+    values: dict[str, Any] | None = None
+    represented_type: type | None = None
+
+
+def _instance_dict(obj: Any) -> dict[str, Any] | None:
+    try:
+        value = object.__getattribute__(obj, "__dict__")
+    except AttributeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _extract_instance(obj: Any) -> tuple[TypeInfo, dict[str, Any]] | None:
+    if not _is_structured_instance(obj, respect_custom_repr=False):
+        return None
+
+    obj_type = type(obj)
+    instance_meta = (_instance_dict(obj) or {}).get("_agentdoc_fields_docs") or {}
+    has_overrides = any(meta.get("hidden") is False for meta in instance_meta.values())
+    extractor = get_type_info_extractor(obj_type)
+    if extractor:
+        result = extractor(obj)
+        if isinstance(result, tuple):
+            info, values = result
+        else:
+            info, values = result, _extract_instance_values(obj, result)
+    elif isinstance(obj, SupportsInstanceValues):
+        info = extract_type_info(obj_type)
+        if has_overrides:
+            raw = extract_type_info(obj_type, _skip_protocol=True, _include_hidden=True)
+            info = TypeInfo(
+                info.name,
+                info.base,
+                [f for f in raw.fields if not is_hidden_field(obj, f.name)],
+                info.methods,
+                info.docstring,
+            )
+        values = obj.__instance_values__()
+    else:
+        info = extract_type_info(obj_type)
+        if has_overrides:
+            raw = extract_type_info(obj_type, _skip_protocol=True, _include_hidden=True)
+            info = TypeInfo(
+                info.name,
+                info.base,
+                [f for f in raw.fields if not is_hidden_field(obj, f.name)],
+                info.methods,
+                info.docstring,
+            )
+        values = _extract_instance_values(obj, info)
+
+    info = TypeInfo(
+        info.name,
+        info.base,
+        [f for f in info.fields if not is_hidden_field(obj, f.name)],
+        info.methods,
+        info.docstring,
+    )
+    return info, values
+
+
+def normalize_subject(obj: Any) -> DocumentSubject:
+    """Extract a primary exactly once, preserving non-document values."""
+    if isinstance(obj, (TypeInfo, CallableInfo, ModuleInfo)):
+        return DocumentSubject(obj, obj)
+    if isinstance(obj, type):
+        return DocumentSubject(obj, extract_type_info(obj), represented_type=obj)
+    if inspect.isfunction(obj) or inspect.ismethod(obj):
+        return DocumentSubject(obj, extract_callable_info(obj))
+    if inspect.ismodule(obj):
+        extractor = get_module_info_extractor(obj)
+        info = extractor(obj) if extractor else extract_module_info(obj)
+        return DocumentSubject(obj, info)
+    extracted = _extract_instance(obj)
+    if extracted is None:
+        return DocumentSubject(obj)
+    info, values = extracted
+    return DocumentSubject(obj, info, values, type(obj))
+
+
+def reference_seeds(subject: DocumentSubject) -> list[type]:
+    """Return visible declared and runtime reference types for a subject."""
+    obj, info = subject.obj, subject.info
+    if isinstance(info, TypeInfo) and subject.represented_type is not None:
+        visible = {field.name for field in info.fields}
+        seeds = list(
+            discover_referenced_types(
+                subject.represented_type,
+                field_names=visible if subject.values is not None else None,
+                type_info=info,
+            )
+        )
+        if subject.values:
+            runtime = _IdentityTypeSet()
+            for name, value in subject.values.items():
+                if name.startswith("_") or is_hidden_field(obj, name):
+                    continue
+                if callable(value) and not isinstance(value, type):
+                    continue
+                _extract_types_from_hint(value if isinstance(value, type) else type(value), runtime)
+            seeds.extend(item for item in runtime if _is_custom_type(item))
+        return seeds
+    if isinstance(info, CallableInfo) and (inspect.isfunction(obj) or inspect.ismethod(obj)):
+        return list(discover_referenced_types(obj))
+    return []
+
+
+def collect_references(
+    seed_types: list[type], *, exclude: list[type], max_depth: int
+) -> list[DocumentSubject]:
+    """Traverse a bounded graph, deduplicating and excluding strictly by identity."""
+    seen = {id(item) for item in exclude}
+    found: list[DocumentSubject] = []
+    frontier = [item for item in seed_types if id(item) not in seen and not is_expand_false(item)]
+    for _ in range(max_depth):
+        if not frontier:
+            break
+        following: list[type] = []
+        for ref_type in frontier:
+            if id(ref_type) in seen:
+                continue
+            seen.add(id(ref_type))
+            subject = normalize_subject(ref_type)
+            found.append(subject)
+            following.extend(reference_seeds(subject))
+        frontier = [
+            item for item in following if id(item) not in seen and not is_expand_false(item)
+        ]
+    return sorted(
+        found,
+        key=lambda subject: (
+            subject.obj.__name__,
+            subject.obj.__module__,
+            subject.obj.__qualname__,
+        ),
+    )
+
+
+def normalize_subjects(objs: list[Any]) -> list[DocumentSubject]:
+    """Normalize primaries once, deduplicating by identity in caller order."""
+    unique: list[Any] = []
+    seen: set[int] = set()
+    for obj in objs:
+        if id(obj) not in seen:
+            seen.add(id(obj))
+            unique.append(obj)
+    return [normalize_subject(obj) for obj in unique]
+
+
+def collect_subject_references(
+    subjects: list[DocumentSubject], *, max_depth: int
+) -> list[DocumentSubject]:
+    """Collect references for subjects, excluding all represented primary types."""
+    if max_depth <= 0:
+        return []
+    seeds = [seed for subject in subjects for seed in reference_seeds(subject)]
+    primaries = [
+        subject.represented_type for subject in subjects if subject.represented_type is not None
+    ]
+    return collect_references(seeds, exclude=primaries, max_depth=max_depth)

--- a/src/nooa/agentdoc/_introspection.py
+++ b/src/nooa/agentdoc/_introspection.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Safe instance classification and value extraction for agent documentation."""
+
+import inspect
+from typing import Any
+
+from nooa.agentdoc._info import TypeInfo
+from nooa.agentdoc._structured import _ClassRef, _InstanceRef
+
+_MISSING = object()
+
+
+def _instance_dict(obj: Any) -> dict[str, Any] | None:
+    """Return an instance ``__dict__`` without invoking ``__getattr__``."""
+    try:
+        value = object.__getattribute__(obj, "__dict__")
+    except AttributeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _is_structured_instance(obj: Any, *, respect_custom_repr: bool = True) -> bool:
+    """Check if object is an instance that should be formatted with type info.
+
+    Returns True for:
+    - Pydantic models
+    - dataclasses
+    - NamedTuples
+    - attrs classes
+    - Any custom class instance with __dict__ (not built-in types)
+
+    Args:
+        obj: Candidate instance.
+        respect_custom_repr: If true, plain classes with custom ``__repr__``
+            are treated as values. ``doc()`` disables this to retain type docs.
+
+    Returns False for:
+    - Types (classes themselves)
+    - Built-in types (str, int, list, dict, etc.)
+    - None
+    """
+    if isinstance(obj, type):
+        return False
+
+    # Skip built-in types and None
+    if obj is None:
+        return False
+
+    if isinstance(obj, (str, int, float, bool, bytes, bytearray)):
+        return False
+
+    if isinstance(obj, (_ClassRef, _InstanceRef)):
+        return False
+
+    obj_type = type(obj)
+
+    # Check for NamedTuple BEFORE checking for regular tuples
+    # NamedTuples have a _fields attribute
+    if (
+        hasattr(obj_type, "_fields")
+        and isinstance(getattr(obj_type, "_fields", None), tuple)
+        and isinstance(obj, tuple)
+    ):
+        return True
+
+    # Now safe to exclude regular tuples, lists, sets, dicts
+    if isinstance(obj, (list, tuple, set, frozenset, dict)):
+        return False
+
+    # Pydantic (check before builtins guard — classes defined in exec()/REPL
+    # get __module__='builtins' but are still structured types)
+    if hasattr(obj_type, "model_fields"):
+        return True
+
+    # dataclass
+    import dataclasses
+
+    if dataclasses.is_dataclass(obj_type):
+        return True
+
+    # attrs
+    if hasattr(obj_type, "__attrs_attrs__"):
+        return True
+
+    # Skip if it's a built-in type (range, slice, memoryview, etc.)
+    if obj_type.__module__ == "builtins":
+        return False
+
+    # pformat() respects a custom __repr__, while doc() always renders the
+    # type-level API contract and augments it with runtime instance fields.
+    if respect_custom_repr:
+        for klass in obj_type.__mro__:
+            if klass is object:
+                break
+            if "__repr__" in klass.__dict__:
+                return False
+
+    # In doc mode, every non-builtin instance is documentable even when an
+    # empty/private-only __slots__ leaves it with no runtime values. pformat()
+    # still requires a public slot before choosing structured value rendering.
+    if _instance_dict(obj) is None:
+        if not respect_custom_repr:
+            return True
+        return any(
+            slot
+            for klass in obj_type.__mro__
+            if klass is not object
+            for slot in getattr(klass, "__slots__", ())
+            if not slot.startswith("_")
+        )
+
+    # Any other custom class instance with __dict__
+    return True
+
+
+def _extract_instance_values(obj: Any, type_info: TypeInfo) -> dict[str, Any]:
+    """Extract current field values from an instance.
+
+    Args:
+        obj: Instance to extract values from
+        type_info: TypeInfo describing the type
+
+    Returns:
+        Dictionary mapping field names to current values
+    """
+    values = {}
+
+    # First, get values for type fields
+    obj_type = type(obj)
+
+    # Respect Pydantic's exclude=True — those fields often contain large
+    # internal state (e.g. captured_locals with arbitrary user objects that
+    # can trigger expensive I/O when formatted, blocking the event loop).
+    _excluded_fields: set[str] = set()
+    if hasattr(obj_type, "model_fields"):
+        _excluded_fields = {
+            name
+            for name, field_info in obj_type.model_fields.items()
+            if getattr(field_info, "exclude", False)
+        }
+
+    obj_dict = _instance_dict(obj) or {}
+
+    # Collect slot names for __slots__-based classes (no __dict__)
+    _slots: set[str] = set()
+    for cls in obj_type.__mro__:
+        slots = getattr(cls, "__slots__", ())
+        if isinstance(slots, str):
+            _slots.add(slots)
+        else:
+            _slots.update(slots)
+
+    for field in type_info.fields:
+        if field.name in _excluded_fields:
+            continue
+        # Read from __dict__ first (instance data, always safe).
+        if field.name in obj_dict:
+            values[field.name] = obj_dict[field.name]
+        elif field.name in _slots:
+            # A subclass may replace an inherited slot with an arbitrary
+            # descriptor. Only invoke the concrete member descriptor found by
+            # static lookup; properties and custom descriptors are not safe.
+            slot_descriptor = inspect.getattr_static(obj_type, field.name, _MISSING)
+            if inspect.ismemberdescriptor(slot_descriptor):
+                try:
+                    values[field.name] = slot_descriptor.__get__(obj, obj_type)
+                except AttributeError:
+                    pass
+        elif isinstance(obj, dict) and field.name in obj:
+            # TypedDict instances are dicts
+            values[field.name] = obj[field.name]
+        else:
+            # Fall back to class-level plain values (non-descriptors).
+            # This handles annotated class defaults like `x: int = 5`.
+            # Descriptors (property, classmethod, etc.) are skipped — they
+            # can trigger arbitrary I/O.
+            class_val = inspect.getattr_static(obj_type, field.name, _MISSING)
+            if (
+                class_val is not _MISSING
+                and inspect.getattr_static(type(class_val), "__get__", None) is None
+            ):
+                values[field.name] = class_val
+
+    # Also include runtime-only attributes that are not declared type fields.
+    # Most objects store them in __dict__; Pydantic models with extra="allow"
+    # store them separately in __pydantic_extra__.
+    from nooa.agentdoc._visibility import is_hidden_field as _is_hidden_field
+
+    def _include_dynamic(name: str, value: Any) -> bool:
+        return (
+            name not in values
+            and not name.startswith("_")
+            and not callable(value)
+            and not _is_hidden_field(obj, name)
+            and name not in _excluded_fields
+        )
+
+    for name, value in obj_dict.items():
+        if _include_dynamic(name, value):
+            values[name] = value
+
+    pydantic_extra = None
+    if hasattr(obj_type, "model_fields"):
+        try:
+            pydantic_extra = object.__getattribute__(obj, "__pydantic_extra__")
+        except AttributeError:
+            pass
+    if isinstance(pydantic_extra, dict):
+        for name, value in pydantic_extra.items():
+            if _include_dynamic(name, value):
+                values[name] = value
+
+    return values

--- a/src/nooa/agentdoc/_pformat.py
+++ b/src/nooa/agentdoc/_pformat.py
@@ -22,8 +22,17 @@ import io
 import re
 from typing import Any
 
+from nooa.agentdoc._document import (
+    DocumentSubject,
+    collect_subject_references,
+    normalize_subjects,
+)
 from nooa.agentdoc._info import REQUIRED, CallableInfo, ModuleInfo, TypeInfo
-from nooa.agentdoc._metadata import is_expand_false
+from nooa.agentdoc._introspection import (
+    _extract_instance_values,
+    _instance_dict,
+    _is_structured_instance,
+)
 from nooa.agentdoc._structured import _ClassRef, _InstanceRef
 from nooa.agentdoc.protocols import SupportsInstanceValues
 
@@ -81,41 +90,6 @@ def _resolve_field_type_by_name(type_name: str, context_obj: type | None) -> typ
     return None
 
 
-def _collect_referenced_types(
-    seed_types: set[type],
-    *,
-    exclude: type | None = None,
-    max_depth: int,
-) -> list[type]:
-    """Collect referenced types with bounded breadth-first traversal.
-
-    ``seed_types`` are the direct references (depth 1). Each subsequent level
-    follows references from the preceding level until ``max_depth`` is reached.
-    """
-    from nooa.agentdoc._discover import discover_referenced_types
-
-    all_types: set[type] = set()
-    # Exclude the primary type from the seed too: a type that references itself in its
-    # own method signatures (common, e.g. DataFrame methods returning DataFrame) must
-    # not list itself under "Referenced Types".
-    frontier = {t for t in seed_types if t is not exclude}
-    for _ in range(max_depth):
-        if not frontier:
-            break
-        all_types.update(frontier)
-        next_frontier: set[type] = set()
-        for ref_type in frontier:
-            for new_type in discover_referenced_types(ref_type):
-                if (
-                    new_type not in all_types
-                    and not is_expand_false(new_type)
-                    and new_type is not exclude
-                ):
-                    next_frontier.add(new_type)
-        frontier = next_frontier
-    return sorted(all_types, key=lambda type_: type_.__name__)
-
-
 def _field_type_docstring(
     field_default: Any, context_obj: type | None, type_name: str | None = None
 ) -> str | None:
@@ -132,6 +106,72 @@ def _field_type_docstring(
         return None
     docstring = inspect.cleandoc(raw_doc)
     return docstring.split("\n")[0].strip()
+
+
+def _format_document_subject(
+    subject: DocumentSubject,
+    *,
+    concise: bool,
+    max_length: int | None = None,
+    indent: int = 0,
+) -> str:
+    """Format one already-normalized document subject without discovering references."""
+    info = subject.info
+    if isinstance(info, TypeInfo):
+        return _format_type_info(
+            info,
+            concise=concise,
+            type_depth=0,
+            max_length=max_length,
+            indent=indent,
+            context_obj=subject.represented_type,
+            instance_values=subject.values,
+            visibility_obj=subject.obj if subject.values is not None else None,
+        )
+    if isinstance(info, CallableInfo):
+        return _format_callable_info(info, concise=concise, type_depth=0, indent=indent)
+    if isinstance(info, ModuleInfo):
+        return _format_module_info(
+            info,
+            concise=concise,
+            concise_members=bool(getattr(subject.obj, "__agentdoc_concise_members__", False)),
+            indent=indent,
+        )
+    return _pformat_to_str(
+        subject.obj,
+        concise=concise,
+        inline_depth=0,
+        max_length=None,
+        max_string=None,
+        max_depth=3,
+        instance_mode="type",
+    )
+
+
+def render_document(objs: list[Any], *, concise: bool, inline_depth: int) -> str:
+    """Render primaries and one shared referenced-types section."""
+    subjects = normalize_subjects(objs)
+    sections = [_format_document_subject(subject, concise=concise) for subject in subjects]
+    references = collect_subject_references(subjects, max_depth=inline_depth)
+    if references:
+        sections.extend(("", "## Referenced Types"))
+        sections.extend(_format_document_subject(subject, concise=True) for subject in references)
+    return "\n".join(sections)
+
+
+def _render_inline_references(
+    subject: DocumentSubject, *, depth: int, max_length: int | None, indent: int
+) -> str:
+    """Render the historical inline reference suffix used by direct ``pformat`` calls."""
+    references = collect_subject_references([subject], max_depth=depth)
+    if not references:
+        return ""
+    ind = "    " * indent
+    rendered = [
+        _format_document_subject(ref, concise=True, max_length=max_length, indent=indent)
+        for ref in references
+    ]
+    return f"{ind}## Referenced Types\n" + "\n\n".join(rendered)
 
 
 def _pformat(
@@ -242,88 +282,9 @@ def _pformat(
             # Instance of a structured type. doc() deliberately ignores a custom
             # __repr__: documentation must retain the type's API contract.
             if instance_mode == "type":
-                # Show type structure with runtime values (for doc())
-                from nooa.agentdoc._structured import extract_type_info
-                from nooa.agentdoc._visibility import is_hidden_field
-                from nooa.agentdoc.registry import get_type_info_extractor
-
-                obj_type = type(_object)
-                # Check if instance has spec() overrides that could unhide class-hidden fields.
-                # spec(self, "field", hidden=False) in __init__ → per-instance opt-in.
-                _instance_fields_meta = (_instance_dict(_object) or {}).get(
-                    "_agentdoc_fields_docs"
-                ) or {}
-                _has_instance_overrides = any(
-                    meta.get("hidden") is False for meta in _instance_fields_meta.values()
-                )
-                extractor = get_type_info_extractor(obj_type)
-                if extractor:
-                    result = extractor(_object)
-                    if isinstance(result, tuple):
-                        type_info, values = result
-                    else:
-                        type_info = result
-                        values = _extract_instance_values(_object, result)
-                    # Filter with instance (supports instance-level spec() overrides)
-                    type_info = TypeInfo(
-                        name=type_info.name,
-                        base=type_info.base,
-                        fields=[
-                            f for f in type_info.fields if not is_hidden_field(_object, f.name)
-                        ],
-                        methods=type_info.methods,
-                        docstring=type_info.docstring,
-                    )
-                elif isinstance(_object, SupportsInstanceValues):
-                    if _has_instance_overrides:
-                        # Get all fields (including class-hidden) then re-filter by instance.
-                        # Use _skip_protocol to get raw fields; take methods from protocol path.
-                        raw_info = extract_type_info(
-                            obj_type, _skip_protocol=True, _include_hidden=True
-                        )
-                        protocol_info = extract_type_info(obj_type)
-                        type_info = TypeInfo(
-                            name=protocol_info.name,
-                            base=protocol_info.base,
-                            fields=[
-                                f for f in raw_info.fields if not is_hidden_field(_object, f.name)
-                            ],
-                            methods=protocol_info.methods,
-                            docstring=protocol_info.docstring,
-                        )
-                    else:
-                        type_info = extract_type_info(obj_type)
-                    values = _object.__instance_values__()
-                else:
-                    if _has_instance_overrides:
-                        raw_info = extract_type_info(
-                            obj_type, _skip_protocol=True, _include_hidden=True
-                        )
-                        protocol_info = extract_type_info(obj_type)
-                        type_info = TypeInfo(
-                            name=protocol_info.name,
-                            base=protocol_info.base,
-                            fields=[
-                                f for f in raw_info.fields if not is_hidden_field(_object, f.name)
-                            ],
-                            methods=protocol_info.methods,
-                            docstring=protocol_info.docstring,
-                        )
-                    else:
-                        type_info = extract_type_info(obj_type)
-                    values = _extract_instance_values(_object, type_info)
-
-                # Apply per-instance visibility in every extraction branch.
-                # This handles both hidden=False opt-ins and hidden=True overrides
-                # on fields already present in the type-level contract.
-                type_info = TypeInfo(
-                    name=type_info.name,
-                    base=type_info.base,
-                    fields=[f for f in type_info.fields if not is_hidden_field(_object, f.name)],
-                    methods=type_info.methods,
-                    docstring=type_info.docstring,
-                )
-
+                subject = normalize_subjects([_object])[0]
+                assert isinstance(subject.info, TypeInfo)
+                type_info, values = subject.info, subject.values or {}
                 _stream.write(
                     _format_type_info(
                         type_info,
@@ -331,7 +292,7 @@ def _pformat(
                         type_depth=inline_depth,
                         max_length=max_length,
                         indent=_indent,
-                        context_obj=obj_type,
+                        context_obj=type(_object),
                         instance_values=values,
                         visibility_obj=_object,
                     )
@@ -390,111 +351,6 @@ def _pformat_to_str(
         _indent=_indent,
     )
     return stream.getvalue()
-
-
-def _instance_dict(obj: Any) -> dict[str, Any] | None:
-    """Return an instance ``__dict__`` without invoking ``__getattr__``."""
-    try:
-        value = object.__getattribute__(obj, "__dict__")
-    except AttributeError:
-        return None
-    return value if isinstance(value, dict) else None
-
-
-def _is_structured_instance(obj: Any, *, respect_custom_repr: bool = True) -> bool:
-    """Check if object is an instance that should be formatted with type info.
-
-    Returns True for:
-    - Pydantic models
-    - dataclasses
-    - NamedTuples
-    - attrs classes
-    - Any custom class instance with __dict__ (not built-in types)
-
-    Args:
-        obj: Candidate instance.
-        respect_custom_repr: If true, plain classes with custom ``__repr__``
-            are treated as values. ``doc()`` disables this to retain type docs.
-
-    Returns False for:
-    - Types (classes themselves)
-    - Built-in types (str, int, list, dict, etc.)
-    - None
-    """
-    if isinstance(obj, type):
-        return False
-
-    # Skip built-in types and None
-    if obj is None:
-        return False
-
-    if isinstance(obj, (str, int, float, bool, bytes, bytearray)):
-        return False
-
-    from nooa.agentdoc._structured import _ClassRef, _InstanceRef
-
-    if isinstance(obj, (_ClassRef, _InstanceRef)):
-        return False
-
-    obj_type = type(obj)
-
-    # Check for NamedTuple BEFORE checking for regular tuples
-    # NamedTuples have a _fields attribute
-    if (
-        hasattr(obj_type, "_fields")
-        and isinstance(getattr(obj_type, "_fields", None), tuple)
-        and isinstance(obj, tuple)
-    ):
-        return True
-
-    # Now safe to exclude regular tuples, lists, sets, dicts
-    if isinstance(obj, (list, tuple, set, frozenset, dict)):
-        return False
-
-    # Pydantic (check before builtins guard — classes defined in exec()/REPL
-    # get __module__='builtins' but are still structured types)
-    if hasattr(obj_type, "model_fields"):
-        return True
-
-    # dataclass
-    import dataclasses
-
-    if dataclasses.is_dataclass(obj_type):
-        return True
-
-    # attrs
-    if hasattr(obj_type, "__attrs_attrs__"):
-        return True
-
-    # Skip if it's a built-in type (range, slice, memoryview, etc.)
-    if obj_type.__module__ == "builtins":
-        return False
-
-    # pformat() respects a custom __repr__, while doc() always renders the
-    # type-level API contract and augments it with runtime instance fields.
-    if respect_custom_repr:
-        for klass in obj_type.__mro__:
-            if klass is object:
-                break
-            if "__repr__" in klass.__dict__:
-                return False
-
-    # In doc mode, every non-builtin instance is documentable even when an
-    # empty/private-only __slots__ leaves it with no runtime values. pformat()
-    # still requires a public slot before choosing structured value rendering.
-    if _instance_dict(obj) is None:
-        if not respect_custom_repr:
-            return True
-        return any(
-            slot
-            for klass in obj_type.__mro__
-            if klass is not object
-            for slot in getattr(klass, "__slots__", ())
-            if not slot.startswith("_")
-        )
-
-    # Any other custom class instance with __dict__
-    return True
 
 
 def _format_type_info(
@@ -697,72 +553,21 @@ def _format_type_info(
         if truncated_methods:
             lines.append(f"{ind}    # ... +{truncated_methods} more methods")
 
-    # Add Referenced Types section if we have context and type_depth > 0
+    # Direct pformat() keeps its historical inline suffix, but delegates graph policy.
     if context_obj is not None and type_depth > 0:
-        from nooa.agentdoc._discover import (
-            _extract_types_from_hint,
-            _is_custom_type,
-            discover_referenced_types,
-        )
-        from nooa.agentdoc._structured import extract_type_info
-        from nooa.agentdoc._visibility import is_hidden_field as _is_hidden_field
-
-        visible_field_names = {field.name for field in info.fields}
-        seed_set: set[type] = {
-            t
-            for t in discover_referenced_types(
+        suffix = _render_inline_references(
+            DocumentSubject(
                 context_obj,
-                field_names=visible_field_names if visibility_obj is not None else None,
-            )
-            if not is_expand_false(t)
-        }
-
-        # Also discover types from extra instance attributes
-        if instance_values:
-            extra_discovered: set[type] = set()
-
-            for name, value in instance_values.items():
-                if name.startswith("_"):
-                    continue
-                if visibility_obj is not None and _is_hidden_field(visibility_obj, name):
-                    continue
-                # Skip callables unless they're classes
-                if callable(value) and not isinstance(value, type):
-                    continue
-
-                # Extract type from the value
-                value_type = type(value)
-                if isinstance(value, type):
-                    # It's a class itself (like WorkerAgent = WorkerAgent)
-                    value_type = value
-
-                # Extract types from the value's type
-                _extract_types_from_hint(value_type, extra_discovered)
-
-            # Filter to only custom types and add to seed_set
-            for extra_type in extra_discovered:
-                if _is_custom_type(extra_type) and not is_expand_false(extra_type):
-                    seed_set.add(extra_type)
-
-        # Collect referenced types to the requested depth, then render them flat.
-        referenced_types = _collect_referenced_types(
-            seed_set, exclude=context_obj, max_depth=type_depth
+                info,
+                instance_values,
+                context_obj if isinstance(context_obj, type) else type(context_obj),
+            ),
+            depth=type_depth,
+            max_length=max_length,
+            indent=indent,
         )
-        if referenced_types:
-            lines.append(f"{ind}## Referenced Types")
-
-            for ref_type in referenced_types:
-                ref_info = extract_type_info(ref_type)
-                ref_doc = _format_type_info(
-                    ref_info,
-                    concise=True,
-                    type_depth=0,  # All types already collected — no nested ## sections
-                    max_length=max_length,
-                    indent=indent,
-                    context_obj=ref_type,
-                )
-                lines.append(ref_doc)
-                lines.append("")
+        if suffix:
+            lines.append(suffix)
 
     return re.sub(r"\n{3,}", "\n\n", "\n".join(lines)).rstrip("\n")
 
@@ -826,33 +631,17 @@ def _format_callable_info(
     else:
         lines.append(f"{ind}    ...")
 
-    # Add Referenced Types section if we have context and type_depth > 0
-    # (not when formatting as a method within a class)
+    # Direct pformat() keeps its historical inline suffix, but delegates graph policy.
     if context_obj is not None and type_depth > 0 and not as_method:
-        from nooa.agentdoc._discover import discover_referenced_types
-        from nooa.agentdoc._structured import extract_type_info
-
-        seed_set = {t for t in discover_referenced_types(context_obj) if not is_expand_false(t)}
-        referenced_types = _collect_referenced_types(
-            seed_set, exclude=context_obj, max_depth=type_depth
+        suffix = _render_inline_references(
+            DocumentSubject(context_obj, info),
+            depth=type_depth,
+            max_length=None,
+            indent=indent,
         )
-
-        if referenced_types:
+        if suffix:
             lines.append("")
-            lines.append(f"{ind}## Referenced Types")
-
-            for ref_type in referenced_types:
-                ref_info = extract_type_info(ref_type)
-                ref_doc = _format_type_info(
-                    ref_info,
-                    concise=True,
-                    type_depth=0,  # All types already collected — no nested ## sections
-                    max_length=None,
-                    indent=indent,
-                    context_obj=ref_type,
-                )
-                lines.append(ref_doc)
-                lines.append("")
+            lines.append(suffix)
 
     return re.sub(r"\n{3,}", "\n\n", "\n".join(lines)).rstrip("\n")
 
@@ -1193,106 +982,6 @@ def _format_instance_repr(
                 return r
 
     return f"{type_name}({', '.join(parts)})"
-
-
-def _extract_instance_values(obj: Any, type_info: TypeInfo) -> dict[str, Any]:
-    """Extract current field values from an instance.
-
-    Args:
-        obj: Instance to extract values from
-        type_info: TypeInfo describing the type
-
-    Returns:
-        Dictionary mapping field names to current values
-    """
-    values = {}
-
-    # First, get values for type fields
-    obj_type = type(obj)
-
-    # Respect Pydantic's exclude=True — those fields often contain large
-    # internal state (e.g. captured_locals with arbitrary user objects that
-    # can trigger expensive I/O when formatted, blocking the event loop).
-    _excluded_fields: set[str] = set()
-    if hasattr(obj_type, "model_fields"):
-        _excluded_fields = {
-            name
-            for name, field_info in obj_type.model_fields.items()
-            if getattr(field_info, "exclude", False)
-        }
-
-    obj_dict = _instance_dict(obj) or {}
-
-    # Collect slot names for __slots__-based classes (no __dict__)
-    _slots: set[str] = set()
-    for cls in obj_type.__mro__:
-        slots = getattr(cls, "__slots__", ())
-        if isinstance(slots, str):
-            _slots.add(slots)
-        else:
-            _slots.update(slots)
-
-    for field in type_info.fields:
-        if field.name in _excluded_fields:
-            continue
-        # Read from __dict__ first (instance data, always safe).
-        if field.name in obj_dict:
-            values[field.name] = obj_dict[field.name]
-        elif field.name in _slots:
-            # A subclass may replace an inherited slot with an arbitrary
-            # descriptor. Only invoke the concrete member descriptor found by
-            # static lookup; properties and custom descriptors are not safe.
-            slot_descriptor = inspect.getattr_static(obj_type, field.name, _MISSING)
-            if inspect.ismemberdescriptor(slot_descriptor):
-                try:
-                    values[field.name] = slot_descriptor.__get__(obj, obj_type)
-                except AttributeError:
-                    pass
-        elif isinstance(obj, dict) and field.name in obj:
-            # TypedDict instances are dicts
-            values[field.name] = obj[field.name]
-        else:
-            # Fall back to class-level plain values (non-descriptors).
-            # This handles annotated class defaults like `x: int = 5`.
-            # Descriptors (property, classmethod, etc.) are skipped — they
-            # can trigger arbitrary I/O.
-            class_val = inspect.getattr_static(obj_type, field.name, _MISSING)
-            if (
-                class_val is not _MISSING
-                and inspect.getattr_static(type(class_val), "__get__", None) is None
-            ):
-                values[field.name] = class_val
-
-    # Also include runtime-only attributes that are not declared type fields.
-    # Most objects store them in __dict__; Pydantic models with extra="allow"
-    # store them separately in __pydantic_extra__.
-    from nooa.agentdoc._visibility import is_hidden_field as _is_hidden_field
-
-    def _include_dynamic(name: str, value: Any) -> bool:
-        return (
-            name not in values
-            and not name.startswith("_")
-            and not callable(value)
-            and not _is_hidden_field(obj, name)
-            and name not in _excluded_fields
-        )
-
-    for name, value in obj_dict.items():
-        if _include_dynamic(name, value):
-            values[name] = value
-
-    pydantic_extra = None
-    if hasattr(obj_type, "model_fields"):
-        try:
-            pydantic_extra = object.__getattribute__(obj, "__pydantic_extra__")
-        except AttributeError:
-            pass
-    if isinstance(pydantic_extra, dict):
-        for name, value in pydantic_extra.items():
-            if _include_dynamic(name, value):
-                values[name] = value
-
-    return values
 
 
 def _format_nested_instance(

--- a/src/nooa/agentdoc/_structured.py
+++ b/src/nooa/agentdoc/_structured.py
@@ -975,10 +975,10 @@ def _extract_plain_class_fields(obj: type) -> list[FieldInfo]:
     # siblings, respect forward-MRO priority (lower index = higher priority = first).
     # This ensures Base1 fields appear before Base2 fields for Child(Base1, Base2).
     all_raw_annotations: dict[str, Any] = {}
-    mro_index = {c: i for i, c in enumerate(obj.__mro__)}
-    for _klass in sorted(
-        (c for c in obj.__mro__ if c is not object),
-        key=lambda c: (len(c.__mro__), mro_index[c]),
+    mro_items = list(enumerate(obj.__mro__))
+    for _, _klass in sorted(
+        ((index, klass) for index, klass in mro_items if klass is not object),
+        key=lambda item: (len(item[1].__mro__), item[0]),
     ):
         for name, raw_hint in inspect.get_annotations(_klass).items():
             all_raw_annotations[name] = raw_hint
@@ -1021,12 +1021,12 @@ def _extract_plain_class_fields(obj: type) -> list[FieldInfo]:
     # each name within the class MRO before the metaclass, so metaclass attributes
     # are never pulled in. The effective (leaf-resolved) value is used, so the leaf
     # class wins on name collisions.
-    # (mro_index was computed in step 1 above; reuse it for the same ordering.)
+    # Reuse the identity-safe indexed MRO from step 1 for the same ordering.
     candidate_names: list[str] = []
     seen_candidates: set[str] = set()  # O(1) dedup alongside the ordered list
-    for _klass in sorted(
-        (c for c in obj.__mro__ if c is not object),
-        key=lambda c: (len(c.__mro__), mro_index[c]),
+    for _, _klass in sorted(
+        ((index, klass) for index, klass in mro_items if klass is not object),
+        key=lambda item: (len(item[1].__mro__), item[0]),
     ):
         for name in _klass.__dict__:
             if name not in seen_candidates:

--- a/src/nooa/agentdoc/core.py
+++ b/src/nooa/agentdoc/core.py
@@ -6,6 +6,7 @@ import inspect
 from typing import Annotated, Any, Literal
 
 from nooa.agentdoc._pformat import _pformat_to_str as _pformat
+from nooa.agentdoc._pformat import render_document
 from nooa.agentdoc._structured import format_type as _format_type_impl
 from nooa.agentdoc.doc_config import DocConfig
 from nooa.agentdoc.format import (
@@ -87,114 +88,8 @@ def doc(
     if inline_depth < 0:
         raise ValueError("inline_depth must be a non-negative integer")
 
-    # Single object: use optimized path
-    if len(flat_objs) == 1:
-        return _pformat(
-            flat_objs[0],
-            concise=concise,
-            inline_depth=inline_depth,
-            max_length=None,
-            max_string=None,
-            max_depth=3,
-            instance_mode="type",
-        )
-
-    # Multiple objects: use multi-type formatting with deduplication
-    return _doc_multiple(flat_objs, concise=concise, inline_depth=inline_depth)
-
-
-def _doc_multiple(
-    objs: list[Any],
-    *,
-    concise: bool,
-    inline_depth: int,
-) -> str:
-    """Format multiple objects with deduplicated referenced types.
-
-    Args:
-        objs: List of objects to document
-        concise: If True, show first-line docstrings only
-        inline_depth: How deep to expand referenced types inline
-
-    Returns:
-        Formatted documentation with each type appearing exactly once
-    """
-    from nooa.agentdoc._discover import discover_referenced_types
-
-    sections: list[str] = []
-    seen_types: set[type] = set()
-
-    # Track primary contract types for deduplication. Instances document their
-    # type API, so their types must not reappear under Referenced Types.
-    for obj in objs:
-        if isinstance(obj, type):
-            seen_types.add(obj)
-        elif not (inspect.isfunction(obj) or inspect.ismethod(obj) or inspect.ismodule(obj)):
-            obj_type = type(obj)
-            if obj_type.__module__ != "builtins":
-                seen_types.add(obj_type)
-
-    # 1. Format each primary object (without their own referenced types section)
-    for obj in objs:
-        # Format with inline_depth=0 to suppress per-object referenced types
-        # We'll collect and show them all at the end
-        obj_doc = _pformat(
-            obj,
-            concise=concise,
-            inline_depth=0,  # Don't show references per-object
-            max_length=None,
-            max_string=None,
-            max_depth=3,
-            instance_mode="type",
-        )
-        sections.append(obj_doc)
-
-    # 2. Collect referenced types from all objects (if inline_depth > 0)
-    if inline_depth > 0:
-        all_referenced: list[type] = []
-
-        for obj in objs:
-            # Discover referenced types, excluding already-seen types
-            referenced = discover_referenced_types(obj, seen=seen_types)
-            for ref_type in referenced:
-                if ref_type not in seen_types:
-                    seen_types.add(ref_type)
-                    all_referenced.append(ref_type)
-
-        # 3. If inline_depth > 1, recursively discover from referenced types
-        current_level = all_referenced
-        for _ in range(inline_depth - 1):
-            if not current_level:
-                break
-            next_level: list[type] = []
-            for ref_type in current_level:
-                nested_refs = discover_referenced_types(ref_type, seen=seen_types)
-                for nested in nested_refs:
-                    if nested not in seen_types:
-                        seen_types.add(nested)
-                        next_level.append(nested)
-                        all_referenced.append(nested)
-            current_level = next_level
-
-        # 4. Format referenced types section if any found
-        if all_referenced:
-            sections.append("")
-            sections.append("## Referenced Types")
-
-            for ref_type in all_referenced:
-                # Format referenced types in concise mode
-                ref_doc = _pformat(
-                    ref_type,
-                    concise=True,  # Always concise for referenced types
-                    inline_depth=0,  # No nested references
-                    max_length=50,
-                    max_string=500,
-                    max_depth=3,
-                    instance_mode="type",
-                )
-                sections.append(ref_doc)
-
-    return "\n".join(sections)
+    # One shared pipeline handles both single- and multi-object documents.
+    return render_document(flat_objs, concise=concise, inline_depth=inline_depth)
 
 
 def methods(

--- a/src/nooa/agentdoc/registry.py
+++ b/src/nooa/agentdoc/registry.py
@@ -24,7 +24,7 @@ TypeInfoExtractorFunc = Callable[[Any], TypeInfo | tuple[TypeInfo, dict[str, Any
 ModuleInfoExtractorFunc = Callable[[Any], ModuleInfo]
 
 # Global registry: type -> extractor function
-_extractor_registry: dict[type, TypeInfoExtractorFunc] = {}
+_extractor_registry: list[tuple[type, TypeInfoExtractorFunc]] = []
 
 # Global registry: module qualified name -> extractor function
 _module_extractor_registry: dict[str, ModuleInfoExtractorFunc] = {}
@@ -64,7 +64,8 @@ def register_type_info_extractor(
 
     def decorator(func: TypeInfoExtractorFunc) -> TypeInfoExtractorFunc:
         with _registry_lock:
-            _extractor_registry[target_type] = func
+            unregister_type_info_extractor(target_type)
+            _extractor_registry.append((target_type, func))
         return func
 
     return decorator
@@ -88,8 +89,9 @@ def get_type_info_extractor(obj: Any) -> TypeInfoExtractorFunc | None:
     # Check type and all base classes in MRO order
     with _registry_lock:
         for base_type in target_type.__mro__:
-            if base_type in _extractor_registry:
-                return _extractor_registry[base_type]
+            for registered_type, extractor in _extractor_registry:
+                if registered_type is base_type:
+                    return extractor
 
     return None
 
@@ -103,7 +105,9 @@ def unregister_type_info_extractor(target_type: type) -> None:
         target_type: Type to unregister
     """
     with _registry_lock:
-        _extractor_registry.pop(target_type, None)
+        _extractor_registry[:] = [
+            item for item in _extractor_registry if item[0] is not target_type
+        ]
 
 
 def register_module_info_extractor(

--- a/tests/agentdoc/test_multi_type_doc.py
+++ b/tests/agentdoc/test_multi_type_doc.py
@@ -2,11 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for multi-type doc() functionality and inline_depth parameter."""
 
+import types
+
 import pytest
 from pydantic import BaseModel
 
-from nooa.agentdoc import doc
+from nooa.agentdoc import doc, pformat
 from nooa.agentdoc._discover import discover_referenced_types
+from nooa.agentdoc._info import CallableInfo, FieldInfo, ModuleInfo, TypeInfo
+from nooa.agentdoc._metadata import set_docs_metadata, set_field_metadata
+from nooa.agentdoc.registry import (
+    register_module_info_extractor,
+    register_type_info_extractor,
+    unregister_module_info_extractor,
+    unregister_type_info_extractor,
+)
 
 
 # Test fixtures - types with overlapping referenced types
@@ -341,3 +351,401 @@ class TestMultiTypeOutput:
 
         assert "def my_function" in result
         assert "class SimpleA" in result
+
+
+class TestUnifiedMultiDocumentPolicy:
+    """Regression coverage for policy parity between one and many primaries."""
+
+    def test_expand_false_is_honored_at_every_graph_level(self):
+        class Hidden(BaseModel):
+            value: int
+
+        class Middle(BaseModel):
+            hidden: Hidden
+
+        class Root(BaseModel):
+            middle: Middle
+
+        set_docs_metadata(Hidden, expand=False)
+        result = doc(Root, SimpleA, inline_depth=2)
+        assert "class Middle(BaseModel):" in result
+        assert "class Hidden(BaseModel):" not in result
+
+    def test_referenced_members_are_not_capped_at_fifty(self):
+        Wide = type(
+            "Wide",
+            (),
+            {"__annotations__": {f"field_{index:02}": int for index in range(55)}},
+        )
+
+        class Root:
+            wide: Wide
+
+        result = doc(Root, SimpleA)
+        assert "field_54: int" in result
+        assert "# ..." not in result
+
+    def test_references_are_globally_sorted_not_breadth_first(self):
+        class ADeep(BaseModel):
+            value: int
+
+        class ZDirect(BaseModel):
+            deep: ADeep
+
+        class Root(BaseModel):
+            direct: ZDirect
+
+        result = doc(Root, SimpleA, inline_depth=2)
+        assert result.index("class ADeep(BaseModel):") < result.index("class ZDirect(BaseModel):")
+
+    def test_duplicate_primaries_are_identity_deduplicated(self):
+        obj = SimpleA(value_a="same")
+        result = doc(obj, obj)
+        assert result.count("class SimpleA(BaseModel):") == 1
+
+    def test_info_objects_are_primaries_not_discovered_dataclasses(self):
+        type_info = TypeInfo(
+            name="Described",
+            base=None,
+            fields=[FieldInfo("value", "int")],
+            methods=[],
+            docstring=None,
+        )
+        callable_info = CallableInfo("work", "()", "None", None)
+        result = doc(type_info, callable_info)
+        assert "class Described:" in result
+        assert "def work() -> None:" in result
+        assert "class TypeInfo" not in result
+        assert "class CallableInfo" not in result
+        assert "## Referenced Types" not in result
+
+
+class TestIdentityAndNormalizedSubjects:
+    def test_equal_hash_colliding_types_remain_distinct_and_sort_by_module(self):
+        class EqualMeta(type):
+            def __eq__(cls, other):
+                return isinstance(other, EqualMeta)
+
+            def __hash__(cls):
+                return 1
+
+        first = EqualMeta("Same", (), {"__module__": "zzz", "__doc__": "Z module."})
+        second = EqualMeta("Same", (), {"__module__": "aaa", "__doc__": "A module."})
+        root = type(
+            "CollisionRoot",
+            (),
+            {"__module__": __name__, "__annotations__": {"first": first, "second": second}},
+        )
+
+        result = doc(root, SimpleA)
+        assert result.count("class Same:") == 2
+        assert result.index("A module.") < result.index("Z module.")
+
+    def test_unhashable_metaclass_types_can_be_discovered(self):
+        class UnhashableMeta(type):
+            __hash__ = None
+
+        referenced = UnhashableMeta("UnhashableReference", (), {"__module__": __name__})
+        root = type(
+            "UnhashableRoot",
+            (),
+            {"__module__": __name__, "__annotations__": {"reference": referenced}},
+        )
+
+        result = doc(root, SimpleA)
+        assert "class UnhashableReference:" in result
+
+    def test_custom_instance_extractor_runs_once_and_its_values_seed_references(self):
+        class RuntimeOnly:
+            pass
+
+        class Custom:
+            pass
+
+        calls = 0
+
+        @register_type_info_extractor(Custom)
+        def extract(obj):
+            nonlocal calls
+            calls += 1
+            return (
+                TypeInfo(
+                    name="Custom",
+                    base=None,
+                    fields=[FieldInfo("runtime", "RuntimeOnly")],
+                    methods=[],
+                    docstring=None,
+                ),
+                {"runtime": RuntimeOnly()},
+            )
+
+        try:
+            result = doc(Custom(), SimpleA)
+        finally:
+            unregister_type_info_extractor(Custom)
+
+        assert calls == 1
+        assert "runtime: RuntimeOnly" in result
+        assert result.count("class RuntimeOnly:") == 1
+
+    def test_supports_instance_values_runtime_only_reference_matches_single_doc(self):
+        class RuntimeOnly:
+            pass
+
+        class ProtocolValues:
+            declared: str
+
+            def __instance_values__(self):
+                return {"declared": "yes", "runtime": RuntimeOnly()}
+
+        value = ProtocolValues()
+        single = doc(value)
+        multiple = doc(value, SimpleA)
+        assert "runtime: RuntimeOnly" in single
+        assert "runtime: RuntimeOnly" in multiple
+        assert "class RuntimeOnly:" in single
+        assert "class RuntimeOnly:" in multiple
+
+    def test_mixed_function_module_and_value_with_no_expansion(self):
+        def work(value: Customer) -> Order:
+            return Order(order_id=1, customer=value)
+
+        module = types.ModuleType("sample_module", "Sample module.")
+        result = doc(work, module, 42, inline_depth=0)
+        assert "def work" in result
+        assert "# sample_module" in result
+        assert "42" in result
+        assert "## Referenced Types" not in result
+
+
+class TestDocumentPipelineCoverage:
+    """Focused branch and parity coverage for the shared document pipeline."""
+
+    def test_class_and_referenced_extractors_each_run_once(self):
+        class Referenced:
+            marker: int
+
+        class Root:
+            child: Referenced
+
+        root_calls = 0
+        referenced_calls = 0
+
+        @register_type_info_extractor(Root)
+        def extract_root(obj):
+            nonlocal root_calls
+            root_calls += 1
+            return TypeInfo("Root", None, [FieldInfo("child", "Referenced")], [], None)
+
+        @register_type_info_extractor(Referenced)
+        def extract_referenced(obj):
+            nonlocal referenced_calls
+            referenced_calls += 1
+            return TypeInfo("Referenced", None, [FieldInfo("marker", "int")], [], None)
+
+        try:
+            result = doc(Root)
+        finally:
+            unregister_type_info_extractor(Root)
+            unregister_type_info_extractor(Referenced)
+
+        assert root_calls == 1
+        assert referenced_calls == 1
+        assert result.count("class Referenced:") == 1
+
+    def test_instance_extractor_returning_type_info_runs_once(self):
+        class Custom:
+            def __init__(self):
+                self.value = 17
+
+        calls = 0
+
+        @register_type_info_extractor(Custom)
+        def extract(obj):
+            nonlocal calls
+            calls += 1
+            return TypeInfo("Custom", None, [FieldInfo("value", "int")], [], None)
+
+        try:
+            result = doc(Custom())
+        finally:
+            unregister_type_info_extractor(Custom)
+
+        assert calls == 1
+        assert "value: int = 17" in result
+
+    def test_cycle_and_diamond_are_deduplicated_and_exclude_primary(self):
+        class Root:
+            pass
+
+        class Shared:
+            pass
+
+        class Left:
+            pass
+
+        class Right:
+            pass
+
+        Root.__annotations__ = {"left": Left, "right": Right}
+        Left.__annotations__ = {"root": Root, "shared": Shared}
+        Right.__annotations__ = {"root": Root, "shared": Shared}
+
+        result = doc(Root, inline_depth=3)
+
+        assert result.count("class Root:") == 1
+        assert result.count("class Left:") == 1
+        assert result.count("class Right:") == 1
+        assert result.count("class Shared:") == 1
+        assert result.count("## Referenced Types") == 1
+
+    @pytest.mark.parametrize("depth", [1, 2])
+    def test_single_and_multi_reference_suffixes_match(self, depth):
+        def suffix(text):
+            return text.split("## Referenced Types", 1)[1]
+
+        single = doc(Order, inline_depth=depth)
+        multiple = doc(Order, SimpleA, inline_depth=depth)
+
+        assert suffix(single) == suffix(multiple)
+
+    def test_function_and_bound_method_follow_reference_depth(self):
+        def work(customer: Customer) -> Order:
+            return Order(order_id=1, customer=customer)
+
+        class Service:
+            def work(self, customer: Customer) -> Order:
+                return Order(order_id=1, customer=customer)
+
+        for callable_obj in (work, Service().work):
+            direct = doc(callable_obj, 42, inline_depth=1)
+            transitive = doc(callable_obj, 42, inline_depth=2)
+            assert direct.count("class Customer(BaseModel):") == 1
+            assert direct.count("class Order(BaseModel):") == 1
+            assert "class Address(BaseModel):" not in direct
+            assert transitive.count("class Address(BaseModel):") == 1
+
+    def test_structured_info_primaries_preserve_order_and_do_not_discover_internals(self):
+        type_info = TypeInfo("Described", None, [FieldInfo("value", "int")], [], None)
+        callable_info = CallableInfo("work", "()", "None", None)
+        module_info = ModuleInfo(
+            "curated",
+            "Curated module.",
+            [CallableInfo("run", "()", "None", "Run it.")],
+        )
+
+        result = doc(type_info, callable_info, module_info)
+
+        assert result.index("class Described:") < result.index("def work() -> None:")
+        assert result.index("def work() -> None:") < result.index("# curated")
+        assert "def run() -> None:" in result
+        assert "## Referenced Types" not in result
+        assert "class TypeInfo" not in result
+        assert "class ModuleInfo" not in result
+
+    def test_distinct_equal_primary_instances_are_not_deduplicated(self):
+        class EqualValue:
+            marker: str
+
+            def __init__(self, marker: str):
+                self.marker = marker
+
+            def __eq__(self, other):
+                return isinstance(other, EqualValue)
+
+            def __hash__(self):
+                return 1
+
+        result = doc(EqualValue("first"), EqualValue("second"), inline_depth=0)
+
+        assert "marker: str = 'first'" in result
+        assert "marker: str = 'second'" in result
+
+    def test_hidden_declared_and_runtime_fields_do_not_seed_references(self):
+        class HiddenDeclared:
+            pass
+
+        class HiddenRuntime:
+            pass
+
+        class VisibleRuntime:
+            pass
+
+        class Subject:
+            declared: HiddenDeclared
+
+            def __init__(self):
+                self.declared = HiddenDeclared()
+                self.secret_runtime = HiddenRuntime()
+                self.visible_runtime = VisibleRuntime()
+
+        value = Subject()
+        set_field_metadata(value, "declared", hidden=True)
+        set_field_metadata(value, "secret_runtime", hidden=True)
+
+        for result in (doc(value), doc(value, SimpleA)):
+            assert "declared:" not in result
+            assert "secret_runtime:" not in result
+            assert "class HiddenDeclared:" not in result
+            assert "class HiddenRuntime:" not in result
+            assert "visible_runtime: VisibleRuntime" in result
+            assert result.count("class VisibleRuntime:") == 1
+
+    def test_same_name_and_module_references_sort_by_qualname(self):
+        later = type("Same", (), {"__module__": "shared", "__doc__": "Later marker."})
+        earlier = type("Same", (), {"__module__": "shared", "__doc__": "Earlier marker."})
+        later.__qualname__ = "Zulu.Same"
+        earlier.__qualname__ = "Alpha.Same"
+
+        class Root:
+            pass
+
+        Root.__annotations__ = {"later": later, "earlier": earlier}
+        result = doc(Root)
+
+        assert result.count("class Same:") == 2
+        assert result.index("Earlier marker.") < result.index("Later marker.")
+
+    def test_registered_module_extractor_runs_once_in_mixed_document(self):
+        module = types.ModuleType("curated_module")
+        calls = 0
+
+        @register_module_info_extractor(module)
+        def extract(mod):
+            nonlocal calls
+            calls += 1
+            return ModuleInfo(
+                "curated_module",
+                "Curated module.",
+                [CallableInfo("curated", "()", "None", "Curated callable.")],
+            )
+
+        try:
+            result = doc(module, 42)
+        finally:
+            unregister_module_info_extractor(module)
+
+        assert calls == 1
+        assert result.count("# curated_module") == 1
+        assert result.count("def curated() -> None:") == 1
+        assert result.rstrip().endswith("42")
+
+    def test_direct_callable_pformat_preserves_reference_spacing(self):
+        class Alpha:
+            pass
+
+        class Beta:
+            pass
+
+        def work(alpha: Alpha) -> Beta:
+            return Beta()
+
+        result = pformat(work)
+
+        assert result == (
+            "def work(alpha: Alpha) -> Beta:\n"
+            "    ...\n\n"
+            "## Referenced Types\n"
+            "class Alpha:\n\n"
+            "class Beta:"
+        )

--- a/tests/agentdoc/test_registry.py
+++ b/tests/agentdoc/test_registry.py
@@ -59,6 +59,35 @@ def test_register_and_get_type_info_extractor():
     assert extractor is sample_extractor
 
 
+def test_registry_distinguishes_unhashable_equal_types_by_identity():
+    """Registration and removal use type identity, not metaclass equality or hashing."""
+
+    class EqualUnhashableMeta(type):
+        __hash__ = None
+
+        def __eq__(cls, other):
+            return isinstance(other, EqualUnhashableMeta)
+
+    first = EqualUnhashableMeta("First", (), {})
+    second = EqualUnhashableMeta("Second", (), {})
+
+    @register_type_info_extractor(first)
+    def extract_first(obj):
+        return TypeInfo("First", None, [], [], None)
+
+    @register_type_info_extractor(second)
+    def extract_second(obj):
+        return TypeInfo("Second", None, [], [], None)
+
+    assert get_type_info_extractor(first) is extract_first
+    assert get_type_info_extractor(second) is extract_second
+
+    unregister_type_info_extractor(first)
+
+    assert get_type_info_extractor(first) is None
+    assert get_type_info_extractor(second) is extract_second
+
+
 def test_get_type_info_extractor_returns_none_if_not_registered():
     """Test that get_type_info_extractor returns None for unregistered types."""
     obj = SampleType(42)

--- a/tests/agentdoc/test_structured.py
+++ b/tests/agentdoc/test_structured.py
@@ -876,3 +876,24 @@ class TestPropertyExtraction:
         result = doc(Agent)
         assert "name" in result
         assert "upper_name" in result
+
+
+def test_plain_class_fields_support_unhashable_equal_metaclass_mro():
+    class EqualUnhashableMeta(type):
+        __hash__ = None
+
+        def __eq__(cls, other):
+            return isinstance(other, EqualUnhashableMeta)
+
+    left = EqualUnhashableMeta("Left", (), {"__annotations__": {"left": int, "shared": str}})
+    right = EqualUnhashableMeta("Right", (), {"__annotations__": {"right": int}})
+    child = EqualUnhashableMeta(
+        "Child",
+        (left, right),
+        {"__annotations__": {"shared": bool, "child": int}},
+    )
+
+    info = extract_type_info(child)
+
+    assert [field.name for field in info.fields] == ["left", "shared", "right", "child"]
+    assert next(field for field in info.fields if field.name == "shared").type == "bool"


### PR DESCRIPTION
## Summary

- route every `doc()` call through one typed subject-normalization and reference-graph pipeline
- separate neutral instance introspection from formatting, with one-way dependencies
- centralize bounded traversal, deduplication, `expand=False`, primary exclusion, and deterministic ordering
- extract every primary and referenced contract once so discovery and rendering cannot diverge
- make identity handling robust for equal/hash-colliding and unhashable metaclass types
- add focused parity, extractor, visibility, registry, cycle/diamond, structured-info, and compatibility coverage

## Why

Follow-up to #209. While reviewing the `inline_depth` fix, we found the single-object and multi-object implementations had independently accumulated different behavior. Adding an unrelated second object could expose `expand=False` types, truncate referenced APIs at 50 members, reorder references, or introspect `TypeInfo` itself.

This makes one-object documentation the one-element case of the same pipeline rather than maintaining two policy implementations.

## Architecture

- `_document.py` owns typed `DocumentSubject` normalization and reference-graph traversal.
- `_introspection.py` owns neutral, safe instance classification and value extraction.
- `_pformat.py` consumes those layers and remains responsible for rendering.
- Dependency direction is one-way: `_pformat` → `_document` / `_introspection`; `_document` does not import `_pformat`.
- Direct `pformat()` keeps its historical inline referenced-type behavior while reusing the shared graph policy.

## Behavior changes

- `spec(expand=False)` is honored in single and multi-object docs at every traversal level.
- Referenced APIs in multi-object docs are no longer silently capped at 50 members.
- Referenced types use deterministic `(name, module, qualname)` ordering.
- Repeated primary objects are deduplicated by identity while first-occurrence order is retained.
- Structured `TypeInfo`, `CallableInfo`, and `ModuleInfo` inputs are not misclassified as ordinary instances.
- Custom extractors run once per documented primary or referenced contract, and the extracted contract is reused for discovery and rendering.
- Distinct types remain distinct even when their metaclass overloads equality/hash; unhashable metaclasses are supported.

## Review

Two focused review rounds covered simplicity/maintainability and test coverage. Their architecture findings were incorporated, followed by two final read-only reviews. The final reviewers reported no remaining actionable architecture/correctness findings; the sole low-priority test assertion was strengthened to an exact-output check.

## Validation

- `uv run pytest tests/agentdoc src/nooa/agentdoc/tests -q` — **739 passed**
- full `uv run pytest -q` — **6,829 passed**, 7 skipped, 284 deselected, 3 xfailed
- changed-file pre-commit hooks — passed (`ruff`, format, Pyright, whitespace, SPDX, etc.)
- changed-source Pyright — **0 errors**
- `git diff --check` — passed

## Dependency

This is intentionally stacked on #209 (`fix/issue-199-doc-instance-parity`). Once #209 merges, this PR can be retargeted to `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified documentation rendering for single and multiple objects.
  * Added structured instance inspection for dataclasses, Pydantic models, NamedTuples, attrs classes, slotted classes, and custom objects.
  * Added metadata and runtime value extraction, including linked type and callable references.
  * Added bounded reference discovery with deterministic ordering and cycle handling.

* **Bug Fixes**
  * Improved support for unhashable or equality-customized types.
  * Preserved field ordering and override behavior across inheritance hierarchies.
  * Improved extractor registration and unregistration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->