### PR TITLE
fix(repo): support current Tree-sitter query API

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tools/_tree_sitter_backend.py
+++ b/packages/nooa-cli/src/nooa_cli/tools/_tree_sitter_backend.py
@@ -139,6 +139,14 @@ def _get_parser(lang: str) -> ts.Parser | None:
         return None
 
 
+def _compile_query(language: ts.Language, source: str) -> ts.Query:
+    """Compile a query using the API exposed by the installed Tree-sitter version."""
+    legacy_query = getattr(language, "query", None)
+    if callable(legacy_query):
+        return legacy_query(source)
+    return ts.Query(language, source)
+
+
 def _query_captures(query: ts.Query, root_node: ts.Node) -> list[tuple[ts.Node, str]]:
     legacy_captures = getattr(query, "captures", None)
     if legacy_captures is not None:
@@ -176,7 +184,7 @@ def ts_extract_symbols(path: Path, lang: str, max_symbols: int = 200) -> list[st
 
     try:
         language = parser.language
-        query = language.query(query_src)
+        query = _compile_query(language, query_src)
     except Exception as e:
         logger.debug(f"tree-sitter query compilation failed for {lang}: {e}")
         return None
@@ -237,7 +245,7 @@ def ts_find_references(
 
     try:
         language = parser.language
-        query = language.query(query_src)
+        query = _compile_query(language, query_src)
     except Exception:
         return None
 

--- a/packages/nooa-cli/src/nooa_cli/tools/_tree_sitter_backend.py
+++ b/packages/nooa-cli/src/nooa_cli/tools/_tree_sitter_backend.py
@@ -58,7 +58,7 @@ _DEFINITION_QUERIES = {
     """,
     "typescript": """
         (function_declaration name: (identifier) @name) @def
-        (class_declaration name: (identifier) @name) @def
+        (class_declaration name: (type_identifier) @name) @def
         (interface_declaration name: (type_identifier) @name) @def
         (type_alias_declaration name: (type_identifier) @name) @def
         (method_definition name: (property_identifier) @name) @def
@@ -147,18 +147,21 @@ def _compile_query(language: ts.Language, source: str) -> ts.Query:
     return ts.Query(language, source)
 
 
-def _query_captures(query: ts.Query, root_node: ts.Node) -> list[tuple[ts.Node, str]]:
-    legacy_captures = getattr(query, "captures", None)
-    if legacy_captures is not None:
-        return legacy_captures(root_node)
-
-    captures = ts.QueryCursor(query).captures(root_node)
+def _normalize_captures(captures) -> list[tuple[ts.Node, str]]:
+    """Normalize capture results returned by different Tree-sitter releases."""
     if isinstance(captures, dict):
-        flattened = [
+        captures = [
             (node, capture_name) for capture_name, nodes in captures.items() for node in nodes
         ]
-        return sorted(flattened, key=lambda item: item[0].start_byte)
+        return sorted(captures, key=lambda item: item[0].start_byte)
     return captures
+
+
+def _query_captures(query: ts.Query, root_node: ts.Node) -> list[tuple[ts.Node, str]]:
+    legacy_captures = getattr(query, "captures", None)
+    if callable(legacy_captures):
+        return _normalize_captures(legacy_captures(root_node))
+    return _normalize_captures(ts.QueryCursor(query).captures(root_node))
 
 
 def ts_extract_symbols(path: Path, lang: str, max_symbols: int = 200) -> list[str] | None:

--- a/packages/nooa-cli/tests/test_tree_sitter_backend.py
+++ b/packages/nooa-cli/tests/test_tree_sitter_backend.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility tests for the optional Tree-sitter RepoTools backend."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from nooa_cli.tools import _tree_sitter_backend as backend
+
+
+def test_compile_query_uses_language_method_when_available(monkeypatch):
+    expected = object()
+    legacy_query = Mock(return_value=expected)
+    language = Mock(query=legacy_query)
+    constructor = Mock(side_effect=AssertionError("modern API should not be used"))
+    monkeypatch.setattr(backend, "ts", SimpleNamespace(Query=constructor), raising=False)
+
+    assert backend._compile_query(language, "(identifier) @name") is expected
+    legacy_query.assert_called_once_with("(identifier) @name")
+    constructor.assert_not_called()
+
+
+def test_compile_query_uses_query_constructor_without_language_method(monkeypatch):
+    expected = object()
+    language = object()
+    constructor = Mock(return_value=expected)
+    monkeypatch.setattr(backend, "ts", SimpleNamespace(Query=constructor), raising=False)
+
+    assert backend._compile_query(language, "(identifier) @name") is expected
+    constructor.assert_called_once_with(language, "(identifier) @name")
+
+
+def test_current_tree_sitter_extracts_symbols_and_references(tmp_path: Path):
+    if not backend.TREE_SITTER_AVAILABLE:
+        pytest.skip("Tree-sitter AST extra is not installed")
+    if backend._get_parser("javascript") is None:
+        pytest.skip("JavaScript Tree-sitter grammar is not installed")
+
+    source = tmp_path / "sample.js"
+    source.write_text(
+        "class Example {\n"
+        "  target() { return 1; }\n"
+        "}\n"
+        "new Example().target();\n"
+        'const text = "target() is not a reference";\n'
+        "// target() is not a reference\n"
+    )
+
+    symbols = backend.ts_extract_symbols(source, "javascript")
+    references = backend.ts_find_references(source, "javascript", "target")
+
+    assert symbols is not None
+    assert any("method target" in symbol for symbol in symbols)
+    assert references == [(4, "new Example().target();")]

--- a/packages/nooa-cli/tests/test_tree_sitter_backend.py
+++ b/packages/nooa-cli/tests/test_tree_sitter_backend.py
@@ -54,3 +54,32 @@ def test_current_tree_sitter_extracts_symbols_and_references(tmp_path: Path):
     assert symbols is not None
     assert any("method target" in symbol for symbol in symbols)
     assert references == [(4, "new Example().target();")]
+
+
+def test_query_captures_normalizes_legacy_mapping_results(monkeypatch):
+    later = SimpleNamespace(start_byte=20)
+    earlier = SimpleNamespace(start_byte=10)
+    query = SimpleNamespace(captures=Mock(return_value={"name": [later, earlier]}))
+    constructor = Mock(side_effect=AssertionError("QueryCursor should not be used"))
+    monkeypatch.setattr(backend, "ts", SimpleNamespace(QueryCursor=constructor), raising=False)
+
+    assert backend._query_captures(query, object()) == [
+        (earlier, "name"),
+        (later, "name"),
+    ]
+    constructor.assert_not_called()
+
+
+def test_typescript_definition_query_compiles_with_installed_grammar(tmp_path: Path):
+    if not backend.TREE_SITTER_AVAILABLE:
+        pytest.skip("Tree-sitter AST extra is not installed")
+    if backend._get_parser("typescript") is None:
+        pytest.skip("TypeScript Tree-sitter grammar is not installed")
+
+    source = tmp_path / "sample.ts"
+    source.write_text("class Example {}\n")
+
+    symbols = backend.ts_extract_symbols(source, "typescript")
+
+    assert symbols is not None
+    assert any("class Example" in symbol for symbol in symbols)


### PR DESCRIPTION
## Summary
- compile Tree-sitter queries through `Language.query(...)` when the installed binding exposes the legacy API
- use `tree_sitter.Query(language, source)` for Tree-sitter 0.26+
- add branch-level compatibility tests and a real 0.26 integration regression for symbols and references

Capability detection is used instead of parsing package version strings, so compatible backports and future releases follow the API they actually expose.

## Validation
- focused compatibility suite: 3 passed with the locked Tree-sitter 0.26.0 AST extra
- complete `packages/nooa-cli/tests`: 1514 passed, with only 2 known unrelated macOS `/var` vs `/private/var` failures
- real Tree-sitter 0.26 symbol extraction and reference filtering verified
- Ruff format/check passed
- Pyright: 0 errors, 0 warnings
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy and current Tree-sitter APIs.
  * Restored reliable symbol extraction and reference detection for JavaScript, while correctly ignoring comments and strings.
  * Improved TypeScript class definition detection.

* **Tests**
  * Added coverage for Tree-sitter query compilation and capture handling.
  * Added integration tests for JavaScript symbol and reference analysis.
  * Added validation for TypeScript definition queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->