### PR TITLE
fix(tui): newline sanitization, separator lines, and mouse scroll routing in fullscreen explorers

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -108,6 +108,8 @@ class EventExplorerModel:
         self.cursor = 0
         self.detail_offset = 0
         self.search_line_cursor = 0
+        self._last_detail_match_lines = []
+        self._last_detail_match_occurrences = []
 
     def set_enabled_types(self, enabled: set[str]) -> None:
         self.enabled_types = set(enabled)
@@ -163,6 +165,8 @@ class EventExplorerModel:
         old_cursor = self.cursor
         self.move(delta)
         if self.cursor != old_cursor:
+            self._last_detail_match_lines = []
+            self._last_detail_match_occurrences = []
             self.search_line_cursor = 0 if delta > 0 else 10**9
 
     def move_or_scroll(self, delta: int) -> None:

--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -240,10 +240,22 @@ class EventExplorerView(ExplorerView):
 
     def detail_lines(self, row: EventExplorerRow, width: int) -> list[str]:
         self.model._last_detail_match_lines = detail_match_lines(row, width, self.model.query)
-        self.model._last_detail_match_occurrences = detail_match_occurrences(
-            row, width, self.model.query
+        occurrences = detail_match_occurrences(row, width, self.model.query)
+        self.model._last_detail_match_occurrences = occurrences
+        current_line = None
+        current_occurrence = None
+        if occurrences:
+            self.model.search_line_cursor = min(
+                max(self.model.search_line_cursor, 0), len(occurrences) - 1
+            )
+            current_line, current_occurrence = occurrences[self.model.search_line_cursor]
+        return highlighted_detail_lines(
+            row,
+            width,
+            self.model.query,
+            current_match_line=current_line,
+            current_match_occurrence=current_occurrence,
         )
-        return highlighted_detail_lines(row, width, self.model.query)
 
     def handle_action(self, action: str, row: Any) -> SubviewKeyResult:
         return "ignored"

--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -239,6 +239,10 @@ class EventExplorerView(ExplorerView):
         return f"{row.tag:<8} {row.event_type:<22} {row.summary}"[:width]
 
     def detail_lines(self, row: EventExplorerRow, width: int) -> list[str]:
+        self.model._last_detail_match_lines = detail_match_lines(row, width, self.model.query)
+        self.model._last_detail_match_occurrences = detail_match_occurrences(
+            row, width, self.model.query
+        )
         return highlighted_detail_lines(row, width, self.model.query)
 
     def handle_action(self, action: str, row: Any) -> SubviewKeyResult:

--- a/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
@@ -293,21 +293,30 @@ class ExplorerModel:
 
     def move_or_scroll(self, delta: int) -> None:
         if self.search_active and self._last_detail_match_lines:
-            self._move_detail_match(delta)
+            if self._move_detail_match(delta):
+                return
+            old_cursor = self.cursor
+            self.move(delta)
+            if self.cursor != old_cursor:
+                self.search_line_cursor = 0 if delta > 0 else 10**9
         elif self.focus == "list":
             self.move(delta)
         else:
             self.scroll_detail(delta)
 
-    def _move_detail_match(self, delta: int) -> None:
+    def _move_detail_match(self, delta: int) -> bool:
         if not self._last_detail_match_lines:
-            return
+            return False
         count = len(self._last_detail_match_lines)
-        self.search_line_cursor = min(max(self.search_line_cursor + delta, 0), count - 1)
+        next_cursor = self.search_line_cursor + delta
+        if not 0 <= next_cursor < count:
+            return False
+        self.search_line_cursor = next_cursor
         line = self._last_detail_match_lines[self.search_line_cursor]
         visible = max(self._last_detail_visible_lines, 1)
         self.detail_offset = max(line - visible // 2, 0)
         self.clamp_detail_offset(visible)
+        return True
 
     def jump_home(self) -> None:
         self.cursor = 0

--- a/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
@@ -298,6 +298,7 @@ class ExplorerModel:
             old_cursor = self.cursor
             self.move(delta)
             if self.cursor != old_cursor:
+                self._last_detail_match_lines = []
                 self.search_line_cursor = 0 if delta > 0 else 10**9
         elif self.focus == "list":
             self.move(delta)

--- a/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
@@ -254,6 +254,7 @@ class ExplorerModel:
         self.cursor = 0
         self.detail_offset = 0
         self.search_line_cursor = 0
+        self._last_detail_match_lines = []
 
     def set_view(
         self,

--- a/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
@@ -292,7 +292,7 @@ class ExplorerModel:
         self.search_line_cursor = 0
 
     def move_or_scroll(self, delta: int) -> None:
-        if self.search_active and self.focus != "list":
+        if self.search_active and self._last_detail_match_lines:
             self._move_detail_match(delta)
         elif self.focus == "list":
             self.move(delta)

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -539,10 +539,8 @@ class ExplorerBrowser:
                 " class:fullscreen-browser.selected" if selected else ""
             )
             marker = "❯ " if selected else "  "
-            text = sanitize_live_text(
-                marker + self.view.format_row(self.model.rows[row_index], max(1, width - 2))
-            )
-            text = text.replace("\n", " ").replace("\r", "")[:width]
+            text = marker + self.view.format_row(self.model.rows[row_index], max(1, width - 2))
+            text = sanitize_live_text(text.replace("\n", " ").replace("\r", " "))[:width]
             query = self.buffer.text.casefold().strip()
             if not query:
                 output.append((base, text))

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -384,7 +384,7 @@ class ExplorerBrowser:
 
     def _query_changed(self) -> None:
         self.model.edit_query(self.buffer.text)
-        self.model.search_active = False
+        self.model.search_active = bool(self.buffer.text.strip())
         self.list_offset = 0
         self._list_offset_detached = False
         self.invalidate()
@@ -570,9 +570,9 @@ class ExplorerBrowser:
             self.change_option(delta)
         elif self.active_control == "list":
             self._list_offset_detached = False
-            self.model.move(delta)
+            self.model.move_or_scroll(delta)
         else:
-            self.model.scroll_detail(delta)
+            self.model.move_or_scroll(delta)
         self.invalidate()
 
     def page(self, delta: int) -> None:

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -184,7 +184,11 @@ class _BrowserOptionControl(FormattedTextControl):
         style = "class:fullscreen-browser.control" + (
             " class:fullscreen-browser.control-focused" if focused else ""
         )
-        return [(style, f"[{option.label}: {option.display_value}]")]
+        fragments = []
+        if focused and getattr(option, "dropdown", False):
+            fragments.append(("[SetMenuPosition]", ""))
+        fragments.append((style, f"[{option.label}: {option.display_value}]"))
+        return fragments
 
     def mouse_handler(self, mouse_event: MouseEvent):
         if (
@@ -294,10 +298,13 @@ class ExplorerBrowser:
             _BrowserOptionControl(self, index) for index in range(len(view.options))
         ]
         option_windows: list[Any] = []
+        self.option_windows: list[Window] = []
         for index, control in enumerate(self.option_controls):
             if index:
                 option_windows.append(Window(FormattedTextControl(" "), width=1, height=1))
-            option_windows.append(Window(control, width=Dimension(min=12, preferred=22), height=1))
+            option_window = Window(control, width=Dimension(min=12, preferred=22), height=1)
+            self.option_windows.append(option_window)
+            option_windows.append(option_window)
         search = VSplit(
             [
                 Window(FormattedTextControl(self._search_label), width=9, height=1),
@@ -322,7 +329,6 @@ class ExplorerBrowser:
                 18,
                 min(44, max(len(label) for _value, label in option.choices) + 6),
             )
-            right = 23 * (len(view.options) - index - 1)
             dropdown_floats.append(
                 Float(
                     content=ConditionalContainer(
@@ -336,10 +342,11 @@ class ExplorerBrowser:
                         ),
                         filter=Condition(lambda index=index: self.option_cursor == index),
                     ),
-                    top=4,
-                    right=right,
                     width=menu_width,
                     height=lambda option=option: len(option.choices) + 2,
+                    xcursor=True,
+                    ycursor=True,
+                    attach_to_window=self.option_windows[index],
                     z_index=10,
                 )
             )

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -69,6 +69,7 @@ def build_fullscreen_browser(
     main_body = HSplit(
         [
             Window(title_control, height=1),
+            separator(),
             Window(help_control, height=1),
             area(
                 "list",
@@ -76,6 +77,7 @@ def build_fullscreen_browser(
                     [
                         controls,
                         Window(list_header_control, height=1),
+                        separator(),
                         Window(
                             list_control,
                             height=list_height or Dimension(min=1, preferred=4, max=5),
@@ -334,7 +336,7 @@ class ExplorerBrowser:
                         ),
                         filter=Condition(lambda index=index: self.option_cursor == index),
                     ),
-                    top=3,
+                    top=4,
                     right=right,
                     width=menu_width,
                     height=lambda option=option: len(option.choices) + 2,
@@ -532,7 +534,8 @@ class ExplorerBrowser:
             marker = "❯ " if selected else "  "
             text = sanitize_live_text(
                 marker + self.view.format_row(self.model.rows[row_index], max(1, width - 2))
-            )[:width]
+            )
+            text = text.replace("\n", " ").replace("\r", "")[:width]
             query = self.buffer.text.casefold().strip()
             if not query:
                 output.append((base, text))
@@ -659,6 +662,9 @@ class ExplorerBrowser:
         elif action == "end":
             self.model.jump_end()
             self.invalidate()
+        elif action in {"scroll_down", "scroll_up"}:
+            delta = 3 if action == "scroll_down" else -3
+            self.mouse_scroll(self.active_control, delta)
         elif action == "backspace":
             if self.active_control == "list":
                 self.buffer.delete_before_cursor()

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -35,6 +35,7 @@ from prompt_toolkit.document import Document
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.formatted_text import ANSI, AnyFormattedText
 from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
+from prompt_toolkit.key_binding.bindings.mouse import load_mouse_bindings
 from prompt_toolkit.key_binding.bindings.scroll import scroll_page_down, scroll_page_up
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.layout import (
@@ -2607,6 +2608,22 @@ class TUIApplication:
                 else "Native terminal selection enabled (F6 to restore app mouse)"
             )
             event.app.invalidate()
+
+        mouse_bindings = load_mouse_bindings()
+        vt100_mouse_handler = mouse_bindings.get_bindings_for_keys((Keys.Vt100MouseEvent,))[
+            -1
+        ].handler
+        windows_mouse_handler = mouse_bindings.get_bindings_for_keys((Keys.WindowsMouseEvent,))[
+            -1
+        ].handler
+
+        @kb.add(Keys.Vt100MouseEvent, filter=subview_active, eager=True)
+        def _(event):
+            return vt100_mouse_handler(event)
+
+        @kb.add(Keys.WindowsMouseEvent, filter=subview_active, eager=True)
+        def _(event):
+            return windows_mouse_handler(event)
 
         @kb.add(Keys.Any, filter=subview_active, eager=True)
         def _(event):

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2619,10 +2619,14 @@ class TUIApplication:
 
         @kb.add(Keys.Vt100MouseEvent, filter=subview_active, eager=True)
         def _(event):
+            if self._is_fullscreen and not self._fullscreen_mouse_navigation:
+                return NotImplemented
             return vt100_mouse_handler(event)
 
         @kb.add(Keys.WindowsMouseEvent, filter=subview_active, eager=True)
         def _(event):
+            if self._is_fullscreen and not self._fullscreen_mouse_navigation:
+                return NotImplemented
             return windows_mouse_handler(event)
 
         @kb.add(Keys.Any, filter=subview_active, eager=True)

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -62,6 +62,56 @@ def test_event_explorer_builds_rows_and_full_text_searches() -> None:
     assert [rows[i].tag for i in model.matches] == ["2", "3"]
 
 
+def test_event_explorer_search_boundary_clears_cached_occurrences() -> None:
+    rows = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                ("1", _FakeEvent("TUIUserInput", text="alpha alpha")),
+                ("2", _FakeEvent("TUIUserInput", text="alpha alpha")),
+                ("3", _FakeEvent("TUIUserInput", text="alpha alpha")),
+            ]
+        )
+    )
+    model = EventExplorerModel(rows)
+    model.set_query("alpha")
+    model.search_active = True
+    model._last_detail_match_lines = [0]
+    model._last_detail_match_occurrences = [(0, 0), (0, 1)]
+    model.search_line_cursor = 1
+
+    model.move_search_occurrence(1)
+
+    assert model.cursor == 1
+    assert model._last_detail_match_lines == []
+    assert model._last_detail_match_occurrences == []
+    assert model.search_line_cursor == 0
+
+    # A second move before rendering must not reuse the previous event's matches.
+    model.move_search_occurrence(1)
+    assert model.cursor == 2
+
+
+def test_event_explorer_query_change_clears_cached_occurrences() -> None:
+    rows = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                ("1", _FakeEvent("TUIUserInput", text="alpha beta")),
+                ("2", _FakeEvent("TUIUserInput", text="alpha beta")),
+            ]
+        )
+    )
+    model = EventExplorerModel(rows)
+    model._last_detail_match_lines = [0]
+    model._last_detail_match_occurrences = [(0, 0), (0, 1)]
+
+    model.edit_query("beta")
+
+    assert model._last_detail_match_lines == []
+    assert model._last_detail_match_occurrences == []
+    model.move_search_occurrence(1)
+    assert model.cursor == 1
+
+
 def test_event_explorer_renders_shared_session_events() -> None:
     rows = build_event_rows(
         SimpleNamespace(

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -640,7 +640,18 @@ async def test_tui_app_event_explorer_routes_real_mouse_wheel_to_list() -> None:
     agent = FakeAgent()
     agent.event_manager = SimpleNamespace(
         items=lambda: [
-            (str(index), _FakeEvent("TUIUserInput", text=f"event {index}")) for index in range(30)
+            (
+                str(index),
+                _FakeEvent(
+                    "TUIUserInput",
+                    text=(
+                        "\n".join(f"detail line {line}" for line in range(100))
+                        if index == 29
+                        else f"event {index}"
+                    ),
+                ),
+            )
+            for index in range(30)
         ]
     )
     async with TUIHarness(agent=agent) as h:
@@ -650,12 +661,15 @@ async def test_tui_app_event_explorer_routes_real_mouse_wheel_to_list() -> None:
         assert browser is not None
         await h.wait_for(lambda: browser.list_control.viewport[1] > 1)
         await h.wait_for(lambda: browser.list_offset > 0)
+        await h.wait_for(lambda: browser.model._last_detail_line_count > 20)
         initial_offset = browser.list_offset
+        initial_detail_offset = browser.model.detail_offset
 
         # Xterm SGR wheel-up at column 10, row 8 (inside the list pane).
         await h.type_keys("\x1b[<64;10;8M")
         await h.wait_for(lambda: browser.list_offset < initial_offset)
 
+        assert browser.model.detail_offset == initial_detail_offset
         assert browser.model.cursor == 29
         await h.press("escape")
         await asyncio.wait_for(task, timeout=1)

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -751,7 +751,13 @@ async def test_tui_app_routes_grouped_options_without_editing_prompt() -> None:
         assert len(browser.dropdown_floats) == 1
         event_type_menu = browser.dropdown_floats[0]
         assert event_type_menu.z_index == 10
-        assert event_type_menu.top == 4
+        assert event_type_menu.attach_to_window is browser.option_windows[0]
+        assert event_type_menu.xcursor is True
+        assert event_type_menu.ycursor is True
+        assert event_type_menu.top is None
+        assert event_type_menu.right is None
+        option_fragments = browser.option_controls[0]._text()
+        assert option_fragments[0] == ("[SetMenuPosition]", "")
         dropdown_text = "".join(text for _style, text in browser.dropdown_controls[0]._text())
         assert "☑ All" in dropdown_text
         assert "☑ PythonOutput" in dropdown_text

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -690,7 +690,7 @@ async def test_tui_app_routes_grouped_options_without_editing_prompt() -> None:
         assert len(browser.dropdown_floats) == 1
         event_type_menu = browser.dropdown_floats[0]
         assert event_type_menu.z_index == 10
-        assert event_type_menu.top == 3
+        assert event_type_menu.top == 4
         dropdown_text = "".join(text for _style, text in browser.dropdown_controls[0]._text())
         assert "☑ All" in dropdown_text
         assert "☑ PythonOutput" in dropdown_text

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -618,6 +618,67 @@ async def test_tui_app_event_explorer_fts_can_search_printable_navigation_and_qu
         await asyncio.wait_for(task, timeout=1)
 
 
+@pytest.mark.asyncio
+async def test_tui_app_event_explorer_routes_real_mouse_wheel_to_list() -> None:
+    from .tui_app_harness import FakeAgent, TUIHarness
+
+    agent = FakeAgent()
+    agent.event_manager = SimpleNamespace(
+        items=lambda: [
+            (str(index), _FakeEvent("TUIUserInput", text=f"event {index}")) for index in range(30)
+        ]
+    )
+    async with TUIHarness(agent=agent) as h:
+        task = asyncio.create_task(h.app.open_event_explorer(agent.event_manager))
+        await h.wait_for(lambda: h.app._event_explorer_model is not None)
+        browser = h.app.active_subview
+        assert browser is not None
+        await h.wait_for(lambda: browser.list_control.viewport[1] > 1)
+        await h.wait_for(lambda: browser.list_offset > 0)
+        initial_offset = browser.list_offset
+
+        # Xterm SGR wheel-up at column 10, row 8 (inside the list pane).
+        await h.type_keys("\x1b[<64;10;8M")
+        await h.wait_for(lambda: browser.list_offset < initial_offset)
+
+        assert browser.model.cursor == 29
+        await h.press("escape")
+        await asyncio.wait_for(task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_tui_app_event_explorer_routes_real_mouse_wheel_to_detail() -> None:
+    from .tui_app_harness import FakeAgent, TUIHarness
+
+    agent = FakeAgent()
+    agent.event_manager = SimpleNamespace(
+        items=lambda: [
+            (
+                "1",
+                _FakeEvent(
+                    "TUIUserInput",
+                    text="\n".join(f"detail line {index}" for index in range(100)),
+                ),
+            )
+        ]
+    )
+    async with TUIHarness(agent=agent) as h:
+        task = asyncio.create_task(h.app.open_event_explorer(agent.event_manager))
+        await h.wait_for(lambda: h.app._event_explorer_model is not None)
+        browser = h.app.active_subview
+        assert browser is not None
+        await h.wait_for(lambda: browser.preview_control.viewport[1] > 1)
+        await h.wait_for(lambda: browser.model._last_detail_line_count > 20)
+
+        # Xterm SGR wheel-down at column 10, row 30 (inside the detail pane).
+        await h.type_keys("\x1b[<65;10;30M")
+        await h.wait_for(lambda: browser.model.detail_offset > 0)
+
+        assert browser.list_offset == 0
+        await h.press("escape")
+        await asyncio.wait_for(task, timeout=1)
+
+
 def test_event_explorer_has_in_app_mouse_scroll_bindings() -> None:
     source = Path("packages/nooa-cli/src/nooa_cli/tui/tui_application.py").read_text()
 

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -392,6 +392,21 @@ def test_event_explorer_current_match_highlights_second_match_on_same_line() -> 
     )
 
 
+def test_event_explorer_view_highlights_selected_occurrence_on_same_line() -> None:
+    from nooa_cli.tui.event_explorer import EventExplorerView
+
+    manager = SimpleNamespace(
+        items=lambda: [("1", _FakeEvent("TUIUserInput", text="alpha beta alpha gamma"))]
+    )
+    view = EventExplorerView(manager)
+    view.model.set_query("alpha")
+    view.model.search_line_cursor = 1
+
+    lines = view.detail_lines(view.model.current, width=120)
+
+    assert "".join(lines).count(f"{highlight_style_code(current=True)}alpha\x1b[0m") == 1
+
+
 def test_event_explorer_search_highlights_matches_inside_detail_text() -> None:
     row = build_event_rows(
         SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="find alpha here"))])

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -347,3 +347,12 @@ def test_explorer_browser_search_match_boundary_moves_to_next_row() -> None:
     # A second move before rendering must not reuse the previous row's matches.
     browser.navigate_vertical(1)
     assert browser.model.cursor == 2
+
+
+def test_explorer_query_change_clears_cached_detail_matches() -> None:
+    browser = _browser()
+    browser.model._last_detail_match_lines = [0, 2]
+
+    browser.model.edit_query("alpha")
+
+    assert browser.model._last_detail_match_lines == []

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -332,6 +332,8 @@ def test_explorer_browser_navigate_vertical_jumps_search_matches() -> None:
 
 def test_explorer_browser_search_match_boundary_moves_to_next_row() -> None:
     browser = _browser()
+    browser.model.rows.append(MagicMock(search_text="gamma", title="Gamma"))
+    browser.model.set_query("")
     browser.model.search_active = True
     browser.model._last_detail_match_lines = [1, 3]
     browser.model.search_line_cursor = 1
@@ -339,4 +341,9 @@ def test_explorer_browser_search_match_boundary_moves_to_next_row() -> None:
     browser.navigate_vertical(1)
 
     assert browser.model.cursor == 1
+    assert browser.model._last_detail_match_lines == []
     assert browser.model.search_line_cursor == 0
+
+    # A second move before rendering must not reuse the previous row's matches.
+    browser.navigate_vertical(1)
+    assert browser.model.cursor == 2

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -217,14 +217,14 @@ def test_explorer_browser_list_text_replaces_newlines_in_summary() -> None:
     """Newlines in row summaries are replaced with spaces to prevent rendering corruption."""
 
     class _MultiLineRow:
-        search_text = "line1\nline2"
+        search_text = "Multi-line Item\nsecond line\rthird line"
         title = "Multi-line Item"
         tag = "1"
 
     browser = _browser()
     browser.model.rows.clear()
     browser.model.rows.append(_MultiLineRow())
-    browser.view.format_row = lambda row, w: f"{row.tag} {row.title}"
+    browser.view.format_row = lambda row, w: f"{row.tag} {row.search_text}"
     browser.model.set_query("")
     browser.list_control.viewport = (80, 4)
 
@@ -232,18 +232,36 @@ def test_explorer_browser_list_text_replaces_newlines_in_summary() -> None:
     joined = "".join(text for _style, text in fragments)
 
     assert "\n" not in joined
-    assert "Multi-line Item" in joined
+    assert "\r" not in joined
+    assert "Multi-line Item second line third line" in joined
 
 
 def test_explorer_browser_has_separator_under_title() -> None:
-    """The browser layout includes separator lines under the title and list header."""
-    import inspect
+    """Separators follow the title, list header, and preview area."""
+    from prompt_toolkit.layout import FloatContainer, HSplit, VSplit, Window
 
-    from nooa_cli.tui.fullscreen_browser import build_fullscreen_browser
+    browser = _browser()
+    main = browser.container._get_container()
+    assert isinstance(main, FloatContainer)
+    body = main.content
+    assert isinstance(body, HSplit)
 
-    source = inspect.getsource(build_fullscreen_browser)
-    # Separators: after title, after list header, after preview header
-    assert source.count("separator()") >= 3
+    assert body.children[0].content is browser.title_control
+    assert isinstance(body.children[1], Window)
+    assert body.children[1].char == "─"
+
+    list_area = body.children[3]
+    assert isinstance(list_area, VSplit)
+    list_body = list_area.children[1]
+    assert isinstance(list_body, HSplit)
+    assert list_body.children[1].content is browser.list_header_control
+    assert isinstance(list_body.children[2], Window)
+    assert list_body.children[2].char == "─"
+
+    preview_area = body.children[5]
+    assert isinstance(preview_area, VSplit)
+    assert isinstance(body.children[6], Window)
+    assert body.children[6].char == "─"
 
 
 def test_explorer_browser_handle_key_scroll_down_scrolls_list() -> None:
@@ -258,7 +276,7 @@ def test_explorer_browser_handle_key_scroll_down_scrolls_list() -> None:
 
     browser.handle_key("scroll_down")
 
-    assert browser.list_offset > 0
+    assert browser.list_offset == 3
     assert browser.model.cursor == 0  # selection doesn't move
 
 
@@ -277,7 +295,7 @@ def test_explorer_browser_handle_key_scroll_up_detail() -> None:
 
     browser.handle_key("scroll_up")
 
-    assert browser.model.detail_offset < 10
+    assert browser.model.detail_offset == 7
 
 
 def test_explorer_browser_navigate_vertical_jumps_search_matches() -> None:
@@ -310,3 +328,15 @@ def test_explorer_browser_navigate_vertical_jumps_search_matches() -> None:
     browser.navigate_vertical(1)
     assert browser.model.search_line_cursor == 1
     assert browser.model.cursor == 0  # selection stays
+
+
+def test_explorer_browser_search_match_boundary_moves_to_next_row() -> None:
+    browser = _browser()
+    browser.model.search_active = True
+    browser.model._last_detail_match_lines = [1, 3]
+    browser.model.search_line_cursor = 1
+
+    browser.navigate_vertical(1)
+
+    assert browser.model.cursor == 1
+    assert browser.model.search_line_cursor == 0

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -278,3 +278,35 @@ def test_explorer_browser_handle_key_scroll_up_detail() -> None:
     browser.handle_key("scroll_up")
 
     assert browser.model.detail_offset < 10
+
+
+def test_explorer_browser_navigate_vertical_jumps_search_matches() -> None:
+    """When search is active, up/down jumps between matches instead of moving list selection."""
+
+    class _MatchRow:
+        search_text = "alpha beta alpha"
+        title = "Match Row"
+        tag = "1"
+
+    browser = _browser()
+    browser.model.rows.clear()
+    browser.model.rows.append(_MatchRow())
+    browser.model.set_query("")
+    browser.list_control.viewport = (80, 4)
+    browser.preview_control.viewport = (80, 4)
+    browser.active_control = "list"
+
+    # Simulate a search query being typed
+    browser.buffer.text = "alpha"
+    browser._query_changed()
+
+    assert browser.model.search_active is True
+
+    # Populate match lines (as detail_lines would)
+    browser.model._last_detail_match_lines = [0, 2]
+    browser.model._last_detail_visible_lines = 4
+
+    # Down should jump to match, not move cursor
+    browser.navigate_vertical(1)
+    assert browser.model.search_line_cursor == 1
+    assert browser.model.cursor == 0  # selection stays

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -211,3 +211,70 @@ async def test_remaining_explorers_are_wrapped_in_shared_fullscreen_browser(kind
 
         await harness.press("c-c")
         await asyncio.wait_for(opened, timeout=1)
+
+
+def test_explorer_browser_list_text_replaces_newlines_in_summary() -> None:
+    """Newlines in row summaries are replaced with spaces to prevent rendering corruption."""
+
+    class _MultiLineRow:
+        search_text = "line1\nline2"
+        title = "Multi-line Item"
+        tag = "1"
+
+    browser = _browser()
+    browser.model.rows.clear()
+    browser.model.rows.append(_MultiLineRow())
+    browser.view.format_row = lambda row, w: f"{row.tag} {row.title}"
+    browser.model.set_query("")
+    browser.list_control.viewport = (80, 4)
+
+    fragments = browser.list_text(80, 4)
+    joined = "".join(text for _style, text in fragments)
+
+    assert "\n" not in joined
+    assert "Multi-line Item" in joined
+
+
+def test_explorer_browser_has_separator_under_title() -> None:
+    """The browser layout includes separator lines under the title and list header."""
+    import inspect
+
+    from nooa_cli.tui.fullscreen_browser import build_fullscreen_browser
+
+    source = inspect.getsource(build_fullscreen_browser)
+    # Separators: after title, after list header, after preview header
+    assert source.count("separator()") >= 3
+
+
+def test_explorer_browser_handle_key_scroll_down_scrolls_list() -> None:
+    """scroll_down action routes to the active pane via handle_key."""
+    browser = _browser()
+    browser.model.rows.extend(
+        MagicMock(search_text=f"item {i}", title=f"Item {i}") for i in range(10)
+    )
+    browser.model.set_query("")
+    browser.list_control.viewport = (80, 4)
+    browser.active_control = "list"
+
+    browser.handle_key("scroll_down")
+
+    assert browser.list_offset > 0
+    assert browser.model.cursor == 0  # selection doesn't move
+
+
+def test_explorer_browser_handle_key_scroll_up_detail() -> None:
+    """scroll_up in the detail pane scrolls detail, not the list."""
+    browser = _browser()
+    browser.model.rows.extend(
+        MagicMock(search_text=f"item {i}", title=f"Item {i}") for i in range(3)
+    )
+    browser.model.set_query("")
+    browser.list_control.viewport = (80, 4)
+    browser.preview_control.viewport = (80, 4)
+    browser.active_control = "preview"
+    browser.model._last_detail_line_count = 20
+    browser.model.detail_offset = 10
+
+    browser.handle_key("scroll_up")
+
+    assert browser.model.detail_offset < 10

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+from unittest.mock import MagicMock
 
 import pytest
 from nooa_cli.tui.config import DisplayMode
@@ -3355,6 +3356,20 @@ async def test_fullscreen_alt_drag_is_not_consumed_by_composer_or_completion_men
         completion_control.mouse_handler(_mouse_event(MouseEventType.MOUSE_UP, x=0, y=0, alt=True))
         is NotImplemented
     )
+
+
+def test_subview_mouse_bindings_defer_when_native_selection_is_active() -> None:
+    from prompt_toolkit.keys import Keys
+
+    app = _make_fullscreen_app()
+    app._active_subview = object()  # Activate the subview-only mouse bindings.
+    app._fullscreen_mouse_navigation = False
+    bindings = app._app.key_bindings
+
+    for key in (Keys.Vt100MouseEvent, Keys.WindowsMouseEvent):
+        active = [binding for binding in bindings.get_bindings_for_keys((key,)) if binding.filter()]
+        assert active
+        assert active[-1].handler(MagicMock()) is NotImplemented
 
 
 def test_fullscreen_alt_mouse_is_not_consumed_by_subview_control() -> None:


### PR DESCRIPTION
## What does this PR do?

Four follow-on fixes for the fullscreen explorer browser:

1. **Newline sanitization in list rows** — Event summaries (and any other row text) containing newlines were corrupting list rendering by spilling across rows. `list_text` now replaces `
`/`` with spaces before truncation.

2. **Thin horizontal separator lines** — Added separator lines under the title bar and under the list column header row for visual clarity, matching the existing separator above the preview pane. Adjusted the event-type dropdown float position to account for the new separator.

3. **Mouse scroll routing for all explorers** — `Keys.ScrollDown`/`ScrollUp` key bindings were routing scroll events through `EventExplorerView.handle_key`, which always scrolled the detail pane. `ExplorerBrowser.handle_key` now handles `scroll_down`/`scroll_up` and routes them to the active pane (list or preview) via `mouse_scroll`.

4. **Search match jumping in event explorer detail view** — Up/down navigation was calling `model.move()` directly, bypassing `model.move_or_scroll()`, so search match navigation never engaged. Now `navigate_vertical` calls `model.move_or_scroll()` which jumps between search matches in the detail pane when search is active. `EventExplorerView.detail_lines` now populates `_last_detail_match_lines`/`_last_detail_match_occurrences` so the match-jump logic has data to work with. `_query_changed` sets `search_active` based on query presence.

## Validation

- `uv run ruff check` (changed files) — passed
- `uv run pyright` (changed files) — 0 errors, 0 warnings
- `git diff --check` — clean
- `uv run pytest packages/nooa-cli/tests/tui -q` — 1331 passed, 2 failed (pre-existing macOS `/var` vs `/private/var` temp-path issues, unrelated)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mouse-wheel scrolling for event lists and detail panes based on pointer location.
  * Improved detail search navigation and highlighting, including multiple matches on the same line.
  * Improved full-screen browser layout with clearer separators and cleaner multiline summaries.
  * Dropdown options now remain aligned with their corresponding menu entries.
  * Added support for native terminal mouse selection in applicable views.

* **Bug Fixes**
  * Improved scrolling and navigation consistency between list and detail panes.
  * Corrected search state handling for blank queries and between selected rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->