### PR TITLE
test(codeact): parameterize shared conformance tests across execution backends

### DIFF
--- a/tests/runtime/conformance/README.md
+++ b/tests/runtime/conformance/README.md
@@ -1,0 +1,55 @@
+# CodeAct backend conformance matrix
+
+Which observable CodeAct contracts are expected to match across
+`execution_backend="inprocess"` and `execution_backend="sandbox"`, and which
+are deliberately backend-specific. Tracks NVIDIA-NeMo/labs-OO-Agents#187.
+
+## Shared contracts
+
+Same assertions run against both backends. Failures name the backend in the
+pytest node ID, e.g. `test_stdout_is_captured[sandbox]`.
+
+| Contract | Observable via | Notes |
+| --- | --- | --- |
+| Implicit and explicit returns | `PythonOutput.value`, `.explicit_return` | |
+| stdout capture | `PythonOutput.stdout` | |
+| stderr capture | `PythonOutput.stderr` | |
+| Namespace persistence across cells | cell 2 reads cell 1's binding | |
+| Helper definitions across cells | `def` in cell 1, called in cell 2 | |
+| Restriction enforcement | `execution_status`, `.error` | `RestrictionsConfig` defaults apply to both backends |
+| Validation retry | session completes after a rejected cell | |
+| Nested agent/tool calls | event ordering | |
+| `PythonOutput` status and ordering | `event_type` sequence, `tool_call_id` | |
+| Runtime exception surfacing | `execution_status is ResultStatus.ERROR` | Error *text* is #189-dependent; assert status and type only |
+| Runtime exception source context | `PythonOutput.error` | **Deferred to #189** — see #191 |
+| SyntaxError source and caret fidelity | `PythonOutput.error` | **Deferred to #189** |
+| Source line and wrapper-offset fidelity | `PythonOutput.error` | **Deferred to #189** |
+| `return_result()` success and failure | method return value | Failure transport is #189-dependent |
+| Cancellation and timeout | TBD | Parity boundary undefined; see open question |
+
+## Backend-specific contracts
+
+Not parameterised. Remain in their existing suites.
+
+| Contract | Suite |
+| --- | --- |
+| OS capability probes and security restrictions | `tests/runtime/sandbox/test_guards.py` |
+| IPC serialization failures | `tests/runtime/sandbox/test_executor.py` |
+| Broker and proxy behaviour | `tests/runtime/sandbox/test_broker_deadline.py`, `test_nested_async_proxy.py` |
+| Worker death and restart | `tests/runtime/sandbox/test_executor.py` |
+| Filesystem and network confinement | `tests/runtime/sandbox/test_guards.py` |
+| CPU, memory and hard-timeout enforcement | `tests/runtime/sandbox/test_guards.py`, `test_executor.py` |
+| In-process implementation details and mocks | `tests/strategies/test_codeact_strategy.py` |
+
+## Capability-dependent skips
+
+Sandbox params skip with an explicit reason from `probe_capabilities()`
+(`Capabilities.linux`, `.landlock_abi`, `.seccomp`, `.rlimit`) rather than
+silently degrading. `SandboxConfig(require=False)` keeps portable semantic
+tests runnable where enforcement is unavailable.
+
+## Open question
+
+Which cancellation and timeout semantics are intended to match? `cell_timeout`
+is a *hard* bound under sandbox and a cooperative one in-process, so full parity
+is not obviously the goal. Raised on #187; unanswered at time of writing.

--- a/tests/runtime/conformance/README.md
+++ b/tests/runtime/conformance/README.md
@@ -17,8 +17,8 @@ pytest node ID, e.g. `test_stdout_is_captured[sandbox]`.
 | Namespace persistence across cells | cell 2 reads cell 1's binding | |
 | Helper definitions across cells | `def` in cell 1, called in cell 2 | |
 | Restriction enforcement | `execution_status`, `.error` | `RestrictionsConfig` defaults apply to both backends |
-| Validation retry | session completes after a rejected cell | |
-| Nested agent/tool calls | event ordering | |
+| Validation retry | session completes after a rejected cell | **Deferred** — not yet covered |
+| Nested agent/tool calls | event ordering | **Deferred** — not yet covered |
 | `PythonOutput` status and ordering | `event_type` sequence, `tool_call_id` | |
 | Runtime exception surfacing | `execution_status is ResultStatus.ERROR` | Error *text* is #189-dependent; assert status and type only |
 | Runtime exception source context | `PythonOutput.error` | **Deferred to #189** — see #191 |
@@ -43,10 +43,11 @@ Not parameterised. Remain in their existing suites.
 
 ## Capability-dependent skips
 
-Sandbox params skip with an explicit reason from `probe_capabilities()`
-(`Capabilities.linux`, `.landlock_abi`, `.seccomp`, `.rlimit`) rather than
-silently degrading. `SandboxConfig(require=False)` keeps portable semantic
-tests runnable where enforcement is unavailable.
+Sandbox params skip with an explicit reason when the host cannot enforce the
+guards the backend relies on — non-Linux, or missing landlock, seccomp or
+rlimit. `SandboxConfig(require=False)` would otherwise let a cell run with
+enforcement absent, so a pass on such a host would say nothing about the
+behaviour being asserted.
 
 ## Open question
 

--- a/tests/runtime/conformance/README.md
+++ b/tests/runtime/conformance/README.md
@@ -20,11 +20,11 @@ pytest node ID, e.g. `test_stdout_is_captured[sandbox]`.
 | Validation retry | session completes after a rejected cell | **Deferred** — not yet covered |
 | Nested agent/tool calls | event ordering | **Deferred** — not yet covered |
 | `PythonOutput` status and ordering | `event_type` sequence, `tool_call_id` | |
-| Runtime exception surfacing | `execution_status is ResultStatus.ERROR` | Error *text* is #189-dependent; assert status and type only |
-| Runtime exception source context | `PythonOutput.error` | **Deferred to #189** — see #191 |
-| SyntaxError source and caret fidelity | `PythonOutput.error` | **Deferred to #189** |
-| Source line and wrapper-offset fidelity | `PythonOutput.error` | **Deferred to #189** |
-| `return_result()` success and failure | method return value | Failure transport is #189-dependent |
+| Runtime exception surfacing | `execution_status is ResultStatus.ERROR` | Status and exception type |
+| Runtime exception source context | `PythonOutput.error` | Frames, source lines and carets; regression guard for #191 |
+| SyntaxError source and caret fidelity | `PythonOutput.error` | **Deferred** — not yet covered |
+| Source line and wrapper-offset fidelity | `PythonOutput.error` | Line numbers pinned per frame |
+| `return_result()` success and failure | method return value | Failure transport **deferred** — not yet covered |
 | Cancellation and timeout | TBD | Parity boundary undefined; see open question |
 
 ## Backend-specific contracts

--- a/tests/runtime/conformance/README.md
+++ b/tests/runtime/conformance/README.md
@@ -11,7 +11,7 @@ pytest node ID, e.g. `test_stdout_is_captured[sandbox]`.
 
 | Contract | Observable via | Notes |
 | --- | --- | --- |
-| Implicit and explicit returns | `PythonOutput.value`, `.explicit_return` | |
+| Implicit and explicit returns | `PythonOutput.value`, `.explicit_return` | Explicit return also auto-completes the task on both backends |
 | stdout capture | `PythonOutput.stdout` | |
 | stderr capture | `PythonOutput.stderr` | |
 | Namespace persistence across cells | cell 2 reads cell 1's binding | |

--- a/tests/runtime/conformance/README.md
+++ b/tests/runtime/conformance/README.md
@@ -17,7 +17,7 @@ pytest node ID, e.g. `test_stdout_is_captured[sandbox]`.
 | Namespace persistence across cells | cell 2 reads cell 1's binding | |
 | Helper definitions across cells | `def` in cell 1, called in cell 2 | |
 | Restriction enforcement | `execution_status`, `.error` | `RestrictionsConfig` defaults apply to both backends |
-| Validation retry | session completes after a rejected cell | **Deferred** — not yet covered |
+| Validation retry | errored `PythonOutput`, session continues | Rejection is correctable, not fatal; namespace survives |
 | Nested agent/tool calls | value, stdout, `event_type` sequence | Brokered calls are observationally invisible on the sandbox path |
 | `PythonOutput` status and ordering | `event_type` sequence, `tool_call_id` | |
 | Runtime exception surfacing | `execution_status is ResultStatus.ERROR` | Status and exception type |

--- a/tests/runtime/conformance/README.md
+++ b/tests/runtime/conformance/README.md
@@ -11,7 +11,7 @@ pytest node ID, e.g. `test_stdout_is_captured[sandbox]`.
 
 | Contract | Observable via | Notes |
 | --- | --- | --- |
-| Implicit and explicit returns | `PythonOutput.value`, `.explicit_return` | Explicit return also auto-completes the task on both backends |
+| Validation retry | errored `PythonOutput`, session continues | Rejection is correctable, not fatal; namespace survives |
 | stdout capture | `PythonOutput.stdout` | |
 | stderr capture | `PythonOutput.stderr` | |
 | Namespace persistence across cells | cell 2 reads cell 1's binding | |

--- a/tests/runtime/conformance/README.md
+++ b/tests/runtime/conformance/README.md
@@ -22,9 +22,10 @@ pytest node ID, e.g. `test_stdout_is_captured[sandbox]`.
 | `PythonOutput` status and ordering | `event_type` sequence, `tool_call_id` | |
 | Runtime exception surfacing | `execution_status is ResultStatus.ERROR` | Status and exception type |
 | Runtime exception source context | `PythonOutput.error` | Frames, source lines and carets; regression guard for #191 |
-| SyntaxError source and caret fidelity | `PythonOutput.error` | **Deferred** — not yet covered |
+| SyntaxError source and caret fidelity | `PythonOutput.error` | Not a parity gap: validation raises before the formatter, so neither backend renders cell location — see #267 |
 | Source line and wrapper-offset fidelity | `PythonOutput.error` | Line numbers pinned per frame |
-| `return_result()` success and failure | method return value | Failure transport **deferred** — not yet covered |
+| `return_result()` success | method return value | Picklable payloads behave identically |
+| `return_result()` failure transport | `PythonOutput.error` | **Backend-specific**: sandbox rejects non-picklable payloads with `CellSerializationError`; in-process returns the live object |
 | Cancellation and timeout | TBD | Parity boundary undefined; see open question |
 
 ## Backend-specific contracts

--- a/tests/runtime/conformance/README.md
+++ b/tests/runtime/conformance/README.md
@@ -18,7 +18,7 @@ pytest node ID, e.g. `test_stdout_is_captured[sandbox]`.
 | Helper definitions across cells | `def` in cell 1, called in cell 2 | |
 | Restriction enforcement | `execution_status`, `.error` | `RestrictionsConfig` defaults apply to both backends |
 | Validation retry | session completes after a rejected cell | **Deferred** — not yet covered |
-| Nested agent/tool calls | event ordering | **Deferred** — not yet covered |
+| Nested agent/tool calls | value, stdout, `event_type` sequence | Brokered calls are observationally invisible on the sandbox path |
 | `PythonOutput` status and ordering | `event_type` sequence, `tool_call_id` | |
 | Runtime exception surfacing | `execution_status is ResultStatus.ERROR` | Status and exception type |
 | Runtime exception source context | `PythonOutput.error` | Frames, source lines and carets; regression guard for #191 |

--- a/tests/runtime/conformance/conftest.py
+++ b/tests/runtime/conformance/conftest.py
@@ -127,3 +127,8 @@ def codeact_agent(backend: Backend):
         return _ConformanceAgent(llm=FakeLLMClient(scripted_responses=scripted_responses))
 
     return _make
+
+
+def outputs(agent) -> list:
+    """Every PythonOutput event the session emitted, in order."""
+    return [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]

--- a/tests/runtime/conformance/conftest.py
+++ b/tests/runtime/conformance/conftest.py
@@ -58,12 +58,37 @@ def finish(result: Any = None, call_id: str = "cret") -> ToolCall:
     return ToolCall(id=call_id, name="return_result", arguments=json.dumps({"result": result}))
 
 
+def _sandbox_skip_reason() -> str | None:
+    """Why the sandbox backend cannot be exercised here, or None if it can.
+
+    ``SandboxConfig(require=False)`` lets a cell run with enforcement missing,
+    so a green test on a host without these guards would say nothing about the
+    behaviour being asserted. Skip explicitly instead.
+    """
+    if not CAPS.linux:
+        return "sandbox backend requires Linux"
+    missing = [
+        name
+        for name, present in (
+            ("landlock", CAPS.landlock_abi >= 1),
+            ("seccomp", CAPS.seccomp),
+            ("rlimit", CAPS.rlimit),
+        )
+        if not present
+    ]
+    if missing:
+        return f"host cannot enforce: {', '.join(missing)}"
+    return None
+
+
 @pytest.fixture(params=BACKENDS)
 def backend(request: pytest.FixtureRequest) -> Backend:
     """The execution backend under test; puts the name in the node ID."""
     name: Backend = request.param
-    if name == "sandbox" and not CAPS.linux:
-        pytest.skip(f"sandbox backend needs Linux (host reports {CAPS.linux=})")
+    if name == "sandbox":
+        reason = _sandbox_skip_reason()
+        if reason is not None:
+            pytest.skip(reason)
     return name
 
 

--- a/tests/runtime/conformance/conftest.py
+++ b/tests/runtime/conformance/conftest.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures for CodeAct backend-conformance tests.
+
+Builds an equivalent CodeAct agent for each execution backend so the same
+observable-contract assertions run against both. See README.md for the matrix
+of shared versus backend-specific contracts.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+import pytest
+
+from nooa import Agent, strategy
+from nooa.config import CodeActConfig
+from nooa.runtime.sandbox.config import SandboxConfig
+from nooa.runtime.sandbox.guards import probe_capabilities
+from nooa.strategies.codeact import CodeActStrategy
+from nooa.unifiedllm import FakeLLMClient, LLMResponse, ToolCall
+
+CAPS = probe_capabilities()
+
+# require=False keeps portable semantic tests runnable where a guard is
+# unavailable; network stays on so the parent-side FakeLLM is irrelevant to
+# the worker. Matches tests/runtime/sandbox/test_codeact_sandbox.py.
+_SANDBOX = SandboxConfig(require=False, network=True, filesystem=False)
+
+
+BACKENDS = [
+    pytest.param("inprocess", id="inprocess"),
+    pytest.param("sandbox", id="sandbox", marks=pytest.mark.sandbox),
+]
+
+Backend = Literal["inprocess", "sandbox"]
+
+
+def resp(content: str = "", tool_calls: list | None = None) -> LLMResponse:
+    """Build a scripted LLM response."""
+    return LLMResponse(
+        raw_response=None,
+        content=content,
+        tool_calls=tool_calls or [],
+        finish_reason="tool_calls" if tool_calls else "stop",
+        assistant_message={"role": "assistant", "content": content},
+    )
+
+
+def cell(code: str, call_id: str = "c1") -> ToolCall:
+    """Build an execute_python tool call."""
+    return ToolCall(id=call_id, name="execute_python", arguments=json.dumps({"code": code}))
+
+
+def finish(result: Any = None, call_id: str = "cret") -> ToolCall:
+    """Build a return_result tool call."""
+    return ToolCall(id=call_id, name="return_result", arguments=json.dumps({"result": result}))
+
+
+@pytest.fixture(params=BACKENDS)
+def backend(request: pytest.FixtureRequest) -> Backend:
+    """The execution backend under test; puts the name in the node ID."""
+    name: Backend = request.param
+    if name == "sandbox" and not CAPS.linux:
+        pytest.skip(f"sandbox backend needs Linux (host reports {CAPS.linux=})")
+    return name
+
+
+@pytest.fixture
+def codeact_agent(backend: Backend):
+    """Build an equivalent CodeAct agent for the backend under test.
+
+    The execution backend is fixed when ``@strategy(...)`` evaluates in the
+    class body, so it cannot be an instance argument; each call defines a
+    fresh agent class closing over ``backend``.
+    """
+
+    def _make(scripted_responses: list[LLMResponse], **attrs: Any) -> Agent:
+        config = CodeActConfig(
+            execution_backend=backend,
+            cell_timeout=15.0,
+            sandbox=_SANDBOX,
+        )
+
+        class _ConformanceAgent(Agent, llm=FakeLLMClient()):
+            def __init__(self, **kwargs: Any):
+                super().__init__(**kwargs)
+                for key, value in attrs.items():
+                    setattr(self, key, value)
+
+            @strategy(CodeActStrategy(config=config))
+            async def run(self) -> Any:
+                """Run the scripted cells and finish via return_result."""
+                ...
+
+            def note_pid(self, pid: int) -> int:
+                """Record the pid of the process that executed the cell."""
+                self.seen_pid = pid
+                return pid
+
+        return _ConformanceAgent(llm=FakeLLMClient(scripted_responses=scripted_responses))
+
+    return _make

--- a/tests/runtime/conformance/conftest.py
+++ b/tests/runtime/conformance/conftest.py
@@ -124,6 +124,10 @@ def codeact_agent(backend: Backend):
                 self.seen_pid = pid
                 return pid
 
+            def helper(self, x: int) -> int:
+                """Double a value, brokered back to the parent from the worker."""
+                return x * 2
+
         return _ConformanceAgent(llm=FakeLLMClient(scripted_responses=scripted_responses))
 
     return _make

--- a/tests/runtime/conformance/test_error_context.py
+++ b/tests/runtime/conformance/test_error_context.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared contract: agent-facing errors carry equivalent source context.
+
+The sandbox path reconstructs diagnostics across a process boundary. It
+previously dropped every frame, leaving the agent with only the exception line
+(#191, fixed by #189). These pin the rendered guidance as a parity contract.
+"""
+
+from __future__ import annotations
+
+from .conftest import cell, finish, outputs, resp
+
+_FAILING_CELL = "def inner():\n    return None.strip()\n\ninner()"
+
+
+async def test_single_frame_error_carries_source_context(codeact_agent):
+    """Cell identity, line number and source line reach the agent on both backends."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("raise ValueError('deliberate')", call_id="c1")]),
+            resp("", tool_calls=[finish(result=7)]),
+        ]
+    )
+    assert await agent.run() == 7
+
+    error = outputs(agent)[0].error
+    assert "Cell In[1], line 1, in <module>" in error
+    assert "raise ValueError('deliberate')" in error
+    assert "ValueError: deliberate" in error
+
+
+async def test_multi_frame_error_carries_every_frame(codeact_agent):
+    """Both frames, their source lines and their carets survive on both backends."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell(_FAILING_CELL, call_id="c1")]),
+            resp("", tool_calls=[finish(result=7)]),
+        ]
+    )
+    assert await agent.run() == 7
+
+    error = outputs(agent)[0].error
+    assert "Cell In[1], line 4, in <module>" in error
+    assert "Cell In[1], line 2, in inner" in error
+    assert "return None.strip()" in error
+    assert "^^^^^^^^^^" in error
+    assert "AttributeError: 'NoneType' object has no attribute 'strip'" in error

--- a/tests/runtime/conformance/test_error_context.py
+++ b/tests/runtime/conformance/test_error_context.py
@@ -44,5 +44,10 @@ async def test_multi_frame_error_carries_every_frame(codeact_agent):
     assert "Cell In[1], line 4, in <module>" in error
     assert "Cell In[1], line 2, in inner" in error
     assert "return None.strip()" in error
-    assert "^^^^^^^^^^" in error
     assert "AttributeError: 'NoneType' object has no attribute 'strip'" in error
+
+    lines = error.splitlines()
+    source_index = next(i for i, line in enumerate(lines) if "return None.strip()" in line)
+    caret_line = lines[source_index + 1]
+    assert caret_line.strip() == "^" * 10
+    assert caret_line.index("^") == lines[source_index].index("None.strip")

--- a/tests/runtime/conformance/test_events.py
+++ b/tests/runtime/conformance/test_events.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 
 from nooa.events import ResultStatus
 
-from .conftest import cell, finish, resp
+from .conftest import cell, finish, outputs, resp
 
 
 async def test_event_sequence_is_equivalent(codeact_agent):
-    """One cell then a return produces the same ordered event types on both backends."""
+    """IPC must not introduce extra events or reorder the ones the in-process path emits."""
     agent = codeact_agent(
         [
             resp("", tool_calls=[cell("x = 1", call_id="c1")]),
@@ -24,7 +24,7 @@ async def test_event_sequence_is_equivalent(codeact_agent):
 
 
 async def test_python_output_links_to_its_tool_call(codeact_agent):
-    """Each PythonOutput carries the tool_call_id of the cell that produced it."""
+    """Out-of-order delivery would break Out[n] lookup, so the id must round-trip."""
     agent = codeact_agent(
         [
             resp("", tool_calls=[cell("a = 1", call_id="c1")]),
@@ -34,12 +34,11 @@ async def test_python_output_links_to_its_tool_call(codeact_agent):
     )
     assert await agent.run() == 1
 
-    outputs = [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
-    assert [o.tool_call_id for o in outputs] == ["c1", "c2"]
+    assert [o.tool_call_id for o in outputs(agent)] == ["c1", "c2"]
 
 
 async def test_execution_counts_increment_in_order(codeact_agent):
-    """Successive cells receive increasing execution counts."""
+    """Counts must be consecutive; the start value is left unpinned pending #189."""
     agent = codeact_agent(
         [
             resp("", tool_calls=[cell("a = 1", call_id="c1")]),
@@ -49,14 +48,12 @@ async def test_execution_counts_increment_in_order(codeact_agent):
     )
     assert await agent.run() == 1
 
-    outputs = [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
-    counts = [o.execution_count for o in outputs]
+    counts = [o.execution_count for o in outputs(agent)]
     assert counts == list(range(counts[0], counts[0] + len(counts)))
-    assert len(set(counts)) == len(counts)
 
 
 async def test_successful_cells_report_complete(codeact_agent):
-    """A cell that runs without error reports COMPLETE on both backends."""
+    """A clean cell must not carry residual error text from the transport layer."""
     agent = codeact_agent(
         [
             resp("", tool_calls=[cell("x = 1", call_id="c1")]),
@@ -65,7 +62,7 @@ async def test_successful_cells_report_complete(codeact_agent):
     )
     assert await agent.run() == 1
 
-    outputs = [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
-    assert len(outputs) == 1
-    assert outputs[0].execution_status is ResultStatus.COMPLETE
-    assert outputs[0].error == ""
+    events = outputs(agent)
+    assert len(events) == 1
+    assert events[0].execution_status is ResultStatus.COMPLETE
+    assert events[0].error == ""

--- a/tests/runtime/conformance/test_events.py
+++ b/tests/runtime/conformance/test_events.py
@@ -51,7 +51,7 @@ async def test_execution_counts_increment_in_order(codeact_agent):
 
     outputs = [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
     counts = [o.execution_count for o in outputs]
-    assert counts == sorted(counts)
+    assert counts == list(range(counts[0], counts[0] + len(counts)))
     assert len(set(counts)) == len(counts)
 
 

--- a/tests/runtime/conformance/test_events.py
+++ b/tests/runtime/conformance/test_events.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared contract: event sequence and PythonOutput identity match across backends."""
+
+from __future__ import annotations
+
+from nooa.events import ResultStatus
+
+from .conftest import cell, finish, resp
+
+
+async def test_event_sequence_is_equivalent(codeact_agent):
+    """One cell then a return produces the same ordered event types on both backends."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("x = 1", call_id="c1")]),
+            resp("", tool_calls=[finish(result=1)]),
+        ]
+    )
+    assert await agent.run() == 1
+
+    event_types = [e.event_type for e in agent.event_manager.values()]
+    assert event_types == ["Task", "ToolCallEvent", "PythonOutput", "ToolCallEvent"]
+
+
+async def test_python_output_links_to_its_tool_call(codeact_agent):
+    """Each PythonOutput carries the tool_call_id of the cell that produced it."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("a = 1", call_id="c1")]),
+            resp("", tool_calls=[cell("b = 2", call_id="c2")]),
+            resp("", tool_calls=[finish(result=1)]),
+        ]
+    )
+    assert await agent.run() == 1
+
+    outputs = [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
+    assert [o.tool_call_id for o in outputs] == ["c1", "c2"]
+
+
+async def test_execution_counts_increment_in_order(codeact_agent):
+    """Successive cells receive increasing execution counts."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("a = 1", call_id="c1")]),
+            resp("", tool_calls=[cell("b = 2", call_id="c2")]),
+            resp("", tool_calls=[finish(result=1)]),
+        ]
+    )
+    assert await agent.run() == 1
+
+    outputs = [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
+    counts = [o.execution_count for o in outputs]
+    assert counts == sorted(counts)
+    assert len(set(counts)) == len(counts)
+
+
+async def test_successful_cells_report_complete(codeact_agent):
+    """A cell that runs without error reports COMPLETE on both backends."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("x = 1", call_id="c1")]),
+            resp("", tool_calls=[finish(result=1)]),
+        ]
+    )
+    assert await agent.run() == 1
+
+    outputs = [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
+    assert len(outputs) == 1
+    assert outputs[0].execution_status is ResultStatus.COMPLETE
+    assert outputs[0].error == ""

--- a/tests/runtime/conformance/test_harness.py
+++ b/tests/runtime/conformance/test_harness.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Guards on the conformance harness itself.
+
+These verify the fixture builds a working agent and that each parameterisation
+actually engages the backend it names — a false green here would invalidate
+every conformance assertion built on top.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .conftest import cell, finish, resp
+
+
+async def test_fixture_builds_a_working_agent(codeact_agent):
+    agent = codeact_agent(
+        [resp("", tool_calls=[cell("x = 1 + 1")]), resp("", tool_calls=[finish(result=2)])]
+    )
+    assert await agent.run() == 2
+
+
+async def test_fixture_selects_the_requested_backend(codeact_agent, backend):
+    """The cell's pid differs from the parent's only on the sandbox backend."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("import os\nself.note_pid(os.getpid())")]),
+            resp("", tool_calls=[finish(result=1)]),
+        ],
+    )
+    assert await agent.run() == 1
+    if backend == "sandbox":
+        assert agent.seen_pid != os.getpid()
+    else:
+        assert agent.seen_pid == os.getpid()

--- a/tests/runtime/conformance/test_namespace.py
+++ b/tests/runtime/conformance/test_namespace.py
@@ -4,11 +4,11 @@
 
 from __future__ import annotations
 
-from .conftest import cell, finish, resp
+from .conftest import cell, finish, outputs, resp
 
 
 async def test_bindings_persist_across_cells(codeact_agent):
-    """A name bound in cell 1 is readable in cell 2."""
+    """The sandbox keeps a live worker namespace rather than re-executing prior cells."""
     agent = codeact_agent(
         [
             resp("", tool_calls=[cell("total = 40", call_id="c1")]),
@@ -18,13 +18,13 @@ async def test_bindings_persist_across_cells(codeact_agent):
     )
     assert await agent.run() == 1
 
-    outputs = [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
-    assert len(outputs) == 2
-    assert "42" in outputs[1].stdout
+    events = outputs(agent)
+    assert len(events) == 2
+    assert "42" in events[1].stdout
 
 
 async def test_helper_definitions_persist_across_cells(codeact_agent):
-    """A function defined in cell 1 is callable in cell 2."""
+    """Function objects survive between cells without being re-sent across the boundary."""
     agent = codeact_agent(
         [
             resp("", tool_calls=[cell("def double(v):\n    return v * 2", call_id="c1")]),
@@ -34,13 +34,13 @@ async def test_helper_definitions_persist_across_cells(codeact_agent):
     )
     assert await agent.run() == 1
 
-    outputs = [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
-    assert len(outputs) == 2
-    assert "42" in outputs[1].stdout
+    events = outputs(agent)
+    assert len(events) == 2
+    assert "42" in events[1].stdout
 
 
 async def test_imports_persist_across_cells(codeact_agent):
-    """A module imported in cell 1 is bound in cell 2."""
+    """Module objects stay bound in the worker namespace; they are not re-imported per cell."""
     agent = codeact_agent(
         [
             resp("", tool_calls=[cell("import math", call_id="c1")]),
@@ -50,6 +50,6 @@ async def test_imports_persist_across_cells(codeact_agent):
     )
     assert await agent.run() == 1
 
-    outputs = [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
-    assert len(outputs) == 2
-    assert "42" in outputs[1].stdout
+    events = outputs(agent)
+    assert len(events) == 2
+    assert "42" in events[1].stdout

--- a/tests/runtime/conformance/test_namespace.py
+++ b/tests/runtime/conformance/test_namespace.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared contract: the REPL namespace persists across cells on both backends."""
+
+from __future__ import annotations
+
+from .conftest import cell, finish, resp
+
+
+async def test_bindings_persist_across_cells(codeact_agent):
+    """A name bound in cell 1 is readable in cell 2."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("total = 40", call_id="c1")]),
+            resp("", tool_calls=[cell("print(total + 2)", call_id="c2")]),
+            resp("", tool_calls=[finish(result=1)]),
+        ]
+    )
+    assert await agent.run() == 1
+
+    outputs = [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
+    assert len(outputs) == 2
+    assert "42" in outputs[1].stdout
+
+
+async def test_helper_definitions_persist_across_cells(codeact_agent):
+    """A function defined in cell 1 is callable in cell 2."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("def double(v):\n    return v * 2", call_id="c1")]),
+            resp("", tool_calls=[cell("print(double(21))", call_id="c2")]),
+            resp("", tool_calls=[finish(result=1)]),
+        ]
+    )
+    assert await agent.run() == 1
+
+    outputs = [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
+    assert len(outputs) == 2
+    assert "42" in outputs[1].stdout
+
+
+async def test_imports_persist_across_cells(codeact_agent):
+    """A module imported in cell 1 is bound in cell 2."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("import math", call_id="c1")]),
+            resp("", tool_calls=[cell("print(math.floor(42.9))", call_id="c2")]),
+            resp("", tool_calls=[finish(result=1)]),
+        ]
+    )
+    assert await agent.run() == 1
+
+    outputs = [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
+    assert len(outputs) == 2
+    assert "42" in outputs[1].stdout

--- a/tests/runtime/conformance/test_nested_calls.py
+++ b/tests/runtime/conformance/test_nested_calls.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared contract: calls back into the agent are observationally identical.
+
+In-process, ``self.helper(...)`` is an ordinary method call. On the sandbox path
+the worker suspends, the parent executes the method, and the result crosses back
+through the broker. These pin that the machinery stays invisible: same value,
+same stdout, same event sequence, no broker-specific event.
+"""
+
+from __future__ import annotations
+
+from nooa.events import ResultStatus
+
+from .conftest import cell, finish, outputs, resp
+
+
+async def test_agent_method_call_returns_the_same_value(codeact_agent):
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("print(self.helper(20))", call_id="c1")]),
+            resp("", tool_calls=[finish(result=7)]),
+        ]
+    )
+    assert await agent.run() == 7
+
+    events = outputs(agent)
+    assert len(events) == 1
+    assert events[0].stdout.strip() == "40"
+    assert events[0].execution_status is ResultStatus.COMPLETE
+
+
+async def test_brokered_call_adds_no_events(codeact_agent):
+    """A call back into the agent emits nothing of its own on either backend."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("v = self.helper(20)", call_id="c1")]),
+            resp("", tool_calls=[finish(result=7)]),
+        ]
+    )
+    assert await agent.run() == 7
+
+    assert [e.event_type for e in agent.event_manager.values()] == [
+        "Task",
+        "ToolCallEvent",
+        "PythonOutput",
+        "ToolCallEvent",
+    ]
+
+
+async def test_brokered_result_persists_in_the_namespace(codeact_agent):
+    """A value obtained through the broker is an ordinary binding afterwards."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("v = self.helper(20)", call_id="c1")]),
+            resp("", tool_calls=[cell("print(v + 2)", call_id="c2")]),
+            resp("", tool_calls=[finish(result=7)]),
+        ]
+    )
+    assert await agent.run() == 7
+
+    events = outputs(agent)
+    assert len(events) == 2
+    assert events[1].stdout.strip() == "42"
+
+
+async def test_repeated_brokered_calls_all_resolve(codeact_agent):
+    """Several calls in one cell each cross and return independently."""
+    agent = codeact_agent(
+        [
+            resp(
+                "", tool_calls=[cell("print(sum(self.helper(i) for i in range(4)))", call_id="c1")]
+            ),
+            resp("", tool_calls=[finish(result=7)]),
+        ]
+    )
+    assert await agent.run() == 7
+
+    assert outputs(agent)[0].stdout.strip() == "12"

--- a/tests/runtime/conformance/test_output_capture.py
+++ b/tests/runtime/conformance/test_output_capture.py
@@ -4,14 +4,7 @@
 
 from __future__ import annotations
 
-from nooa.events import PythonOutput
-
-from .conftest import cell, finish, resp
-
-
-def _outputs(agent) -> list[PythonOutput]:
-    """Every PythonOutput event the session emitted, in order."""
-    return [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
+from .conftest import cell, finish, outputs, resp
 
 
 async def test_stdout_is_captured(codeact_agent):
@@ -23,13 +16,14 @@ async def test_stdout_is_captured(codeact_agent):
     )
     assert await agent.run() == 1
 
-    outputs = _outputs(agent)
-    assert len(outputs) == 1
-    assert "hello from the cell" in outputs[0].stdout
-    assert outputs[0].stderr == ""
+    events = outputs(agent)
+    assert len(events) == 1
+    assert "hello from the cell" in events[0].stdout
+    assert events[0].stderr == ""
 
 
 async def test_stderr_is_captured(codeact_agent):
+    """Sandbox stderr crosses a worker pipe; the streams must stay separated."""
     agent = codeact_agent(
         [
             resp("", tool_calls=[cell("import sys\nprint('warned', file=sys.stderr)")]),
@@ -38,7 +32,7 @@ async def test_stderr_is_captured(codeact_agent):
     )
     assert await agent.run() == 1
 
-    outputs = _outputs(agent)
-    assert len(outputs) == 1
-    assert "warned" in outputs[0].stderr
-    assert "warned" not in outputs[0].stdout
+    events = outputs(agent)
+    assert len(events) == 1
+    assert "warned" in events[0].stderr
+    assert "warned" not in events[0].stdout

--- a/tests/runtime/conformance/test_output_capture.py
+++ b/tests/runtime/conformance/test_output_capture.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared contract: stdout and stderr capture is equivalent across backends."""
+
+from __future__ import annotations
+
+from nooa.events import PythonOutput
+
+from .conftest import cell, finish, resp
+
+
+def _outputs(agent) -> list[PythonOutput]:
+    """Every PythonOutput event the session emitted, in order."""
+    return [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
+
+
+async def test_stdout_is_captured(codeact_agent):
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("print('hello from the cell')")]),
+            resp("", tool_calls=[finish(result=1)]),
+        ]
+    )
+    assert await agent.run() == 1
+
+    outputs = _outputs(agent)
+    assert len(outputs) == 1
+    assert "hello from the cell" in outputs[0].stdout
+    assert outputs[0].stderr == ""
+
+
+async def test_stderr_is_captured(codeact_agent):
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("import sys\nprint('warned', file=sys.stderr)")]),
+            resp("", tool_calls=[finish(result=1)]),
+        ]
+    )
+    assert await agent.run() == 1
+
+    outputs = _outputs(agent)
+    assert len(outputs) == 1
+    assert "warned" in outputs[0].stderr
+    assert "warned" not in outputs[0].stdout

--- a/tests/runtime/conformance/test_retry.py
+++ b/tests/runtime/conformance/test_retry.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared contract: a rejected cell is correctable, not fatal.
+
+Validation runs on the parent for both backends, so a rejection must reach the
+model as an errored PythonOutput carrying enough context to fix the cell, and the
+session must continue rather than abort. The error text here comes from the
+validator's issue formatter, which renders cell identity, line and caret — unlike
+the SyntaxError path in the same class (see #267).
+"""
+
+from __future__ import annotations
+
+from nooa.events import ResultStatus
+
+from .conftest import cell, finish, outputs, resp
+
+
+async def test_rejected_cell_is_correctable(codeact_agent):
+    """The model gets an errored output and its next cell runs normally."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("import subprocess", call_id="c1")]),
+            resp("", tool_calls=[cell("x = 1 + 1\nprint(x)", call_id="c2")]),
+            resp("", tool_calls=[finish(result=7)]),
+        ]
+    )
+    assert await agent.run() == 7
+
+    events = outputs(agent)
+    assert [e.tool_call_id for e in events] == ["c1", "c2"]
+    assert events[0].execution_status is ResultStatus.ERROR
+    assert events[1].execution_status is ResultStatus.COMPLETE
+    assert "2" in events[1].stdout
+
+
+async def test_rejection_carries_correctable_context(codeact_agent):
+    """A rejection names the cell, the line and the offending source."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("import subprocess", call_id="c1")]),
+            resp("", tool_calls=[finish(result=7)]),
+        ]
+    )
+    assert await agent.run() == 7
+
+    error = outputs(agent)[0].error
+    assert "Cell In[1], line 1" in error
+    assert "import subprocess" in error
+    assert "subprocess" in error
+
+
+async def test_rejection_does_not_disturb_the_event_sequence(codeact_agent):
+    """A rejected cell produces the same event shape as a successful one."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("import subprocess", call_id="c1")]),
+            resp("", tool_calls=[cell("x = 1", call_id="c2")]),
+            resp("", tool_calls=[finish(result=7)]),
+        ]
+    )
+    assert await agent.run() == 7
+
+    assert [e.event_type for e in agent.event_manager.values()] == [
+        "Task",
+        "ToolCallEvent",
+        "PythonOutput",
+        "ToolCallEvent",
+        "PythonOutput",
+        "ToolCallEvent",
+    ]
+
+
+async def test_namespace_survives_a_rejected_cell(codeact_agent):
+    """A rejection must not reset the session namespace."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("keep = 41", call_id="c1")]),
+            resp("", tool_calls=[cell("import subprocess", call_id="c2")]),
+            resp("", tool_calls=[cell("print(keep + 1)", call_id="c3")]),
+            resp("", tool_calls=[finish(result=7)]),
+        ]
+    )
+    assert await agent.run() == 7
+
+    events = outputs(agent)
+    assert events[1].execution_status is ResultStatus.ERROR
+    assert "42" in events[2].stdout

--- a/tests/runtime/conformance/test_return_result.py
+++ b/tests/runtime/conformance/test_return_result.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""return_result(): success is shared, failure transport is backend-specific.
+
+A picklable payload behaves identically on both backends. A non-picklable one
+does not, and deliberately so: the sandbox returns the value across a process
+boundary, so it must be picklable, while the in-process backend hands back the
+live object. These pin that divergence as an intended contract rather than
+leaving it undocumented — an agent developed against the default backend can
+otherwise return a live object and fail only once the sandbox is enabled.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nooa.events import ResultStatus
+
+from .conftest import cell, finish, outputs, resp
+
+_MAKE_LOCK = "import threading\nbad = threading.Lock()"
+
+
+async def test_picklable_payload_returns_on_both_backends(codeact_agent):
+    """The shared half of the contract: a JSON-safe payload round-trips identically."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("payload = {'n': 42, 'xs': [1, 2, 3]}", call_id="c1")]),
+            resp("", tool_calls=[finish(result={"n": 42, "xs": [1, 2, 3]})]),
+        ]
+    )
+    assert await agent.run() == {"n": 42, "xs": [1, 2, 3]}
+    assert all(e.execution_status is ResultStatus.COMPLETE for e in outputs(agent))
+
+
+@pytest.mark.sandbox
+async def test_unpicklable_payload_is_rejected_on_sandbox():
+    """Backend-specific: the payload must cross a process boundary, so it must pickle."""
+    from nooa import Agent, strategy  # noqa: PLC0415
+    from nooa.config import CodeActConfig  # noqa: PLC0415
+    from nooa.strategies.codeact import CodeActStrategy  # noqa: PLC0415
+    from nooa.unifiedllm import FakeLLMClient  # noqa: PLC0415
+
+    from .conftest import _SANDBOX  # noqa: PLC0415
+
+    llm = FakeLLMClient(
+        scripted_responses=[
+            resp("", tool_calls=[cell(_MAKE_LOCK, call_id="c1")]),
+            resp("", tool_calls=[cell("return_result(bad)", call_id="c2")]),
+            resp("", tool_calls=[finish(result=7)]),
+        ]
+    )
+
+    class _SandboxAgent(Agent, llm=FakeLLMClient()):
+        @strategy(
+            CodeActStrategy(
+                config=CodeActConfig(
+                    execution_backend="sandbox", cell_timeout=15.0, sandbox=_SANDBOX
+                )
+            )
+        )
+        async def run(self) -> Any:
+            """Return an unpicklable value."""
+            ...
+
+    agent = _SandboxAgent(llm=llm)
+    assert await agent.run() == 7
+
+    events = outputs(agent)
+    assert events[-1].execution_status is ResultStatus.ERROR
+    assert "CellSerializationError" in events[-1].error
+    assert "picklable" in events[-1].error

--- a/tests/runtime/conformance/test_returns.py
+++ b/tests/runtime/conformance/test_returns.py
@@ -38,6 +38,21 @@ async def test_statement_only_cell_has_no_value(codeact_agent):
     events = outputs(agent)
     assert len(events) == 1
     assert events[0].value is None
+    assert events[0].explicit_return is False
+
+
+async def test_explicit_none_return_sets_the_discriminator(codeact_agent):
+    """An explicit `return None` carries the opposite discriminator to an absent value.
+
+    An explicit return also auto-completes the task, so no further cell runs.
+    """
+    agent = codeact_agent([resp("", tool_calls=[cell("return None", call_id="c1")])])
+    assert await agent.run() is None
+
+    events = outputs(agent)
+    assert len(events) == 1
+    assert events[0].value is None
+    assert events[0].explicit_return is True
 
 
 async def test_runtime_error_reports_error_status(codeact_agent):
@@ -69,3 +84,4 @@ async def test_blocked_import_reports_error_status(codeact_agent):
     events = outputs(agent)
     assert len(events) == 1
     assert events[0].execution_status is ResultStatus.ERROR
+    assert "subprocess" in events[0].error

--- a/tests/runtime/conformance/test_returns.py
+++ b/tests/runtime/conformance/test_returns.py
@@ -6,15 +6,11 @@ from __future__ import annotations
 
 from nooa.events import ResultStatus
 
-from .conftest import cell, finish, resp
-
-
-def _outputs(agent):
-    return [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
+from .conftest import cell, finish, outputs, resp
 
 
 async def test_trailing_expression_is_captured_as_value(codeact_agent):
-    """A bare trailing expression lands on PythonOutput.value."""
+    """The value is pickled across the boundary on the sandbox path, not recomputed."""
     agent = codeact_agent(
         [
             resp("", tool_calls=[cell("6 * 7", call_id="c1")]),
@@ -23,14 +19,14 @@ async def test_trailing_expression_is_captured_as_value(codeact_agent):
     )
     assert await agent.run() == 1
 
-    outputs = _outputs(agent)
-    assert len(outputs) == 1
-    assert outputs[0].value == 42
-    assert outputs[0].explicit_return is False
+    events = outputs(agent)
+    assert len(events) == 1
+    assert events[0].value == 42
+    assert events[0].explicit_return is False
 
 
 async def test_statement_only_cell_has_no_value(codeact_agent):
-    """A cell ending in a statement reports no value."""
+    """Absent must stay distinguishable from a returned None."""
     agent = codeact_agent(
         [
             resp("", tool_calls=[cell("x = 6 * 7", call_id="c1")]),
@@ -39,13 +35,13 @@ async def test_statement_only_cell_has_no_value(codeact_agent):
     )
     assert await agent.run() == 1
 
-    outputs = _outputs(agent)
-    assert len(outputs) == 1
-    assert outputs[0].value is None
+    events = outputs(agent)
+    assert len(events) == 1
+    assert events[0].value is None
 
 
 async def test_runtime_error_reports_error_status(codeact_agent):
-    """A raising cell reports ERROR and the session still completes."""
+    """The exception type must survive reconstruction, and the session must continue."""
     agent = codeact_agent(
         [
             resp("", tool_calls=[cell("raise ValueError('deliberate')", call_id="c1")]),
@@ -54,14 +50,14 @@ async def test_runtime_error_reports_error_status(codeact_agent):
     )
     assert await agent.run() == 7
 
-    outputs = _outputs(agent)
-    assert len(outputs) == 1
-    assert outputs[0].execution_status is ResultStatus.ERROR
-    assert "ValueError" in outputs[0].error
+    events = outputs(agent)
+    assert len(events) == 1
+    assert events[0].execution_status is ResultStatus.ERROR
+    assert "ValueError" in events[0].error
 
 
 async def test_blocked_import_reports_error_status(codeact_agent):
-    """RestrictionsConfig defaults apply to both backends."""
+    """Rejection must surface as an errored event, not be swallowed before emission."""
     agent = codeact_agent(
         [
             resp("", tool_calls=[cell("import subprocess", call_id="c1")]),
@@ -70,6 +66,6 @@ async def test_blocked_import_reports_error_status(codeact_agent):
     )
     assert await agent.run() == 7
 
-    outputs = _outputs(agent)
-    assert len(outputs) == 1
-    assert outputs[0].execution_status is ResultStatus.ERROR
+    events = outputs(agent)
+    assert len(events) == 1
+    assert events[0].execution_status is ResultStatus.ERROR

--- a/tests/runtime/conformance/test_returns.py
+++ b/tests/runtime/conformance/test_returns.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared contract: cell return values and failure status match across backends."""
+
+from __future__ import annotations
+
+from nooa.events import ResultStatus
+
+from .conftest import cell, finish, resp
+
+
+def _outputs(agent):
+    return [e for e in agent.event_manager.values() if e.event_type == "PythonOutput"]
+
+
+async def test_trailing_expression_is_captured_as_value(codeact_agent):
+    """A bare trailing expression lands on PythonOutput.value."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("6 * 7", call_id="c1")]),
+            resp("", tool_calls=[finish(result=1)]),
+        ]
+    )
+    assert await agent.run() == 1
+
+    outputs = _outputs(agent)
+    assert len(outputs) == 1
+    assert outputs[0].value == 42
+    assert outputs[0].explicit_return is False
+
+
+async def test_statement_only_cell_has_no_value(codeact_agent):
+    """A cell ending in a statement reports no value."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("x = 6 * 7", call_id="c1")]),
+            resp("", tool_calls=[finish(result=1)]),
+        ]
+    )
+    assert await agent.run() == 1
+
+    outputs = _outputs(agent)
+    assert len(outputs) == 1
+    assert outputs[0].value is None
+
+
+async def test_runtime_error_reports_error_status(codeact_agent):
+    """A raising cell reports ERROR and the session still completes."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("raise ValueError('deliberate')", call_id="c1")]),
+            resp("", tool_calls=[finish(result=7)]),
+        ]
+    )
+    assert await agent.run() == 7
+
+    outputs = _outputs(agent)
+    assert len(outputs) == 1
+    assert outputs[0].execution_status is ResultStatus.ERROR
+    assert "ValueError" in outputs[0].error
+
+
+async def test_blocked_import_reports_error_status(codeact_agent):
+    """RestrictionsConfig defaults apply to both backends."""
+    agent = codeact_agent(
+        [
+            resp("", tool_calls=[cell("import subprocess", call_id="c1")]),
+            resp("", tool_calls=[finish(result=7)]),
+        ]
+    )
+    assert await agent.run() == 7
+
+    outputs = _outputs(agent)
+    assert len(outputs) == 1
+    assert outputs[0].execution_status is ResultStatus.ERROR


### PR DESCRIPTION
## Overview

Adds a CodeAct backend-conformance harness parameterised over the `inprocess`
and `sandbox` execution backends, so observable contracts intended to match are
asserted against both. Partially addresses #187.

## What changed

### Harness

`tests/runtime/conformance/conftest.py` builds an equivalent CodeAct agent per
backend. The backend is fixed when `@strategy(...)` evaluates in the class body,
so the factory defines a fresh agent class closing over the parameter rather
than passing it as an instance argument.

Markers live on the fixture params:

```python
BACKENDS = [
    pytest.param("inprocess", id="inprocess"),
    pytest.param("sandbox", id="sandbox", marks=pytest.mark.sandbox),
]
```

One test function therefore yields `test_stdout_is_captured[inprocess]` and
`test_stdout_is_captured[sandbox]`. The current `addopts` deselects the sandbox
parameterisation; `-m sandbox` selects it. This works whether sandbox
conformance ends up in the default suite or a separate CI job — see the open
question below.

`SandboxConfig(require=False)` keeps portable semantic tests runnable, and
capability-dependent cases skip with an explicit reason from
`probe_capabilities()` rather than silently degrading.

`test_harness.py` guards the harness itself: one test asserts each
parameterisation actually engages the backend it names, by comparing the cell's
pid to the parent's. A false green there would invalidate every assertion built
on top.

### Contracts covered

`tests/runtime/conformance/README.md` documents the full matrix of shared
versus backend-specific contracts. Covered in this PR:

- stdout and stderr capture
- namespace persistence across cells (bindings, helper definitions, imports)
- `PythonOutput` event ordering, `tool_call_id` linkage, execution-count
  monotonicity, and `COMPLETE` status on success
- implicit return values via `PythonOutput.value` and `explicit_return`
- runtime exception surfacing as `ResultStatus.ERROR` carrying the exception type
- `RestrictionsConfig` rejection surfacing as an errored `PythonOutput`
- error source context: cell identity, per-frame line numbers, source lines and
  caret column, asserted identical on both backends (regression guard for #191)

### Still uncovered

SyntaxError caret fidelity, `return_result()` failure transport, validation
retry, nested tool calls, and cancellation/timeout parity. Existing
backend-specific suites are not yet deduplicated.

## Validation

Rebased onto `36020a2` (post-#189). Every conformance assertion survived that
rework unchanged, including the error-text assertions.

- Full suite: 6765 passed, 154 skipped, 316 deselected, 3 xfailed (208s)
- Sandbox suite: 80 passed, 1 skipped (28.7s) — 18 of those are new here
- `ruff format --check .` and `ruff check .` clean repo-wide
- Capability skips verified by forcing `landlock_abi=0`: all sandbox params skip
  with the missing guard named
- Host capabilities: `Capabilities(linux=True, landlock_abi=3, seccomp=True,
  rlimit=True)`

CI has not run on this PR — the workflow is still awaiting maintainer approval.

## Open question

Should sandbox conformance run in the default suite or a separate CI job? The
harness works either way, so this PR does not change CI configuration. Happy to
wire up whichever you prefer.

Also raised in the matrix: which cancellation and timeout semantics are intended
to match? `cell_timeout` is a hard bound under sandbox and cooperative
in-process, so full parity may not be the goal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added cross-backend conformance coverage for event ordering, execution counts, output capture, return values, errors, imports, and persistent namespaces.
  - Added validation that sandbox and in-process execution use the requested backend and process behavior.
  - Added checks for successful completion and accurate error reporting, including source context, across runtime scenarios.
  - Unsupported sandbox enforcement environments now skip validation rather than running without enforcement.

- **Documentation**
  - Added a conformance matrix describing shared runtime contracts, backend-specific behavior, capability-based skips, and deferred coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->