### PR TITLE
fix(tui): make theme switching comprehensive

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/activity_overlay.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/activity_overlay.py
@@ -9,13 +9,12 @@ import textwrap
 from collections.abc import Iterable
 
 from rich.console import Console as RichConsole
-from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 
 from .output import CodeExecution, Output, TableOutput, TextOutput
 from .subapp import SubviewKeyResult
-from .theme import COLORS
+from .theme import COLORS, ThemeSyntax
 
 _BAR_STYLE = "\x1b[48;5;236;38;5;252m"
 
@@ -114,10 +113,9 @@ def _code_lines(output: CodeExecution, width: int, *, ansi: bool) -> list[str]:
             lines.extend(
                 _render_rich_lines(
                     [
-                        Syntax(
+                        ThemeSyntax(
                             code,
                             "python",
-                            theme="monokai",
                             line_numbers=True,
                             word_wrap=True,
                             start_line=output.start_line,

--- a/packages/nooa-cli/src/nooa_cli/tui/agent_event_renderer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/agent_event_renderer.py
@@ -38,11 +38,11 @@ from collections.abc import Callable
 from typing import Any, Protocol
 
 from rich.rule import Rule
-from rich.syntax import Syntax
 from rich.text import Text
 
 from .code_preview import _code_preview
 from .copyable_markdown import TerminalMarkdown
+from .theme import ThemeSyntax
 
 
 class _ReasoningEvent(Protocol):
@@ -280,9 +280,7 @@ class AgentEventRenderer:
             red = self._colors["red"]
             text_color = self._colors["text"]
             self._emit_text(Rule(Text("oo python", style=mauve), style="dim", align="left"))
-            self._emit_text(
-                Syntax(code.strip(), "python", theme="monokai", background_color="default")
-            )
+            self._emit_text(ThemeSyntax(code.strip(), "python", background_color="default"))
             if stdout.strip():
                 self._emit_text(Rule(Text("oo stdout", style=mauve), style="dim", align="left"))
                 self._emit_text(Text(stdout.rstrip("\n"), style=text_color))
@@ -318,7 +316,7 @@ class AgentEventRenderer:
             **kwargs,
         )
         self._emit_text(
-            Syntax(diff, "diff", theme="monokai", background_color="default", word_wrap=True),
+            ThemeSyntax(diff, "diff", background_color="default", word_wrap=True),
             **kwargs,
         )
         if not bool(getattr(event, "diff_complete", True)):

--- a/packages/nooa-cli/src/nooa_cli/tui/agent_event_renderer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/agent_event_renderer.py
@@ -200,7 +200,7 @@ class AgentEventRenderer:
         if not self._agent_has_messaged:
             self._agent_has_messaged = True
             self._emit_text(
-                Rule(Text("OO ", style=self._colors["mauve"]), style="dim", align="left"),
+                Rule(Text("OO ", style="agent"), style="dim", align="left"),
                 **emit_kwargs,
             )
         self._emit_text(TerminalMarkdown(str(text)), agent_message=True, **emit_kwargs)
@@ -276,17 +276,14 @@ class AgentEventRenderer:
         # rule, syntax-highlighted code, 'oo stdout' rule + stdout,
         # 'oo stderr' rule + stderr.
         if self._show_python() and code:
-            mauve = self._colors["mauve"]
-            red = self._colors["red"]
-            text_color = self._colors["text"]
-            self._emit_text(Rule(Text("oo python", style=mauve), style="dim", align="left"))
+            self._emit_text(Rule(Text("oo python", style="agent"), style="dim", align="left"))
             self._emit_text(ThemeSyntax(code.strip(), "python", background_color="default"))
             if stdout.strip():
-                self._emit_text(Rule(Text("oo stdout", style=mauve), style="dim", align="left"))
-                self._emit_text(Text(stdout.rstrip("\n"), style=text_color))
+                self._emit_text(Rule(Text("oo stdout", style="agent"), style="dim", align="left"))
+                self._emit_text(Text(stdout.rstrip("\n"), style="agent.response"))
             if stderr.strip():
-                self._emit_text(Rule(Text("oo stderr", style=red), style="dim", align="left"))
-                self._emit_text(Text(stderr.rstrip("\n"), style=red))
+                self._emit_text(Rule(Text("oo stderr", style="error"), style="dim", align="left"))
+                self._emit_text(Text(stderr.rstrip("\n"), style="error"))
             return
 
         # Preview mode: show a one-line error summary (muted red).
@@ -309,7 +306,7 @@ class AgentEventRenderer:
         kwargs = self._event_emit_kwargs(event)
         self._emit_text(
             Rule(
-                Text(f"oo {operation} · {path}", style=self._colors["mauve"]),
+                Text(f"oo {operation} · {path}", style="agent"),
                 style="dim",
                 align="left",
             ),

--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -1032,25 +1032,9 @@ class ThemeCommand(Command):
         theme_module.set_theme(name)
         self.config.theme = name
 
-        # Replace the base theme in Rich Console's ThemeStack
-        # We can't just push - we need to replace the base entry
-        if hasattr(self.frontend, "_console") and hasattr(self.frontend._console, "console"):  # type: ignore[attr-defined]
-            console = self.frontend._console.console  # type: ignore[attr-defined]
-            new_theme = theme_module.create_theme()
-
-            # Directly replace the base theme in the stack
-            # This is the only way to actually change colors since Theme snapshots
-            # the COLORS dict at creation time
-            console._theme_stack._entries[0] = new_theme.styles
-            console._theme_stack.get = console._theme_stack._entries[-1].get
-
-        # Rebuild prompt_toolkit style for the new theme
-        if hasattr(self.frontend, "_input_handler") and self.frontend._input_handler is not None:  # type: ignore[attr-defined]
-            self.frontend._input_handler.refresh_style()  # type: ignore[attr-defined]
-        app = getattr(self.frontend, "_app", None)
-        refresh_app_style = getattr(app, "refresh_style", None)
-        if callable(refresh_app_style):
-            refresh_app_style()
+        refresh_theme = getattr(self.frontend, "refresh_theme", None)
+        if callable(refresh_theme):
+            refresh_theme()
 
         try:
             path = self._persist_tui_setting("theme", name)

--- a/packages/nooa-cli/src/nooa_cli/tui/console.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/console.py
@@ -34,6 +34,22 @@ class TUIConsole:
         """
         self.console = console
 
+    def refresh_theme(self) -> None:
+        """Replace the Rich console with one using the active palette."""
+        old = self.console
+        self.console = Console(
+            file=old.file,
+            force_terminal=old.is_terminal,
+            color_system=old.color_system,
+            width=old.width,
+            height=old.height,
+            no_color=old.no_color,
+            tab_size=old.tab_size,
+            legacy_windows=old.legacy_windows,
+            safe_box=old.safe_box,
+            theme=create_theme(),
+        )
+
     def start_spinner(self, message: str = "thinking...") -> None:
         """Start the thinking spinner with an empty input prompt.
 

--- a/packages/nooa-cli/src/nooa_cli/tui/console.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/console.py
@@ -23,6 +23,7 @@ class TUIConsole:
         self.console = Console(theme=create_theme())
         self._live_spinner: Live | None = None
         self._spinner: Spinner | None = None
+        self._spinner_message: str | None = None
 
     def replace_console(self, console: Console) -> None:
         """Swap the underlying Rich Console (e.g. to redirect output).
@@ -36,6 +37,9 @@ class TUIConsole:
 
     def refresh_theme(self) -> None:
         """Replace the Rich console with one using the active palette."""
+        spinner_message = self._spinner_message
+        if self._live_spinner is not None:
+            self.stop_spinner()
         old = self.console
         self.console = Console(
             file=old.file,
@@ -49,6 +53,8 @@ class TUIConsole:
             safe_box=old.safe_box,
             theme=create_theme(),
         )
+        if spinner_message is not None:
+            self.start_spinner(spinner_message)
 
     def start_spinner(self, message: str = "thinking...") -> None:
         """Start the thinking spinner with an empty input prompt.
@@ -62,6 +68,7 @@ class TUIConsole:
 
         from rich.console import Group
 
+        self._spinner_message = message
         self._spinner = Spinner(
             "dots",
             text=Text(message, style=f"{COLORS['subtext1']}"),
@@ -83,6 +90,7 @@ class TUIConsole:
             self._live_spinner.stop()
             self._live_spinner = None
             self._spinner = None
+            self._spinner_message = None
 
     def print_agent(self, message: str, *, show_rule: bool = True, soft_wrap: bool = False) -> None:
         """Print an agent response, optionally with terminal-managed wrapping."""

--- a/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
@@ -16,6 +16,7 @@ from rich.syntax import Syntax
 from rich.text import Text
 
 from .terminal_safety import safe_hyperlink_target
+from .theme import get_syntax_theme
 
 _COPY_URI_PREFIX = "nooa-copy://"
 _CODE_SOURCE_URI_PREFIX = "nooa-code-source://"
@@ -25,6 +26,9 @@ class TerminalMarkdown(Markdown):
     """Rich Markdown whose parser also permits validated ``file://`` links."""
 
     def __init__(self, markup: str, **kwargs: Any) -> None:
+        self.uses_active_code_theme = "code_theme" not in kwargs
+        if self.uses_active_code_theme:
+            kwargs["code_theme"] = get_syntax_theme()
         super().__init__(markup, **kwargs)
         if "file:" not in markup.lower():
             return
@@ -48,6 +52,12 @@ class TerminalMarkdown(Markdown):
                 if normalized is not None and target != normalized:
                     child.attrSet("href", normalized)
 
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        # Retained Markdown objects are replayed after live /theme changes.
+        if self.uses_active_code_theme:
+            self.code_theme = get_syntax_theme()
+        yield from super().__rich_console__(console, options)
+
 
 def visible_code_line(source: str) -> tuple[str, tuple[tuple[int, int], ...]]:
     """Expose terminal controls and map each rendered code point to source."""
@@ -56,9 +66,11 @@ def visible_code_line(source: str) -> tuple[str, tuple[tuple[int, int], ...]]:
     column = 0
     cursor = 0
     while cursor < len(source):
-        control = ord(source[cursor]) < 0x20 or ord(source[cursor]) == 0x7F or 0x80 <= ord(
-            source[cursor]
-        ) <= 0x9F
+        control = (
+            ord(source[cursor]) < 0x20
+            or ord(source[cursor]) == 0x7F
+            or 0x80 <= ord(source[cursor]) <= 0x9F
+        )
         if control:
             stop = cursor + 1
             codepoint = ord(source[cursor])

--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -20,6 +20,7 @@ from .explorer_base import (
     wrap_plain_line,
 )
 from .subapp import SubviewKeyResult
+from .theme import ThemeSyntax, get_syntax_theme
 
 
 def highlight_terms_with_current(
@@ -775,7 +776,6 @@ def _highlight_syntax(text: str, width: int, language: str = "python") -> str:
         import io
 
         from rich.console import Console as RichConsole
-        from rich.syntax import Syntax
 
         render_width = max(int(width), 20)
         buf = io.StringIO()
@@ -787,10 +787,9 @@ def _highlight_syntax(text: str, width: int, language: str = "python") -> str:
             _environ={"COLUMNS": str(render_width), "LINES": "25"},
         )
         console.print(
-            Syntax(
+            ThemeSyntax(
                 text,
                 language or "python",
-                theme="monokai",
                 word_wrap=True,
                 line_numbers=False,
                 background_color="default",
@@ -820,7 +819,7 @@ def _render_markdown(markdown: str, width: int) -> str:
             width=render_width,
             _environ={"COLUMNS": str(render_width), "LINES": "25"},
         )
-        console.print(Markdown(markdown))
+        console.print(Markdown(markdown, code_theme=get_syntax_theme()))
         return buf.getvalue()
     except Exception:
         wrapped: list[str] = []

--- a/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .subapp import SubviewKeyResult
+from .theme import get_syntax_theme
 
 # ─── ANSI styling primitives ─────────────────────────────────────────────────
 
@@ -127,7 +128,7 @@ def render_markdown_lines(markdown: str, width: int) -> list[str]:
             width=render_width,
             _environ={"COLUMNS": str(render_width), "LINES": "25"},
         )
-        console.print(Markdown(markdown))
+        console.print(Markdown(markdown, code_theme=get_syntax_theme()))
         return buf.getvalue().splitlines() or [""]
     except Exception:
         lines: list[str] = []

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -33,7 +33,7 @@ from .output import (
     TextOutput,
     Thinking,
 )
-from .theme import COLORS
+from .theme import COLORS, ThemeSyntax
 
 if TYPE_CHECKING:
     from contextlib import AbstractContextManager
@@ -140,6 +140,10 @@ class Frontend(Protocol):
 
     async def render(self, output: Output) -> None:
         """Render one structured output object."""
+        ...
+
+    def refresh_theme(self) -> None:
+        """Apply the active theme to live rendering surfaces."""
         ...
 
     def batch_render(self) -> "AbstractContextManager[None]":
@@ -282,6 +286,15 @@ class TerminalFrontend:
             raise RuntimeError("TUI application is not ready.")
         await self._app.open_activity_overlay(outputs)
 
+    def refresh_theme(self) -> None:
+        """Refresh all live rendering surfaces from the active palette."""
+        self._console.refresh_theme()
+        if self._input_handler is not None:
+            self._input_handler.refresh_style()
+        refresh_app = getattr(self._app, "refresh_style", None)
+        if callable(refresh_app):
+            refresh_app()
+
     def init_input(self, registry) -> None:
         """Wire up the prompt_toolkit input handler with slash completions."""
         from .input_handler import TUIInputHandler
@@ -317,7 +330,52 @@ class TerminalFrontend:
                 self._console.console.width = max(
                     int(replay_width(self._console.console.width or 80)), 1
                 )
+            stream = getattr(self._console.console, "file", None)
+            semantic_replay = getattr(stream, "semantic_replay", None)
+            replayable = not isinstance(
+                output, (ClearScreen, HistoryReplay, SplashScreen, Thinking)
+            )
+            if replayable and callable(semantic_replay):
+                width = self._console.console.width or 80
+                with semantic_replay(
+                    lambda o=output, s=stream, w=width: self._render_output_to_ansi(
+                        o,
+                        s.replay_width(w) if callable(getattr(s, "replay_width", None)) else w,
+                    )
+                ):
+                    handler(output)
+            else:
+                handler(output)
+
+    def _render_output_to_ansi(self, output: Output, width: int) -> str:
+        """Render one structured output with the current palette for replay."""
+        from rich.console import Console as RichConsole
+
+        from .console import TUIConsole
+        from .theme import create_theme
+
+        buf = io.StringIO()
+        console = TUIConsole()
+        console.replace_console(
+            RichConsole(
+                file=buf,
+                force_terminal=True,
+                color_system="256",
+                width=max(int(width), 1),
+                height=1,
+                theme=create_theme(),
+            )
+        )
+        renderer = object.__new__(TerminalFrontend)
+        renderer._config = self._config
+        renderer._console = console
+        renderer._input_handler = None
+        renderer._app = self._app
+        renderer._renderers = renderer._build_renderer_map()
+        handler = renderer._renderers.get(type(output))
+        if handler is not None:
             handler(output)
+        return buf.getvalue()
 
     def batch_render(self):
         """Coalesce the enclosed ``render()`` calls into one scrollback block.
@@ -527,7 +585,6 @@ class TerminalFrontend:
     def _render_diff(self, output: DiffOutput) -> None:
         """Render a unified diff with syntax highlighting."""
         from rich.rule import Rule
-        from rich.syntax import Syntax
 
         if not output.diff.strip():
             return
@@ -535,7 +592,7 @@ class TerminalFrontend:
         self._console.console.print(
             Rule(title=f"[bold]{label}[/bold]", style=COLORS["surface2"], align="left")
         )
-        self._console.console.print(Syntax(output.diff, "diff", theme="monokai", word_wrap=True))
+        self._console.console.print(ThemeSyntax(output.diff, "diff", word_wrap=True))
 
     async def open_editor(
         self, filename: str, content: str, language: str = "plaintext"
@@ -696,7 +753,6 @@ class TerminalFrontend:
         """Render a code execution panel (reasoning + code + output)."""
 
         from rich.rule import Rule
-        from rich.syntax import Syntax
         from rich.text import Text
 
         try:
@@ -724,10 +780,9 @@ class TerminalFrontend:
             # highlighted line drift. Only full-cell blocks get the cosmetic strip.
             code = execution.code.rstrip() if execution.start_line > 1 else execution.code.strip()
             elements.append(
-                Syntax(
+                ThemeSyntax(
                     code,
                     "python",
-                    theme="monokai",
                     line_numbers=True,
                     word_wrap=True,
                     start_line=execution.start_line,

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -144,7 +144,7 @@ class Frontend(Protocol):
 
     def refresh_theme(self) -> None:
         """Apply the active theme to live rendering surfaces."""
-        ...
+        pass
 
     def batch_render(self) -> "AbstractContextManager[None]":
         """Context manager grouping multiple ``render()`` calls into one block.

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -133,10 +133,18 @@ class _EmitStream:
         self._held = 0
         self._agent_message_depth = 0
         self._buffer_has_agent_message = False
+        self._semantic_replay: Callable[[], str] | None = None
+        self._semantic_replay_recorded = False
+        self._semantic_replay_parts: list[str | Callable[[], str]] = []
 
     def write(self, text: str) -> int:
         if text:
             self._buf.append(text)
+            if self._semantic_replay is None:
+                self._semantic_replay_parts.append(text)
+            elif not self._semantic_replay_recorded:
+                self._semantic_replay_parts.append(self._semantic_replay)
+                self._semantic_replay_recorded = True
             self._buffer_has_agent_message |= self._agent_message_depth > 0
         return len(text)
 
@@ -154,13 +162,37 @@ class _EmitStream:
         self._buf.clear()
         agent_message = self._buffer_has_agent_message
         self._buffer_has_agent_message = False
+        kwargs: dict[str, Any] = {}
         if agent_message:
-            self._emit(chunk, agent_message=True)
-        else:
-            self._emit(chunk)
+            kwargs["agent_message"] = True
+        replay_parts = tuple(self._semantic_replay_parts)
+        self._semantic_replay_parts.clear()
+        if any(callable(part) for part in replay_parts):
+            kwargs["replay"] = lambda parts=replay_parts: "".join(
+                part() if callable(part) else part for part in parts
+            )
+        self._emit(chunk, **kwargs)
+
+    @contextmanager
+    def semantic_replay(self, replay: Callable[[], str]):
+        """Retain one structured render without mixing adjacent output blocks."""
+        previous = self._semantic_replay
+        previous_recorded = self._semantic_replay_recorded
+        self._semantic_replay = replay
+        self._semantic_replay_recorded = False
+        self._held += 1
+        try:
+            yield
+        finally:
+            self._held -= 1
+            self._semantic_replay = previous
+            self._semantic_replay_recorded = previous_recorded
+            if self._held == 0:
+                self.flush()
 
     def clear_transcript(self) -> None:
         self._buf.clear()
+        self._semantic_replay_parts.clear()
         self._buffer_has_agent_message = False
         if self._clear is not None:
             self._clear()
@@ -1039,15 +1071,16 @@ class Session:
             from rich.markdown import Markdown
 
             if type(renderable) in {Markdown, TerminalMarkdown}:
-                renderable = CopyableMarkdown(
-                    renderable.markup,
-                    code_theme=renderable.code_theme,
-                    justify=renderable.justify,
-                    style=renderable.style,
-                    hyperlinks=renderable.hyperlinks,
-                    inline_code_lexer=renderable.inline_code_lexer,
-                    inline_code_theme=renderable.inline_code_theme,
-                )
+                markdown_options = {
+                    "justify": renderable.justify,
+                    "style": renderable.style,
+                    "hyperlinks": renderable.hyperlinks,
+                    "inline_code_lexer": renderable.inline_code_lexer,
+                    "inline_code_theme": renderable.inline_code_theme,
+                }
+                if not getattr(renderable, "uses_active_code_theme", False):
+                    markdown_options["code_theme"] = renderable.code_theme
+                renderable = CopyableMarkdown(renderable.markup, **markdown_options)
         rendered = self._render_to_ansi(renderable)
         replay = (lambda r=renderable: self._render_to_ansi(r)) if full_screen else None
         code_copy_actions = (

--- a/packages/nooa-cli/src/nooa_cli/tui/theme.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme.py
@@ -17,6 +17,8 @@ Usage::
     console._theme = create_theme()
 """
 
+from rich.console import Console, ConsoleOptions, RenderResult
+from rich.syntax import Syntax
 from rich.theme import Theme
 
 # ---------------------------------------------------------------------------
@@ -148,6 +150,16 @@ THEMES: dict[str, dict[str, str]] = {
     "vslight": _VS_LIGHT,
 }
 
+# Pygments styles selected to match each UI palette. Syntax renderers keep
+# their existing transparent/default background policy; this mapping only
+# changes token colours.
+SYNTAX_THEMES: dict[str, str] = {
+    "mocha": "monokai",
+    "latte": "gruvbox-light",
+    "vsdark": "github-dark",
+    "vslight": "vs",
+}
+
 # ---------------------------------------------------------------------------
 # Active palette — a mutable dict updated in-place so that callers who did
 # `from .theme import COLORS` keep a live reference after set_theme().
@@ -160,6 +172,30 @@ _active_name: str = "mocha"
 def get_theme() -> str:
     """Return the name of the currently active theme."""
     return _active_name
+
+
+def get_syntax_theme(name: str | None = None) -> str:
+    """Return the Pygments style paired with a built-in UI theme."""
+    selected = _active_name if name is None else name
+    try:
+        return SYNTAX_THEMES[selected]
+    except KeyError as exc:
+        raise ValueError(f"Unknown theme {selected!r}. Choose from: {', '.join(THEMES)}") from exc
+
+
+class ThemeSyntax(Syntax):
+    """Syntax highlighting that follows the active UI theme when replayed."""
+
+    def __init__(self, code: str, lexer: object, **kwargs: object) -> None:
+        self._uses_active_theme = "theme" not in kwargs
+        if self._uses_active_theme:
+            kwargs["theme"] = get_syntax_theme()
+        super().__init__(code, lexer, **kwargs)  # type: ignore[arg-type]
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        if self._uses_active_theme:
+            self._theme = self.get_theme(get_syntax_theme())
+        yield from super().__rich_console__(console, options)
 
 
 def set_theme(name: str) -> None:

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1616,8 +1616,14 @@ class TUIApplication:
             for block in self._transcript_blocks:
                 block.replay_cache.clear()
             self._rebuild_fullscreen_transcript()
-        else:
-            self._app.invalidate()
+            return
+        if self.full_screen and self._resize_replays_enabled and self._transcript_blocks:
+            current = self._read_terminal_size()
+            if current is not None and self._resize_reflow.observed_size is None:
+                self._resize_reflow.observe(current)
+            if self._resize_reflow.request_replay():
+                self._schedule_resize_replay()
+        self._app.invalidate()
 
     async def open_event_explorer(self, event_manager: Any) -> None:
         """Open the event explorer as an in-app subview."""

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1615,7 +1615,7 @@ class TUIApplication:
             # must force each semantic callback to render again at this width.
             for block in self._transcript_blocks:
                 block.replay_cache.clear()
-            self._rebuild_fullscreen_transcript()
+            self._schedule_fullscreen_rebuild()
             return
         if self.full_screen and self._resize_replays_enabled and self._transcript_blocks:
             current = self._read_terminal_size()

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -4254,3 +4254,36 @@ def test_fullscreen_theme_refresh_recolors_retained_agent_event_syntax() -> None
         assert app._fullscreen_transcript.text.count("def greet") == 1
     finally:
         theme.set_theme(original_theme)
+
+
+@pytest.mark.asyncio
+async def test_native_replay_theme_refresh_requests_same_width_replay() -> None:
+    from nooa_cli.tui.tui_application import (
+        TranscriptBlock,
+        TUIApplication,
+        _ResizeReplayQueueItem,
+    )
+
+    from .tui_app_harness import MutableRecordingOutput
+
+    output = MutableRecordingOutput(columns=80, rows=24)
+    with create_app_session(input=DummyInput(), output=output):
+        app = TUIApplication(display_mode=DisplayMode.NATIVE_REPLAY)
+    app._loop = asyncio.get_running_loop()
+    app._block_queue = asyncio.Queue()
+    app._resize_replays_enabled = True
+    app._resize_reflow.observe((80, 24))
+    app.emit_block("old theme\n", replay=lambda: "new theme\n")
+
+    app.refresh_style()
+
+    assert app._resize_reflow.replay_required is True
+    assert app._resize_reflow.pending_width == 80
+    await asyncio.sleep(0.1)
+    queued = app._block_queue.get_nowait()
+    assert isinstance(queued, TranscriptBlock)
+    queued = app._block_queue.get_nowait()
+    assert isinstance(queued, _ResizeReplayQueueItem)
+    assert queued.request.required is True
+    assert queued.request.width == 80
+    app._cancel_resize_replay_work()

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -3639,9 +3639,7 @@ def test_copyable_markdown_renders_and_hit_tests_file_links() -> None:
 
     model = FullscreenTranscriptModel()
     model.append(ansi)
-    assert model.hyperlink_at(x=label_start, y=0, width=60, height=2) == (
-        "file:///path/to/file"
-    )
+    assert model.hyperlink_at(x=label_start, y=0, width=60, height=2) == ("file:///path/to/file")
 
 
 def test_copyable_markdown_preserves_nested_and_multiline_list_structure() -> None:
@@ -3702,12 +3700,8 @@ def test_copyable_markdown_places_copy_action_in_top_code_padding() -> None:
         " " * 30,
     ]
     fragments = to_formatted_text(ANSI(sanitize_transcript_ansi(ansi)))
-    copy_style = next(
-        style for style, text, *_rest in fragments if text == "C" and "bg:" in style
-    )
-    code_style = next(
-        style for style, text, *_rest in fragments if text == "p" and "bg:" in style
-    )
+    copy_style = next(style for style, text, *_rest in fragments if text == "C" and "bg:" in style)
+    code_style = next(style for style, text, *_rest in fragments if text == "p" and "bg:" in style)
     assert copy_style.split("bg:", 1)[1].split()[0] == code_style.split("bg:", 1)[1].split()[0]
 
 
@@ -4124,3 +4118,139 @@ def test_fullscreen_code_copy_drag_away_does_not_copy(
     control.mouse_handler(_mouse_event(MouseEventType.MOUSE_UP, x=x, y=y))
 
     assert copied == []
+
+
+async def test_fullscreen_theme_refresh_recolors_mixed_retained_history_for_all_themes() -> None:
+    from types import SimpleNamespace
+
+    from nooa_cli.tui import theme
+    from nooa_cli.tui.frontend import TerminalFrontend
+    from nooa_cli.tui.output import (
+        AgentMessage,
+        HelpOutput,
+        HistoryReplay,
+        HistoryTurn,
+        StartupInfo,
+        TableOutput,
+        TextOutput,
+    )
+    from nooa_cli.tui.session import _EmitStream
+    from rich.console import Console
+
+    original_theme = theme.get_theme()
+    try:
+        theme.set_theme("mocha")
+        app = _make_fullscreen_app()
+        frontend = TerminalFrontend(SimpleNamespace(tui=SimpleNamespace(theme="mocha")))
+        frontend.bind_app(app)
+        stream = _EmitStream(
+            app.emit_block,
+            replay_width=lambda: 72,
+            layout_width=lambda: 72,
+            supports_code_copy_actions=True,
+        )
+        frontend._console.replace_console(
+            Console(
+                file=stream,
+                force_terminal=True,
+                color_system="256",
+                width=72,
+                theme=theme.create_theme(),
+            )
+        )
+        app.emit_block("raw retained output\n", event_id="raw", tags={"raw"}, keep=True)
+        outputs = [
+            *(
+                TextOutput(f"retained {level}", level)
+                for level in ("info", "error", "warning", "success", "status")
+            ),
+            TableOutput(["kind", "value"], [["theme", "live"]], title="retained table"),
+            HelpOutput({"/theme": "Switch theme"}),
+            AgentMessage("Retained prose with `inline code` and:\n\n```python\nprint('live')\n```"),
+            StartupInfo(
+                model="provider/model",
+                short_model="model",
+                working_dir="/work",
+                vi_mode=False,
+            ),
+            HistoryReplay(
+                turns=[HistoryTurn(role="agent", content="Earlier retained response with `code`")],
+                session_id="theme-history",
+                show_header=True,
+                show_footer=True,
+            ),
+        ]
+        with frontend.batch_render():
+            for output in outputs:
+                await frontend.render(output)
+
+        assert len(app._transcript_blocks) == 3
+        raw_block, batched_block, history_block = app._transcript_blocks
+        assert raw_block.replay is None
+        assert raw_block.event_id == "raw"
+        assert raw_block.tags == frozenset({"raw"})
+        assert raw_block.keep is True
+        assert batched_block.replay is not None
+        assert history_block.replay is not None
+        record_ids = [block.transcript_record_id for block in app._transcript_blocks]
+        copy_actions = [dict(block.code_copy_actions) for block in app._transcript_blocks]
+        raw_rendered = raw_block.fullscreen_rendered
+        rendered_by_theme = {}
+        for name in theme.THEMES:
+            theme.set_theme(name)
+            frontend.refresh_theme()
+            rendered_by_theme[name] = "".join(
+                block.fullscreen_rendered or "" for block in app._transcript_blocks
+            )
+            plain = app._fullscreen_transcript.text
+            assert raw_block.fullscreen_rendered == raw_rendered
+            assert [block.transcript_record_id for block in app._transcript_blocks] == record_ids
+            assert [block.code_copy_actions for block in app._transcript_blocks] == copy_actions
+            for expected in (
+                "raw retained output",
+                *(
+                    f"retained {level}"
+                    for level in ("info", "error", "warning", "success", "status")
+                ),
+                "retained table",
+                "/theme",
+                "Retained prose",
+                "NOOA ready",
+                "Earlier retained response",
+            ):
+                assert plain.count(expected) == 1
+
+        assert len(set(rendered_by_theme.values())) == len(theme.THEMES)
+    finally:
+        theme.set_theme(original_theme)
+
+
+def test_fullscreen_theme_refresh_recolors_retained_agent_event_syntax() -> None:
+    from nooa_cli.tui import theme
+    from nooa_cli.tui.session import Session
+    from nooa_cli.tui.theme import ThemeSyntax
+
+    original_theme = theme.get_theme()
+    try:
+        theme.set_theme("mocha")
+        app = _make_fullscreen_app()
+        session = Session.__new__(Session)
+        session._app = app
+        syntax = ThemeSyntax(
+            "def greet(name: str) -> str:\n    return name",
+            "python",
+            background_color="default",
+        )
+        session._emit_text(syntax)
+        before = app._transcript_blocks[0].fullscreen_rendered
+        assert before is not None
+
+        theme.set_theme("vslight")
+        app.refresh_style()
+        after = app._transcript_blocks[0].fullscreen_rendered
+
+        assert after is not None
+        assert after != before
+        assert app._fullscreen_transcript.text.count("def greet") == 1
+    finally:
+        theme.set_theme(original_theme)

--- a/packages/nooa-cli/tests/tui/test_input_style.py
+++ b/packages/nooa-cli/tests/tui/test_input_style.py
@@ -155,3 +155,43 @@ def test_console_theme_refresh_replaces_console_without_disturbing_temporary_the
     # The old console's temporary scope remains balanced and independently usable.
     assert original.get_style("temporary").bold is True
     original.pop_theme()
+
+
+def test_console_theme_refresh_rebinds_active_spinner(monkeypatch) -> None:
+    from nooa_cli.tui import console as console_module
+    from nooa_cli.tui.console import TUIConsole
+
+    instances = []
+
+    class FakeLive:
+        def __init__(self, _renderable, *, console, **_kwargs) -> None:
+            self.console = console
+            self.started = False
+            self.stopped = False
+            instances.append(self)
+
+        def start(self) -> None:
+            self.started = True
+
+        def stop(self) -> None:
+            self.stopped = True
+
+    monkeypatch.setattr(console_module, "Live", FakeLive)
+    tui_console = TUIConsole()
+    original_console = tui_console.console
+    tui_console.start_spinner("still working")
+    old_live = tui_console._live_spinner
+
+    tui_console.refresh_theme()
+
+    assert old_live is not None
+    assert old_live.stopped is True
+    assert tui_console.console is not original_console
+    assert tui_console._live_spinner is instances[-1]
+    assert tui_console._live_spinner.console is tui_console.console
+    assert tui_console._live_spinner.started is True
+    assert tui_console._spinner_message == "still working"
+
+    tui_console.stop_spinner()
+    assert instances[-1].stopped is True
+    assert tui_console._live_spinner is None

--- a/packages/nooa-cli/tests/tui/test_input_style.py
+++ b/packages/nooa-cli/tests/tui/test_input_style.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 from nooa_cli.tui import theme
 from nooa_cli.tui.commands import ThemeCommand
 from nooa_cli.tui.config import Config, TUIConfig
@@ -32,9 +33,7 @@ def test_input_uses_terminal_background_across_themes() -> None:
         theme.set_theme(original_theme)
 
 
-async def test_theme_command_refreshes_and_persists_selection(
-    tmp_path, monkeypatch
-) -> None:
+async def test_theme_command_refreshes_and_persists_selection(tmp_path, monkeypatch) -> None:
     import yaml
 
     class LiveApp:
@@ -47,7 +46,7 @@ async def test_theme_command_refreshes_and_persists_selection(
     monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project_dir))
     original_theme = theme.get_theme()
     app = LiveApp()
-    frontend = SimpleNamespace(_app=app, _input_handler=None)
+    frontend = SimpleNamespace(refresh_theme=app.refresh_style)
     config = TUIConfig()
     command = ThemeCommand(frontend, config=config, agent=object())
     try:
@@ -78,3 +77,81 @@ def test_terminal_frontend_restores_persisted_theme(tmp_path, monkeypatch) -> No
         assert frontend._console.console.get_style("agent").color.triplet == (111, 66, 193)
     finally:
         theme.set_theme(original_theme)
+
+
+@pytest.mark.parametrize(
+    ("name", "syntax_theme"),
+    [
+        ("mocha", "monokai"),
+        ("latte", "gruvbox-light"),
+        ("vsdark", "github-dark"),
+        ("vslight", "vs"),
+    ],
+)
+def test_each_ui_theme_has_a_matching_syntax_theme(name: str, syntax_theme: str) -> None:
+    from pygments.styles import get_style_by_name
+
+    original_theme = theme.get_theme()
+    try:
+        theme.set_theme(name)
+        assert theme.get_syntax_theme() == syntax_theme
+        assert get_style_by_name(syntax_theme) is not None
+    finally:
+        theme.set_theme(original_theme)
+
+
+def test_unknown_syntax_theme_name_fails_clearly() -> None:
+    with pytest.raises(ValueError, match="Unknown theme 'ultraviolet'"):
+        theme.get_syntax_theme("ultraviolet")
+
+
+def test_retained_markdown_tracks_live_theme_but_explicit_override_does_not() -> None:
+    import io
+
+    from nooa_cli.tui.copyable_markdown import TerminalMarkdown
+    from rich.console import Console
+
+    original_theme = theme.get_theme()
+    active = TerminalMarkdown("```python\nprint('hello')\n```")
+    explicit = TerminalMarkdown("```python\nprint('hello')\n```", code_theme="ansi_dark")
+    try:
+        for name in theme.THEMES:
+            theme.set_theme(name)
+            for renderable in (active, explicit):
+                Console(file=io.StringIO(), width=80).print(renderable)
+            assert active.code_theme == theme.get_syntax_theme(name)
+            assert explicit.code_theme == "ansi_dark"
+    finally:
+        theme.set_theme(original_theme)
+
+
+def test_console_theme_refresh_replaces_console_without_disturbing_temporary_themes() -> None:
+    import io
+
+    from nooa_cli.tui.console import TUIConsole
+    from rich.console import Console
+    from rich.theme import Theme
+
+    output = io.StringIO()
+    tui_console = TUIConsole()
+    original = Console(
+        file=output,
+        force_terminal=True,
+        color_system="256",
+        width=73,
+        theme=theme.create_theme(),
+    )
+    tui_console.replace_console(original)
+    original.push_theme(Theme({"temporary": "bold red"}))
+    original_width = original.width
+
+    tui_console.refresh_theme()
+
+    assert tui_console.console is not original
+    assert tui_console.console.file is output
+    assert tui_console.console.width == original_width
+    assert tui_console.console.color_system == "256"
+    assert tui_console.console.get_style("agent").color is not None
+    # The old console's temporary scope remains balanced and independently usable.
+    assert original.get_style("temporary").bold is True
+    original.pop_theme()


### PR DESCRIPTION
## Summary

- pair each built-in TUI palette with a matching Pygments syntax theme across Markdown, code cells, diffs, activity, and event explorers
- replace private Rich theme-stack mutation with a public frontend/console refresh path
- retain semantic replay for ordinary fullscreen and native-replay output so `/theme` recolors help, tables, statuses, startup output, agent messages, and resumed history in place
- preserve terminal-background policy, output batching/order, record metadata, and code-copy metadata

## Manual acceptance

Validated interactively in the fullscreen TUI using retained Python, TypeScript, JSON, and diff code fences while switching among all four themes. Syntax colors and retained output updated in place, and the terminal background remained unchanged. Result: **accepted**.

## Review follow-up

Four independent read-only reviews traced syntax, Rich integration, and transcript replay behavior. Their actionable findings were fixed:

- retained agent-event syntax had captured the old theme; replay-aware `ThemeSyntax` now resolves the current palette
- retained agent-event rules/stdout/stderr had captured concrete old colors; they now use semantic Rich styles
- console refresh could disturb a temporary Rich theme and leave an active spinner attached to the old console; refresh now replaces the console and safely restarts the spinner
- native-replay mode did not refresh retained history on `/theme`; it now requests a same-width atomic replay
- fullscreen theme refresh performed a potentially expensive synchronous rebuild; it now uses the existing coalesced rebuild scheduler

CodeRabbit's one actionable comment—the protocol method's ellipsis body—was also fixed.

## Validation

- `ruff check` on all changed Python files: passed
- `git diff --check`: passed
- focused theme/render/replay suites after review fixes: **317 passed**
- full TUI suite after review fixes: **1249 passed, 2 failed**
  - both failures are pre-existing macOS `/var` vs `/private/var` temp-path issues:
    - `TestBangShell::test_get_bang_shell_syncs_cwd`
    - `test_connect_prompts_for_missing_secret_and_saves_it`

## Background policy

No terminal or syntax background behavior was changed. Existing `background_color="default"` call sites remain transparent/default, and other syntax renderers preserve their previous behavior.
