### PR TITLE
fix(runtime): honor parameter truncation specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ to follow semantic versioning.
 ## [Unreleased]
 
 - Initial public release of NVIDIA Object-Oriented Agents (NOOA).
+- Fixed generation runtimes ignoring per-parameter
+  `Annotated[T, spec(max_string=..., max_length=..., max_depth=...)]` rendering
+  overrides, and aligned `print_prompt()` with method-level truncation settings.
 - Security: MCP server configurations no longer expand host environment variables
   from `${VAR}` placeholders. Trusted caller code must resolve secrets and pass
   their values explicitly.

--- a/docs/concepts/prompts-and-context.md
+++ b/docs/concepts/prompts-and-context.md
@@ -41,6 +41,42 @@ because it is trusted configuration not present in the method signature.
 The `text` parameter is already rendered by the strategy. Do not repeat it as
 `{text}` in the docstring.
 
+## Per-parameter rendering limits
+
+Use `spec()` metadata when one parameter needs different rendering limits from
+the rest of the agent:
+
+```python
+from typing import Annotated
+
+from nooa import Agent, spec
+
+
+class Analyzer(Agent, llm=llm):
+    async def analyze(
+        self,
+        document: Annotated[str, spec(max_string=None)],
+        samples: Annotated[list[dict], spec(max_length=100, max_depth=6)],
+    ) -> str:
+        """Analyze the document and representative samples."""
+        ...
+```
+
+`max_string`, `max_length`, and `max_depth` override
+`TruncationConfig.prefill_format` for that parameter. `None` disables the
+corresponding formatting limit. The complete objects remain live in CodeAct's
+REPL even when their printed previews are truncated.
+
+Rendering settings resolve from framework defaults through agent class, agent
+instance, and method-level `@strategy(..., truncation=...)` configuration. A
+parameter's `spec()` metadata has final precedence for that parameter.
+
+CodeAct's inspection prefill writes rendered values to stdout, which has an
+independent capture limit (`capture.max_stdout`, 50,000 characters by default).
+Consequently, `spec(max_string=None)` disables string formatting truncation but
+does not disable stdout capture truncation. Raise `capture.max_stdout`
+explicitly when a complete printed value can exceed that separate limit.
+
 ## Context blocks are deliberate prompt input
 
 Context blocks are named sections added to the system prompt:

--- a/skills/nooa-codeact-advanced/SKILL.md
+++ b/skills/nooa-codeact-advanced/SKILL.md
@@ -21,6 +21,18 @@ Before the first LLM turn, CodeAct runs up to two **synthetic `execute_python` c
 1. **The prefill plugin** (default `InspectInputsPrefill()`): generates code that prints the call signature, `pprint()`s each parameter under `truncation.prefill_format` limits (defaults `max_string=2000, max_length=25, max_depth=4`), auto-`show()`s `Media` parameters for multimodal perception, and prints `doc()` of a complex return type. Per-parameter limits come from `Annotated[T, spec(max_string=..., max_length=...)]` on the signature.
 2. **Pre-ellipsis code**: statements between the docstring and the `...` are extracted from the AST and run verbatim as the second prefill cell — with or without the plugin.
 
+Use `None` to disable one formatting limit for a specific parameter:
+
+```python
+async def analyze(
+    self,
+    document: Annotated[str, spec(max_string=None)],
+    samples: Annotated[list, spec(max_length=100, max_depth=6)],
+) -> Result:
+    """Analyze the document and samples."""
+    ...
+```
+
 ```python
 class Notifier(Agent, llm=llm):
     async def notify_stale(self) -> str:
@@ -71,6 +83,13 @@ Two independent mechanisms — set them separately:
 
 1. **Capture time** (`capture: CaptureConfig`) — per-cell stream caps with head/tail truncation: `max_stdout=50_000`, `max_stderr=2_000`, `max_error=10_000` chars; `tail=None` (half the budget); `file_backed=True` (default `False`) streams the *full* output to a temp file and puts its path in the truncation notice so the LLM can grep it.
 2. **Render time** (`FormatConfig` triplet = `pformat` bounds `max_string/max_length/max_depth`): `event_format` (event fields, every turn; defaults 10_000/200/5), `prefill_format` (parameter inspection; 2_000/25/4), `context_block_format` (non-string context values; unlimited — overflow handled by block eviction).
+
+Rendering precedence is framework defaults → agent class → agent instance →
+method `@strategy(..., truncation=...)` → the parameter's `spec()` metadata.
+`spec(max_string=None)` disables the formatting bound only for that parameter.
+Because the inspection prefill prints through stdout, `capture.max_stdout` still
+applies independently; raise it explicitly if the complete printed value can
+exceed the default 50,000-character capture budget.
 
 Context budget: `max_context_tokens` — or, when unset and the model exposes a context window, half the *usable* window (`(context_window - reserved_output) // 2`, where `reserved_output` is the call's `max_tokens`, else `TruncationConfig.response_reserve_tokens`, default 4096; setting `response_reserve_tokens=0` disables the auto-derived budget). Over-budget triggers **whole-block eviction** of SYSTEM context blocks — newest non-`static` user blocks first, marked `EVICTED: over context budget` in place. Static framework blocks (`system_prompt`, `self`) are never evicted. No token counter is required: eviction sizes blocks as `chars × ratio`, where the ratio is calibrated from each provider response's reported prompt tokens (cold-start ~4 chars/token before the first response). Inspect usage via `agent.context_stats` — token figures are provider-reported (`prompt_tokens`); the context-vs-events breakdown is attributed by character share and `ctx N%` is measured against the usable window.
 

--- a/src/nooa/prompts.py
+++ b/src/nooa/prompts.py
@@ -67,12 +67,12 @@ async def _get_task_prompt(runtime: Any, strategy: Any, call: Any) -> str:
 # ---------------------------------------------------------------------------
 # Prefill
 # ---------------------------------------------------------------------------
-def _get_prefill(strategy: Any, call: Any, agent: Any) -> tuple[str | None, str | None]:
+def _get_prefill(strategy: Any, call: Any, truncation_config: Any) -> tuple[str | None, str | None]:
     """Return ``(inspect_code, pre_ellipsis_code)`` for *strategy* and *call*.
 
     Mirrors the runtime prefill path (``CodeActStrategy._run_prefill``): the
     configured ``CodeActConfig.prefill`` plugin drives the inspect prefill,
-    resolved against the agent's truncation config. ``prefill`` may be ``None``
+    resolved against the runtime truncation config. ``prefill`` may be ``None``
     (inspect prefill disabled) or a custom ``Prefill`` instance.
 
     For strategies that don't have explicit prefill support, ``pre_ellipsis``
@@ -89,12 +89,13 @@ def _get_prefill(strategy: Any, call: Any, agent: Any) -> tuple[str | None, str 
         prefill = strategy.config.prefill
         if prefill is None:
             return None, pre_ellipsis
-        truncation_config = getattr(agent, "_truncation", DEFAULT_TRUNCATION_CONFIG)
-        return prefill.get_code(call, config=truncation_config), pre_ellipsis
+        resolved_config = truncation_config or DEFAULT_TRUNCATION_CONFIG
+        return prefill.get_code(call, config=resolved_config), pre_ellipsis
 
     if isinstance(strategy, PurePythonStrategy):
         # PurePythonStrategy always has a prefill (InspectInputsPrefill by default)
-        return strategy.prefill.get_code(call), pre_ellipsis
+        resolved_config = truncation_config or DEFAULT_TRUNCATION_CONFIG
+        return strategy.prefill.get_code(call, config=resolved_config), pre_ellipsis
 
     return None, pre_ellipsis
 
@@ -123,6 +124,8 @@ async def _build_prompt_data_from_agent(
 
     strategy = getattr(wrapper, "_plan_strategy", None) or get_default_strategy()
     call = CurrentCall.from_method(original_func, args=args, kwargs=kwargs)
+    method_truncation = getattr(wrapper, "_strategy_truncation", None)
+    resolved_truncation = agent._truncation.merge_with(method_truncation)
 
     # Pre-expand docstring with call arguments (mirrors actor.py behavior).
     # Without this, {param} placeholders in the user's docstring remain literal
@@ -149,7 +152,7 @@ async def _build_prompt_data_from_agent(
     )
 
     task_prompt = await _get_task_prompt(agent.runtime, strategy, call)
-    inspect_code, pre_ellipsis = _get_prefill(strategy, call, agent)
+    inspect_code, pre_ellipsis = _get_prefill(strategy, call, resolved_truncation)
 
     return PromptData(
         system_prompt=system_prompt,

--- a/src/nooa/runtime/actor.py
+++ b/src/nooa/runtime/actor.py
@@ -16,8 +16,9 @@ import types
 import warnings
 from collections.abc import Callable
 from contextlib import contextmanager
+from dataclasses import replace
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, cast, get_type_hints
+from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 from pydantic import BaseModel
@@ -2665,47 +2666,26 @@ class ActorRuntime:
                 # Use strategy's execute() method directly
                 from nooa.strategies.current_call import CurrentCall
 
-                # Expand {placeholders} in method docstring using call arguments
+                # Build the call from the original method so annotation metadata and
+                # pre-ellipsis source are extracted by the same path used by prompt
+                # inspection. Runtime-only state is overlaid below.
+                original_method = getattr(method, "_original", method)
+                parent_id = self._agent_call_stack[-2] if len(self._agent_call_stack) >= 2 else None
+                call = CurrentCall.from_method(
+                    original_method,
+                    args=args,
+                    kwargs=kwargs,
+                    parent_id=parent_id,
+                )
+
+                # Preserve the runtime's docstring expansion behavior. from_method()
+                # has already mapped positional arguments into call.kwargs.
                 raw_docstring = getattr(method, "__doc__", None)
                 expanded_docstring = None
                 if raw_docstring:
-                    # Build context: map parameter names to argument values
-                    sig = inspect.signature(method)
-                    param_names = list(sig.parameters.keys())[1:]  # Skip 'self'
-                    arg_context = dict(zip(param_names, args, strict=False))
-                    arg_context.update(kwargs)
                     expanded_docstring = await self.expand_variables(
-                        raw_docstring, extra_context=arg_context, error_mode="silent"
+                        raw_docstring, extra_context=call.kwargs, error_mode="silent"
                     )
-
-                # Build CurrentCall for the strategy
-                # Map positional args to parameter names for kwargs (like from_method does)
-                sig = inspect.signature(method)
-                param_names = [p for p in sig.parameters.keys() if p != "self"]
-                merged_kwargs = dict(kwargs)
-                for i, value in enumerate(args):
-                    if i < len(param_names):
-                        param_name = param_names[i]
-                        if param_name not in merged_kwargs:
-                            merged_kwargs[param_name] = value
-
-                # Extract return type annotation — use get_type_hints to
-                # resolve PEP 563 stringified annotations.
-                return_type = None
-                try:
-                    hints = get_type_hints(method, include_extras=True)
-                    return_annotation = hints.get("return", inspect.Signature.empty)
-                except (NameError, TypeError, AttributeError):
-                    return_annotation = sig.return_annotation
-                if return_annotation is not inspect.Signature.empty:
-                    return_type = return_annotation
-
-                # Extract pre-ellipsis code (setup code before ... marker)
-                # Use _original if method was wrapped by metaclass
-                from nooa.ellipsis_detection import get_pre_ellipsis_code
-
-                original_method = getattr(method, "_original", method)
-                pre_ellipsis_code = get_pre_ellipsis_code(original_method)
 
                 # Use the call_id already pushed by the wrapper so events added
                 # during this call have metadata["call_id"] matching the agent
@@ -2714,24 +2694,11 @@ class ActorRuntime:
                 # _prepare_context uses _agent_call_id (the stack value) for
                 # EventQuery.current_call() filtering, not current_call.id.
                 call_id = self._agent_call_id or str(uuid4())
-                call = CurrentCall(
+                call = replace(
+                    call,
                     id=call_id,
-                    method_name=method_name,
-                    decorator="plan",
-                    signature=str(sig),
                     docstring=expanded_docstring,
-                    args=args,
-                    kwargs=merged_kwargs,
-                    parent_id=self._agent_call_stack[-2]
-                    if len(self._agent_call_stack) >= 2
-                    else None,
-                    is_async=inspect.iscoroutinefunction(method),
-                    return_type=return_type,
-                    pre_ellipsis_code=pre_ellipsis_code,
                     session_locals=call_session_locals,
-                    # Authoritative ordered names from the live signature (excludes
-                    # 'self') so format_parameters_as_code never re-parses the string.
-                    param_names=[p for p in sig.parameters if p != "self"],
                 )
 
                 # Store current call context in context vars for RuntimeServices.generate()

--- a/tests/strategies/test_param_spec_runtime.py
+++ b/tests/strategies/test_param_spec_runtime.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime regressions for per-parameter prefill truncation overrides."""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated
+
+import pytest
+
+from nooa import Agent, CodeActStrategy, spec, strategy
+from nooa.config.truncation_config import FormatConfig, TruncationConfig
+from nooa.unifiedllm import FakeLLMClient
+
+_TEST_LLM = FakeLLMClient()
+
+
+def _messages(llm: FakeLLMClient) -> str:
+    """Serialize provider-shaped messages for content-only assertions."""
+    return json.dumps(llm.last_messages)
+
+
+def _payload(label: str, size: int = 2_400) -> str:
+    return f"{label}-BEGIN-" + "x" * size + f"-{label}-END"
+
+
+class _ExplicitCodeActAgent(Agent, llm=_TEST_LLM):
+    @strategy(CodeActStrategy())
+    async def solve(self, instruction: Annotated[str, spec(max_string=None)]) -> str:
+        """Solve the instruction."""
+        ...
+
+
+class _DefaultCodeActAgent(Agent, llm=_TEST_LLM):
+    async def solve(self, instruction: Annotated[str, spec(max_string=None)]) -> str:
+        """Solve the instruction."""
+        ...
+
+
+class _UnannotatedAgent(Agent, llm=_TEST_LLM):
+    async def solve(self, instruction: str) -> str:
+        """Solve the instruction."""
+        ...
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("agent_type", [_ExplicitCodeActAgent, _DefaultCodeActAgent])
+async def test_runtime_honors_unlimited_string_override(agent_type):
+    llm = FakeLLMClient.with_tool_call("return_result", {"result": "done"})
+    agent = agent_type(llm=llm)
+    instruction = _payload(agent_type.__name__)
+
+    assert await agent.solve(instruction) == "done"
+
+    messages = _messages(llm)
+    assert instruction in messages
+    assert f"str(len={len(instruction)}" not in messages
+    assert "Output too large" not in messages
+
+
+@pytest.mark.asyncio
+async def test_unannotated_string_keeps_default_formatter_limit():
+    llm = FakeLLMClient.with_tool_call("return_result", {"result": "done"})
+    agent = _UnannotatedAgent(llm=llm)
+    instruction = _payload("DEFAULT")
+
+    assert await agent.solve(instruction) == "done"
+
+    messages = _messages(llm)
+    assert instruction not in messages
+    assert f"str(len={len(instruction)}, [:1000]=" in messages
+    assert "Output too large" not in messages
+
+
+@pytest.mark.asyncio
+async def test_finite_param_override_wins_over_agent_and_method_defaults():
+    llm = FakeLLMClient.with_tool_call("return_result", {"result": "done"})
+
+    class FiniteOverrideAgent(
+        Agent,
+        llm=llm,
+        truncation=TruncationConfig(prefill_format=FormatConfig(max_string=40)),
+    ):
+        @strategy(
+            CodeActStrategy(),
+            truncation=TruncationConfig(prefill_format=FormatConfig(max_string=80)),
+        )
+        async def solve(self, instruction: Annotated[str, spec(max_string=120)]) -> str:
+            """Solve the instruction."""
+            ...
+
+    instruction = _payload("FINITE", size=240)
+    assert await FiniteOverrideAgent().solve(instruction) == "done"
+
+    messages = _messages(llm)
+    assert instruction not in messages
+    assert f"str(len={len(instruction)}, [:60]=" in messages
+    assert "[:40]=" not in messages
+    assert "[:20]=" not in messages
+
+
+@pytest.mark.asyncio
+async def test_stdout_capture_limit_remains_independent_of_param_override():
+    llm = FakeLLMClient.with_tool_call("return_result", {"result": "done"})
+    agent = _DefaultCodeActAgent(llm=llm)
+    instruction = _payload("CAPTURE", size=55_000)
+
+    assert await agent.solve(instruction) == "done"
+
+    messages = _messages(llm)
+    assert instruction not in messages
+    assert "Output too large" in messages
+    assert f"str(len={len(instruction)}" not in messages

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -6,6 +6,7 @@ import pytest
 
 import nooa
 from nooa import Agent, CodeActStrategy, PromptData, strategy
+from nooa.config.truncation_config import FormatConfig, TruncationConfig
 from nooa.prompts import (
     _get_prefill,
     _get_task_prompt,
@@ -323,6 +324,60 @@ class TestBuildPromptDataRuntime:
         data = await build_prompt_data(agent.with_pre_ellipsis, 5)
         assert data.pre_ellipsis is not None
         assert "value * 2" in data.pre_ellipsis
+
+    @pytest.mark.asyncio
+    async def test_method_truncation_override_used_for_codeact_prefill(self):
+        class MethodOverrideAgent(Agent, llm=_LLM):
+            @strategy(
+                CodeActStrategy(),
+                truncation=TruncationConfig(prefill_format=FormatConfig(max_string=90_000)),
+            )
+            async def analyze(self, data: str) -> str:
+                """Analyze the data."""
+                ...
+
+        data = await build_prompt_data(MethodOverrideAgent().analyze, "hello")
+        assert data.inspect_prefill is not None
+        assert "max_string=90000" in data.inspect_prefill
+
+    @pytest.mark.asyncio
+    async def test_method_truncation_override_used_for_pure_python_prefill(self):
+        class MethodOverrideAgent(Agent, llm=_LLM):
+            @strategy(
+                PurePythonStrategy(),
+                truncation=TruncationConfig(prefill_format=FormatConfig(max_string=91_000)),
+            )
+            async def analyze(self, data: str) -> str:
+                """Analyze the data."""
+                ...
+
+        data = await build_prompt_data(MethodOverrideAgent().analyze, "hello")
+        assert data.inspect_prefill is not None
+        assert "max_string=91000" in data.inspect_prefill
+
+    @pytest.mark.asyncio
+    async def test_class_and_instance_truncation_layers_used_for_prefill(self):
+        class LayeredAgent(
+            Agent,
+            llm=_LLM,
+            truncation=TruncationConfig(prefill_format=FormatConfig(max_string=321)),
+        ):
+            async def analyze(self, data: str) -> str:
+                """Analyze the data."""
+                ...
+
+        class_data = await build_prompt_data(LayeredAgent().analyze, "hello")
+        instance_data = await build_prompt_data(
+            LayeredAgent(
+                truncation=TruncationConfig(prefill_format=FormatConfig(max_string=654))
+            ).analyze,
+            "hello",
+        )
+
+        assert class_data.inspect_prefill is not None
+        assert instance_data.inspect_prefill is not None
+        assert "max_string=321" in class_data.inspect_prefill
+        assert "max_string=654" in instance_data.inspect_prefill
 
 
 class TestPrintPromptRuntime:


### PR DESCRIPTION
## Summary

- construct runtime `CurrentCall` objects through the shared factory so parameter-level `Annotated[..., spec(...)]` truncation metadata reaches generation strategies
- make `build_prompt_data()` and `print_prompt()` apply the same method-level truncation merge as runtime, including PurePython prefill
- add end-to-end regressions for explicit/default CodeAct, default and finite formatting limits, configuration precedence, and the independent stdout capture boundary
- document per-parameter rendering limits, precedence, and capture semantics

## Validation

- `110 passed` across the targeted truncation and prompt suites on Python 3.12
- full-project Ruff lint and format checks passed
- live checks passed with `openai/nvidia/nvidia/nemotron-3.5-lightning` for both explicit and default CodeAct paths; the complete 2,400+ character payload reached the real request and produced the expected SHA-256

Signed-off-by: Severin Klingler <sklingler@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed per-parameter prompt rendering limits and overrides across supported runtimes.
  * Ensured method- and instance-level truncation settings are honored when displaying prompts.
  * Preserved live CodeAct objects while applying formatting limits.
  * Kept stdout capture limits independent from prompt rendering limits.

* **Documentation**
  * Added guidance for configuring rendering limits with parameter annotations, including disabling limits and configuration precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->