### PR TITLE
fix(tui): stabilize context usage status

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -338,6 +338,11 @@ class Session:
         self._toolbar = ToolbarRegistry()
         self._initial_outputs = list(initial_outputs or [])
         self._session_title_requested = False
+        # Building the next request temporarily replaces context_stats with a
+        # version whose provider token count is unknown. Keep the last exact
+        # display for the same context-window budget so the toolbar does not
+        # flicker back to its placeholder while that request is in flight.
+        self._last_context_usage_display: tuple[int | None, int | None, str] | None = None
         # Invalidates user-message UI callbacks queued before a session swap.
         self._session_generation = 0
 
@@ -390,15 +395,23 @@ class Session:
         so 100% means "the next call at the current completion budget will be
         rejected", not "the window is byte-full". Until the first response
         returns usage (``prompt_tokens`` is None) we show the placeholder
-        ``"ctx —"`` rather than a local estimate.
+        ``"ctx —"`` rather than a local estimate. While a later request is in
+        flight, retain the last exact value for the same context-window budget.
         """
         stats = getattr(self.agent, "context_stats", None)
         if stats is None:
             return "ctx —"
+        window = stats.model_context_window
+        reserve = stats.reserved_output_tokens
         util = stats.overall_utilization  # prompt / (window - output reserve)
-        if util is None:
-            return "ctx —"
-        return f"ctx {util * 100:.0f}%"
+        if util is not None:
+            label = f"ctx {util * 100:.0f}%"
+            self._last_context_usage_display = (window, reserve, label)
+            return label
+        cached = getattr(self, "_last_context_usage_display", None)
+        if cached is not None and cached[:2] == (window, reserve):
+            return cached[2]
+        return "ctx —"
 
     # ------------------------------------------------------------------
     # Exit diagnostics

--- a/packages/nooa-cli/tests/tui/test_context_usage_display.py
+++ b/packages/nooa-cli/tests/tui/test_context_usage_display.py
@@ -87,6 +87,24 @@ def test_context_usage_label_uses_model_context_window():
     assert session._context_usage_label() == "ctx 10%"
 
 
+def test_context_usage_label_keeps_last_exact_value_while_next_call_is_pending():
+    session = _make_session_for_label(_stats(total=9_000, model_context_window=100_000))
+    assert session._context_usage_label() == "ctx 9%"
+
+    session.agent.context_stats = _stats(total=None, model_context_window=100_000)
+
+    assert session._context_usage_label() == "ctx 9%"
+
+
+def test_context_usage_label_does_not_reuse_value_for_different_window():
+    session = _make_session_for_label(_stats(total=9_000, model_context_window=100_000))
+    assert session._context_usage_label() == "ctx 9%"
+
+    session.agent.context_stats = _stats(total=None, model_context_window=200_000)
+
+    assert session._context_usage_label() == "ctx —"
+
+
 # ── TUI agent registers the context_usage dynamic block -----------------------
 
 


### PR DESCRIPTION
## Summary
- retain the last provider-reported context utilization while the next request is in flight
- invalidate that cached display when the model context-window budget changes
- add regressions for both same-window retention and changed-window invalidation

## Root cause
Building each request replaces `context_stats` with fresh render stats whose `prompt_tokens` is intentionally unknown until the provider responds. Toolbar repaints during that interval therefore changed `ctx 9%` to `ctx —`, then back to a percentage.

## Validation
- `uv run pytest -q packages/nooa-cli/tests/tui/test_context_usage_display.py packages/nooa-cli/tests/tui/test_session_rule_width.py` — 145 passed
- `uv run pytest -q packages/nooa-cli/tests/tui` — 1349 passed, 2 known unrelated macOS `/var` vs `/private/var` failures
- Ruff format/check passed
- Pyright: 0 errors, 0 warnings
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context usage display during requests by retaining the most recent exact percentage when usage is temporarily unavailable.
  * Prevented outdated context percentages from appearing after the model’s context capacity changes.
  * Displays an unavailable state when no valid usage value can be shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->