### PR TITLE
canonical typed model for context blocks and snapshots

### DIFF
--- a/src/nooa/context_blocks/__init__.py
+++ b/src/nooa/context_blocks/__init__.py
@@ -42,8 +42,11 @@ from nooa.context_blocks.formatter import (
 from nooa.context_blocks.models import (
     BlockMetadata,
     Context,
+    ContextBlock,
     ContextWindowStats,
     DynamicContext,
+    ExpressionContextBlock,
+    LiteralContextBlock,
     RenderedMessage,
     ResolvedBlock,
     Role,
@@ -60,7 +63,10 @@ from nooa.context_blocks.scoped import ScopedContext
 __all__ = [
     # Core types
     "Context",
+    "ContextBlock",
     "DynamicContext",
+    "LiteralContextBlock",
+    "ExpressionContextBlock",
     "ResolvedBlock",
     "Role",
     "BlockMetadata",

--- a/src/nooa/context_blocks/models.py
+++ b/src/nooa/context_blocks/models.py
@@ -13,7 +13,7 @@ Role: Re-exported from roles.py for backward compatibility.
 
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # Import EventBase here (not forward ref) — possible because events.py imports
 # Role from roles.py, breaking the circular dependency.
@@ -143,6 +143,47 @@ class Context(BaseModel):
         if self.prefix:
             parts.append("prefix=True")
         return f"Context({', '.join(parts)})"
+
+
+class LiteralContextBlock(BaseModel):
+    """Canonical runtime record for a literal context block."""
+
+    model_config = ConfigDict(frozen=True)
+
+    key: Annotated[str, Field(description="Unique context block key")]
+    type: Literal["literal"] = "literal"
+    value: Any = Field(default=None, description="Literal value rendered into the prompt")
+    prefix: bool = Field(default=False, description="Place in the cacheable prefix when true")
+
+
+class ExpressionContextBlock(BaseModel):
+    """Canonical runtime record for an evaluated context block."""
+
+    model_config = ConfigDict(frozen=True)
+
+    key: Annotated[str, Field(description="Unique context block key")]
+    type: Literal["expression"] = "expression"
+    expr: Annotated[str, Field(description="Python expression evaluated each turn")]
+    display_expr: str | None = Field(
+        default=None,
+        description="Optional expression shown in rendered block metadata instead of expr",
+    )
+    prefix: bool = Field(default=False, description="Place in the cacheable prefix when true")
+
+    @field_validator("expr")
+    @classmethod
+    def _validate_expr(cls, expr: str) -> str:
+        try:
+            compile(expr, "<context_block_expr>", "eval")
+        except SyntaxError as exc:
+            raise BlockSyntaxError(key="<expression>", expr=expr, original_error=exc) from exc
+        return expr
+
+
+type ContextBlock = Annotated[
+    LiteralContextBlock | ExpressionContextBlock,
+    Field(discriminator="type"),
+]
 
 
 class BlockMetadata(BaseModel):

--- a/src/nooa/runtime/context_builder.py
+++ b/src/nooa/runtime/context_builder.py
@@ -27,6 +27,8 @@ from nooa.context_blocks import (
     BlockMetadata,
     Context,
     DynamicContext,
+    ExpressionContextBlock,
+    LiteralContextBlock,
     ResolvedBlock,
     Role,
 )
@@ -286,7 +288,7 @@ async def _phase_persistent_blocks(
 
     Protected blocks (framework blocks like system_prompt, self, state) get
     ``user_block=False`` so they survive truncation.  User-set blocks get
-    ``user_block=True``.  All DynamicContext blocks get ``source_dynamic=True``
+    ``user_block=True``.  All expression blocks get ``source_dynamic=True``
     regardless of origin.
 
     Returns:
@@ -296,27 +298,30 @@ async def _phase_persistent_blocks(
     resolved_cache: dict[str, Any] = {}
     protected_keys = context_manager.protected_keys
 
-    for key, value in context_manager._raw_items():
+    for key, block in context_manager._raw_items():
         if context_manager.is_disabled(key):
             continue
 
         is_user = key not in protected_keys
-        is_static = context_manager.is_static(key)
-        if isinstance(value, DynamicContext):
-            # DynamicContext path: resolve via async eval
+        if isinstance(block, ExpressionContextBlock):
+            # Expression path: resolve via async eval. DynamicContext remains
+            # the compatibility input consumed by the shared resolve function.
+            value = DynamicContext(block.expr)
             # resolve_fn returns pre-formatted string (already pprinted if non-string)
             resolved = await resolve_fn(key, value)
             content = resolved if resolved is not None else "None"
             meta = BlockMetadata(
-                expr=value.expr,
+                expr=block.display_expr or block.expr,
                 user_block=is_user,
-                static=is_static,
+                static=block.prefix,
                 source_dynamic=True,
             )
             # Cache the resolved value for __getitem__ access
             resolved_cache[key] = resolved
         else:
-            # Static path: render value through cfg.context_block_format bounds.
+            assert isinstance(block, LiteralContextBlock)
+            value = block.value
+            # Literal path: render value through cfg.context_block_format bounds.
             # Strings pass verbatim; non-strings go through pformat with the
             # supplied structural knobs (max_string / max_length / max_depth).
             if value is None:
@@ -325,7 +330,7 @@ async def _phase_persistent_blocks(
                 kwargs = context_block_format.model_dump() if context_block_format else {}
                 content = _pformat_value(value, unquote_strings=True, **kwargs)
             meta = BlockMetadata(
-                expr=f'self.context["{key}"]', user_block=is_user, static=is_static
+                expr=f'self.context["{key}"]', user_block=is_user, static=block.prefix
             )
 
         blocks = [

--- a/src/nooa/runtime/context_manager.py
+++ b/src/nooa/runtime/context_manager.py
@@ -6,14 +6,14 @@ Provides a simple dict-like API for LLM-generated code to manage
 what information appears in the system prompt.
 
 Usage:
-    self.context["notes"] = "Here are my notes..."              # static
-    self.context.set_dynamic("status", "self.format_status()")  # dynamic
+    self.context["notes"] = "Here are my notes..."              # literal
+    self.context.set_dynamic("status", "self.format_status()")  # expression
     value = self.context["notes"]                                # read
     del self.context["notes"]                                    # remove
     "notes" in self.context                                      # check
 
-Cache lifecycle for DynamicContext blocks:
-    set_dynamic("key", "expr")  → stores DynamicContext in _blocks, invalidates cache
+Cache lifecycle for expression blocks:
+    set_dynamic("key", "expr")  → stores ExpressionContextBlock, invalidates cache
     _prepare_context() runs     → evaluates expr, calls _update_resolved({"key": value})
     self.context["key"]         → returns cached value from _dynamic_cache
 """
@@ -21,7 +21,13 @@ Cache lifecycle for DynamicContext blocks:
 from collections.abc import ItemsView, Iterator, KeysView
 from typing import Any
 
-from nooa.context_blocks import Context, DynamicContext
+from nooa.context_blocks import (
+    Context,
+    ContextBlock,
+    DynamicContext,
+    ExpressionContextBlock,
+    LiteralContextBlock,
+)
 from nooa.context_blocks.exceptions import DynamicNotResolvedError, ProtectedBlockError
 
 _SENTINEL = object()
@@ -30,14 +36,12 @@ _SENTINEL = object()
 class ContextManager:
     """Dict-like API for managing context blocks.
 
-    Stores context blocks as key -> value mappings. Values are either static
-    values (any type) or DynamicContext markers (for expressions re-evaluated each turn).
+    Stores one canonical typed record per key. Each record owns both independent
+    axes: literal/expression content and cacheable-prefix/volatile-suffix placement.
 
-    Single source of truth:
-    - Static blocks: value lives in _blocks only. __getitem__ reads from _blocks.
-    - DynamicContext blocks: DynamicContext marker in _blocks, resolved value in _dynamic_cache.
-      Cache is populated by _update_resolved() after each _prepare_context() run,
-      and invalidated on set_dynamic() or __setitem__().
+    Expression values are resolved into _dynamic_cache after each
+    _prepare_context() run. Protection, disabled state, and that cache remain
+    runtime-only concerns rather than fields on the serializable block record.
 
     Protected blocks (system_prompt, self, state) are registered via
     set_protected() / set_dynamic_protected() and cannot be overwritten
@@ -45,11 +49,29 @@ class ContextManager:
     """
 
     def __init__(self) -> None:
-        self._blocks: dict[str, Any | DynamicContext] = {}
+        self._blocks: dict[str, ContextBlock] = {}
         self.protected_keys: set[str] = set()
         self._dynamic_cache: dict[str, Any] = {}
-        self._static: dict[str, bool] = {}
         self.disabled_keys: set[str] = set()
+
+    @staticmethod
+    def _make_block(key: str, value: Any, *, prefix: bool) -> ContextBlock:
+        """Normalize one supported input value into a canonical block record."""
+        if isinstance(value, DynamicContext):
+            return ExpressionContextBlock(key=key, expr=value.expr, prefix=prefix)
+        return LiteralContextBlock(key=key, value=value, prefix=prefix)
+
+    def _store_block(self, block: ContextBlock, *, protected: bool = False) -> None:
+        """Store a canonical block and refresh runtime-only bookkeeping."""
+        self._blocks[block.key] = block
+        if protected:
+            self.protected_keys.add(block.key)
+        self.disabled_keys.discard(block.key)
+        self._invalidate(block.key)
+
+    def restore_block(self, block: ContextBlock) -> None:
+        """Restore one validated block without inferring content or placement."""
+        self._store_block(block, protected=block.key in self.protected_keys)
 
     def __setitem__(self, key: str, value: Any) -> None:
         """Set a context block via dict syntax.
@@ -71,37 +93,23 @@ class ContextManager:
             self.disable(key)
             if key in self._blocks and key not in self.protected_keys:
                 del self._blocks[key]
-                self._static.pop(key, None)
             return
         if isinstance(value, Context):
             if value.is_dynamic:
-                if value.prefix:
-                    if key in self.protected_keys:
-                        self.set_static_protected(key, expr=value.expr)
-                    else:
-                        self.set_static(key, expr=value.expr)
-                else:
-                    if key in self.protected_keys:
-                        self.set_dynamic_protected(key, value.expr)
-                    else:
-                        self.set_dynamic(key, value.expr)
+                assert value.expr is not None
+                normalized: Any = DynamicContext(value.expr)
             else:
-                if value.prefix:
-                    if key in self.protected_keys:
-                        self.set_static_protected(key, value.value)
-                    else:
-                        self.set_static(key, value.value)
-                else:
-                    if key in self.protected_keys:
-                        self.set_dynamic_protected(key, value=value.value)
-                    else:
-                        self.set_dynamic(key, value=value.value)
+                normalized = value.value
+            self._store_block(
+                self._make_block(key, normalized, prefix=value.prefix),
+                protected=key in self.protected_keys,
+            )
             return
         if isinstance(value, DynamicContext):
-            if key in self.protected_keys:
-                self.set_dynamic_protected(key, value.expr)
-            else:
-                self.set_dynamic(key, value.expr)
+            self._store_block(
+                self._make_block(key, value, prefix=False),
+                protected=key in self.protected_keys,
+            )
             return
         self.set_dynamic(key, value=value)
 
@@ -160,20 +168,17 @@ class ContextManager:
             raise TypeError("Cannot specify both value and expr=")
 
         if expr is not None:
-            self._blocks[key] = DynamicContext(expr)
+            block = self._make_block(key, DynamicContext(expr), prefix=True)
         elif _SENTINEL is not value:
             if isinstance(value, DynamicContext):
                 raise TypeError(
                     f"Use self.context.set_static({key!r}, expr={value.expr!r}) "
                     f"instead of passing a DynamicContext as value"
                 )
-            self._blocks[key] = value
+            block = self._make_block(key, value, prefix=True)
         else:
             raise TypeError("set_static() requires either value or expr=")
-
-        self._static[key] = True
-        self.disabled_keys.discard(key)
-        self._invalidate(key)
+        self._store_block(block)
 
     def set_dynamic(self, key: str, expr: str | None = None, *, value: Any = _SENTINEL) -> None:
         """Set a dynamic context block (placed in the volatile suffix).
@@ -197,24 +202,23 @@ class ContextManager:
             raise TypeError("Cannot specify both expr and value=")
 
         if expr is not None:
-            self._blocks[key] = DynamicContext(expr)
+            block = self._make_block(key, DynamicContext(expr), prefix=False)
         elif _SENTINEL is not value:
-            self._blocks[key] = value
+            block = self._make_block(key, value, prefix=False)
         else:
             raise TypeError("set_dynamic() requires either expr or value=")
-        self._static[key] = False
-        self.disabled_keys.discard(key)
-        self._invalidate(key)
+        self._store_block(block)
 
     def is_static(self, key: str) -> bool:
         """Return True if the block is in the static (cacheable) partition."""
-        return self._static.get(key, False)
+        block = self._blocks.get(key)
+        return block.prefix if block is not None else False
 
     def __getitem__(self, key: str) -> Any:
         """Get the value of a context block.
 
-        Static blocks: Returns the original value directly from _blocks.
-        DynamicContext blocks: Returns the last resolved value from _dynamic_cache.
+        Literal blocks return their original value directly from the canonical
+        record. Expression blocks return the last value in _dynamic_cache.
 
         Raises:
             KeyError: If key not found.
@@ -224,15 +228,13 @@ class ContextManager:
         if key not in self._blocks:
             raise KeyError(key)
 
-        value = self._blocks[key]
+        block = self._blocks[key]
 
-        # Static block: return directly (single source of truth)
-        if not isinstance(value, DynamicContext):
-            return value
+        if isinstance(block, LiteralContextBlock):
+            return block.value
 
-        # DynamicContext block: return from cache, or raise if not yet resolved
         if key not in self._dynamic_cache:
-            raise DynamicNotResolvedError(key, value.expr)
+            raise DynamicNotResolvedError(key, block.expr)
         return self._dynamic_cache[key]
 
     def __delitem__(self, key: str) -> None:
@@ -247,7 +249,6 @@ class ContextManager:
         if key in self.protected_keys:
             raise ProtectedBlockError(key, "remove")
         del self._blocks[key]
-        self._static.pop(key, None)
         self.disabled_keys.discard(key)
         self._invalidate(key)
 
@@ -295,8 +296,8 @@ class ContextManager:
         """Return a copy of currently suppressed block keys."""
         return set(self.disabled_keys)
 
-    def _raw_items(self) -> ItemsView[str, Any]:
-        """Return raw key-value pairs including DynamicContext markers.
+    def _raw_items(self) -> ItemsView[str, ContextBlock]:
+        """Return raw key-record pairs.
 
         Internal method for context_builder — not part of the LLM-facing API.
         Use keys() + __getitem__ for resolved access.
@@ -326,20 +327,19 @@ class ContextManager:
             raise ProtectedBlockError(key, "remove")
 
         # Get value before removal
-        raw = self._blocks[key]
-        if isinstance(raw, DynamicContext):
-            value = self._dynamic_cache.get(key, raw)
+        block = self._blocks[key]
+        if isinstance(block, ExpressionContextBlock):
+            value = self._dynamic_cache.get(key, DynamicContext(block.expr))
         else:
-            value = raw
+            value = block.value
 
         del self._blocks[key]
-        self._static.pop(key, None)
         self.disabled_keys.discard(key)
         self._invalidate(key)
         return value
 
     def _invalidate(self, key: str) -> None:
-        """Invalidate cached resolved value for a dynamic block.
+        """Invalidate the cached resolved value for an expression block.
 
         Called on set, set_dynamic, delete, and pop to ensure
         stale cache entries are cleared.
@@ -357,7 +357,8 @@ class ContextManager:
         plain values go to dynamic (matching __setitem__ behavior).
         """
         is_protected = key in self.protected_keys
-        is_static_block = self._static.get(key, False)
+        existing = self._blocks.get(key)
+        is_static_block = existing.prefix if existing is not None else False
 
         if value is None:
             self.disable(key)
@@ -365,33 +366,31 @@ class ContextManager:
                 # Remove block definition without clearing disabled_keys
                 # (pop() would discard from disabled_keys, undoing the disable)
                 del self._blocks[key]
-                self._static.pop(key, None)
         elif isinstance(value, Context):
             # Route through __setitem__ which handles all Context cases
             self[key] = value
         elif isinstance(value, DynamicContext):
             if is_protected:
                 if is_static_block:
-                    self.set_static_protected(key, expr=value.expr)
+                    self._store_block(self._make_block(key, value, prefix=True), protected=True)
                 else:
-                    self.set_dynamic_protected(key, value.expr)
+                    self._store_block(self._make_block(key, value, prefix=False), protected=True)
             else:
                 self.set_dynamic(key, value.expr)
         else:
             if is_protected:
                 if is_static_block:
-                    self.set_static_protected(key, value)
+                    self._store_block(self._make_block(key, value, prefix=True), protected=True)
                 else:
-                    self.set_dynamic_protected(key, value=value)
+                    self._store_block(self._make_block(key, value, prefix=False), protected=True)
             else:
                 self[key] = value
 
     def _update_resolved(self, resolved: dict[str, Any]) -> None:
-        """Cache resolved DynamicContext block values.
+        """Cache resolved expression-block values.
 
-        Called by _prepare_context() after evaluating all DynamicContext expressions.
-        Only DynamicContext block values should be cached — static blocks are read
-        directly from _blocks.
+        Called by _prepare_context() after evaluating all expressions. Literal
+        block values are read directly from their canonical records.
         """
         self._dynamic_cache.update(resolved)
 
@@ -409,16 +408,8 @@ class ContextManager:
             value: Plain value to store.
             expr: Python expression to evaluate each turn (keyword-only).
         """
-        if expr is not None:
-            self._blocks[key] = DynamicContext(expr)
-        elif isinstance(value, DynamicContext):
-            self._blocks[key] = value
-        else:
-            self._blocks[key] = value
-        self.protected_keys.add(key)
-        self._static[key] = True
-        self.disabled_keys.discard(key)
-        self._invalidate(key)
+        normalized = DynamicContext(expr) if expr is not None else value
+        self._store_block(self._make_block(key, normalized, prefix=True), protected=True)
 
     def set_dynamic_protected(
         self, key: str, expr: str | None = None, *, value: Any = _SENTINEL
@@ -434,15 +425,12 @@ class ContextManager:
             value: Plain value to store (keyword-only).
         """
         if expr is not None:
-            self._blocks[key] = DynamicContext(expr)
+            block = self._make_block(key, DynamicContext(expr), prefix=False)
         elif _SENTINEL is not value:
-            self._blocks[key] = value
+            block = self._make_block(key, value, prefix=False)
         else:
             raise TypeError("set_dynamic_protected() requires either expr or value=")
-        self.protected_keys.add(key)
-        self._static[key] = False
-        self.disabled_keys.discard(key)
-        self._invalidate(key)
+        self._store_block(block, protected=True)
 
     def remove_protected(self, key: str) -> None:
         """Remove a protected block (used by _apply_context_dict with value=None).
@@ -457,6 +445,5 @@ class ContextManager:
             raise KeyError(key)
         del self._blocks[key]
         self.protected_keys.discard(key)
-        self._static.pop(key, None)
         self.disabled_keys.discard(key)
         self._invalidate(key)

--- a/src/nooa/runtime/context_manager.py
+++ b/src/nooa/runtime/context_manager.py
@@ -61,6 +61,16 @@ class ContextManager:
             return ExpressionContextBlock(key=key, expr=value.expr, prefix=prefix)
         return LiteralContextBlock(key=key, value=value, prefix=prefix)
 
+    @classmethod
+    def _make_context_block(cls, key: str, value: Context) -> ContextBlock:
+        """Normalize a public ``Context`` value into a canonical block record."""
+        if value.is_dynamic:
+            assert value.expr is not None
+            normalized: Any = DynamicContext(value.expr)
+        else:
+            normalized = value.value
+        return cls._make_block(key, normalized, prefix=value.prefix)
+
     def _store_block(self, block: ContextBlock, *, protected: bool = False) -> None:
         """Store a canonical block and refresh runtime-only bookkeeping."""
         self._blocks[block.key] = block
@@ -87,29 +97,20 @@ class ContextManager:
             value: Block value (str, Context, DynamicContext, None, or any pformat-able object).
 
         Raises:
-            ProtectedBlockError: If key is protected and value is not None/Context.
+            ProtectedBlockError: If key is protected and value is not None.
         """
         if value is None:
             self.disable(key)
             if key in self._blocks and key not in self.protected_keys:
                 del self._blocks[key]
             return
+        if key in self.protected_keys:
+            raise ProtectedBlockError(key, "modify")
         if isinstance(value, Context):
-            if value.is_dynamic:
-                assert value.expr is not None
-                normalized: Any = DynamicContext(value.expr)
-            else:
-                normalized = value.value
-            self._store_block(
-                self._make_block(key, normalized, prefix=value.prefix),
-                protected=key in self.protected_keys,
-            )
+            self._store_block(self._make_context_block(key, value))
             return
         if isinstance(value, DynamicContext):
-            self._store_block(
-                self._make_block(key, value, prefix=False),
-                protected=key in self.protected_keys,
-            )
+            self._store_block(self._make_block(key, value, prefix=False))
             return
         self.set_dynamic(key, value=value)
 
@@ -367,8 +368,10 @@ class ContextManager:
                 # (pop() would discard from disabled_keys, undoing the disable)
                 del self._blocks[key]
         elif isinstance(value, Context):
-            # Route through __setitem__ which handles all Context cases
-            self[key] = value
+            self._store_block(
+                self._make_context_block(key, value),
+                protected=is_protected,
+            )
         elif isinstance(value, DynamicContext):
             if is_protected:
                 if is_static_block:

--- a/src/nooa/storage/snapshot.py
+++ b/src/nooa/storage/snapshot.py
@@ -7,34 +7,24 @@ Pydantic models provide validation and JSON serialization out of the box.
 """
 
 import logging
-from typing import Any, Final, Literal
+from collections.abc import Mapping
+from typing import Any, Final
 
-from pydantic import BaseModel, field_serializer, field_validator
+from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
 
-from nooa.context_blocks import DynamicContext
+from nooa.context_blocks import (
+    ContextBlock,
+    ExpressionContextBlock,
+    LiteralContextBlock,
+)
 from nooa.errors.storage import SerializationError
 from nooa.storage.markers import is_nosnapshot_field, is_nosnapshot_value
 from nooa.storage.serialization import SKIP, deserialize, serialize
 
-SNAPSHOT_VERSION: Final = 2
+SNAPSHOT_VERSION: Final = 3
+LEGACY_SNAPSHOT_VERSION: Final = 2
 
 logger = logging.getLogger(__name__)
-
-
-class StaticContextBlock(BaseModel):
-    """A static context block with a JSON-serializable value."""
-
-    key: str
-    type: Literal["static"] = "static"
-    value: Any = None
-
-
-class DynamicContextBlock(BaseModel):
-    """A dynamic context block with a Python expression string."""
-
-    key: str
-    type: Literal["dynamic"] = "dynamic"
-    expr: str
 
 
 class AgentSnapshot(BaseModel):
@@ -45,10 +35,42 @@ class AgentSnapshot(BaseModel):
     """
 
     version: int = SNAPSHOT_VERSION
-    context: list[StaticContextBlock | DynamicContextBlock] = []
-    disabled_context: list[str] = []
-    attributes: dict[str, Any] = {}
-    type_allowlist: set[str] = set()
+    context: list[ContextBlock] = Field(default_factory=list)
+    disabled_context: list[str] = Field(default_factory=list)
+    attributes: dict[str, Any] = Field(default_factory=dict)
+    type_allowlist: set[str] = Field(default_factory=set)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_v2(cls, value: Any) -> Any:
+        """Upgrade legacy v2 block tags to the canonical v3 schema."""
+        if not isinstance(value, Mapping) or value.get("version") != LEGACY_SNAPSHOT_VERSION:
+            return value
+
+        migrated = dict(value)
+        blocks: list[Any] = []
+        for raw_block in value.get("context", []):
+            if isinstance(raw_block, BaseModel):
+                raw_block = raw_block.model_dump()
+            if not isinstance(raw_block, Mapping):
+                blocks.append(raw_block)
+                continue
+
+            block = dict(raw_block)
+            block_type = block.get("type")
+            if block_type == "static":
+                block["type"] = "literal"
+            elif block_type == "dynamic":
+                block["type"] = "expression"
+
+            block.setdefault("prefix", False)
+            if block.get("type") == "expression":
+                block.setdefault("display_expr", None)
+            blocks.append(block)
+
+        migrated["context"] = blocks
+        migrated["version"] = SNAPSHOT_VERSION
+        return migrated
 
     @field_serializer("type_allowlist")
     @classmethod
@@ -78,22 +100,22 @@ class AgentSnapshot(BaseModel):
         """
         all_allowlist: set[str] = set()
 
-        context_blocks: list[StaticContextBlock | DynamicContextBlock] = []
+        context_blocks: list[ContextBlock] = []
         protected = agent.context_manager.protected_keys
-        for key, value in agent.context_manager._raw_items():
+        for key, block in agent.context_manager._raw_items():
             if key in protected:
                 continue  # Framework blocks are recreated by __init__
-            if isinstance(value, DynamicContext):
-                context_blocks.append(DynamicContextBlock(key=key, expr=value.expr))
-            else:
+            if isinstance(block, LiteralContextBlock):
                 try:
-                    serialized, allowlist = serialize(value)
+                    serialized, allowlist = serialize(block.value)
                     all_allowlist |= allowlist
                 except SerializationError as exc:
                     raise SerializationError(
                         f"Context block {key!r} is not serializable: {exc}"
                     ) from exc
-                context_blocks.append(StaticContextBlock(key=key, value=serialized))
+                context_blocks.append(block.model_copy(update={"value": serialized}))
+            else:
+                context_blocks.append(block)
 
         attributes: dict[str, Any] = {}
         agent_cls = type(agent)
@@ -153,25 +175,13 @@ class AgentSnapshot(BaseModel):
             )
 
         for block in self.context:
-            # ``from_agent`` skips protected (framework) keys, so snapshots
-            # produced by this codebase never carry them and the
-            # ``is_protected`` branches below are unreachable for round-tripped
-            # data. They are kept deliberately as defensive handling for
-            # externally-supplied snapshot JSON — hand-edited or legacy
-            # payloads that may still contain protected keys — so such keys are
-            # restored via the protected setters rather than corrupting state.
-            is_protected = block.key in agent.context_manager.protected_keys
-            if isinstance(block, DynamicContextBlock):
-                if is_protected:
-                    agent.context_manager.set_dynamic_protected(block.key, block.expr)
-                else:
-                    agent.context_manager.set_dynamic(block.key, block.expr)
+            if isinstance(block, LiteralContextBlock):
+                block = block.model_copy(
+                    update={"value": deserialize(block.value, self.type_allowlist)}
+                )
             else:
-                value = deserialize(block.value, self.type_allowlist)
-                if is_protected:
-                    agent.context_manager.set_static_protected(block.key, value)
-                else:
-                    agent.context_manager[block.key] = value
+                assert isinstance(block, ExpressionContextBlock)
+            agent.context_manager.restore_block(block)
 
         if self.disabled_context:
             agent.context_manager.disable(*self.disabled_context)

--- a/tests/capability/agents/context_notes.py
+++ b/tests/capability/agents/context_notes.py
@@ -10,7 +10,7 @@ This test verifies that the LLM can:
 
 from nooa import Agent
 from nooa.agentdoc import spec
-from nooa.context_blocks import DynamicContext
+from nooa.context_blocks import ExpressionContextBlock
 
 
 class Notes:
@@ -97,7 +97,7 @@ class NoteTakingTestWrapper(Agent):
         dynamic_blocks = {
             k: v.expr
             for k, v in self._inner_agent.context_manager._raw_items()
-            if isinstance(v, DynamicContext)
+            if isinstance(v, ExpressionContextBlock)
         }
 
         return {

--- a/tests/context_blocks/test_models.py
+++ b/tests/context_blocks/test_models.py
@@ -103,6 +103,38 @@ class TestDynamicContext:
         assert d != "self.value"
 
 
+class TestCanonicalContextBlocks:
+    def test_literal_block_accepts_arbitrary_values(self):
+        from nooa.context_blocks import LiteralContextBlock
+
+        value = {"limits": [1, 2, 3]}
+        block = LiteralContextBlock(key="config", value=value, prefix=True)
+
+        assert block.value is value
+        assert block.type == "literal"
+        assert block.prefix is True
+
+    def test_expression_block_keeps_runtime_and_display_expressions_separate(self):
+        from nooa.context_blocks import ExpressionContextBlock
+
+        block = ExpressionContextBlock(
+            key="status",
+            expr="self.render_status()",
+            display_expr="self.context['status']",
+            prefix=False,
+        )
+
+        assert block.expr == "self.render_status()"
+        assert block.display_expr == "self.context['status']"
+
+    def test_expression_block_rejects_invalid_python(self):
+        from nooa.context_blocks import ExpressionContextBlock
+        from nooa.context_blocks.exceptions import BlockSyntaxError
+
+        with pytest.raises(BlockSyntaxError):
+            ExpressionContextBlock(key="bad", expr="not valid python!!!")
+
+
 class TestBlockMetadata:
     """Tests for BlockMetadata Pydantic model."""
 

--- a/tests/runtime/test_context_api.py
+++ b/tests/runtime/test_context_api.py
@@ -5,7 +5,7 @@
 import pytest
 
 from nooa import Agent
-from nooa.context_blocks import DynamicContext
+from nooa.context_blocks import DynamicContext, ExpressionContextBlock, LiteralContextBlock
 from nooa.context_blocks.exceptions import DynamicNotResolvedError, ProtectedBlockError
 from nooa.runtime.context import ContextApi
 from nooa.unifiedllm import FakeLLMClient
@@ -47,7 +47,7 @@ def test_set_static_expr_lands_in_static_partition():
     ctx.set_static("live", expr="1 + 1")
     # Re-evaluated (DynamicContext marker) yet in the static/cacheable partition.
     assert ctx._context.is_static("live") is True
-    assert isinstance(ctx._context._blocks["live"], DynamicContext)
+    assert isinstance(ctx._context._blocks["live"], ExpressionContextBlock)
     assert ctx._context._blocks["live"].expr == "1 + 1"
 
 
@@ -113,7 +113,7 @@ def test_delitem_raises_for_missing_key():
 
 def test_delitem_raises_for_protected_key():
     ctx = _ctx()
-    ctx._context._blocks["guarded"] = "value"
+    ctx._context._blocks["guarded"] = LiteralContextBlock(key="guarded", value="value")
     ctx._context.protected_keys.add("guarded")
     with pytest.raises(ProtectedBlockError):
         del ctx["guarded"]
@@ -180,7 +180,7 @@ def test_pop_static_block():
 
 def test_pop_dynamic_block():
     ctx = _ctx()
-    ctx._context._blocks["dyn"] = DynamicContext("'hello'")
+    ctx.set_dynamic("dyn", "'hello'")
     ctx._context._dynamic_cache["dyn"] = "hello"
     assert ctx.pop("dyn") == "hello"
     assert "dyn" not in ctx
@@ -199,7 +199,7 @@ def test_pop_raises_for_missing_without_default():
 
 def test_pop_raises_for_protected_key():
     ctx = _ctx()
-    ctx._context._blocks["guarded"] = "value"
+    ctx._context._blocks["guarded"] = LiteralContextBlock(key="guarded", value="value")
     ctx._context.protected_keys.add("guarded")
     with pytest.raises(ProtectedBlockError):
         ctx.pop("guarded")

--- a/tests/runtime/test_context_api.py
+++ b/tests/runtime/test_context_api.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from nooa import Agent
+from nooa import Agent, Context
 from nooa.context_blocks import DynamicContext, ExpressionContextBlock, LiteralContextBlock
 from nooa.context_blocks.exceptions import DynamicNotResolvedError, ProtectedBlockError
 from nooa.runtime.context import ContextApi
@@ -34,6 +34,31 @@ def test_setitem_raises_on_protected_key():
     ctx = _ctx()
     with pytest.raises(ProtectedBlockError):
         ctx["system_prompt"] = "overwrite"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        Context("overwrite", prefix=True),
+        Context(expr="'overwrite'", prefix=True),
+        DynamicContext("'overwrite'"),
+    ],
+)
+def test_setitem_rejects_typed_values_for_protected_key(value):
+    ctx = _ctx()
+    with pytest.raises(ProtectedBlockError):
+        ctx["system_prompt"] = value
+
+
+def test_apply_override_can_replace_protected_key_with_context():
+    ctx = _ctx()
+    ctx._context.apply_override("system_prompt", Context("override", prefix=True))
+
+    block = ctx._context._blocks["system_prompt"]
+    assert isinstance(block, LiteralContextBlock)
+    assert block.value == "override"
+    assert block.prefix is True
+    assert "system_prompt" in ctx._context.protected_keys
 
 
 def test_setitem_accepts_dynamic_context_value():

--- a/tests/runtime/test_context_builder.py
+++ b/tests/runtime/test_context_builder.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from nooa.context_blocks import DynamicContext, ResolvedBlock, Role
+from nooa.context_blocks import DynamicContext, ExpressionContextBlock, ResolvedBlock, Role
 from nooa.context_blocks.events import ToolCallEvent, ToolResult, UserEvent
 
 # ---------------------------------------------------------------------------
@@ -242,6 +242,25 @@ class TestPhasePersistentBlocks:
         assert blocks[0].key == "status"
         assert "resolved:" in blocks[0].content
         assert blocks[0].metadata.expr == "self.get_status()"
+
+    @pytest.mark.asyncio
+    async def test_expression_uses_display_expr_only_for_rendered_metadata(self):
+        from nooa.runtime.context_builder import _phase_persistent_blocks
+        from nooa.runtime.context_manager import ContextManager
+
+        cm = ContextManager()
+        cm.restore_block(
+            ExpressionContextBlock(
+                key="status",
+                expr="self.get_status()",
+                display_expr="self.context['status']",
+            )
+        )
+
+        blocks, _ = await _phase_persistent_blocks([], cm, _identity_resolve)
+
+        assert blocks[0].content == "<resolved:self.get_status()>"
+        assert blocks[0].metadata.expr == "self.context['status']"
 
     @pytest.mark.asyncio
     async def test_pprints_non_string_values(self):

--- a/tests/runtime/test_context_integration.py
+++ b/tests/runtime/test_context_integration.py
@@ -8,7 +8,7 @@ Tests the dict-like ContextApi API and integration with Agent.
 import pytest
 
 from nooa.agent import Agent
-from nooa.context_blocks import DynamicContext
+from nooa.context_blocks import DynamicContext, LiteralContextBlock
 from nooa.unifiedllm import FakeLLMClient
 
 
@@ -315,7 +315,7 @@ class TestContextManager:
 
         agent = TestAgent()
         # Directly inject a block into _blocks AND mark as protected
-        agent.context_manager._blocks["guarded"] = "value"
+        agent.context_manager._blocks["guarded"] = LiteralContextBlock(key="guarded", value="value")
         agent.context_manager.protected_keys.add("guarded")
         with pytest.raises(ProtectedBlockError):
             agent.context_manager.pop("guarded")

--- a/tests/runtime/test_snapshot.py
+++ b/tests/runtime/test_snapshot.py
@@ -8,7 +8,8 @@ from typing import Annotated
 import pytest
 from pydantic import BaseModel
 
-from nooa import Agent
+from nooa import Agent, Context
+from nooa.context_blocks import ExpressionContextBlock, LiteralContextBlock
 from nooa.errors.storage import SerializationError
 from nooa.storage.json_snapshot import (
     snapshot_from_dict,
@@ -17,7 +18,7 @@ from nooa.storage.json_snapshot import (
     snapshot_to_json,
 )
 from nooa.storage.markers import nosnapshot
-from nooa.storage.snapshot import SNAPSHOT_VERSION, AgentSnapshot, StaticContextBlock
+from nooa.storage.snapshot import SNAPSHOT_VERSION, AgentSnapshot
 from nooa.unifiedllm import FakeLLMClient
 
 fake_llm = FakeLLMClient()
@@ -63,11 +64,47 @@ class TestSnapshotRoundtrip:
         agent2 = SimpleAgent()
         snapshot_from_json(snap, agent2)
 
-        from nooa.context_blocks import DynamicContext
-
         raw = dict(agent2.context_manager._raw_items())
-        assert isinstance(raw["status"], DynamicContext)
+        assert isinstance(raw["status"], ExpressionContextBlock)
         assert raw["status"].expr == "self.__class__.__name__"
+
+    def test_content_kind_and_placement_roundtrip_independently(self, agent):
+        """All literal/expression and prefix/suffix combinations retain both axes."""
+        agent.context_manager["prefix_literal"] = Context("stable", prefix=True)
+        agent.context_manager["suffix_literal"] = Context("volatile")
+        agent.context_manager["prefix_expression"] = Context(expr="'stable'", prefix=True)
+        agent.context_manager["suffix_expression"] = Context(expr="'volatile'")
+
+        snapshot = snapshot_to_json(agent)
+        restored = SimpleAgent()
+        snapshot_from_json(snapshot, restored)
+
+        blocks = dict(restored.context_manager._raw_items())
+        assert isinstance(blocks["prefix_literal"], LiteralContextBlock)
+        assert blocks["prefix_literal"].prefix is True
+        assert isinstance(blocks["suffix_literal"], LiteralContextBlock)
+        assert blocks["suffix_literal"].prefix is False
+        assert isinstance(blocks["prefix_expression"], ExpressionContextBlock)
+        assert blocks["prefix_expression"].prefix is True
+        assert isinstance(blocks["suffix_expression"], ExpressionContextBlock)
+        assert blocks["suffix_expression"].prefix is False
+
+    def test_expression_display_expr_roundtrip(self, agent):
+        block = ExpressionContextBlock(
+            key="status",
+            expr="self.__class__.__name__",
+            display_expr="self.context['status']",
+            prefix=True,
+        )
+        agent.context_manager.restore_block(block)
+
+        restored = SimpleAgent()
+        snapshot_from_json(snapshot_to_json(agent), restored)
+
+        restored_block = dict(restored.context_manager._raw_items())["status"]
+        assert isinstance(restored_block, ExpressionContextBlock)
+        assert restored_block.display_expr == "self.context['status']"
+        assert restored_block.prefix is True
 
     def test_event_manager_state_not_in_snapshot(self, agent):
         """Snapshots no longer carry next_tag_num; allocation lives on the backend."""
@@ -154,7 +191,7 @@ class TestAgentSnapshot:
         assert isinstance(snap, AgentSnapshot)
         assert snap.version == SNAPSHOT_VERSION
         assert len(snap.context) == 1
-        assert isinstance(snap.context[0], StaticContextBlock)
+        assert isinstance(snap.context[0], LiteralContextBlock)
         assert snap.context[0].key == "key"
         assert snap.context[0].value == "value"
 
@@ -171,6 +208,47 @@ class TestAgentSnapshot:
         assert restored.version == original.version
         assert len(restored.context) == len(original.context)
         assert restored.attributes == {"score": 42}
+
+    @pytest.mark.parametrize(
+        ("legacy_type", "payload_field", "payload_value", "expected_type"),
+        [
+            ("static", "value", {"nested": [1, 2]}, LiteralContextBlock),
+            ("dynamic", "expr", "'value'", ExpressionContextBlock),
+        ],
+    )
+    def test_v2_snapshot_migrates_old_tags(
+        self, legacy_type, payload_field, payload_value, expected_type
+    ):
+        legacy = {
+            "version": 2,
+            "context": [{"key": "legacy", "type": legacy_type, payload_field: payload_value}],
+        }
+
+        migrated = snapshot_from_dict(legacy)
+
+        assert migrated.version == SNAPSHOT_VERSION
+        assert isinstance(migrated.context[0], expected_type)
+        assert migrated.context[0].prefix is False
+
+    def test_v2_snapshot_preserves_compatibility_fix_placement(self):
+        legacy = {
+            "version": 2,
+            "context": [
+                {
+                    "key": "python_cell_tools",
+                    "type": "dynamic",
+                    "expr": "'tools'",
+                    "prefix": True,
+                }
+            ],
+        }
+
+        migrated = snapshot_from_dict(legacy)
+
+        block = migrated.context[0]
+        assert isinstance(block, ExpressionContextBlock)
+        assert block.prefix is True
+        assert block.display_expr is None
 
     def test_restore_via_model(self, agent):
         """AgentSnapshot.restore mutates agent correctly."""

--- a/tests/test_sqlite_storage_latest.py
+++ b/tests/test_sqlite_storage_latest.py
@@ -4,7 +4,9 @@
 
 from __future__ import annotations
 
-from nooa import Agent
+import pytest
+
+from nooa import Agent, Context
 from nooa.storage import SQLiteStorageManager
 from nooa.unifiedllm import CompletionClient
 
@@ -15,6 +17,16 @@ def _make_storage() -> SQLiteStorageManager:
 
 class _SimpleAgent(Agent, llm=CompletionClient(model="openai/gpt-4o-mini", api_key="test")):
     value: int = 0
+
+
+class _PrefixResumeAgent(Agent, llm=CompletionClient(model="openai/gpt-4o-mini", api_key="test")):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.context["python_cell_tools"] = Context(expr="'TOOLS'", prefix=True)
+
+    async def work(self) -> str:
+        """Exercise context rendering after snapshot resume."""
+        ...
 
 
 def test_get_latest_snapshot_id_empty():
@@ -57,3 +69,29 @@ def test_restore_latest_returns_most_recent():
     agent2 = _SimpleAgent(storage=storage)
     storage.restore_latest_snapshot(agent2)
     assert agent2.value == 99
+
+
+@pytest.mark.asyncio
+async def test_restart_resume_keeps_expression_block_in_cached_prefix(tmp_path):
+    db_path = tmp_path / "resume.db"
+    storage = SQLiteStorageManager(db_path)
+    agent = _PrefixResumeAgent(storage=storage)
+    storage.save_snapshot(agent)
+    storage.close()
+
+    restored_storage = SQLiteStorageManager(db_path)
+    try:
+        restored = _PrefixResumeAgent(storage=restored_storage)
+        assert restored_storage.restore_latest_snapshot(restored) is True
+
+        messages = await restored.runtime._build_messages(type(restored).work)
+        system_content = next(m["content"] for m in messages if m["role"] == "system")
+        trailing_context = "\n".join(
+            m["content"] for m in messages if m["role"] == "user" and "<context>" in m["content"]
+        )
+
+        assert "<python_cell_tools " in system_content
+        assert "TOOLS" in system_content
+        assert "python_cell_tools" not in trailing_context
+    finally:
+        restored_storage.close()

--- a/tests/viewer/test_main.py
+++ b/tests/viewer/test_main.py
@@ -247,6 +247,7 @@ def test_dns_search_domain_qualified_name_is_accepted(client, monkeypatch):
     from a DNS search domain, so `<host>.<domain>` must match on the prefix.
     """
     monkeypatch.delenv("NOOA_VIEWER_ALLOWED_HOSTS", raising=False)
+    monkeypatch.setattr(main_module, "_OWN_HOSTNAME", "test-host")
     qualified = f"{main_module._OWN_HOSTNAME}.corp.example.com"
     assert client.get("/api/version", headers={"Host": qualified, **_BROWSER}).status_code == 200
     assert (


### PR DESCRIPTION
This PR Introduces canonical context-block records that keep content type and prompt placement together.

- Replaces the split `_blocks`/`_static` state with discriminated literal and expression block models.
- Preserves `prefix` placement across save, restart, and restore.
- Adds snapshot v3 with automatic migration from v2 snapshots.
- Keeps existing `Context` and dictionary-style APIs backward compatible.
- Adds coverage for literal/expression × prefix/suffix combinations and SQLite restart/resume behavior.
- Makes the DNS-qualified hostname test deterministic across environments.

## Related issues

Closes #230

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`: 6,826 passed)
- [x] Docs updated if behavior or public APIs changed (no public API documentation changes required)
- [x] New source files carry an SPDX license header (no new source files added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed context blocks for literal values and evaluated expressions.
  * Expression blocks support separate runtime and display expressions, prefixes, caching, and syntax validation.
  * Context block types are publicly available for integrations.

* **Improvements**
  * Context rendering preserves prefixes and display metadata during runtime operations.
  * Protected context entries retain their safeguards when overridden.
  * Saved agent snapshots preserve context blocks and migrate from the previous format.

* **Bug Fixes**
  * Improved context restoration after saving and resuming agents, including correct prompt placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->