### PR TITLE
docs(config): mark event budgets as reserved

### DIFF
--- a/src/nooa/config/truncation_config.py
+++ b/src/nooa/config/truncation_config.py
@@ -5,7 +5,7 @@
 Two layers of bounds:
 
 1. **Whole-context token budget** (optional, applied at assembly):
-   ``max_context_tokens``, ``max_event_tokens``.
+   ``max_context_tokens``.
 2. **Sub-configs by mechanism**:
    - ``capture`` (head/tail truncation of raw text streams via
      ``TruncatingStringIO`` — used for execute_python's stdout / stderr /
@@ -25,6 +25,13 @@ Two layers of bounds:
      intentionally by the author, often large (e.g. ``doc(self)``,
      formatted state). Defaults to fully unlimited; whole-block eviction
      handles overflow at the assembly step.
+
+``max_event_tokens`` and ``min_preserved_events`` are retained for
+configuration compatibility, but are not currently enforced because events
+are not evicted separately. Event-level eviction is planned as part of the
+context API refactor; the fields remain so configuring them stays a visible
+no-op rather than becoming a silently swallowed keyword. Use
+``max_context_tokens`` for an enforced budget.
 """
 
 from typing import Annotated
@@ -181,13 +188,23 @@ class TruncationConfig(BaseModel):
     max_context_tokens: Annotated[int | None, Field(description="Total context token budget")] = (
         None
     )
-    max_event_tokens: Annotated[int | None, Field(description="Total event token budget")] = None
-    # L4 eviction: never evict fewer than this many recent events. Guarantees
-    # the model always sees its current Task + recent reasoning even when older
-    # events get evicted to fit the budget.
+    max_event_tokens: Annotated[
+        int | None,
+        Field(
+            description=(
+                "Reserved for compatibility; not currently enforced because events "
+                "are not evicted separately. Use max_context_tokens for an enforced budget."
+            )
+        ),
+    ] = None
     min_preserved_events: Annotated[
         int,
-        Field(description="Minimum number of recent events preserved during eviction"),
+        Field(
+            description=(
+                "Reserved for compatibility; not currently enforced because events "
+                "are not evicted separately. Use max_context_tokens for an enforced budget."
+            )
+        ),
     ] = 5
     # Output-token planning reserve. When a call sets ``max_tokens``
     # explicitly, THAT value is reserved out of the model window (the provider

--- a/tests/runtime/test_truncation_config_integration.py
+++ b/tests/runtime/test_truncation_config_integration.py
@@ -245,7 +245,7 @@ class TestConfigMergeEdgeCases:
 
 
 class TestTokenBudgetIntegration:
-    """Tests for token budget fields (max_context_tokens, max_event_tokens)."""
+    """Tests for enforced and reserved token-budget settings."""
 
     @pytest.mark.asyncio
     async def test_max_context_tokens_does_not_crash_on_generation(self):
@@ -272,7 +272,7 @@ class TestTokenBudgetIntegration:
         assert result == "done"
 
     @pytest.mark.asyncio
-    async def test_max_event_tokens_does_not_crash_on_generation(self):
+    async def test_max_event_tokens_is_accepted_but_inert(self):
         """Agent with max_event_tokens set should not raise ValueError during generation."""
         from nooa.unifiedllm import FakeLLMClient
 


### PR DESCRIPTION
## Summary

- list only `max_context_tokens` as the enforced assembly-time token budget
- document `max_event_tokens` and `min_preserved_events` as compatibility fields that do not currently evict events
- strengthen the existing integration test so an event is proven to survive an impossible reserved event budget

## Scope

This intentionally does not add event eviction or warnings. The existing fields remain accepted and validated for configuration compatibility while their current behavior is documented honestly.

## Testing

- `uv run ruff format --check src/nooa/config/truncation_config.py tests/runtime/test_truncation_config_integration.py`
- `uv run ruff check src/nooa/config/truncation_config.py tests/runtime/test_truncation_config_integration.py`
- focused tests: 166 passed
- `uv run pyright src/nooa/config/truncation_config.py`: 0 errors
- full suite: 6,806 passed, 7 skipped, 284 deselected, 3 xfailed

Fixes #125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `max_context_tokens` controls the enforced context budget.
  * Documented `max_event_tokens` and `min_preserved_events` as compatibility settings that are accepted but do not independently evict events.

* **Tests**
  * Updated token-budget coverage to verify that compatibility settings remain inert and existing events stay available when configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->