### PR TITLE
feat(tui): add subtle edges to user message bars

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/user_message.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/user_message.py
@@ -27,9 +27,11 @@ def render_user_bar(text: str, cols: int, colors: dict[str, str]) -> str:
     width = max(int(cols), 1)
     foreground = _hex_to_ansi256(colors["text"])
     background = _hex_to_ansi256(colors["surface2"])
-    terminal_background = _hex_to_ansi256(colors["base"])
     style_on = f"\x1b[38;5;{foreground};48;5;{background}m"
-    edge_style = f"\x1b[38;5;{terminal_background};48;5;{background}m"
+    # Reverse the bar color over SGR's semantic default background. After
+    # reversal, the glyph uses the terminal's real background while the rest
+    # of each cell remains the user-bar color—without querying OSC 11.
+    edge_style = f"\x1b[38;5;{background};49;7m"
     style_off = "\x1b[0m"
 
     def styled_row(content: str = "") -> str:

--- a/packages/nooa-cli/src/nooa_cli/tui/user_message.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/user_message.py
@@ -27,22 +27,28 @@ def render_user_bar(text: str, cols: int, colors: dict[str, str]) -> str:
     width = max(int(cols), 1)
     foreground = _hex_to_ansi256(colors["text"])
     background = _hex_to_ansi256(colors["surface2"])
+    terminal_background = _hex_to_ansi256(colors["base"])
     style_on = f"\x1b[38;5;{foreground};48;5;{background}m"
+    edge_style = f"\x1b[38;5;{terminal_background};48;5;{background}m"
     style_off = "\x1b[0m"
 
     def styled_row(content: str = "") -> str:
         return f"{style_on}{set_cell_size(content, width)}{style_off}"
 
-    # Keep one full-width, same-background blank row above and below every
-    # accepted message so the padding survives both live output and replay.
-    rows: list[str] = [styled_row()]
+    def edge_row(glyph: str) -> str:
+        return f"{edge_style}{glyph * width}{style_off}"
+
+    # One-eighth block elements draw a subtle terminal-background edge while
+    # preserving nearly a full row of highlighted breathing room. Consecutive
+    # user messages therefore retain a narrow visual seam between their bars.
+    rows: list[str] = [edge_row("▔")]
     for index, line in enumerate(sanitize_live_text(text).split("\n")):
         shown = f" ❯ {line} " if index == 0 else f" {line} "
         # Rich's cell helpers preserve grapheme clusters and measure wide
         # glyphs correctly. Every row is exactly the safe content width.
         chunks = chop_cells(shown, width) or [""]
         rows.extend(styled_row(chunk) for chunk in chunks)
-    rows.append(styled_row())
+    rows.append(edge_row("▁"))
     return "\n".join(rows) + "\n"
 
 

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -900,7 +900,7 @@ def test_fullscreen_session_production_rendering_reprojects_narrow_then_wide(
     assert app.output_buffer.text == ""
     assert expected_wide != expected_narrow
     expected_visible = (
-        "abcdefgh\n" if producer == "rich" else " " * 13 + "\n ❯ abcdefgh  \n" + " " * 13 + "\n"
+        "abcdefgh\n" if producer == "rich" else "▔" * 13 + "\n ❯ abcdefgh  \n" + "▁" * 13 + "\n"
     )
     assert wide == expected_visible
     assert wide != narrow

--- a/packages/nooa-cli/tests/tui/test_terminal_safety.py
+++ b/packages/nooa-cli/tests/tui/test_terminal_safety.py
@@ -108,6 +108,11 @@ def test_user_bar_is_control_safe_cell_aware_and_reserves_final_column() -> None
     assert styled_lines[0] == edge_style + "▔" * 9 + "\x1b[0m"
     assert styled_lines[-1] == edge_style + "▁" * 9 + "\x1b[0m"
 
+    from prompt_toolkit.formatted_text import ANSI, to_formatted_text
+
+    parsed_edge_style = to_formatted_text(ANSI(styled_lines[0]))[0][0]
+    assert parsed_edge_style == "#5f5f5f bg:ansidefault reverse"
+
 
 def test_hyperlink_target_length_is_bounded() -> None:
     prefix = "https://example.test/"

--- a/packages/nooa-cli/tests/tui/test_terminal_safety.py
+++ b/packages/nooa-cli/tests/tui/test_terminal_safety.py
@@ -91,9 +91,9 @@ def test_user_bar_is_control_safe_cell_aware_and_reserves_final_column() -> None
         def transcript_columns() -> int:
             return 9  # ten physical columns, with one deliberately reserved
 
-    colors = {"text": "#cdd6f4", "surface2": "#585b70", "base": "#1e1e2e"}
+    colors = {"text": "#cdd6f4", "surface2": "#585b70"}
     bar = _build_user_bar("wide 界\x1b[2J\r", _App(), colors)  # type: ignore[arg-type]
-    assert bar.startswith("\x1b[38;5;16;48;5;59m" + "▔" * 9)
+    assert bar.startswith("\x1b[38;5;59;49;7m" + "▔" * 9)
     assert "\x1b[38;5;189;48;5;59m" in bar
 
     assert "\x1b[2J" not in bar
@@ -104,7 +104,7 @@ def test_user_bar_is_control_safe_cell_aware_and_reserves_final_column() -> None
     assert all(cell_len(line) == 9 for line in visible_lines)
 
     styled_lines = bar.splitlines()
-    edge_style = "\x1b[38;5;16;48;5;59m"
+    edge_style = "\x1b[38;5;59;49;7m"
     assert styled_lines[0] == edge_style + "▔" * 9 + "\x1b[0m"
     assert styled_lines[-1] == edge_style + "▁" * 9 + "\x1b[0m"
 

--- a/packages/nooa-cli/tests/tui/test_terminal_safety.py
+++ b/packages/nooa-cli/tests/tui/test_terminal_safety.py
@@ -91,20 +91,22 @@ def test_user_bar_is_control_safe_cell_aware_and_reserves_final_column() -> None
         def transcript_columns() -> int:
             return 9  # ten physical columns, with one deliberately reserved
 
-    colors = {"text": "#cdd6f4", "surface2": "#585b70"}
+    colors = {"text": "#cdd6f4", "surface2": "#585b70", "base": "#1e1e2e"}
     bar = _build_user_bar("wide 界\x1b[2J\r", _App(), colors)  # type: ignore[arg-type]
-    assert bar.startswith("\x1b[38;5;189;48;5;59m")
+    assert bar.startswith("\x1b[38;5;16;48;5;59m" + "▔" * 9)
+    assert "\x1b[38;5;189;48;5;59m" in bar
 
     assert "\x1b[2J" not in bar
     visible_lines = strip_safe_ansi(sanitize_transcript_ansi(bar)).splitlines()
     assert len(visible_lines) >= 3
-    assert visible_lines[0] == visible_lines[-1] == " " * 9
+    assert visible_lines[0] == "▔" * 9
+    assert visible_lines[-1] == "▁" * 9
     assert all(cell_len(line) == 9 for line in visible_lines)
 
     styled_lines = bar.splitlines()
-    assert styled_lines[0] == styled_lines[-1] == (
-        "\x1b[38;5;189;48;5;59m" + " " * 9 + "\x1b[0m"
-    )
+    edge_style = "\x1b[38;5;16;48;5;59m"
+    assert styled_lines[0] == edge_style + "▔" * 9 + "\x1b[0m"
+    assert styled_lines[-1] == edge_style + "▁" * 9 + "\x1b[0m"
 
 
 def test_hyperlink_target_length_is_bounded() -> None:


### PR DESCRIPTION
## Summary

- replace the solid padding rows around user-message bars with one-eighth-cell edges
- use ANSI's semantic default background (`SGR 49`) plus reverse video so the thin edge matches the terminal's actual background without an OSC color query
- keep live messages, resumed history, and fullscreen transcript reprojection consistent

## Validation

- `uv run --frozen ruff check packages/nooa-cli/src/nooa_cli/tui/user_message.py packages/nooa-cli/tests/tui/test_terminal_safety.py packages/nooa-cli/tests/tui/test_fullscreen_transcript.py`
- `uv run --frozen ruff format --check packages/nooa-cli/src/nooa_cli/tui/user_message.py packages/nooa-cli/tests/tui/test_terminal_safety.py packages/nooa-cli/tests/tui/test_fullscreen_transcript.py`
- `uv run --frozen pyright packages/nooa-cli/src/nooa_cli/tui/user_message.py`
- focused TUI rendering suite: 259 passed
- full TUI suite: 1261 passed, 2 unrelated existing macOS temp-path failures (`/var` vs `/private/var`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual separation of adjacent user message bars in the terminal interface.
  * Added subtle top and bottom edge markers while preserving highlighted message content.
  * Enhanced color contrast using the terminal’s default background styling.

* **Tests**
  * Updated terminal rendering and safety checks to reflect the new user-bar borders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->