### PR TITLE
fix(tui): wrap quoted and user text safely

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
@@ -10,7 +10,7 @@ from typing import Any
 from markdown_it import MarkdownIt
 from rich.cells import cell_len, split_graphemes
 from rich.console import Console, ConsoleOptions, RenderResult
-from rich.markdown import CodeBlock, ListItem, Markdown
+from rich.markdown import BlockQuote, CodeBlock, ListItem, Markdown
 from rich.segment import Segment
 from rich.syntax import Syntax
 from rich.text import Text
@@ -179,6 +179,39 @@ class _CopyableCodeBlock(CodeBlock):
         yield from console.render(syntax, options.update(no_wrap=False, overflow="fold"))
 
 
+class _SemanticBlockQuote(BlockQuote):
+    """Render complete quoted prose instead of cropping it under soft-wrap."""
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        # The outer soft-wrap keeps semantic source reflowable in fullscreen,
+        # but Rich's stock BlockQuote combines it with render_lines(), which
+        # crops long children. Wrap quote children here and repeat the marker.
+        # Avoid ``render_lines`` here: nested semantic list items deliberately
+        # emit complete logical lines, which another width-cropping pass would
+        # truncate. Convert each complete styled line to Text and word-wrap it
+        # before adding the quote marker to every resulting visual row.
+        prefix_text = "▌ " if options.max_width >= 3 else ""
+        content_width = max(options.max_width - cell_len(prefix_text), 1)
+        rendered = console.render(self.elements, options.update(height=None))
+        logical_lines = list(Segment.split_lines(Segment.apply_style(rendered, self.style))) or [[]]
+        prefix = Segment(prefix_text, self.style)
+        for logical_line in logical_lines:
+            text = Text()
+            for segment in logical_line:
+                if not segment.control:
+                    text.append(segment.text, segment.style)
+            wrapped = text.wrap(
+                console,
+                content_width,
+                overflow="fold",
+                no_wrap=False,
+            ) or [Text()]
+            for line in wrapped:
+                yield prefix
+                yield from line.render(console)
+                yield Segment.line()
+
+
 class _SemanticListItem(ListItem):
     """Render complete list-item text for renderer-owned wrapping.
 
@@ -225,6 +258,7 @@ class CopyableMarkdown(TerminalMarkdown):
         **Markdown.elements,
         "fence": _CopyableCodeBlock,
         "code_block": _CopyableCodeBlock,
+        "blockquote_open": _SemanticBlockQuote,
         "list_item_open": _SemanticListItem,
     }
 

--- a/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/copyable_markdown.py
@@ -192,7 +192,15 @@ class _SemanticBlockQuote(BlockQuote):
         # before adding the quote marker to every resulting visual row.
         prefix_text = "▌ " if options.max_width >= 3 else ""
         content_width = max(options.max_width - cell_len(prefix_text), 1)
-        rendered = console.render(self.elements, options.update(height=None))
+        rendered = console.render(
+            self.elements,
+            options.update(
+                width=max(options.max_width, 80),
+                height=None,
+                no_wrap=False,
+                overflow="fold",
+            ),
+        )
         logical_lines = list(Segment.split_lines(Segment.apply_style(rendered, self.style))) or [[]]
         prefix = Segment(prefix_text, self.style)
         for logical_line in logical_lines:

--- a/packages/nooa-cli/src/nooa_cli/tui/user_message.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/user_message.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Shared rendering for live and resumed user-message bars."""
 
-from rich.cells import chop_cells, set_cell_size
+from rich.cells import cell_len, split_graphemes
 
 from .terminal_safety import sanitize_live_text
 
@@ -34,22 +34,75 @@ def render_user_bar(text: str, cols: int, colors: dict[str, str]) -> str:
     edge_style = f"\x1b[38;5;{background};49;7m"
     style_off = "\x1b[0m"
 
+    inset = 1 if width >= 3 else 0
+    inner_width = width - 2 * inset
+
     def styled_row(content: str = "") -> str:
-        return f"{style_on}{set_cell_size(content, width)}{style_off}"
+        # Reserve one highlighted cell on both sides whenever the viewport can
+        # still display content; pathological 1–2-cell terminals keep text.
+        padding = " " * max(inner_width - cell_len(content), 0)
+        edge = " " * inset
+        return f"{style_on}{edge}{content}{padding}{edge}{style_off}"
 
     def edge_row(glyph: str) -> str:
         return f"{edge_style}{glyph * width}{style_off}"
+
+    def take_chunk(value: str, available: int) -> tuple[str, str]:
+        """Take one cell-bounded chunk, preferring a whitespace boundary."""
+        if not value or available <= 0:
+            return "", value
+        spans, _ = split_graphemes(value)
+        graphemes = [(value[start:stop], cells) for start, stop, cells in spans]
+        used = 0
+        stop = 0
+        last_space = -1
+        for index, (cluster, cells) in enumerate(graphemes):
+            if stop and used + cells > available:
+                break
+            if not stop and cells > available:
+                # Match fullscreen transcript behavior for a grapheme that is
+                # physically wider than the entire available content row.
+                remainder = "".join(item for item, _item_cells in graphemes[index + 1 :])
+                return "…", remainder
+            used += cells
+            stop = index + 1
+            if cluster.isspace():
+                last_space = stop
+        if stop < len(graphemes) and last_space > 0:
+            stop = last_space
+        chunk = "".join(cluster for cluster, _cells in graphemes[:stop])
+        remainder = "".join(cluster for cluster, _cells in graphemes[stop:])
+        return chunk, remainder
 
     # One-eighth block elements draw a subtle terminal-background edge while
     # preserving nearly a full row of highlighted breathing room. Consecutive
     # user messages therefore retain a narrow visual seam between their bars.
     rows: list[str] = [edge_row("▔")]
-    for index, line in enumerate(sanitize_live_text(text).split("\n")):
-        shown = f" ❯ {line} " if index == 0 else f" {line} "
-        # Rich's cell helpers preserve grapheme clusters and measure wide
-        # glyphs correctly. Every row is exactly the safe content width.
-        chunks = chop_cells(shown, width) or [""]
-        rows.extend(styled_row(chunk) for chunk in chunks)
+    first_visual_row = True
+    for line in sanitize_live_text(text).split("\n"):
+        remainder = line
+        first_chunk = True
+        while remainder or first_chunk:
+            prefix = "❯ " if first_visual_row and inner_width >= 3 else ""
+            available = max(inner_width - cell_len(prefix), 0)
+            # The prompt makes row one narrower. If the first grapheme fits
+            # an ordinary continuation row, move it intact before chunking so
+            # it isn't replaced merely because the rest of its token is long.
+            spans, _ = split_graphemes(remainder)
+            first_cells = spans[0][2] if spans else 0
+            first_token_cells = cell_len(remainder.partition(" ")[0])
+            defer_first = (first_cells > available and first_cells <= inner_width) or (
+                first_token_cells > available and first_token_cells <= inner_width
+            )
+            if prefix and defer_first:
+                rows.append(styled_row(prefix))
+                first_visual_row = False
+                first_chunk = False
+                continue
+            chunk, remainder = take_chunk(remainder, available)
+            rows.append(styled_row(f"{prefix}{chunk}"))
+            first_visual_row = False
+            first_chunk = False
     rows.append(edge_row("▁"))
     return "\n".join(rows) + "\n"
 

--- a/packages/nooa-cli/src/nooa_cli/tui/user_message.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/user_message.py
@@ -2,9 +2,69 @@
 # SPDX-License-Identifier: Apache-2.0
 """Shared rendering for live and resumed user-message bars."""
 
+import unicodedata
+
 from rich.cells import cell_len, split_graphemes
 
 from .terminal_safety import sanitize_live_text
+
+
+def _display_graphemes(value: str) -> list[tuple[str, int]]:
+    """Return indivisible display clusters with nonzero terminal widths."""
+    spans, _ = split_graphemes(value)
+    raw: list[tuple[str, int]] = []
+    for start, stop, cells in spans:
+        cluster = value[start:stop]
+        # A dangling joiner can combine with the row's layout padding after
+        # wrapping, changing its measured width. Keep joiners inside valid
+        # emoji clusters, but expose terminal-unstable trailing joiners.
+        if cluster.endswith(("\u200c", "\u200d")):
+            stable = cluster.rstrip("\u200c\u200d")
+            replacements = "�" * (len(cluster) - len(stable))
+            cluster = stable + replacements
+            cells = cell_len(cluster)
+        raw.append((cluster, cells))
+    clusters: list[tuple[str, int]] = []
+    index = 0
+    while index < len(raw):
+        cluster, cells = raw[index]
+        # Rich intentionally separates regional indicators. Terminals render
+        # a pair as one flag, so keep adjacent indicators in the same atom.
+        if (
+            len(cluster) == 1
+            and 0x1F1E6 <= ord(cluster) <= 0x1F1FF
+            and index + 1 < len(raw)
+            and len(raw[index + 1][0]) == 1
+            and 0x1F1E6 <= ord(raw[index + 1][0]) <= 0x1F1FF
+        ):
+            next_cluster, next_cells = raw[index + 1]
+            clusters.append((cluster + next_cluster, cells + next_cells))
+            index += 2
+            continue
+        # Standalone format controls may combine with prefixes or padding
+        # after layout and change a completed row's measured width. Expose
+        # those controls, while preserving whitespace bundled into Rich's
+        # zero-cell span as its own breakable cluster.
+        if cells <= 0 and any(unicodedata.category(char) == "Cf" for char in cluster):
+            for char in cluster:
+                visible = "�" if unicodedata.category(char) == "Cf" else char
+                clusters.append((visible, max(cell_len(visible), 1)))
+            index += 1
+            continue
+        # Attach a leading combining mark to the following base. A standalone
+        # zero-cell cluster has no stable presentation, so expose it instead.
+        if cells <= 0:
+            if index + 1 < len(raw) and not raw[index + 1][0].isspace():
+                next_cluster, next_cells = raw[index + 1]
+                clusters.append((cluster + next_cluster, max(next_cells, 1)))
+                index += 2
+                continue
+            clusters.append(("�", 1))
+            index += 1
+            continue
+        clusters.append((cluster, cells))
+        index += 1
+    return clusters
 
 
 def _hex_to_ansi256(hex_color: str) -> int:
@@ -47,32 +107,28 @@ def render_user_bar(text: str, cols: int, colors: dict[str, str]) -> str:
     def edge_row(glyph: str) -> str:
         return f"{edge_style}{glyph * width}{style_off}"
 
-    def take_chunk(value: str, available: int) -> tuple[str, str]:
+    def take_chunk(graphemes: list[tuple[str, int]], start: int, available: int) -> tuple[str, int]:
         """Take one cell-bounded chunk, preferring a whitespace boundary."""
-        if not value or available <= 0:
-            return "", value
-        spans, _ = split_graphemes(value)
-        graphemes = [(value[start:stop], cells) for start, stop, cells in spans]
+        if start >= len(graphemes) or available <= 0:
+            return "", start
         used = 0
-        stop = 0
+        stop = start
         last_space = -1
-        for index, (cluster, cells) in enumerate(graphemes):
-            if stop and used + cells > available:
+        for index in range(start, len(graphemes)):
+            cluster, cells = graphemes[index]
+            if stop > start and used + cells > available:
                 break
-            if not stop and cells > available:
+            if stop == start and cells > available:
                 # Match fullscreen transcript behavior for a grapheme that is
                 # physically wider than the entire available content row.
-                remainder = "".join(item for item, _item_cells in graphemes[index + 1 :])
-                return "…", remainder
+                return "…", start + 1
             used += cells
             stop = index + 1
             if cluster.isspace():
                 last_space = stop
-        if stop < len(graphemes) and last_space > 0:
+        if stop < len(graphemes) and last_space > start:
             stop = last_space
-        chunk = "".join(cluster for cluster, _cells in graphemes[:stop])
-        remainder = "".join(cluster for cluster, _cells in graphemes[stop:])
-        return chunk, remainder
+        return "".join(cluster for cluster, _cells in graphemes[start:stop]), stop
 
     # One-eighth block elements draw a subtle terminal-background edge while
     # preserving nearly a full row of highlighted breathing room. Consecutive
@@ -80,17 +136,24 @@ def render_user_bar(text: str, cols: int, colors: dict[str, str]) -> str:
     rows: list[str] = [edge_row("▔")]
     first_visual_row = True
     for line in sanitize_live_text(text).split("\n"):
-        remainder = line
+        graphemes = _display_graphemes(line)
+        # Cache each non-whitespace suffix's token width. This keeps prompt
+        # deferral linear even for very large pasted, unbreakable tokens.
+        token_cells = [0] * (len(graphemes) + 1)
+        for index in range(len(graphemes) - 1, -1, -1):
+            cluster, cells = graphemes[index]
+            if not cluster.isspace():
+                token_cells[index] = cells + token_cells[index + 1]
+        start = 0
         first_chunk = True
-        while remainder or first_chunk:
+        while start < len(graphemes) or first_chunk:
             prefix = "❯ " if first_visual_row and inner_width >= 3 else ""
             available = max(inner_width - cell_len(prefix), 0)
-            # The prompt makes row one narrower. If the first grapheme fits
-            # an ordinary continuation row, move it intact before chunking so
-            # it isn't replaced merely because the rest of its token is long.
-            spans, _ = split_graphemes(remainder)
-            first_cells = spans[0][2] if spans else 0
-            first_token_cells = cell_len(remainder.partition(" ")[0])
+            # The prompt makes row one narrower. If the first grapheme or word
+            # fits an ordinary continuation row, move it intact before
+            # chunking so the prompt alone never forces a split/replacement.
+            first_cells = graphemes[start][1] if start < len(graphemes) else 0
+            first_token_cells = token_cells[start]
             defer_first = (first_cells > available and first_cells <= inner_width) or (
                 first_token_cells > available and first_token_cells <= inner_width
             )
@@ -99,7 +162,7 @@ def render_user_bar(text: str, cols: int, colors: dict[str, str]) -> str:
                 first_visual_row = False
                 first_chunk = False
                 continue
-            chunk, remainder = take_chunk(remainder, available)
+            chunk, start = take_chunk(graphemes, start, available)
             rows.append(styled_row(f"{prefix}{chunk}"))
             first_visual_row = False
             first_chunk = False

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -3601,6 +3601,76 @@ def test_copyable_markdown_preserves_long_list_item_for_fullscreen_reflow() -> N
     assert any(row.endswith(" ") for row in rows[:-1])
 
 
+@pytest.mark.parametrize(
+    "markup",
+    [
+        "ordinary prose {suffix}",
+        "## heading text {suffix}",
+        "- bullet text {suffix}",
+        "1. numbered text {suffix}",
+        "> quoted text {suffix}",
+        "| key | value |\n| --- | --- |\n| row | table text {suffix} |",
+    ],
+)
+def test_copyable_markdown_preserves_long_structural_text(markup: str) -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+
+    suffix = "finalword"
+    _renderable, ansi = _copyable_markdown_ansi(
+        markup.format(suffix=("word " * 12) + suffix),
+        width=24,
+    )
+
+    assert suffix in strip_safe_ansi(ansi)
+
+
+def test_copyable_markdown_wraps_complete_block_quotes_without_cropping() -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+    from rich.cells import cell_len
+
+    sentence = (
+        "Before changing anything, inspect the relevant context and applicable "
+        "repository instructions. Preserve unrelated work. Verify outcomes."
+    )
+    _renderable, ansi = _copyable_markdown_ansi(f"> {sentence}", width=30)
+    lines = [line for line in strip_safe_ansi(ansi).splitlines() if line]
+
+    assert "".join(line.removeprefix("▌ ").rstrip() + " " for line in lines).split() == (
+        sentence.split()
+    )
+    assert len(lines) > 1
+    assert all(line.startswith("▌ ") for line in lines)
+    assert all(cell_len(line) <= 30 for line in lines)
+
+
+def test_copyable_markdown_preserves_a_long_list_nested_in_a_quote() -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+
+    suffix = "complete-end"
+    _renderable, ansi = _copyable_markdown_ansi(
+        "> - " + "word " * 20 + suffix,
+        width=20,
+    )
+    plain = strip_safe_ansi(ansi)
+
+    assert suffix in plain
+    assert all(line.startswith("▌ ") for line in plain.splitlines() if line)
+
+
+@pytest.mark.parametrize("width", [1, 2, 3, 5, 10, 21])
+def test_copyable_markdown_keeps_quotes_within_pathological_widths(width: int) -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+    from rich.cells import cell_len
+
+    _renderable, ansi = _copyable_markdown_ansi("> - alpha beta END", width=width)
+    plain = strip_safe_ansi(ansi)
+
+    lines = plain.splitlines()
+    content = "".join(line.removeprefix("▌ ") for line in lines)
+    assert "".join(content.split()) == "•alphabetaEND"
+    assert all(cell_len(line) <= width for line in lines)
+
+
 def test_copyable_markdown_preserves_safe_markdown_links() -> None:
     from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
     from nooa_cli.tui.terminal_safety import safe_hyperlink_spans, strip_safe_ansi

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -3671,6 +3671,29 @@ def test_copyable_markdown_keeps_quotes_within_pathological_widths(width: int) -
     assert all(cell_len(line) <= width for line in lines)
 
 
+@pytest.mark.parametrize(
+    "markup",
+    [
+        "> plain prose alpha beta END",
+        "> | heading |\n> | --- |\n> | cell-END |",
+        "> ```text\n> code-END\n> ```",
+    ],
+)
+@pytest.mark.parametrize("width", [1, 2, 3, 4, 10])
+def test_copyable_markdown_preserves_nested_quote_content_at_narrow_widths(
+    markup: str, width: int
+) -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+    from rich.cells import cell_len
+
+    _renderable, ansi = _copyable_markdown_ansi(markup, width=width)
+    plain = strip_safe_ansi(ansi)
+
+    content = "".join(line.removeprefix("▌ ") for line in plain.splitlines())
+    assert "END" in content
+    assert all(cell_len(line) <= width for line in plain.splitlines())
+
+
 def test_copyable_markdown_preserves_safe_markdown_links() -> None:
     from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
     from nooa_cli.tui.terminal_safety import safe_hyperlink_spans, strip_safe_ansi

--- a/packages/nooa-cli/tests/tui/test_terminal_safety.py
+++ b/packages/nooa-cli/tests/tui/test_terminal_safety.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import pytest
 from nooa_cli.tui.session import _build_user_bar
 from nooa_cli.tui.terminal_safety import (
     hyperlink_at_plain_offset,
@@ -112,6 +113,89 @@ def test_user_bar_is_control_safe_cell_aware_and_reserves_final_column() -> None
 
     parsed_edge_style = to_formatted_text(ANSI(styled_lines[0]))[0][0]
     assert parsed_edge_style == "#5f5f5f bg:ansidefault reverse"
+
+
+def test_user_bar_wraps_words_with_symmetric_content_insets() -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+    from nooa_cli.tui.user_message import render_user_bar
+
+    colors = {"text": "#cdd6f4", "surface2": "#585b70"}
+    bar = render_user_bar("alpha betaword omega", 16, colors)
+    lines = strip_safe_ansi(bar).splitlines()
+
+    assert lines == [
+        "▔" * 16,
+        " ❯ alpha        ",
+        " betaword omega ",
+        "▁" * 16,
+    ]
+    assert all(line.startswith(" ") and line.endswith(" ") for line in lines[1:-1])
+
+
+def test_user_bar_folds_only_words_too_wide_for_a_content_row() -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+    from nooa_cli.tui.user_message import render_user_bar
+
+    colors = {"text": "#cdd6f4", "surface2": "#585b70"}
+    lines = strip_safe_ansi(render_user_bar("abcdefghijklmno", 10, colors)).splitlines()
+
+    assert lines[1:-1] == [" ❯ abcdef ", " ghijklmn ", " o        "]
+    assert all(cell_len(line) == 10 for line in lines)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_rows"),
+    [
+        ("  lead", [" ❯     ", " lead  "]),
+        ("a  b", [" ❯ a   ", " b     "]),
+        ("trail  ", [" ❯     ", " trail ", "       "]),
+    ],
+)
+def test_user_bar_preserves_source_whitespace_while_wrapping(
+    text: str,
+    expected_rows: list[str],
+) -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+    from nooa_cli.tui.user_message import render_user_bar
+
+    colors = {"text": "#cdd6f4", "surface2": "#585b70"}
+    lines = strip_safe_ansi(render_user_bar(text, 7, colors)).splitlines()
+
+    assert lines[1:-1] == expected_rows
+    assert all(cell_len(line) == 7 for line in lines)
+
+
+def test_user_bar_moves_a_word_that_only_fits_after_the_prompt() -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+    from nooa_cli.tui.user_message import render_user_bar
+
+    colors = {"text": "#cdd6f4", "surface2": "#585b70"}
+    lines = strip_safe_ansi(render_user_bar("abcdefg", 10, colors)).splitlines()
+
+    assert lines == ["▔" * 10, " ❯        ", " abcdefg  ", "▁" * 10]
+    assert all(cell_len(line) == 10 for line in lines)
+
+
+def test_user_bar_moves_wide_grapheme_past_narrow_prompt_without_replacing_it() -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+    from nooa_cli.tui.user_message import render_user_bar
+
+    colors = {"text": "#cdd6f4", "surface2": "#585b70"}
+    lines = strip_safe_ansi(render_user_bar("界ab", 5, colors)).splitlines()
+
+    assert lines == ["▔" * 5, " ❯   ", " 界a ", " b   ", "▁" * 5]
+    assert all(cell_len(line) == 5 for line in lines)
+
+
+def test_user_bar_replaces_a_grapheme_wider_than_the_content_row() -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+    from nooa_cli.tui.user_message import render_user_bar
+
+    colors = {"text": "#cdd6f4", "surface2": "#585b70"}
+    lines = strip_safe_ansi(render_user_bar("界", 3, colors)).splitlines()
+
+    assert lines == ["▔" * 3, " … ", "▁" * 3]
+    assert all(cell_len(line) == 3 for line in lines)
 
 
 def test_hyperlink_target_length_is_bounded() -> None:

--- a/packages/nooa-cli/tests/tui/test_terminal_safety.py
+++ b/packages/nooa-cli/tests/tui/test_terminal_safety.py
@@ -165,6 +165,17 @@ def test_user_bar_preserves_source_whitespace_while_wrapping(
     assert all(cell_len(line) == 7 for line in lines)
 
 
+def test_user_bar_treats_unicode_whitespace_as_a_word_boundary() -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+    from nooa_cli.tui.user_message import render_user_bar
+
+    colors = {"text": "#cdd6f4", "surface2": "#585b70"}
+    lines = strip_safe_ansi(render_user_bar("abcdefg x", 10, colors)).splitlines()
+
+    assert lines == ["▔" * 10, " ❯        ", " abcdefg  ", " x        ", "▁" * 10]
+    assert all(cell_len(line) == 10 for line in lines)
+
+
 def test_user_bar_moves_a_word_that_only_fits_after_the_prompt() -> None:
     from nooa_cli.tui.terminal_safety import strip_safe_ansi
     from nooa_cli.tui.user_message import render_user_bar
@@ -185,6 +196,21 @@ def test_user_bar_moves_wide_grapheme_past_narrow_prompt_without_replacing_it() 
 
     assert lines == ["▔" * 5, " ❯   ", " 界a ", " b   ", "▁" * 5]
     assert all(cell_len(line) == 5 for line in lines)
+
+
+@pytest.mark.parametrize("text", ["🇺🇸x", "́界", "\u200d", "a\u200d", "\u200d\u200d\u2003🇺"])
+def test_user_bar_handles_edge_unicode_as_indivisible_visible_cells(text: str) -> None:
+    from nooa_cli.tui.terminal_safety import strip_safe_ansi
+    from nooa_cli.tui.user_message import render_user_bar
+
+    colors = {"text": "#cdd6f4", "surface2": "#585b70"}
+    lines = strip_safe_ansi(render_user_bar(text, 5, colors)).splitlines()
+
+    assert all(cell_len(line) == 5 for line in lines)
+    if text.startswith("🇺🇸"):
+        assert any("🇺🇸" in line for line in lines)
+    if text.startswith("́"):
+        assert any("́界" in line for line in lines)
 
 
 def test_user_bar_replaces_a_grapheme_wider_than_the_content_row() -> None:


### PR DESCRIPTION
## Summary

- preserve complete blockquote and nested-list content before fullscreen projection
- word-wrap user messages without avoidable mid-word splits while preserving whitespace and grapheme clusters
- add symmetric one-cell user-message insets and narrow-width fallbacks
- cover common Markdown structures, nested quotes, whitespace, wide graphemes, and pathological widths

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- 383 focused wrapping/replay/width tests passed
- full `packages/nooa-cli/tests`: 1410 passed; 2 known macOS `/var` vs `/private/var` path-alias failures
- independent exact-commit acceptance review approved all requested cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal rendering for long messages, including prose, headings, lists, tables, and quoted content.
  * Wrapped block quotes without cropping and preserved quote markers across lines.
  * Improved user input wrapping, whitespace preservation, prompt placement, and handling of wide characters.
  * Enhanced display safety on narrow terminals and oversized content.

* **Tests**
  * Added coverage for wrapped content, nested quotes, narrow viewports, terminal insets, and wide graphemes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->