### PR TITLE
feat(tui): improve TUI first-run model connection flow

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/bootstrap.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/bootstrap.py
@@ -299,20 +299,38 @@ async def bootstrap(
     _load_llm_registry(messages, config.llm_config_paths)
     tracing_enabled, set_trace_session = _enable_tracing(config, messages)
 
-    from .config import UnresolvedModelError, get_llm
+    from .config import DEFAULT_MODEL, UnresolvedModelError, get_llm
 
     blocking_llm_health = None
+    llm = None
     try:
-        llm = get_llm(config)
+        from nooa.unifiedllm import FakeLLMClient, MODELS
+
+        if config.tui.default_model == DEFAULT_MODEL and DEFAULT_MODEL not in MODELS:
+            from .health_check import no_models_configured_health
+
+            blocking_llm_health = no_models_configured_health()
+            llm = FakeLLMClient()
+    except Exception:
+        logger.debug("Could not inspect loaded LLM registry", exc_info=True)
+
+    try:
+        if llm is None:
+            llm = get_llm(config)
     except UnresolvedModelError as exc:
         from nooa.unifiedllm import FakeLLMClient
 
         from .health_check import unresolved_model_health
 
-        blocking_llm_health = unresolved_model_health(exc.model)
-        messages.append(TextOutput(f"⚠️  {blocking_llm_health.error_message}", "error"))
-        if blocking_llm_health.fix_hint:
-            messages.append(TextOutput(blocking_llm_health.fix_hint, "info"))
+        if exc.model == DEFAULT_MODEL:
+            from .health_check import no_models_configured_health
+
+            blocking_llm_health = no_models_configured_health()
+        else:
+            blocking_llm_health = unresolved_model_health(exc.model)
+            messages.append(TextOutput(f"⚠️  {blocking_llm_health.error_message}", "error"))
+            if blocking_llm_health.fix_hint:
+                messages.append(TextOutput(blocking_llm_health.fix_hint, "info"))
         llm = FakeLLMClient()
     except Exception as exc:
         from nooa.unifiedllm import FakeLLMClient
@@ -486,8 +504,13 @@ def build_startup_info(result: BootstrapResult) -> Output:
     config = result.config
     agent = result.agent
     health = result.blocking_llm_health
+    from .health_check import is_no_models_configured_health
+
+    no_models_configured = is_no_models_configured_health(health)
     if health is None:
         llm_status = "ready"
+    elif no_models_configured:
+        llm_status = "not_connected"
     elif getattr(health, "pending", False):
         llm_status = "checking"
     else:
@@ -499,8 +522,10 @@ def build_startup_info(result: BootstrapResult) -> Output:
         configured = config.tui.trace_dir
         trace_dir = str(get_project_dir("traces") if str(configured) == ":project:" else configured)
     return StartupInfo(
-        model=config.tui.default_model,
-        short_model=_short_model_name(config.tui.default_model),
+        model="run /connect to configure one" if no_models_configured else config.tui.default_model,
+        short_model="No LLM connected"
+        if no_models_configured
+        else _short_model_name(config.tui.default_model),
         working_dir=str(config.agent.working_dir),
         vi_mode=config.tui.vi_mode,
         history_policy=(config.agent.summarization.policy if isinstance(agent, TUIAgent) else None),

--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -455,6 +455,28 @@ class ModelCommand(Command):
             return False, "Usage: /model [name]"
         return True, None
 
+    def _mark_model_ready(self, selected: str) -> None:
+        """Update shared model UI state after a successful switch."""
+        if self._registry is not None:
+            self._registry.blocking_llm_health = None
+            startup_info = getattr(self._registry, "startup_info", None)
+            if startup_info is not None:
+                from nooa_cli.tui.session import _short_model_name
+
+                startup_info.model = selected
+                startup_info.short_model = _short_model_name(selected)
+                startup_info.llm_ready = True
+                startup_info.llm_status = "ready"
+
+        app = getattr(self.frontend, "_app", None)
+        refreshed = False
+        refresh_transcript_blocks = getattr(app, "refresh_transcript_blocks", None)
+        if callable(refresh_transcript_blocks):
+            refreshed = bool(refresh_transcript_blocks("startup-info"))
+        invalidate = getattr(app, "invalidate", None)
+        if callable(invalidate) and not refreshed:
+            invalidate()
+
     async def execute(self, args: list[str]) -> "CommandResult":
         if not args:
             return CommandResult.ok(
@@ -501,27 +523,24 @@ class ModelCommand(Command):
         except Exception as e:
             return CommandResult.err(f"Failed to switch model: {e}")
         self.config.default_model = selected
-        if self._registry is not None:
-            self._registry.blocking_llm_health = None
-            startup_info = getattr(self._registry, "startup_info", None)
-            if startup_info is not None:
-                from nooa_cli.tui.session import _short_model_name
-
-                startup_info.model = selected
-                startup_info.short_model = _short_model_name(selected)
-                startup_info.llm_ready = True
-                startup_info.llm_status = "ready"
+        self._mark_model_ready(selected)
         try:
             settings_path = self._persist_tui_setting("default_model", selected)
         except Exception as e:
             logger.warning("Failed to persist selected TUI model %r: %s", selected, e)
-            return CommandResult.ok(
-                TextOutput(f"Switched to model: {selected}", "success"),
-                TextOutput(f"Could not save the project default: {e}", "warning"),
+            return CommandResult(
+                success=True,
+                outputs=[
+                    TextOutput(f"Switched to model: {selected}", "success"),
+                    TextOutput(f"Could not save the project default: {e}", "warning"),
+                ],
             )
-        return CommandResult.ok(
-            TextOutput(f"Switched to model: {selected}", "success"),
-            TextOutput(f"Saved as the project default in {settings_path}", "status"),
+        return CommandResult(
+            success=True,
+            outputs=[
+                TextOutput(f"Switched to model: {selected}", "success"),
+                TextOutput(f"Saved as the project default in {settings_path}", "status"),
+            ],
         )
 
     async def _add_to_registry(self, server_url: str) -> "CommandResult":
@@ -845,13 +864,20 @@ class ModelCommand(Command):
 class ConnectCommand(ModelCommand):
     """Friendly model-backend setup entry point."""
 
+    _PRESET_ENDPOINTS: ClassVar[dict[str, str]] = {
+        "OpenAI": "https://api.openai.com/v1",
+        "Anthropic": "https://api.anthropic.com",
+        "Ollama local": "http://localhost:11434",
+    }
+    _CUSTOM_ENDPOINT = "Custom OpenAI-compatible endpoint..."
+
     @property
     def name(self) -> str:
         return "connect"
 
     @classmethod
     def help_text(cls) -> dict[str, str]:
-        return {"/connect [server-url]": "Connect a model backend by URL"}
+        return {"/connect [server-url]": "Connect a model backend; prompts if URL is omitted"}
 
     def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
         if len(args) > 1:
@@ -862,15 +888,28 @@ class ConnectCommand(ModelCommand):
         server_url = args[0] if args else ""
         if not server_url:
             prompt_text = getattr(self.frontend, "prompt_text", None)
-            if not callable(prompt_text):
-                return CommandResult.err("Usage: /connect <server-url>")
-            server_url = await prompt_text(
-                "Connect model backend",
-                "API base URL (Anthropic, Ollama, and OpenAI-compatible servers are auto-detected).",
-                "http://localhost:11434",
-            )
+            prompt_choice = getattr(self.frontend, "prompt_choice", None)
+            if callable(prompt_choice):
+                selected = await prompt_choice(
+                    "Connect model backend",
+                    "Choose a provider or endpoint type.",
+                    [*self._PRESET_ENDPOINTS.keys(), self._CUSTOM_ENDPOINT],
+                )
+                if not selected:
+                    return CommandResult.ok(TextOutput("Model setup cancelled.", "info"))
+                server_url = self._PRESET_ENDPOINTS.get(selected, "")
+                if not server_url and selected != self._CUSTOM_ENDPOINT:
+                    return CommandResult.ok(TextOutput("Model setup cancelled.", "info"))
+            if not server_url and not callable(prompt_text):
+                return CommandResult.err("Usage: /connect [server-url]")
             if not server_url:
-                return CommandResult.ok(TextOutput("Model setup cancelled.", "info"))
+                server_url = await prompt_text(
+                    "Custom model endpoint",
+                    "API base URL (OpenAI-compatible servers, Anthropic, and Ollama are auto-detected).",
+                    "http://localhost:11434",
+                )
+                if not server_url:
+                    return CommandResult.ok(TextOutput("Model setup cancelled.", "info"))
         return await self._add_to_registry(server_url)
 
 

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -691,7 +691,43 @@ class TerminalFrontend:
         stream.write(rendered)
         stream.flush()
 
+    def _render_startup_to_string(self, info: StartupInfo, width: int) -> str:
+        from rich.console import Console as RichConsole
+
+        from .theme import CATPPUCCIN_THEME
+
+        buf = io.StringIO()
+        render_width = max(int(width), 1)
+        console = RichConsole(
+            file=buf,
+            width=render_width,
+            highlight=False,
+            force_terminal=True,
+            color_system="256",
+            theme=CATPPUCCIN_THEME,
+            _environ={"COLUMNS": str(render_width), "LINES": "25"},
+        )
+        self._print_startup(info, console)
+        return buf.getvalue()
+
     def _render_startup(self, info: StartupInfo) -> None:
+        stream = getattr(self._console.console, "file", None)
+        semantic_replay = getattr(stream, "semantic_replay", None)
+        if getattr(stream, "supports_semantic_replay", False) is True and callable(semantic_replay):
+            with semantic_replay(
+                lambda s=stream: self._render_startup_to_string(
+                    info,
+                    s.layout_width(120) if callable(getattr(s, "layout_width", None)) else 120,
+                ),
+                tags={"startup-info"},
+                keep=True,
+            ):
+                self._print_startup(info, self._console.console)
+            return
+
+        self._print_startup(info, self._console.console)
+
+    def _print_startup(self, info: StartupInfo, console: Any) -> None:
         from rich.rule import Rule
         from rich.table import Table
 
@@ -702,11 +738,13 @@ class TerminalFrontend:
         peach = COLORS["peach"]
 
         llm_status = getattr(info, "llm_status", "ready" if info.llm_ready else "unavailable")
-        if llm_status in {"ready", "checking"}:
+        if llm_status == "not_connected":
+            title = f"[bold {COLORS['mauve']}]NOOA[/]"
+        elif llm_status in {"ready", "checking"}:
             title = f"[bold {COLORS['mauve']}]NOOA ready[/]"
         else:
             title = f"[bold {COLORS['red']}]NOOA — LLM unavailable[/]"
-        self._console.console.print(Rule(title=title, style=COLORS["surface2"]))
+        console.print(Rule(title=title, style=COLORS["surface2"]))
 
         table = Table.grid(padding=(0, 2))
         table.add_column(style=f"bold {sapphire}", no_wrap=True)
@@ -746,8 +784,8 @@ class TerminalFrontend:
         )
         table.add_row("!cmd", f"[{overlay}]run a bash command (e.g. !ls -la)[/]")
 
-        self._console.console.print(table)
-        self._console.console.print()
+        console.print(table)
+        console.print()
 
     def _render_code_execution(self, execution: CodeExecution) -> None:
         """Render a code execution panel (reasoning + code + output)."""

--- a/packages/nooa-cli/src/nooa_cli/tui/health_check.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/health_check.py
@@ -46,6 +46,8 @@ _PROVIDER_API_KEY_ENV: dict[str, str] = {
     "nvidia_nim": "NVIDIA_API_KEY",
 }
 
+_NO_MODELS_CONFIGURED_MESSAGE = "No LLM connected. Run `/connect` to configure one."
+
 
 @dataclass
 class HealthCheckResult:
@@ -95,6 +97,20 @@ def unresolved_model_health(model: str) -> HealthCheckResult:
         ),
         blocking=True,
     )
+
+
+def no_models_configured_health() -> HealthCheckResult:
+    """Return the first-run result when no model aliases are configured."""
+    return HealthCheckResult(
+        ok=False,
+        error_message=_NO_MODELS_CONFIGURED_MESSAGE,
+        blocking=True,
+    )
+
+
+def is_no_models_configured_health(result: HealthCheckResult | None) -> bool:
+    """Return True when *result* is the first-run no-models state."""
+    return result is not None and result.error_message == _NO_MODELS_CONFIGURED_MESSAGE
 
 
 def _get_expected_env_var(llm: UnifiedLLM) -> str | None:

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -136,6 +136,8 @@ class _EmitStream:
         self._semantic_replay: Callable[[], str] | None = None
         self._semantic_replay_recorded = False
         self._semantic_replay_parts: list[str | Callable[[], str]] = []
+        self._buffer_tags: set[str] = set()
+        self._buffer_keep = False
 
     def write(self, text: str) -> int:
         if text:
@@ -171,15 +173,31 @@ class _EmitStream:
             kwargs["replay"] = lambda parts=replay_parts: "".join(
                 part() if callable(part) else part for part in parts
             )
+        if self._buffer_tags:
+            kwargs["tags"] = frozenset(self._buffer_tags)
+            self._buffer_tags.clear()
+        if self._buffer_keep:
+            kwargs["keep"] = True
+            self._buffer_keep = False
         self._emit(chunk, **kwargs)
 
     @contextmanager
-    def semantic_replay(self, replay: Callable[[], str]):
+    def semantic_replay(
+        self,
+        replay: Callable[[], str],
+        *,
+        tags: set[str] | frozenset[str] | None = None,
+        keep: bool = False,
+    ):
         """Retain one structured render without mixing adjacent output blocks."""
         previous = self._semantic_replay
         previous_recorded = self._semantic_replay_recorded
+        previous_tags = set(self._buffer_tags)
+        previous_keep = self._buffer_keep
         self._semantic_replay = replay
         self._semantic_replay_recorded = False
+        self._buffer_tags.update(tags or ())
+        self._buffer_keep = self._buffer_keep or keep
         self._held += 1
         try:
             yield
@@ -187,12 +205,16 @@ class _EmitStream:
             self._held -= 1
             self._semantic_replay = previous
             self._semantic_replay_recorded = previous_recorded
+            self._buffer_tags.update(previous_tags)
+            self._buffer_keep = self._buffer_keep or previous_keep
             if self._held == 0:
                 self.flush()
 
     def clear_transcript(self) -> None:
         self._buf.clear()
         self._semantic_replay_parts.clear()
+        self._buffer_tags.clear()
+        self._buffer_keep = False
         self._buffer_has_agent_message = False
         if self._clear is not None:
             self._clear()
@@ -220,6 +242,8 @@ class _EmitStream:
         replay: Callable[[], str],
         *,
         code_copy_actions: dict[str, str] | None = None,
+        tags: set[str] | frozenset[str] | None = None,
+        keep: bool = False,
     ) -> None:
         if self._buf:
             self._emit_buffer()
@@ -227,6 +251,10 @@ class _EmitStream:
             kwargs: dict[str, Any] = {"replay": replay}
             if code_copy_actions:
                 kwargs["code_copy_actions"] = code_copy_actions
+            if tags:
+                kwargs["tags"] = tags
+            if keep:
+                kwargs["keep"] = keep
             self._emit(text, **kwargs)
 
     @contextmanager
@@ -1281,13 +1309,20 @@ class Session:
         """Render configured toolbar items on the rule above the input."""
         from .toolbar import ToolbarContext
 
+        model = self.config.tui.default_model
+        health = getattr(self.registry, "blocking_llm_health", None)
+        from .health_check import is_no_models_configured_health
+
+        if is_no_models_configured_health(health):
+            model = "No LLM"
+
         manager = self._session_manager
         shell = getattr(self.agent, "shell", None)
         cwd = Path(getattr(shell, "cwd", self.config.agent.working_dir)).resolve()
         return self._toolbar.render(
             self.config.tui.toolbar_items,
             ToolbarContext(
-                model=self.config.tui.default_model,
+                model=model,
                 working_directory=cwd,
                 context_usage=self._context_usage_label(),
                 session_id=manager.session_id if manager is not None else None,

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -976,6 +976,12 @@ class _ResizeReplayQueueItem:
     transcript_epoch: int
 
 
+@dataclass(frozen=True)
+class _NativeTranscriptReplayQueueItem:
+    transcript_blocks: tuple[TranscriptBlock, ...]
+    transcript_epoch: int
+
+
 @dataclass(frozen=True, slots=True)
 class _PasteAttachment:
     """Immutable payload represented by one private-use composer character."""
@@ -1295,7 +1301,12 @@ class TUIApplication:
         # direct run_in_terminal in _render_message, etc.) now funnels
         # through this one queue — no races.
         self._block_queue: (
-            asyncio.Queue[TranscriptBlock | _ResizeReplayQueueItem | _ClearTranscriptQueueItem]
+            asyncio.Queue[
+                TranscriptBlock
+                | _ResizeReplayQueueItem
+                | _NativeTranscriptReplayQueueItem
+                | _ClearTranscriptQueueItem
+            ]
             | None
         ) = None
         self._consumer_task: asyncio.Task | None = None
@@ -3550,8 +3561,29 @@ class TUIApplication:
             self._app.invalidate()
         elif changed:
             self._replace_output_buffer_blocks(native_replacements)
-            self.invalidate()
+            if not self._enqueue_native_transcript_replay():
+                self.invalidate()
         return changed
+
+    def _enqueue_native_transcript_replay(self) -> bool:
+        """Queue a native scrollback rewrite for refreshed replayable blocks."""
+        queue = self._block_queue
+        if (
+            not self.full_screen
+            or self._is_fullscreen
+            or queue is None
+            or not self._resize_replays_enabled
+            or self._active_subview is not None
+        ):
+            return False
+        self._prune_transcript_blocks_for_active_events()
+        queue.put_nowait(
+            _NativeTranscriptReplayQueueItem(
+                transcript_blocks=tuple(self._transcript_blocks),
+                transcript_epoch=self._transcript_epoch,
+            )
+        )
+        return True
 
     def _note_unseen_agent_message(self, block: TranscriptBlock) -> None:
         """Show a notice when agent prose arrives outside the anchored viewport."""
@@ -3827,6 +3859,8 @@ class TUIApplication:
                             out.flush()
 
                     await run_in_terminal(_write)
+                elif isinstance(item, _NativeTranscriptReplayQueueItem):
+                    await self._consume_native_transcript_replay(item)
                 elif isinstance(item, _ResizeReplayQueueItem):
                     await self._consume_resize_replay(item)
                 else:
@@ -4209,6 +4243,45 @@ class TUIApplication:
         from prompt_toolkit.application import run_in_terminal
 
         await run_in_terminal(lambda: self._clear_terminal_if_current(item))
+
+    async def _consume_native_transcript_replay(
+        self, item: _NativeTranscriptReplayQueueItem
+    ) -> None:
+        if (
+            not self._resize_replays_enabled
+            or item.transcript_epoch != self._transcript_epoch
+            or self._active_subview is not None
+            or self._app._running_in_terminal
+        ):
+            return
+        try:
+            self._app.run_atomic_native_replay(
+                lambda output: self._replay_native_transcript_if_current(item, output=output)
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("Could not replay refreshed native transcript", exc_info=True)
+
+    def _replay_native_transcript_if_current(
+        self,
+        item: _NativeTranscriptReplayQueueItem,
+        *,
+        output: Any | None = None,
+    ) -> bool:
+        if (
+            not self._resize_replays_enabled
+            or self._active_subview is not None
+            or item.transcript_epoch != self._transcript_epoch
+        ):
+            return False
+        return self._replay_fullscreen_transcript(
+            item.transcript_blocks,
+            clear_even_if_empty=True,
+            output=output,
+            flush=False,
+            count_invalidation=False,
+        )
 
     def _clear_terminal_if_current(self, item: _ClearTranscriptQueueItem) -> bool:
         if not self._resize_replays_enabled or item.transcript_epoch != self._transcript_epoch:

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -963,6 +963,7 @@ class TranscriptBlock:
     resident_bytes: int = 0
     replay_cache: dict[int, str] = field(default_factory=dict)
     fullscreen_rendered: str | None = None
+    native_visible_text: str | None = None
     code_copy_actions: dict[str, str] = field(default_factory=dict)
     agent_message: bool = False
 
@@ -3355,7 +3356,7 @@ class TUIApplication:
                 self._note_unseen_agent_message(block)
                 self._app.invalidate()
                 return
-            self._append_stripped_to_buffer(rendered)
+            block.native_visible_text = self._append_stripped_to_buffer(rendered)
             import sys as _sys
 
             try:
@@ -3493,7 +3494,7 @@ class TUIApplication:
             self._note_unseen_agent_message(block)
             self._app.invalidate()
             return
-        self._append_stripped_to_buffer(rendered)
+        block.native_visible_text = self._append_stripped_to_buffer(rendered)
         if queue is not None:
             queue.put_nowait(block)
             return
@@ -3511,6 +3512,37 @@ class TUIApplication:
             except Exception:
                 pass
 
+    def refresh_transcript_blocks(self, tag: str) -> bool:
+        """Refresh retained replayable transcript blocks carrying *tag*."""
+        changed = False
+        native_replacements: list[tuple[str, str]] = []
+        for block in self._transcript_blocks:
+            if tag not in block.tags or block.replay is None:
+                continue
+            old_native_text = block.native_visible_text
+            try:
+                source = block.replay()
+            except Exception:
+                logger.debug("Could not refresh transcript block tagged %r", tag, exc_info=True)
+                continue
+            block.source = source
+            block.replay_cache.clear()
+            block.fullscreen_rendered = None
+            if old_native_text is not None:
+                rendered = self._render_transcript_source(source)
+                new_native_text = _strip_ansi(rendered)
+                native_replacements.append((old_native_text, new_native_text))
+                block.native_visible_text = new_native_text
+            changed = True
+
+        if changed and self._is_fullscreen:
+            self._rebuild_fullscreen_transcript()
+            self._app.invalidate()
+        elif changed:
+            self._replace_output_buffer_blocks(native_replacements)
+            self.invalidate()
+        return changed
+
     def _note_unseen_agent_message(self, block: TranscriptBlock) -> None:
         """Show a notice when agent prose arrives outside the anchored viewport."""
         if self._fullscreen_transcript.viewport.follows_tail:
@@ -3518,7 +3550,7 @@ class TUIApplication:
         elif block.agent_message:
             self._has_unseen_agent_message = True
 
-    def _append_stripped_to_buffer(self, text: str) -> None:
+    def _append_stripped_to_buffer(self, text: str) -> str:
         """Append the ANSI-stripped transcript text to ``output_buffer``.
 
         Runs on the event loop thread (either because ``emit_block``
@@ -3530,6 +3562,19 @@ class TUIApplication:
         appended = stripped if not existing or existing.endswith("\n") else "\n" + stripped
         joined = existing + appended
         self.output_buffer.document = Document(text=joined, cursor_position=len(joined))
+        return stripped
+
+    def _replace_output_buffer_blocks(self, replacements: list[tuple[str, str]]) -> None:
+        """Replace refreshed native transcript blocks without rebuilding history."""
+        text = self.output_buffer.text
+        for old, new in replacements:
+            if not old or old == new:
+                continue
+            index = text.find(old)
+            if index < 0:
+                continue
+            text = text[:index] + new + text[index + len(old) :]
+        self.output_buffer.document = Document(text=text, cursor_position=len(text))
 
     # ── surface the harness (and real callers) rely on ----------------
 

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -964,6 +964,7 @@ class TranscriptBlock:
     replay_cache: dict[int, str] = field(default_factory=dict)
     fullscreen_rendered: str | None = None
     native_visible_text: str | None = None
+    native_visible_start: int | None = None
     code_copy_actions: dict[str, str] = field(default_factory=dict)
     agent_message: bool = False
 
@@ -3356,7 +3357,10 @@ class TUIApplication:
                 self._note_unseen_agent_message(block)
                 self._app.invalidate()
                 return
-            block.native_visible_text = self._append_stripped_to_buffer(rendered)
+            (
+                block.native_visible_text,
+                block.native_visible_start,
+            ) = self._append_stripped_to_buffer(rendered)
             import sys as _sys
 
             try:
@@ -3494,7 +3498,10 @@ class TUIApplication:
             self._note_unseen_agent_message(block)
             self._app.invalidate()
             return
-        block.native_visible_text = self._append_stripped_to_buffer(rendered)
+        (
+            block.native_visible_text,
+            block.native_visible_start,
+        ) = self._append_stripped_to_buffer(rendered)
         if queue is not None:
             queue.put_nowait(block)
             return
@@ -3515,11 +3522,12 @@ class TUIApplication:
     def refresh_transcript_blocks(self, tag: str) -> bool:
         """Refresh retained replayable transcript blocks carrying *tag*."""
         changed = False
-        native_replacements: list[tuple[str, str]] = []
+        native_replacements: list[tuple[TranscriptBlock, int, str, str]] = []
         for block in self._transcript_blocks:
             if tag not in block.tags or block.replay is None:
                 continue
             old_native_text = block.native_visible_text
+            old_native_start = block.native_visible_start
             try:
                 source = block.replay()
             except Exception:
@@ -3531,8 +3539,10 @@ class TUIApplication:
             if old_native_text is not None:
                 rendered = self._render_transcript_source(source)
                 new_native_text = _strip_ansi(rendered)
-                native_replacements.append((old_native_text, new_native_text))
-                block.native_visible_text = new_native_text
+                if old_native_start is not None:
+                    native_replacements.append(
+                        (block, old_native_start, old_native_text, new_native_text)
+                    )
             changed = True
 
         if changed and self._is_fullscreen:
@@ -3550,7 +3560,7 @@ class TUIApplication:
         elif block.agent_message:
             self._has_unseen_agent_message = True
 
-    def _append_stripped_to_buffer(self, text: str) -> str:
+    def _append_stripped_to_buffer(self, text: str) -> tuple[str, int | None]:
         """Append the ANSI-stripped transcript text to ``output_buffer``.
 
         Runs on the event loop thread (either because ``emit_block``
@@ -3560,21 +3570,54 @@ class TUIApplication:
         stripped = _strip_ansi(text)
         existing = self.output_buffer.text
         appended = stripped if not existing or existing.endswith("\n") else "\n" + stripped
+        visible_start = len(existing) + (len(appended) - len(stripped)) if stripped else None
         joined = existing + appended
         self.output_buffer.document = Document(text=joined, cursor_position=len(joined))
-        return stripped
+        return stripped, visible_start
 
-    def _replace_output_buffer_blocks(self, replacements: list[tuple[str, str]]) -> None:
+    def _replace_output_buffer_blocks(
+        self,
+        replacements: list[tuple[TranscriptBlock, int, str, str]],
+    ) -> None:
         """Replace refreshed native transcript blocks without rebuilding history."""
         text = self.output_buffer.text
-        for old, new in replacements:
+        changed = False
+        for block, start, old, new in sorted(replacements, key=lambda item: item[1], reverse=True):
             if not old or old == new:
+                block.native_visible_text = new
+                block.native_visible_start = start
                 continue
-            index = text.find(old)
-            if index < 0:
+            end = start + len(old)
+            if start < 0 or text[start:end] != old:
+                logger.debug(
+                    "Could not refresh native transcript block at stale span %s:%s",
+                    start,
+                    end,
+                )
                 continue
-            text = text[:index] + new + text[index + len(old) :]
-        self.output_buffer.document = Document(text=text, cursor_position=len(text))
+            text = text[:start] + new + text[end:]
+            block.native_visible_text = new
+            block.native_visible_start = start
+            delta = len(new) - len(old)
+            if delta:
+                self._shift_native_visible_starts(start, delta, changed_block=block)
+            changed = True
+        if changed:
+            self.output_buffer.document = Document(text=text, cursor_position=len(text))
+
+    def _shift_native_visible_starts(
+        self,
+        changed_start: int,
+        delta: int,
+        *,
+        changed_block: TranscriptBlock,
+    ) -> None:
+        """Keep native spans aligned after replacing one retained block."""
+        for block in self._transcript_blocks:
+            if block is changed_block or block.native_visible_start is None:
+                continue
+            if block.native_visible_start > changed_start:
+                block.native_visible_start += delta
 
     # ── surface the harness (and real callers) rely on ----------------
 

--- a/packages/nooa-cli/tests/tui/test_model_catalog.py
+++ b/packages/nooa-cli/tests/tui/test_model_catalog.py
@@ -345,10 +345,18 @@ async def test_connect_workflow_writes_local_registry(tmp_path, monkeypatch) -> 
     )
     frontend = _WorkflowFrontend()
     _stub_successful_model_switch(monkeypatch)
+    startup_info = SimpleNamespace(
+        model="not connected",
+        short_model="No LLM",
+        llm_ready=False,
+        llm_status="not_connected",
+    )
+    registry = SimpleNamespace(blocking_llm_health=object(), startup_info=startup_info)
     command = ConnectCommand(
         frontend,
         TUIConfig(),
         MagicMock(),
+        registry=registry,
         root_config=SimpleNamespace(llm_config_paths=[]),
     )
     command._reload_model_registry = MagicMock()
@@ -363,6 +371,12 @@ async def test_connect_workflow_writes_local_registry(tmp_path, monkeypatch) -> 
         "api_base": "http://localhost:8000/v1",
     }
     assert any("Switched to model: org/model" in output.content for output in result.outputs)
+    assert registry.blocking_llm_health is None
+    assert startup_info.model == "org/model"
+    assert startup_info.short_model == "model"
+    assert startup_info.llm_ready is True
+    assert startup_info.llm_status == "ready"
+    assert startup_info not in result.outputs
 
 
 @pytest.mark.asyncio
@@ -428,6 +442,81 @@ async def test_connect_workflow_reuses_model_catalog_setup(tmp_path, monkeypatch
     saved = yaml.safe_load((project_dir / "llm_config.yaml").read_text())
     assert saved["models"]["org/model"]["api_base"] == "http://localhost:8000/v1"
     assert frontend.text_prompts == []
+
+
+@pytest.mark.asyncio
+async def test_connect_without_url_prompts_for_endpoint(tmp_path, monkeypatch) -> None:
+    project_dir = tmp_path / ".nooa"
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project_dir))
+    monkeypatch.setattr(
+        "nooa_cli.tui.model_catalog.fetch_model_catalog",
+        lambda *_args, **_kwargs: (
+            "http://localhost:8000/v1",
+            [CatalogModel(id="org/model")],
+        ),
+    )
+    monkeypatch.setattr(
+        "nooa_cli.tui.model_catalog.lookup_model_token_limits",
+        lambda *_args: (None, None),
+    )
+    frontend = _WorkflowFrontend()
+    frontend.text_answers = ["http://localhost:8000/v1"]
+    frontend.choice_answers = ["Custom OpenAI-compatible endpoint...", "org/model"]
+    _stub_successful_model_switch(monkeypatch)
+    command = ConnectCommand(
+        frontend,
+        TUIConfig(),
+        MagicMock(),
+        root_config=SimpleNamespace(llm_config_paths=[]),
+    )
+    command._reload_model_registry = MagicMock()
+
+    result = await command.execute([])
+
+    assert result.success is True
+    assert frontend.choice_prompts[0][0] == "Connect model backend"
+    assert frontend.choice_prompts[0][2] == [
+        "OpenAI",
+        "Anthropic",
+        "Ollama local",
+        "Custom OpenAI-compatible endpoint...",
+    ]
+    assert frontend.text_prompts[0][0] == "Custom model endpoint"
+    assert any("Switched to model: org/model" in output.content for output in result.outputs)
+
+
+@pytest.mark.asyncio
+async def test_connect_without_url_can_use_standard_endpoint_preset(tmp_path, monkeypatch) -> None:
+    project_dir = tmp_path / ".nooa"
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project_dir))
+    calls = []
+
+    def fake_fetch(server_url, *_args, **_kwargs):
+        calls.append(server_url)
+        return ("http://localhost:11434/v1", [CatalogModel(id="qwen3:1.7b")])
+
+    monkeypatch.setattr("nooa_cli.tui.model_catalog.fetch_model_catalog", fake_fetch)
+    monkeypatch.setattr(
+        "nooa_cli.tui.model_catalog.lookup_model_token_limits",
+        lambda *_args: (None, None),
+    )
+    frontend = _WorkflowFrontend()
+    frontend.choice_answers = ["Ollama local", "qwen3:1.7b"]
+    _stub_successful_model_switch(monkeypatch)
+    command = ConnectCommand(
+        frontend,
+        TUIConfig(),
+        MagicMock(),
+        root_config=SimpleNamespace(llm_config_paths=[]),
+    )
+    command._reload_model_registry = MagicMock()
+
+    result = await command.execute([])
+
+    assert result.success is True
+    assert calls == ["http://localhost:11434"]
+    assert frontend.text_prompts == []
+    assert any("Switched to model: qwen3-1.7b" in output.content for output in result.outputs)
 
 
 @pytest.mark.asyncio

--- a/packages/nooa-cli/tests/tui/test_startup_latency.py
+++ b/packages/nooa-cli/tests/tui/test_startup_latency.py
@@ -39,6 +39,102 @@ def test_tui_package_import_does_not_import_agent_stack() -> None:
 
 
 @pytest.mark.asyncio
+async def test_empty_registry_startup_prompts_connect_without_default_model_probe(
+    tmp_path, monkeypatch
+):
+    from nooa_cli.tui.bootstrap import bootstrap, build_startup_info
+    from nooa_cli.tui.config import Config
+    from nooa_cli.tui.session import Session
+    from nooa_cli.tui.toolbar import ToolbarRegistry
+
+    _configure_project(monkeypatch, tmp_path)
+    cfg = Config()
+    cfg.agent.summarization.policy = "none"
+
+    monkeypatch.setattr("nooa.llm_config.llm_config_chain", lambda: [])
+    monkeypatch.setattr("nooa.secrets.load_secrets_into_env", lambda: None)
+    monkeypatch.setattr(
+        "nooa_cli.tui.config.get_llm",
+        lambda _config: (_ for _ in ()).throw(AssertionError("get_llm should not run")),
+    )
+
+    result = await bootstrap(cfg)
+    try:
+        assert result.blocking_llm_health is not None
+        assert result.blocking_llm_health.blocking is True
+        assert result.blocking_llm_health.pending is False
+        assert result.blocking_llm_health.error_message == (
+            "No LLM connected. Run `/connect` to configure one."
+        )
+        assert result.blocking_llm_health.fix_hint is None
+        contents = [getattr(output, "content", "") for output in result.messages]
+        assert contents == []
+        assert all("ANTHROPIC_API_KEY" not in content for content in contents)
+        assert all("claude-opus" not in content for content in contents)
+
+        startup_info = build_startup_info(result)
+        assert startup_info.model == "run /connect to configure one"
+        assert startup_info.short_model == "No LLM connected"
+        assert startup_info.llm_ready is False
+        assert startup_info.llm_status == "not_connected"
+
+        session = Session.__new__(Session)
+        session.config = cfg
+        session.registry = SimpleNamespace(blocking_llm_health=result.blocking_llm_health)
+        session._toolbar = ToolbarRegistry(load_plugins=False)
+        session._session_manager = SimpleNamespace(session_id="12345678-abcd", name=None)
+        session.agent = SimpleNamespace(shell=SimpleNamespace(cwd=str(tmp_path)))
+        session._context_usage_label = lambda: ""
+        assert "No LLM" in session._session_label()
+        assert "claude-opus" not in session._session_label()
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_builtin_default_prompts_connect_without_claude_probe(
+    tmp_path, monkeypatch
+):
+    from nooa_cli.tui.bootstrap import bootstrap, build_startup_info
+    from nooa_cli.tui.config import Config
+
+    project_dir = _configure_project(monkeypatch, tmp_path)
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "llm_config.yaml").write_text(
+        "models:\n"
+        "  qwen3-1.7b:\n"
+        "    model_name: ollama_chat/qwen3:1.7b\n"
+        "    api_base: http://localhost:11434\n"
+    )
+    cfg = Config()
+    cfg.agent.summarization.policy = "none"
+
+    monkeypatch.setattr("nooa.llm_config.bundled_config_paths", lambda: [])
+    monkeypatch.setattr("nooa.secrets.load_secrets_into_env", lambda: None)
+    monkeypatch.setattr(
+        "nooa_cli.tui.config.get_llm",
+        lambda _config: (_ for _ in ()).throw(AssertionError("get_llm should not run")),
+    )
+
+    result = await bootstrap(cfg)
+    try:
+        assert result.blocking_llm_health is not None
+        assert result.blocking_llm_health.error_message == (
+            "No LLM connected. Run `/connect` to configure one."
+        )
+        assert result.messages == []
+
+        startup_info = build_startup_info(result)
+        assert startup_info.short_model == "No LLM connected"
+        assert startup_info.model == "run /connect to configure one"
+        assert startup_info.llm_status == "not_connected"
+    finally:
+        if result.session_manager is not None:
+            result.session_manager.close()
+
+
+@pytest.mark.asyncio
 async def test_pending_llm_health_does_not_emit_durable_startup_status(tmp_path, monkeypatch):
     from nooa_cli.tui.bootstrap import bootstrap
     from nooa_cli.tui.config import Config
@@ -184,6 +280,10 @@ async def test_model_switch_clears_pending_startup_info(monkeypatch):
     )
     config = SimpleNamespace(default_model="old/model")
     command = ModelCommand(AsyncMock(), config, agent, registry=registry)
+    command.frontend._app = SimpleNamespace(
+        refresh_transcript_blocks=Mock(return_value=True),
+        invalidate=Mock(),
+    )
     command._persist_tui_setting = lambda _key, _value: Path("settings.yaml")
 
     async def _agent_run_async(fn):
@@ -205,6 +305,8 @@ async def test_model_switch_clears_pending_startup_info(monkeypatch):
     assert startup_info.short_model == "model"
     assert startup_info.llm_ready is True
     assert startup_info.llm_status == "ready"
+    command.frontend._app.refresh_transcript_blocks.assert_called_once_with("startup-info")
+    command.frontend._app.invalidate.assert_not_called()
 
 
 async def asyncio_wait_for_background_tasks(session) -> None:

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -257,6 +257,48 @@ async def test_no_active_identity_preserves_tagged_blocks_but_caps_untagged(
     assert len(app._transcript_blocks) == app._untagged_replay_tail + 1
 
 
+async def test_refresh_transcript_blocks_updates_tagged_replayable_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    monkeypatch.setattr("sys.stdout", io.StringIO())
+    app = TUIApplication(display_mode="native-replay")
+    value = {"text": "before\n"}
+
+    app.emit_block(value["text"], replay=lambda: value["text"], tags={"startup-info"})
+    value["text"] = "after\n"
+
+    assert app.refresh_transcript_blocks("startup-info") is True
+    assert app._transcript_blocks[0].source == "after\n"
+    assert app.output_buffer.text == "after\n"
+
+
+async def test_refresh_transcript_blocks_preserves_trimmed_native_visible_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    monkeypatch.setattr("sys.stdout", io.StringIO())
+    app = TUIApplication(display_mode="native-replay")
+    value = {"text": "before\n"}
+
+    app.emit_block(value["text"], replay=lambda: value["text"], tags={"startup-info"})
+    for index in range(app._untagged_replay_tail + 5):
+        app.emit_block(f"line-{index}\n")
+    before = app.output_buffer.text
+    assert "line-0\n" in before
+    assert before.count("\n") == app._untagged_replay_tail + 6
+
+    value["text"] = "after\n"
+
+    assert app.refresh_transcript_blocks("startup-info") is True
+    assert "before\n" not in app.output_buffer.text
+    assert "after\n" in app.output_buffer.text
+    assert "line-0\n" in app.output_buffer.text
+    assert app.output_buffer.text.count("\n") == before.count("\n")
+
+
 async def test_input_composer_has_blank_row_above_and_below_input():
     """The default composer is three rows and expands for multiline input."""
     async with TUIHarness() as h:

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -316,6 +316,33 @@ async def test_refresh_transcript_blocks_replaces_tagged_native_span_by_identity
     assert app.output_buffer.text == "duplicate\nupdated\n"
 
 
+async def test_refresh_transcript_blocks_replays_native_terminal_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = MutableRecordingOutput()
+    capture = io.StringIO()
+    monkeypatch.setattr("sys.__stdout__", capture)
+    async with TUIHarness(full_screen=True, output=output) as h:
+        value = {"text": "before\n"}
+
+        h.app.emit_block(value["text"], replay=lambda: value["text"], tags={"startup-info"})
+        assert h.app._block_queue is not None
+        await h.app._block_queue.join()
+        capture.seek(0)
+        capture.truncate()
+
+        value["text"] = "after\n"
+
+        assert h.app.refresh_transcript_blocks("startup-info") is True
+        await h.app._block_queue.join()
+
+    physical = capture.getvalue()
+    assert "\x1b[3J" in physical
+    assert "after\n" in physical
+    assert "before\n" not in physical
+    assert h.app.output_buffer.text == "after\n"
+
+
 async def test_input_composer_has_blank_row_above_and_below_input():
     """The default composer is three rows and expands for multiline input."""
     async with TUIHarness() as h:

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -299,6 +299,23 @@ async def test_refresh_transcript_blocks_preserves_trimmed_native_visible_histor
     assert app.output_buffer.text.count("\n") == before.count("\n")
 
 
+async def test_refresh_transcript_blocks_replaces_tagged_native_span_by_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    monkeypatch.setattr("sys.stdout", io.StringIO())
+    app = TUIApplication(display_mode="native-replay")
+    value = {"text": "duplicate\n"}
+
+    app.emit_block("duplicate\n")
+    app.emit_block(value["text"], replay=lambda: value["text"], tags={"startup-info"})
+    value["text"] = "updated\n"
+
+    assert app.refresh_transcript_blocks("startup-info") is True
+    assert app.output_buffer.text == "duplicate\nupdated\n"
+
+
 async def test_input_composer_has_blank_row_above_and_below_input():
     """The default composer is three rows and expands for multiline input."""
     async with TUIHarness() as h:


### PR DESCRIPTION
## Summary

  Before this change, first-run TUI startup would show a Claude/Anthropic-oriented unresolved-model warning because the built-in fallback model was `claude-opus-4-8`. Even when the user had not intentionally configured Claude, the TUI could surface errors about that default model instead of clearly saying no LLM was connected.

  This PR makes that startup state explicit and friendlier:
  - Shows `No LLM connected (run /connect to configure one)` in the normal startup header.
  - Avoids probing the built-in Claude default when it is only the fallback sentinel.
  - Updates the existing startup header after `/connect` or `/model` succeeds instead of appending a duplicate or leaving stale “No LLM connected” text.

  ## Previous Behavior

  - On first startup with no usable configured model, the TUI could report an unresolved `claude-opus-4-8` model.
  - The message could mention provider/API-key setup details, even though the user had not selected Claude.
  - `/connect` required an explicit endpoint URL.
  - After connecting a model, the startup/header area could remain stale or be duplicated.
  - Refreshing the startup header in native replay risked rebuilding visible scrollback from bounded replay retention.

  ## New Behavior

  - Startup treats an unconfigured built-in default as “no LLM connected.”
  - The normal header remains visible and shows:
    `No LLM connected (run /connect to configure one)`
  - `/connect` without arguments opens a provider/endpoint picker:
    OpenAI, Anthropic, Ollama local, or custom OpenAI-compatible endpoint.
  - Successful `/connect` or `/model` refreshes the existing startup header in place.
  - Native replay preserves visible scrollback when refreshing the header.

  ## Testing

  - `482 passed, 3 deselected`
  - `ruff format --check` clean
  - `git diff --check` clean

  The 3 deselected tests also fail on clean `origin/dev/tui`, so they are existing base-branch failures rather than regressions from this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive model connection options, including preset backends and custom endpoints.
  * Added clear first-run guidance to connect an LLM when no models are configured.
  * Added clearer startup and session labels for disconnected or unavailable models.

* **Bug Fixes**
  * Improved model switching and transcript refresh behavior.
  * Prevented unnecessary default-model checks when no models are configured.
  * Improved transcript updates when repeated content appears.

* **Tests**
  * Added coverage for connection flows, empty registries, startup messaging, and transcript refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->