### PR TITLE
fix(tui): queue prompts during startup LLM check

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -455,6 +455,31 @@ class ModelCommand(Command):
             return False, "Usage: /model [name]"
         return True, None
 
+    def _begin_model_validation(self) -> None:
+        """Transfer pending startup-prompt ownership to this model check."""
+        health = None if self._registry is None else self._registry.blocking_llm_health
+        if getattr(health, "pending", False) is not True:
+            return
+        generation = getattr(self._registry, "llm_health_generation", 0)
+        self._registry.llm_health_generation = generation + 1
+        app = getattr(self.frontend, "_app", None)
+        set_probe_status = getattr(app, "set_llm_probe_status", None)
+        if callable(set_probe_status):
+            set_probe_status("")
+
+    def _mark_model_check_failed(self, health: Any) -> None:
+        """Reject transferred prompts and publish the failed candidate health."""
+        if self._registry is not None:
+            self._registry.blocking_llm_health = health if health.blocking else None
+            startup_info = getattr(self._registry, "startup_info", None)
+            if startup_info is not None:
+                startup_info.llm_ready = not health.blocking
+                startup_info.llm_status = "unavailable" if health.blocking else "ready"
+        app = getattr(self.frontend, "_app", None)
+        reject_deferred = getattr(app, "reject_deferred_messages", None)
+        if callable(reject_deferred):
+            reject_deferred(health.error_message or "Model validation failed.")
+
     def _mark_model_ready(self, selected: str) -> None:
         """Update shared model UI state after a successful switch."""
         if self._registry is not None:
@@ -486,10 +511,11 @@ class ModelCommand(Command):
                 TextOutput(f"Current model: {self.config.default_model}", "info")
             )
         selected = args[0]
+        model_validation_started = False
         try:
             from nooa.interactive import apply_model_limits
             from nooa_cli.tui.config import UnresolvedModelError, get_llm_for_model
-            from nooa_cli.tui.health_check import probe_llm
+            from nooa_cli.tui.health_check import HealthCheckResult, probe_llm
 
             try:
                 candidate = get_llm_for_model(selected)
@@ -507,8 +533,11 @@ class ModelCommand(Command):
                         TextOutput(health.fix_hint or "", "info"),
                     ],
                 )
+            self._begin_model_validation()
+            model_validation_started = True
             health = await probe_llm(candidate)
             if not health.ok:
+                self._mark_model_check_failed(health)
                 outputs = [
                     TextOutput(
                         f"Could not switch to model '{selected}': {health.error_message}", "error"
@@ -524,6 +553,14 @@ class ModelCommand(Command):
 
             await self.agent_run_async(_switch)
         except Exception as e:
+            if model_validation_started:
+                self._mark_model_check_failed(
+                    HealthCheckResult(
+                        ok=False,
+                        error_message=f"Failed to switch model: {e}",
+                        blocking=True,
+                    )
+                )
             return CommandResult.err(f"Failed to switch model: {e}")
         self.config.default_model = selected
         self._mark_model_ready(selected)
@@ -2593,6 +2630,7 @@ class CommandRegistry:
         self._root_config = root_config
         self.startup_info: Output | None = None  # set by main after bootstrap
         self.blocking_llm_health: Any | None = None
+        self.llm_health_generation = 0
         self._bind_mcp_oauth_prompt()
         self._commands: dict[str, Command] = self._register()
         self._discover_directory_skills()

--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -469,6 +469,9 @@ class ModelCommand(Command):
                 startup_info.llm_status = "ready"
 
         app = getattr(self.frontend, "_app", None)
+        release_deferred = getattr(app, "release_deferred_messages", None)
+        if callable(release_deferred):
+            release_deferred()
         refreshed = False
         refresh_transcript_blocks = getattr(app, "refresh_transcript_blocks", None)
         if callable(refresh_transcript_blocks):

--- a/packages/nooa-cli/src/nooa_cli/tui/health_check.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/health_check.py
@@ -61,7 +61,7 @@ class HealthCheckResult:
     # remain warnings so a real prompt may still succeed moments later.
     blocking: bool = False
     # Startup can render before the real provider probe finishes. While pending,
-    # normal agent prompts stay blocked, but slash and shell commands remain usable.
+    # normal agent prompts queue locally; slash and shell commands remain usable.
     pending: bool = False
 
 

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -609,6 +609,7 @@ class Session:
             config=self.config,
             display_mode=resolve_display_mode(self.config.tui),
             submission_guard=self._llm_submission_error,
+            defer_submission=self._llm_submission_pending,
         )
         app_ref.append(self._app)
 
@@ -921,6 +922,10 @@ class Session:
                     startup_info.llm_ready = True
                     startup_info.llm_status = "ready"
                 self._set_llm_probe_status("")
+                app = getattr(self, "_app", None)
+                release = getattr(app, "release_deferred_messages", None)
+                if callable(release):
+                    release()
                 self._invalidate_app()
                 return
 
@@ -933,6 +938,10 @@ class Session:
                 startup_info.llm_ready = not result.blocking
                 startup_info.llm_status = "unavailable" if result.blocking else "ready"
             self._set_llm_probe_status("")
+            app = getattr(self, "_app", None)
+            reject = getattr(app, "reject_deferred_messages", None)
+            if callable(reject):
+                reject(self._llm_submission_error() or result.error_message or "Message rejected.")
             self._invalidate_app()
 
             level = "error" if result.blocking else "warning"
@@ -1331,25 +1340,22 @@ class Session:
             ),
         )
 
+    def _llm_submission_pending(self) -> bool:
+        """Return whether plain prompts should wait for the startup LLM probe."""
+        health = getattr(self.registry, "blocking_llm_health", None)
+        return bool(
+            health is not None
+            and getattr(health, "blocking", False) is True
+            and getattr(health, "pending", False) is True
+        )
+
     def _llm_submission_error(self) -> str | None:
-        """Explain why agent-bound input is disabled while LLM config is broken."""
+        """Explain why agent-bound input is disabled after LLM validation fails."""
         health = getattr(self.registry, "blocking_llm_health", None)
         if health is None or getattr(health, "blocking", False) is not True:
             return None
         if getattr(health, "pending", False) is True:
-            lines = [
-                "Cannot send this message because the configured LLM is still being checked.",
-            ]
-            if health.error_message:
-                lines.append(health.error_message)
-            lines.extend(
-                (
-                    "",
-                    "Slash commands and !shell commands still work.",
-                    "Prompts will be enabled automatically if the check succeeds.",
-                )
-            )
-            return "\n".join(lines)
+            return None
         lines = [
             "Cannot send this message because the configured LLM is unavailable.",
         ]

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -902,12 +902,15 @@ class Session:
             self._invalidate_app()
             return
         model_at_start = getattr(llm, "model", None)
+        probe_generation = getattr(self.registry, "llm_health_generation", 0)
 
         async def _probe() -> None:
             from .health_check import probe_llm
             from .output import TextOutput
 
             result = await probe_llm(llm)
+            if getattr(self.registry, "llm_health_generation", 0) != probe_generation:
+                return
             if getattr(self.agent, "llm", None) is not llm:
                 self._set_llm_probe_status("")
                 return

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1132,6 +1132,7 @@ class TUIApplication:
         full_screen: bool | None = None,
         display_mode: Any = None,
         submission_guard: Callable[[], str | None] | None = None,
+        defer_submission: Callable[[], bool] | None = None,
     ) -> None:
         """
         Args:
@@ -1161,6 +1162,8 @@ class TUIApplication:
                 one alternate-screen Application-owned transcript renderer.
             submission_guard: Returns an actionable error when plain agent-bound
                 input must be rejected. Slash and bang commands remain available.
+            defer_submission: Returns whether plain agent-bound input should remain
+                queued locally until ``release_deferred_messages`` is called.
 
         The per-message echo ("queued → accepted" transition, user-bar
         render, SessionUserMessage log) is wired on the agent's
@@ -1189,6 +1192,7 @@ class TUIApplication:
         self._session_label_fn: Callable[[], str] | None = session_label
         self._config = config
         self._submission_guard = submission_guard
+        self._defer_submission = defer_submission
         self._ctrl_c_exit_armed = False
         self._ctrl_c_exit_timer: asyncio.TimerHandle | None = None
         self._exit_hint_text = ""
@@ -1287,6 +1291,7 @@ class TUIApplication:
         # Admitted text remains visible here until its accepted transcript
         # block is committed. A worker may dequeue before the next paint.
         self._pending_input_handoff: list[_PendingInputHandoff] = []
+        self._deferred_input_handoffs: list[_PendingInputHandoff] = []
         self._llm_probe_status_text: str = ""
 
         # Large bracketed pastes stay out of the editable source buffer. Each
@@ -2853,6 +2858,8 @@ class TUIApplication:
         empty_buffer = Condition(lambda: self.input_buffer.text == "") & subview_inactive
 
         def _pop_last_queued() -> str | None:
+            if self._deferred_input_handoffs:
+                return self._deferred_input_handoffs.pop().text
             if self._agent_controller.state is None:
                 return None
             return self._agent_controller.withdraw_pending_input()
@@ -3219,10 +3226,15 @@ class TUIApplication:
         display_text: str | None = None,
         draft_text: str | None = None,
     ) -> None:
-        """Submit text through the current interactive agent."""
+        """Submit text now, or retain it locally while admission is deferred."""
         if self._agent_controller.state is None:
             return
-        if self._submission_guard is not None:
+        try:
+            deferred = self._defer_submission is not None and self._defer_submission()
+        except Exception:
+            logger.debug("TUI submission deferral check failed", exc_info=True)
+            deferred = False
+        if not deferred and self._submission_guard is not None:
             try:
                 problem = self._submission_guard()
             except Exception:
@@ -3239,19 +3251,45 @@ class TUIApplication:
             user_message if draft_text is None else draft_text,
         )
         self._pending_input_handoff.append(handoff)
+        if deferred:
+            self._deferred_input_handoffs.append(handoff)
+            if self._app.is_running:
+                self._app.invalidate()
+            return
+        self._submit_handoff(handoff)
+
+    def _submit_handoff(self, handoff: _PendingInputHandoff) -> bool:
+        """Admit one visible handoff to the agent, retiring it on rejection."""
         try:
-            accepted = self._agent_controller.submit(user_message)
+            accepted = self._agent_controller.submit(handoff.text)
         except Exception:
             self._discard_pending_input_handoff(handoff)
             logger.debug("TUI message submission failed", exc_info=True)
             self.emit_block("\x1b[31mMessage rejected.\x1b[0m\n")
-            return
+            return False
         if not accepted:
             self._discard_pending_input_handoff(handoff)
             self.emit_block("\x1b[31mMessage rejected.\x1b[0m\n")
-            return
+            return False
         if self._app.is_running:
             self._app.invalidate()
+        return True
+
+    def release_deferred_messages(self) -> None:
+        """Admit startup-deferred messages to the agent in FIFO order."""
+        deferred = self._deferred_input_handoffs
+        self._deferred_input_handoffs = []
+        for handoff in deferred:
+            self._submit_handoff(handoff)
+
+    def reject_deferred_messages(self, problem: str) -> None:
+        """Discard startup-deferred messages and explain why they were rejected."""
+        deferred = self._deferred_input_handoffs
+        self._deferred_input_handoffs = []
+        for handoff in deferred:
+            self._discard_pending_input_handoff(handoff)
+        if deferred:
+            self.emit_block(f"\x1b[31m{problem}\x1b[0m\n")
 
     def _discard_pending_input_handoff(self, handoff: _PendingInputHandoff) -> None:
         """Discard one exact optimistic admission without disturbing duplicates."""
@@ -3284,6 +3322,7 @@ class TUIApplication:
     def clear_pending_input_handoffs(self) -> None:
         """Discard optimistic queue rows after the runtime queue is flushed."""
         self._pending_input_handoff.clear()
+        self._deferred_input_handoffs.clear()
         self._reclaim_paste_attachments()
         if self._app.is_running:
             self._app.invalidate()

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2857,19 +2857,10 @@ class TUIApplication:
         # already consumed by the agent can't be edited.
         empty_buffer = Condition(lambda: self.input_buffer.text == "") & subview_inactive
 
-        def _pop_last_queued() -> str | None:
-            if self._deferred_input_handoffs:
-                return self._deferred_input_handoffs.pop().text
-            if self._agent_controller.state is None:
-                return None
-            return self._agent_controller.withdraw_pending_input()
-
         @kb.add("up", filter=empty_buffer)
         def _(event):
-            popped = _pop_last_queued()
-            if popped is not None:
-                draft = self._draft_for_withdrawn_input(popped)
-                self.complete_pending_input_handoff(popped)
+            draft = self._withdraw_pending_input_draft()
+            if draft is not None:
                 self.input_buffer.text = draft
                 self.input_buffer.cursor_position = len(draft)
                 return
@@ -3161,6 +3152,21 @@ class TUIApplication:
                 result.append(attachment.text)
         flush_literal()
         return "".join(result)
+
+    def _withdraw_pending_input_draft(self) -> str | None:
+        """Withdraw the newest queued input and recover its editable draft."""
+        if self._deferred_input_handoffs:
+            handoff = self._deferred_input_handoffs.pop()
+            self._discard_pending_input_handoff(handoff)
+            return handoff.draft_text or handoff.text
+        if self._agent_controller.state is None:
+            return None
+        text = self._agent_controller.withdraw_pending_input()
+        if text is None:
+            return None
+        draft = self._draft_for_withdrawn_input(text)
+        self.complete_pending_input_handoff(text)
+        return draft
 
     def _draft_for_withdrawn_input(self, text: str) -> str:
         """Recover compact attachment markers for one withdrawn queue item."""

--- a/packages/nooa-cli/tests/tui/test_startup_latency.py
+++ b/packages/nooa-cli/tests/tui/test_startup_latency.py
@@ -162,7 +162,7 @@ async def test_pending_llm_health_does_not_emit_durable_startup_status(tmp_path,
 
 
 @pytest.mark.asyncio
-async def test_pending_llm_health_blocks_prompts_until_background_probe_succeeds(monkeypatch):
+async def test_pending_llm_health_queues_prompts_until_background_probe_succeeds(monkeypatch):
     from nooa_cli.tui.health_check import HealthCheckResult
     from nooa_cli.tui.session import Session
 
@@ -181,7 +181,12 @@ async def test_pending_llm_health_blocks_prompts_until_background_probe_succeeds
     session.frontend = SimpleNamespace(
         render=AsyncMock(side_effect=lambda output: rendered.append(output))
     )
-    session._app = SimpleNamespace(invalidate=Mock(), set_llm_probe_status=Mock())
+    session._app = SimpleNamespace(
+        invalidate=Mock(),
+        set_llm_probe_status=Mock(),
+        release_deferred_messages=Mock(),
+        reject_deferred_messages=Mock(),
+    )
     session._background_tasks = set()
 
     monkeypatch.setattr(
@@ -189,7 +194,8 @@ async def test_pending_llm_health_blocks_prompts_until_background_probe_succeeds
         AsyncMock(return_value=HealthCheckResult(ok=True)),
     )
 
-    assert "still being checked" in session._llm_submission_error()
+    assert session._llm_submission_pending() is True
+    assert session._llm_submission_error() is None
 
     session._start_llm_health_check()
     await asyncio_wait_for_background_tasks(session)
@@ -201,6 +207,8 @@ async def test_pending_llm_health_blocks_prompts_until_background_probe_succeeds
         call("probing LLM endpoint..."),
         call(""),
     ]
+    session._app.release_deferred_messages.assert_called_once_with()
+    session._app.reject_deferred_messages.assert_not_called()
     session._app.invalidate.assert_called_once()
     assert rendered == []
     assert session._llm_submission_error() is None
@@ -226,7 +234,12 @@ async def test_pending_llm_health_keeps_blocking_on_auth_failure(monkeypatch):
     session.frontend = SimpleNamespace(
         render=AsyncMock(side_effect=lambda output: rendered.append(output))
     )
-    session._app = SimpleNamespace(invalidate=Mock(), set_llm_probe_status=Mock())
+    session._app = SimpleNamespace(
+        invalidate=Mock(),
+        set_llm_probe_status=Mock(),
+        release_deferred_messages=Mock(),
+        reject_deferred_messages=Mock(),
+    )
     session._background_tasks = set()
 
     failure = HealthCheckResult(
@@ -247,10 +260,55 @@ async def test_pending_llm_health_keeps_blocking_on_auth_failure(monkeypatch):
         call("probing LLM endpoint..."),
         call(""),
     ]
+    session._app.release_deferred_messages.assert_not_called()
+    session._app.reject_deferred_messages.assert_called_once()
+    assert "unavailable" in session._app.reject_deferred_messages.call_args.args[0]
     session._app.invalidate.assert_called_once()
     assert "unavailable" in session._llm_submission_error()
     assert any("Authentication failed" in output.content for output in rendered)
     assert any("export API_KEY" in output.content for output in rendered)
+
+
+@pytest.mark.asyncio
+async def test_pending_llm_health_rejects_queued_prompts_on_transient_failure(monkeypatch):
+    from nooa_cli.tui.health_check import HealthCheckResult
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session.agent = SimpleNamespace(llm=SimpleNamespace(model="model-a"))
+    session.registry = SimpleNamespace(
+        blocking_llm_health=HealthCheckResult(
+            ok=False,
+            error_message="Checking LLM endpoint for model 'model-a'.",
+            blocking=True,
+            pending=True,
+        ),
+        startup_info=SimpleNamespace(llm_ready=False, llm_status="checking"),
+    )
+    session.frontend = SimpleNamespace(render=AsyncMock())
+    session._app = SimpleNamespace(
+        invalidate=Mock(),
+        set_llm_probe_status=Mock(),
+        release_deferred_messages=Mock(),
+        reject_deferred_messages=Mock(),
+    )
+    session._background_tasks = set()
+    failure = HealthCheckResult(
+        ok=False,
+        error_message="Temporary endpoint failure.",
+        blocking=False,
+    )
+    monkeypatch.setattr("nooa_cli.tui.health_check.probe_llm", AsyncMock(return_value=failure))
+
+    session._start_llm_health_check()
+    await asyncio_wait_for_background_tasks(session)
+
+    assert session.registry.blocking_llm_health is None
+    assert session.registry.startup_info.llm_ready is True
+    session._app.release_deferred_messages.assert_not_called()
+    session._app.reject_deferred_messages.assert_called_once_with("Temporary endpoint failure.")
+    assert session._llm_submission_pending() is False
+    assert session._llm_submission_error() is None
 
 
 @pytest.mark.asyncio
@@ -281,6 +339,7 @@ async def test_model_switch_clears_pending_startup_info(monkeypatch):
     config = SimpleNamespace(default_model="old/model")
     command = ModelCommand(AsyncMock(), config, agent, registry=registry)
     command.frontend._app = SimpleNamespace(
+        release_deferred_messages=Mock(),
         refresh_transcript_blocks=Mock(return_value=True),
         invalidate=Mock(),
     )
@@ -305,6 +364,7 @@ async def test_model_switch_clears_pending_startup_info(monkeypatch):
     assert startup_info.short_model == "model"
     assert startup_info.llm_ready is True
     assert startup_info.llm_status == "ready"
+    command.frontend._app.release_deferred_messages.assert_called_once_with()
     command.frontend._app.refresh_transcript_blocks.assert_called_once_with("startup-info")
     command.frontend._app.invalidate.assert_not_called()
 

--- a/packages/nooa-cli/tests/tui/test_startup_latency.py
+++ b/packages/nooa-cli/tests/tui/test_startup_latency.py
@@ -369,6 +369,127 @@ async def test_model_switch_clears_pending_startup_info(monkeypatch):
     command.frontend._app.invalidate.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_model_validation_exception_rejects_transferred_prompts(monkeypatch):
+    from nooa_cli.tui.commands import ModelCommand
+    from nooa_cli.tui.health_check import HealthCheckResult
+
+    candidate = SimpleNamespace(model="new/model")
+    agent = SimpleNamespace(llm=SimpleNamespace(model="old/model"))
+    registry = SimpleNamespace(
+        blocking_llm_health=HealthCheckResult(
+            ok=False,
+            error_message="Checking old model.",
+            blocking=True,
+            pending=True,
+        ),
+        startup_info=SimpleNamespace(llm_ready=False, llm_status="checking"),
+        llm_health_generation=0,
+    )
+    command = ModelCommand(
+        AsyncMock(),
+        SimpleNamespace(default_model="old/model"),
+        agent,
+        registry=registry,
+    )
+    command.frontend._app = SimpleNamespace(
+        set_llm_probe_status=Mock(),
+        reject_deferred_messages=Mock(),
+    )
+    monkeypatch.setattr("nooa_cli.tui.config.get_llm_for_model", lambda _model: candidate)
+    monkeypatch.setattr(
+        "nooa_cli.tui.health_check.probe_llm",
+        AsyncMock(side_effect=RuntimeError("validation crashed")),
+    )
+
+    result = await command.execute(["new/model"])
+
+    assert result.success is False
+    assert registry.llm_health_generation == 1
+    assert registry.blocking_llm_health.blocking is True
+    command.frontend._app.reject_deferred_messages.assert_called_once_with(
+        "Failed to switch model: validation crashed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_switch_owns_deferred_prompts_before_old_probe_finishes(monkeypatch):
+    import asyncio
+
+    from nooa_cli.tui.commands import ModelCommand
+    from nooa_cli.tui.health_check import HealthCheckResult
+    from nooa_cli.tui.session import Session
+
+    old_llm = SimpleNamespace(model="old/model")
+    candidate = SimpleNamespace(model="new/model")
+    old_result = asyncio.Future()
+    candidate_result = asyncio.Future()
+    agent = SimpleNamespace(
+        llm=old_llm,
+        set_llm=lambda llm: setattr(agent, "llm", llm),
+    )
+    registry = SimpleNamespace(
+        blocking_llm_health=HealthCheckResult(
+            ok=False,
+            error_message="Checking old model.",
+            blocking=True,
+            pending=True,
+        ),
+        startup_info=SimpleNamespace(llm_ready=False, llm_status="checking"),
+    )
+    app = SimpleNamespace(
+        invalidate=Mock(),
+        set_llm_probe_status=Mock(),
+        release_deferred_messages=Mock(),
+        reject_deferred_messages=Mock(),
+        refresh_transcript_blocks=Mock(return_value=True),
+    )
+    session = Session.__new__(Session)
+    session.agent = agent
+    session.registry = registry
+    session.frontend = SimpleNamespace(render=AsyncMock())
+    session._app = app
+    session._background_tasks = set()
+
+    async def probe(llm):
+        return await (old_result if llm is old_llm else candidate_result)
+
+    monkeypatch.setattr("nooa_cli.tui.health_check.probe_llm", probe)
+    monkeypatch.setattr("nooa_cli.tui.config.get_llm_for_model", lambda _model: candidate)
+    monkeypatch.setattr("nooa.interactive.apply_model_limits", lambda _agent: None)
+
+    session._start_llm_health_check()
+    await asyncio.sleep(0)
+
+    command = ModelCommand(
+        AsyncMock(),
+        SimpleNamespace(default_model="old/model"),
+        agent,
+        registry=registry,
+    )
+    command.frontend._app = app
+    command._persist_tui_setting = lambda _key, _value: Path("settings.yaml")
+    command._agent_run_async = lambda fn: asyncio.sleep(0, result=fn())
+    switch_task = asyncio.create_task(command.execute(["new/model"]))
+    await asyncio.sleep(0)
+
+    old_result.set_result(
+        HealthCheckResult(ok=False, error_message="Old model failed.", blocking=True)
+    )
+    await asyncio_wait_for_background_tasks(session)
+
+    app.release_deferred_messages.assert_not_called()
+    app.reject_deferred_messages.assert_not_called()
+
+    candidate_result.set_result(HealthCheckResult(ok=True))
+    result = await switch_task
+
+    assert result.success is True
+    assert agent.llm is candidate
+    app.release_deferred_messages.assert_called_once_with()
+    app.reject_deferred_messages.assert_not_called()
+
+
 async def asyncio_wait_for_background_tasks(session) -> None:
     import asyncio
 

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -994,20 +994,22 @@ async def test_plain_input_is_deferred_until_submission_is_released():
     assert await agent._user_messages_in.get() == "first\nsecond"
 
 
-async def test_deferred_plain_input_can_be_withdrawn_for_editing():
+async def test_duplicate_deferred_input_withdraws_newest_handoff_by_identity():
     agent = FakeAgent()
     app = make_local_tui_app(agent, defer_submission=lambda: True)
 
-    app.submit_message("first")
-    app.submit_message("second")
-    withdrawn = app._deferred_input_handoffs.pop().text
-    draft = app._draft_for_withdrawn_input(withdrawn)
-    app.complete_pending_input_handoff(withdrawn)
+    app.submit_message("same", display_text="first-display", draft_text="first-draft")
+    app.submit_message("same", display_text="second-display", draft_text="second-draft")
 
-    assert withdrawn == "second"
-    assert draft == "second"
+    draft = app._withdraw_pending_input_draft()
+
+    assert draft == "second-draft"
     assert agent._user_messages_in.qsize() == 0
-    assert app._pending_input_display() == ["first"]
+    assert app._pending_input_display() == ["first-display"]
+    assert [item.draft_text for item in app._deferred_input_handoffs] == ["first-draft"]
+
+    app.reject_deferred_messages("probe failed")
+    assert app._pending_input_display() == []
 
 
 async def test_deferred_plain_input_is_rejected_when_health_check_fails():

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -953,6 +953,89 @@ async def test_plain_input_is_blocked_by_actionable_submission_guard():
     assert "/model <name>" in app.output_buffer.text
 
 
+async def test_commands_bypass_plain_input_deferral():
+    agent = FakeAgent()
+    commands: list[str] = []
+    bangs: list[str] = []
+    app = make_local_tui_app(
+        agent,
+        defer_submission=lambda: True,
+        on_command=commands.append,
+        on_bang=bangs.append,
+    )
+
+    app.input_buffer.text = "/help"
+    app._accept_handler(app.input_buffer)
+    app.input_buffer.text = "!echo hi"
+    app._accept_handler(app.input_buffer)
+
+    assert commands == ["/help"]
+    assert bangs == ["echo hi"]
+    assert app._deferred_input_handoffs == []
+    assert agent._user_messages_in.qsize() == 0
+
+
+async def test_plain_input_is_deferred_until_submission_is_released():
+    agent = FakeAgent()
+    checking = True
+    app = make_local_tui_app(agent, defer_submission=lambda: checking)
+
+    app.submit_message("first")
+    app.submit_message("second")
+
+    assert agent._user_messages_in.qsize() == 0
+    assert app._pending_input_display() == ["first", "second"]
+
+    checking = False
+    app.release_deferred_messages()
+
+    assert agent._user_messages_in.qsize() == 1
+    assert app._pending_input_display() == ["first", "second"]
+    assert await agent._user_messages_in.get() == "first\nsecond"
+
+
+async def test_deferred_plain_input_can_be_withdrawn_for_editing():
+    agent = FakeAgent()
+    app = make_local_tui_app(agent, defer_submission=lambda: True)
+
+    app.submit_message("first")
+    app.submit_message("second")
+    withdrawn = app._deferred_input_handoffs.pop().text
+    draft = app._draft_for_withdrawn_input(withdrawn)
+    app.complete_pending_input_handoff(withdrawn)
+
+    assert withdrawn == "second"
+    assert draft == "second"
+    assert agent._user_messages_in.qsize() == 0
+    assert app._pending_input_display() == ["first"]
+
+
+async def test_deferred_plain_input_is_rejected_when_health_check_fails():
+    agent = FakeAgent()
+    app = make_local_tui_app(agent, defer_submission=lambda: True)
+
+    app.submit_message("first")
+    app.submit_message("second")
+    app.reject_deferred_messages("Configured LLM is unavailable.")
+
+    assert agent._user_messages_in.qsize() == 0
+    assert app._pending_input_display() == []
+    assert "Configured LLM is unavailable." in app.output_buffer.text
+
+
+async def test_failed_release_retires_deferred_handoff(monkeypatch):
+    agent = FakeAgent()
+    app = make_local_tui_app(agent, defer_submission=lambda: True)
+    app.submit_message("queued")
+    monkeypatch.setattr(app._agent_controller, "submit", lambda _text: False)
+
+    app.release_deferred_messages()
+
+    assert app._deferred_input_handoffs == []
+    assert app._pending_input_display() == []
+    assert "Message rejected." in app.output_buffer.text
+
+
 async def test_commands_tab_completion_for_slash():
     async with TUIHarness() as h:
         await h.type_keys("/he")


### PR DESCRIPTION
## Summary
- queue plain user prompts locally while the startup LLM endpoint probe is pending
- release queued prompts in FIFO order after a successful probe or successful `/model`/`/connect` recovery
- reject queued prompts only when the probe fails, while preserving immediate slash and shell commands
- preserve queue visibility, withdrawal/editing, attachment cleanup, and session-transition cleanup

## Validation
- `uv run pytest -q packages/nooa-cli/tests/tui/test_startup_latency.py packages/nooa-cli/tests/tui/test_tui_app_behavior.py` — 150 passed
- full TUI suite — 1344 passed, 2 known unrelated macOS `/var` vs `/private/var` failures
- Ruff and formatting checks passed
- Pyright: 0 errors, 0 warnings
- `git diff --check` passed

## Review
Independent design and implementation reviews completed with no remaining blocking findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plain-text prompts entered during startup health checks are queued locally and submitted automatically once checks succeed.
  - Slash and shell commands remain available immediately during startup.
  - Queued prompts can be withdrawn for editing or cleared normally.
  - Model changes release queued prompts after successful readiness checks.

- **Bug Fixes**
  - Improved handling and error reporting when health checks, model validation, or prompt submissions fail.
  - Prevented outdated health-check results from affecting the active model or queued prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->