### PR TITLE
feat(cli): preserve Harbor verifier metadata

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
@@ -52,15 +52,28 @@ def _viewer_headers(headers: dict[str, str]) -> dict[str, str]:
 
 def inject_resource_attrs(
     body: dict,
-    attrs: dict[str, str | bool | int],
+    attrs: dict[str, str | bool | int | float],
     *,
     overwrite: bool = False,
+    overwrite_keys: set[str] | None = None,
 ) -> dict:
     """Inject additional resource attributes into an OTLP body.
 
-    Existing keys are preserved unless ``overwrite`` is true. Values are typed:
-    str → stringValue, bool → boolValue, int → intValue.
+    Existing keys are preserved unless ``overwrite`` is true or the key is in
+    ``overwrite_keys``. Values are typed: str → stringValue, bool →
+    boolValue, int → intValue, float → doubleValue.
     """
+    overwrite_keys = overwrite_keys or set()
+
+    def otlp_value(val: str | bool | int | float) -> dict:
+        if isinstance(val, bool):
+            return {"boolValue": val}
+        if isinstance(val, int):
+            return {"intValue": val}
+        if isinstance(val, float):
+            return {"doubleValue": val}
+        return {"stringValue": val}
+
     resource_spans = body.get("resourceSpans")
     if not isinstance(resource_spans, list):
         return body
@@ -80,17 +93,11 @@ def inject_resource_attrs(
             if isinstance(attribute, dict) and isinstance(attribute.get("key"), str)
         }
         for key, val in attrs.items():
-            if isinstance(val, bool):
-                otlp_val = {"boolValue": val}
-            elif isinstance(val, int):
-                otlp_val = {"intValue": val}
-            else:
-                otlp_val = {"stringValue": val}
             if key in existing_by_key:
-                if overwrite:
-                    existing_by_key[key]["value"] = otlp_val
+                if overwrite or key in overwrite_keys:
+                    existing_by_key[key]["value"] = otlp_value(val)
             else:
-                existing.append({"key": key, "value": otlp_val})
+                existing.append({"key": key, "value": otlp_value(val)})
     return body
 
 

--- a/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/_otlp_helpers.py
@@ -69,7 +69,9 @@ def inject_resource_attrs(
         if isinstance(val, bool):
             return {"boolValue": val}
         if isinstance(val, int):
-            return {"intValue": val}
+            # OTLP JSON encodes int64 values as decimal strings so values above
+            # JavaScript's safe integer limit retain their exact value.
+            return {"intValue": str(val)}
         if isinstance(val, float):
             return {"doubleValue": val}
         return {"stringValue": val}

--- a/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
@@ -45,6 +45,7 @@ MAX_VERIFIER_FIELDS = 100
 MAX_VERIFIER_DEPTH = 4
 MAX_VERIFIER_SCALAR_CHARS = 1_000
 MAX_VERIFIER_OUTPUT_CHARS = 50_000
+MAX_TRACE_SNIFF_RECORDS = 20
 
 OtlpScalar = str | bool | int | float
 
@@ -96,16 +97,36 @@ class HarborVerifierOutcome:
 
 
 def _find_harbor_traces(root: Path) -> list[Path]:
-    """Find OTLP or portable journal traces under supported Harbor layouts.
-
-    Older integrations wrote beneath ``trial_dir/artifacts``. Current Harbor
-    mounts ``/logs/agent`` at ``trial_dir/agent``, where Nooa writes ``traces``.
-    """
-    traces = set(root.rglob("artifacts/**/*.jsonl"))
-    # Current Harbor mounts /logs/agent directly at <trial>/agent, while older
-    # integrations copied /logs/artifacts to <trial>/artifacts.
-    traces.update(root.rglob("agent/traces/**/*.jsonl"))
+    """Find trace JSONL files within Harbor trials, independent of layout."""
+    traces: set[Path] = set()
+    for trial_dir in _trial_dirs(root):
+        traces.update(path for path in trial_dir.rglob("*.jsonl") if _is_trace_jsonl(path))
     return sorted(traces)
+
+
+def _is_trace_jsonl(path: Path) -> bool:
+    """Return whether a JSONL file contains an OTLP envelope or Nooa journal record."""
+    records_seen = 0
+    try:
+        with path.open() as stream:
+            for line in stream:
+                if not line.strip():
+                    continue
+                try:
+                    body = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                records_seen += 1
+                if isinstance(body, dict) and (
+                    isinstance(body.get("resourceSpans"), list)
+                    or get_journal_record(body) is not None
+                ):
+                    return True
+                if records_seen >= MAX_TRACE_SNIFF_RECORDS:
+                    break
+    except (OSError, UnicodeError):
+        return False
+    return False
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -299,10 +320,11 @@ def _serialize_verifier_output(outcome: HarborVerifierOutcome) -> str | None:
 
 
 def _trial_dir_for_trace(jsonl_path: Path) -> Path:
-    """Resolve a trace file to its Harbor trial across supported host layouts."""
+    """Resolve a trace file to its nearest enclosing Harbor trial directory."""
     for parent in jsonl_path.parents:
-        if parent.name in {"artifacts", "agent"}:
-            return parent.parent
+        result = _read_json(parent / "result.json")
+        if result.get("trial_name") or (parent / "config.json").is_file():
+            return parent
     return jsonl_path.parent
 
 
@@ -318,8 +340,8 @@ def _datetime_ns(value: object, fallback: int) -> int:
     return max(0, int(parsed.timestamp() * 1_000_000_000))
 
 
-def _trial_meta(jsonl_path: Path) -> dict:
-    """Extract Harbor metadata for a trace file from its surrounding directory structure.
+def _trial_meta_from_dir(trial_dir: Path) -> dict:
+    """Extract Harbor metadata from a discovered trial directory.
 
     Expected layout::
 
@@ -330,10 +352,8 @@ def _trial_meta(jsonl_path: Path) -> dict:
                 verifier/
                     result.json      ← arbitrary benchmark verifier result
                     reward.json      ← optional scalar reward (or reward.txt)
-                artifacts/...        ← legacy trace layout
-                agent/traces/...     ← current persisted trace layout
+                <any path>/*.jsonl   ← OTLP or portable journal traces
     """
-    trial_dir = _trial_dir_for_trace(jsonl_path)
     job_dir = trial_dir.parent
 
     trial_result = _read_json(trial_dir / "result.json")
@@ -383,6 +403,11 @@ def _trial_meta(jsonl_path: Path) -> dict:
         "experiment": job_dir.name or harbor_eval or "harbor",
         "job_name": job_dir.name,
     }
+
+
+def _trial_meta(jsonl_path: Path) -> dict:
+    """Extract Harbor metadata for a trace file from its enclosing trial."""
+    return _trial_meta_from_dir(_trial_dir_for_trace(jsonl_path))
 
 
 def _harbor_resource_attrs(meta: dict, experiment: str, batch_id: str) -> dict[str, OtlpScalar]:
@@ -578,11 +603,6 @@ def _trial_dirs(root: Path) -> list[Path]:
     return sorted(out)
 
 
-def _trial_meta_from_dir(trial_dir: Path) -> dict:
-    """Extract Harbor metadata when only a trial directory is available."""
-    return _trial_meta(trial_dir / "artifacts" / "traces" / "_synthetic.jsonl")
-
-
 def _import_trace_file(
     endpoint: str,
     jsonl_path: Path,
@@ -765,7 +785,7 @@ def command(
     else:
         if not files:
             click.echo(f"No Harbor trace files found under {path}")
-            click.echo("Expected: <job>/<trial>/{artifacts/**,agent/traces/**}/*.jsonl")
+            click.echo("Expected: OTLP or Nooa journal JSONL within a Harbor trial directory")
             click.echo("Tip: use --eval-only to group Harbor result metadata without trace files")
             raise SystemExit(1)
 

--- a/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
@@ -100,7 +100,7 @@ def _find_harbor_traces(root: Path) -> list[Path]:
     """Find trace JSONL files within Harbor trials, independent of layout."""
     traces: set[Path] = set()
     for trial_dir in _trial_dirs(root):
-        seen_contents: set[str] = set()
+        candidates_by_size: dict[int, list[Path]] = {}
         candidates = sorted(
             trial_dir.rglob("*.jsonl"),
             key=lambda path: (len(path.relative_to(trial_dir).parts), str(path)),
@@ -108,34 +108,47 @@ def _find_harbor_traces(root: Path) -> list[Path]:
         for path in candidates:
             if not _is_trace_jsonl(path):
                 continue
-            content_hash = _trace_content_hash(path)
-            if content_hash is None or content_hash in seen_contents:
+            try:
+                candidates_by_size.setdefault(path.stat().st_size, []).append(path)
+            except OSError:
                 continue
-            seen_contents.add(content_hash)
-            traces.add(path)
+
+        # Identical content necessarily has an identical byte size.  Avoid a
+        # full streaming digest for the common case of one trace per trial,
+        # while retaining content-based deduplication for mirrored copies.
+        for same_size_paths in candidates_by_size.values():
+            if len(same_size_paths) == 1:
+                traces.add(same_size_paths[0])
+                continue
+
+            seen_contents: set[str] = set()
+            for path in same_size_paths:
+                content_hash = _trace_content_hash(path)
+                if content_hash is None or content_hash in seen_contents:
+                    continue
+                seen_contents.add(content_hash)
+                traces.add(path)
     return sorted(traces)
 
 
 def _is_trace_jsonl(path: Path) -> bool:
     """Return whether a JSONL file contains an OTLP envelope or Nooa journal record."""
-    records_seen = 0
     try:
         with path.open() as stream:
-            for line in stream:
+            for records_seen, line in enumerate(stream, start=1):
+                if records_seen > MAX_TRACE_SNIFF_RECORDS:
+                    break
                 if not line.strip():
                     continue
                 try:
                     body = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                records_seen += 1
                 if isinstance(body, dict) and (
                     isinstance(body.get("resourceSpans"), list)
                     or get_journal_record(body) is not None
                 ):
                     return True
-                if records_seen >= MAX_TRACE_SNIFF_RECORDS:
-                    break
     except (OSError, UnicodeError):
         return False
     return False
@@ -274,11 +287,6 @@ def _read_verifier_outcome(trial_dir: Path, trial_result: dict[str, Any]) -> Har
         error=error,
         source=source,
     )
-
-
-def _read_score(trial_dir: Path, trial_result: dict) -> float | None:
-    """Compatibility wrapper returning the generic verifier outcome's score."""
-    return _read_verifier_outcome(trial_dir, trial_result).score
 
 
 def _attribute_segment(value: object) -> str:

--- a/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Import NOOA OTLP or portable journal traces from Harbor into the viewer.
 
-Walks a Harbor job directory (or any directory containing one), finds all
-traces under ``artifacts/traces/*.jsonl``, enriches them with Harbor metadata
-(trial name, task name, reward score, experiment grouping), and posts them to
-the viewer.
+Walks a Harbor job directory (or any directory containing one), finds persisted
+trace JSONL files, enriches them with trial metadata and arbitrary verifier
+results, and posts them to the viewer. A synthetic ``eval`` span makes the
+verifier result visible in both experiment and trace detail views.
 
 Usage:
     nooa import-harbor ./jobs/my-job/
@@ -13,12 +13,17 @@ Usage:
     nooa import-harbor ./jobs/ --experiment my-eval --batch-id run-42
 """
 
+import hashlib
 import json
+import math
+import re
 import time
 import urllib.parse
 import urllib.request
-import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 import click
 
@@ -36,67 +41,281 @@ from ._otlp_helpers import (
 
 NAME = "import-harbor"
 
+MAX_VERIFIER_FIELDS = 100
+MAX_VERIFIER_DEPTH = 4
+MAX_VERIFIER_SCALAR_CHARS = 1_000
+MAX_VERIFIER_OUTPUT_CHARS = 50_000
+
+OtlpScalar = str | bool | int | float
+
+
+@dataclass(frozen=True)
+class HarborVerifierOutcome:
+    """Benchmark-neutral data recovered from Harbor verifier artifacts."""
+
+    result: dict[str, Any] | None
+    embedded_result: dict[str, Any] | None
+    reward: dict[str, Any] | None
+    reward_text: str | None
+    score: float | None
+    passed: bool | None
+    error: str | None
+    source: str | None
+
+    def output(self) -> object | None:
+        """Return the complete verifier documents with their artifact provenance."""
+        if (
+            self.result is not None
+            and self.embedded_result is None
+            and self.reward is None
+            and self.reward_text is None
+            and self.error is None
+        ):
+            return self.result
+        if (
+            self.result is None
+            and self.embedded_result is None
+            and self.reward is not None
+            and self.reward_text is None
+            and self.error is None
+        ):
+            return self.reward
+
+        documents: dict[str, Any] = {}
+        if self.result is not None:
+            documents["result"] = self.result
+        if self.embedded_result is not None:
+            documents["embedded_result"] = self.embedded_result
+        if self.reward is not None:
+            documents["reward"] = self.reward
+        if self.reward_text is not None:
+            documents["reward_text"] = self.reward_text
+        if self.error is not None:
+            documents["harness_error"] = self.error
+        return documents or None
+
 
 def _find_harbor_traces(root: Path) -> list[Path]:
-    """Find all OTLP or portable journal trace files under Harbor artifacts.
+    """Find OTLP or portable journal traces under supported Harbor layouts.
 
-    Harbor copies the container's ``/logs/artifacts/`` to ``trial_dir/artifacts/``
-    on the host. The agent decides the layout within that directory — a common
-    convention is ``artifacts/traces/*.jsonl``, but we search the full subtree
-    to be robust to other layouts.
+    Older integrations wrote beneath ``trial_dir/artifacts``. Current Harbor
+    mounts ``/logs/agent`` at ``trial_dir/agent``, where Nooa writes ``traces``.
     """
-    return sorted(root.rglob("artifacts/**/*.jsonl"))
+    traces = set(root.rglob("artifacts/**/*.jsonl"))
+    # Current Harbor mounts /logs/agent directly at <trial>/agent, while older
+    # integrations copied /logs/artifacts to <trial>/artifacts.
+    traces.update(root.rglob("agent/traces/**/*.jsonl"))
+    return sorted(traces)
 
 
-def _read_json(path: Path) -> dict:
+def _read_json(path: Path) -> dict[str, Any]:
     """Read a JSON file, returning an empty dict on any failure."""
     try:
-        return json.loads(path.read_text())
+        value = json.loads(path.read_text())
     except Exception:
         return {}
+    return value if isinstance(value, dict) else {}
 
 
 def _coerce_float(value: object) -> float | None:
     """Coerce a value to float, returning None if it cannot be coerced."""
+    if isinstance(value, bool) or not isinstance(value, str | int | float):
+        return None
     try:
-        return float(value)  # type: ignore[arg-type]
+        number = float(value)
     except (TypeError, ValueError, OverflowError):
         return None
+    return number if math.isfinite(number) else None
 
 
-def _read_score(trial_dir: Path, trial_result: dict) -> float | None:
-    """Read the trial reward score, trying current Harbor result shapes in order.
+def _score_from_document(document: dict[str, Any] | None) -> float | None:
+    """Select a conventional score from an arbitrary verifier document."""
+    if not document:
+        return None
 
-    Different Harbor/BinPool versions write the scalar reward in different places.
-    Fallback order (first coercible float wins):
-
-    1. ``verifier/reward.json["score"]``
-    2. ``verifier/reward.json["reward"]``
-    3. ``result.json["verifier_result"]["rewards"]["score"]``
-    4. ``result.json["verifier_result"]["rewards"]["reward"]``
-    5. ``verifier/reward.txt`` (plain float string)
-
-    Explicit ``None`` checks (not truthiness) ensure a valid ``0.0`` is returned.
-    """
-    reward_json = _read_json(trial_dir / "verifier" / "reward.json")
     for key in ("score", "reward"):
-        score = _coerce_float(reward_json.get(key))
+        score = _coerce_float(document.get(key))
         if score is not None:
             return score
 
-    verifier_result = trial_result.get("verifier_result")
-    rewards = verifier_result.get("rewards") if isinstance(verifier_result, dict) else None
-    if isinstance(rewards, dict):
-        for key in ("score", "reward"):
-            score = _coerce_float(rewards.get(key))
-            if score is not None:
-                return score
+    rewards = document.get("rewards")
+    if not isinstance(rewards, dict):
+        return None
+    for key in ("score", "reward"):
+        score = _coerce_float(rewards.get(key))
+        if score is not None:
+            return score
 
-    reward_txt = trial_dir / "verifier" / "reward.txt"
-    if reward_txt.exists():
-        return _coerce_float(reward_txt.read_text().strip())
-
+    # Some validators give their single normalized metric a benchmark-specific
+    # name (for example "progress"). Counts and multiple metrics remain
+    # metadata rather than being guessed into the viewer's 0..1 score field.
+    numeric_rewards = [
+        score for value in rewards.values() if (score := _coerce_float(value)) is not None
+    ]
+    if len(numeric_rewards) == 1 and 0.0 <= numeric_rewards[0] <= 1.0:
+        return numeric_rewards[0]
     return None
+
+
+def _explicit_passed(*documents: dict[str, Any] | None) -> bool | None:
+    """Return the first explicit boolean pass result from verifier documents."""
+    for document in documents:
+        if document and isinstance(document.get("passed"), bool):
+            return document["passed"]
+    return None
+
+
+def _format_error(value: object) -> str | None:
+    if value in (None, "", {}):
+        return None
+    if isinstance(value, str):
+        return value[:MAX_VERIFIER_SCALAR_CHARS]
+    try:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)[
+            :MAX_VERIFIER_SCALAR_CHARS
+        ]
+    except (TypeError, ValueError):
+        return str(value)[:MAX_VERIFIER_SCALAR_CHARS]
+
+
+def _read_verifier_outcome(trial_dir: Path, trial_result: dict[str, Any]) -> HarborVerifierOutcome:
+    """Read Harbor verifier artifacts without assuming benchmark semantics."""
+    result_path = trial_dir / "verifier" / "result.json"
+    result = _read_json(result_path)
+    source: str | None = "verifier/result.json" if result else None
+
+    embedded = trial_result.get("verifier_result")
+    embedded_result = embedded if isinstance(embedded, dict) else None
+    if not result and embedded_result is not None:
+        result = embedded_result
+        embedded_result = None
+        source = "result.json:verifier_result"
+
+    reward = _read_json(trial_dir / "verifier" / "reward.json")
+    if source is None and reward:
+        source = "verifier/reward.json"
+    reward_text: str | None = None
+    reward_text_path = trial_dir / "verifier" / "reward.txt"
+    if reward_text_path.exists():
+        try:
+            reward_text = reward_text_path.read_text().strip()
+        except OSError:
+            reward_text = None
+    if source is None and reward_text is not None:
+        source = "verifier/reward.txt"
+
+    score = _score_from_document(reward)
+    if score is None:
+        score = _score_from_document(result)
+    if score is None and reward_text is not None:
+        score = _coerce_float(reward_text)
+
+    passed = _explicit_passed(result, reward)
+    if passed is None and score is not None and 0.0 <= score <= 1.0:
+        # Preserve Harbor's established 0/1 reward convention. Scores outside
+        # the normalized range are never assigned a guessed pass threshold.
+        passed = score >= 1.0
+
+    error = _format_error(
+        trial_result.get("exception_info")
+        or trial_result.get("error")
+        or trial_result.get("exception")
+    )
+
+    return HarborVerifierOutcome(
+        result=result or None,
+        embedded_result=embedded_result,
+        reward=reward or None,
+        reward_text=reward_text,
+        score=score,
+        passed=passed,
+        error=error,
+        source=source,
+    )
+
+
+def _read_score(trial_dir: Path, trial_result: dict) -> float | None:
+    """Compatibility wrapper returning the generic verifier outcome's score."""
+    return _read_verifier_outcome(trial_dir, trial_result).score
+
+
+def _attribute_segment(value: object) -> str:
+    """Make one arbitrary JSON key safe and readable in an OTLP attribute path."""
+    segment = re.sub(r"[^A-Za-z0-9_-]+", "_", str(value)).strip("_")[:80]
+    return segment or "field"
+
+
+def _flatten_verifier_fields(outcome: HarborVerifierOutcome) -> dict[str, OtlpScalar]:
+    """Flatten bounded scalar verifier leaves for dynamic experiment columns."""
+    flattened: dict[str, OtlpScalar] = {}
+
+    def walk(value: object, prefix: str, depth: int) -> None:
+        if len(flattened) >= MAX_VERIFIER_FIELDS:
+            return
+        if isinstance(value, bool):
+            flattened[prefix] = value
+        elif isinstance(value, int):
+            flattened[prefix] = value
+        elif isinstance(value, float) and math.isfinite(value):
+            flattened[prefix] = value
+        elif isinstance(value, str):
+            flattened[prefix] = value[:MAX_VERIFIER_SCALAR_CHARS]
+        elif isinstance(value, dict) and depth < MAX_VERIFIER_DEPTH:
+            for key in sorted(value, key=str):
+                walk(value[key], f"{prefix}.{_attribute_segment(key)}", depth + 1)
+
+    if outcome.result is not None:
+        walk(outcome.result, "eval.verifier", 0)
+    if outcome.reward is not None:
+        reward_prefix = "eval.verifier.reward_artifact" if outcome.result else "eval.verifier"
+        walk(outcome.reward, reward_prefix, 0)
+    if outcome.reward_text is not None:
+        flattened.setdefault(
+            "eval.verifier.reward_text", outcome.reward_text[:MAX_VERIFIER_SCALAR_CHARS]
+        )
+    if outcome.source:
+        flattened["eval.verifier_source"] = outcome.source
+    return flattened
+
+
+def _serialize_verifier_output(outcome: HarborVerifierOutcome) -> str | None:
+    """Serialize complete verifier artifacts into one bounded, valid JSON attribute."""
+    output = outcome.output()
+    if output is None:
+        return None
+    serialized = json.dumps(output, ensure_ascii=False, sort_keys=True, default=str)
+    if len(serialized) <= MAX_VERIFIER_OUTPUT_CHARS:
+        return serialized
+    return json.dumps(
+        {
+            "_truncated": True,
+            "original_chars": len(serialized),
+            # Leave ample headroom for JSON escaping inside the preview string.
+            "preview": serialized[: MAX_VERIFIER_OUTPUT_CHARS // 8],
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+
+
+def _trial_dir_for_trace(jsonl_path: Path) -> Path:
+    """Resolve a trace file to its Harbor trial across supported host layouts."""
+    for parent in jsonl_path.parents:
+        if parent.name in {"artifacts", "agent"}:
+            return parent.parent
+    return jsonl_path.parent
+
+
+def _datetime_ns(value: object, fallback: int) -> int:
+    if not isinstance(value, str) or not value:
+        return fallback
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return fallback
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return max(0, int(parsed.timestamp() * 1_000_000_000))
 
 
 def _trial_meta(jsonl_path: Path) -> dict:
@@ -109,18 +328,12 @@ def _trial_meta(jsonl_path: Path) -> dict:
             <trial_name>/
                 result.json          ← trial_name, task_name, agent_info
                 verifier/
-                    reward.json      ← {"reward"|"score": <float>}  (or reward.txt)
-                artifacts/           ← copy of /logs/artifacts/ from container
-                    [traces/]        ← agent-defined layout; traces can be here
-                        <file>.jsonl ← this file
+                    result.json      ← arbitrary benchmark verifier result
+                    reward.json      ← optional scalar reward (or reward.txt)
+                artifacts/...        ← legacy trace layout
+                agent/traces/...     ← current persisted trace layout
     """
-    # Walk up from the JSONL file to find the 'artifacts' directory;
-    # trial_dir is its parent (works regardless of depth under artifacts/).
-    trial_dir = jsonl_path.parent
-    for parent in jsonl_path.parents:
-        if parent.name == "artifacts":
-            trial_dir = parent.parent
-            break
+    trial_dir = _trial_dir_for_trace(jsonl_path)
     job_dir = trial_dir.parent
 
     trial_result = _read_json(trial_dir / "result.json")
@@ -128,12 +341,15 @@ def _trial_meta(jsonl_path: Path) -> dict:
 
     trial_name = trial_result.get("trial_name") or trial_dir.name
     task_name = trial_result.get("task_name", "")
-    config = trial_result.get("config") if isinstance(trial_result.get("config"), dict) else {}
-    agent_config = config.get("agent") if isinstance(config.get("agent"), dict) else {}
-    task_config = config.get("task") if isinstance(config.get("task"), dict) else {}
-    agent_name = (trial_result.get("agent_info") or {}).get("name", "") or agent_config.get(
-        "name", ""
-    )
+    config_value = trial_result.get("config")
+    config: dict[str, Any] = config_value if isinstance(config_value, dict) else {}
+    agent_value = config.get("agent")
+    agent_config: dict[str, Any] = agent_value if isinstance(agent_value, dict) else {}
+    task_value = config.get("task")
+    task_config: dict[str, Any] = task_value if isinstance(task_value, dict) else {}
+    agent_info_value = trial_result.get("agent_info")
+    agent_info: dict[str, Any] = agent_info_value if isinstance(agent_info_value, dict) else {}
+    agent_name = agent_info.get("name", "") or agent_config.get("name", "")
     model_name = agent_config.get("model_name", "")
     agent_type = ""
     kwargs = agent_config.get("kwargs") if isinstance(agent_config.get("kwargs"), dict) else {}
@@ -141,8 +357,7 @@ def _trial_meta(jsonl_path: Path) -> dict:
         agent_type = str(kwargs.get("agent_type") or "")
     source = trial_result.get("source") or task_config.get("source") or ""
 
-    # Reward scalar lives in different places across Harbor versions; see _read_score.
-    score = _read_score(trial_dir, trial_result)
+    verifier = _read_verifier_outcome(trial_dir, trial_result)
 
     # Keep the Harbor eval key as metadata, but group viewer Evaluations by
     # Harbor job by default. The eval key is usually broad (for example,
@@ -162,16 +377,17 @@ def _trial_meta(jsonl_path: Path) -> dict:
         "source": source,
         "started_at": trial_result.get("started_at", ""),
         "finished_at": trial_result.get("finished_at", ""),
-        "score": score,
+        "score": verifier.score,
+        "verifier": verifier,
         "harbor_eval": harbor_eval,
         "experiment": job_dir.name or harbor_eval or "harbor",
         "job_name": job_dir.name,
     }
 
 
-def _harbor_resource_attrs(meta: dict, experiment: str, batch_id: str) -> dict[str, str | bool]:
+def _harbor_resource_attrs(meta: dict, experiment: str, batch_id: str) -> dict[str, OtlpScalar]:
     """Build viewer resource attrs that make a Harbor trial appear as an eval row."""
-    attrs: dict[str, str | bool] = {
+    attrs: dict[str, OtlpScalar] = {
         "session.id": meta["trial_name"],
         "experiment": experiment,
         "batch_id": batch_id,
@@ -193,12 +409,35 @@ def _harbor_resource_attrs(meta: dict, experiment: str, batch_id: str) -> dict[s
         attrs["eval.suite_name"] = str(meta["source"])
     if meta.get("harbor_eval"):
         attrs["eval.harbor_eval"] = str(meta["harbor_eval"])
-    if meta.get("score") is not None:
-        score = meta["score"]
-        attrs["eval.score"] = str(score)
-        attrs["eval.weighted_score"] = str(score)
-        attrs["eval.passed"] = score >= 1.0
+
+    verifier = meta.get("verifier")
+    if isinstance(verifier, HarborVerifierOutcome):
+        attrs.update(_flatten_verifier_fields(verifier))
+        attrs["eval.has_exception"] = verifier.error is not None
+        if verifier.error is not None:
+            attrs["eval.error"] = verifier.error
+        if verifier.score is not None:
+            attrs["eval.score"] = verifier.score
+            attrs["eval.weighted_score"] = verifier.score
+        if verifier.passed is not None:
+            attrs["eval.passed"] = verifier.passed
+    elif meta.get("score") is not None:
+        # Compatibility for callers constructing metadata directly.
+        score = float(meta["score"])
+        attrs["eval.score"] = score
+        attrs["eval.weighted_score"] = score
+        if 0.0 <= score <= 1.0:
+            attrs["eval.passed"] = score >= 1.0
     return attrs
+
+
+def _trace_resource_attrs(resource_attrs: dict[str, OtlpScalar]) -> dict[str, OtlpScalar]:
+    """Keep large verifier detail on the single eval span, not every trace envelope."""
+    return {
+        key: value
+        for key, value in resource_attrs.items()
+        if not key.startswith("eval.verifier") and key not in {"eval.error", "eval.has_exception"}
+    }
 
 
 def _find_matching_live_session(endpoint: str, meta: dict, experiment: str) -> str | None:
@@ -233,25 +472,62 @@ def _find_matching_live_session(endpoint: str, meta: dict, experiment: str) -> s
     return request_match("default") or request_match(experiment)
 
 
-def _build_eval_only_body(resource_attrs: dict[str, str | bool]) -> dict:
-    """Build a minimal OTLP payload that enriches/creates one viewer eval session."""
+def _build_eval_only_body(
+    resource_attrs: dict[str, OtlpScalar], meta: dict[str, Any] | None = None
+) -> dict:
+    """Build a deterministic OTLP eval span for regular or eval-only imports."""
     now_ns = time.time_ns()
-    passed = bool(resource_attrs.get("eval.passed", False))
-    score = resource_attrs.get("eval.score")
-    span_attrs: list[dict] = [{"key": "eval.passed", "value": {"boolValue": passed}}]
-    if score is not None:
-        try:
-            span_attrs.append({"key": "eval.score", "value": {"doubleValue": float(score)}})
-            span_attrs.append(
-                {"key": "eval.weighted_score", "value": {"doubleValue": float(score)}}
-            )
-        except (TypeError, ValueError):
-            span_attrs.append({"key": "eval.score", "value": {"stringValue": str(score)}})
+    start_ns = _datetime_ns(meta.get("started_at") if meta else None, now_ns)
+    end_ns = _datetime_ns(meta.get("finished_at") if meta else None, start_ns)
+    end_ns = max(start_ns, end_ns)
 
-    def value(v: str | bool) -> dict:
+    def value(v: OtlpScalar) -> dict:
         if isinstance(v, bool):
             return {"boolValue": v}
+        if isinstance(v, int):
+            return {"intValue": str(v)}
+        if isinstance(v, float):
+            return {"doubleValue": v}
         return {"stringValue": str(v)}
+
+    span_attrs: list[dict[str, Any]] = []
+    for key in (
+        "eval.test_id",
+        "eval.test_name",
+        "eval.display_name",
+        "eval.method",
+        "eval.model",
+        "eval.agent_class",
+        "eval.score",
+        "eval.weighted_score",
+        "eval.passed",
+        "eval.error",
+        "eval.has_exception",
+    ):
+        if key in resource_attrs:
+            span_attrs.append({"key": key, "value": value(resource_attrs[key])})
+
+    verifier = meta.get("verifier") if meta else None
+    serialized_output = (
+        _serialize_verifier_output(verifier)
+        if isinstance(verifier, HarborVerifierOutcome)
+        else None
+    )
+    if serialized_output is not None:
+        span_attrs.append({"key": "eval.output", "value": {"stringValue": serialized_output}})
+
+    trial_name = str(resource_attrs.get("eval.harbor_trial_name") or resource_attrs["session.id"])
+    digest = hashlib.sha256(
+        "\0".join(
+            (
+                str(resource_attrs.get("experiment", "")),
+                str(resource_attrs.get("batch_id", "")),
+                trial_name,
+                "harbor-eval-v1",
+            )
+        ).encode()
+    ).hexdigest()
+    error = verifier.error if isinstance(verifier, HarborVerifierOutcome) else None
 
     return {
         "resourceSpans": [
@@ -266,14 +542,14 @@ def _build_eval_only_body(resource_attrs: dict[str, str | bool]) -> dict:
                         "scope": {"name": "harbor-import"},
                         "spans": [
                             {
-                                "traceId": uuid.uuid4().hex,
-                                "spanId": uuid.uuid4().hex[:16],
+                                "traceId": digest[:32],
+                                "spanId": digest[32:48],
                                 "name": "eval",
                                 "kind": 1,
-                                "startTimeUnixNano": str(now_ns),
-                                "endTimeUnixNano": str(now_ns),
+                                "startTimeUnixNano": str(start_ns),
+                                "endTimeUnixNano": str(end_ns),
                                 "attributes": span_attrs,
-                                "status": {"code": 1 if passed else 2, "message": ""},
+                                "status": {"code": 2 if error else 1, "message": error or ""},
                             }
                         ],
                     }
@@ -310,7 +586,7 @@ def _trial_meta_from_dir(trial_dir: Path) -> dict:
 def _import_trace_file(
     endpoint: str,
     jsonl_path: Path,
-    resource_attrs: dict[str, str | bool | int],
+    resource_attrs: dict[str, OtlpScalar],
     batch_lines: int,
     batch_bytes: int,
 ) -> tuple[bool, list[str]]:
@@ -359,7 +635,11 @@ def _import_trace_file(
             if "resourceSpans" not in body:
                 continue
 
-            inject_resource_attrs(body, resource_attrs)
+            inject_resource_attrs(
+                body,
+                resource_attrs,
+                overwrite_keys={"session.id", "experiment", "batch_id"},
+            )
             batch.append(body)
             # Approximation: raw line length before injection; the re-serialized
             # POST body (with injected resource attrs) is slightly larger.
@@ -451,6 +731,7 @@ def command(
         raise SystemExit(1)
 
     imported = 0
+    enriched = 0
     skipped = 0
     already_exist = 0
     errors = []
@@ -470,7 +751,7 @@ def command(
             matched_session_id = _find_matching_live_session(endpoint, meta, exp)
             if matched_session_id:
                 resource_attrs["session.id"] = matched_session_id
-            body = _build_eval_only_body(resource_attrs)
+            body = _build_eval_only_body(resource_attrs, meta)
             if post_traces_batch(endpoint, [body]):
                 imported += 1
                 score_str = f"{meta['score']:.3f}" if meta["score"] is not None else "n/a"
@@ -484,38 +765,69 @@ def command(
     else:
         if not files:
             click.echo(f"No Harbor trace files found under {path}")
-            click.echo("Expected: <job>/<trial>/artifacts/traces/*.jsonl")
+            click.echo("Expected: <job>/<trial>/{artifacts/**,agent/traces/**}/*.jsonl")
             click.echo("Tip: use --eval-only to group Harbor result metadata without trace files")
             raise SystemExit(1)
 
-        click.echo(f"Found {len(files)} trace file(s)...")
-
+        files_by_trial: dict[Path, list[Path]] = {}
         for jsonl_path in files:
-            meta = _trial_meta(jsonl_path)
+            files_by_trial.setdefault(_trial_dir_for_trace(jsonl_path), []).append(jsonl_path)
+        click.echo(
+            f"Found {len(files)} trace file(s) across {len(files_by_trial)} Harbor trial(s)..."
+        )
+
+        for _trial_dir, trial_files in sorted(files_by_trial.items()):
+            meta = _trial_meta(trial_files[0])
             session_id = meta["trial_name"]
             exp = experiment or meta["experiment"]
             bid = batch_id or meta["job_name"]
-
-            if session_exists(endpoint, session_id):
-                click.echo(f"  ! {session_id}: already exists, skipping")
-                already_exist += 1
-                continue
-
             resource_attrs = _harbor_resource_attrs(meta, exp, bid)
 
-            file_imported, file_errors = _import_trace_file(
-                endpoint, jsonl_path, resource_attrs, batch_lines, batch_bytes
-            )
-            errors.extend(file_errors)
+            matched_session_id = _find_matching_live_session(endpoint, meta, exp)
+            target_session_id = matched_session_id or session_id
+            resource_attrs["session.id"] = target_session_id
 
-            if file_imported:
+            exists = session_exists(endpoint, target_session_id)
+            trace_imported = False
+            if exists:
+                already_exist += 1
+            else:
+                trace_resource_attrs = _trace_resource_attrs(resource_attrs)
+                for jsonl_path in trial_files:
+                    file_imported, file_errors = _import_trace_file(
+                        endpoint,
+                        jsonl_path,
+                        trace_resource_attrs,
+                        batch_lines,
+                        batch_bytes,
+                    )
+                    trace_imported = trace_imported or file_imported
+                    errors.extend(file_errors)
+
+            eval_imported = post_traces_batch(
+                endpoint, [_build_eval_only_body(resource_attrs, meta)]
+            )
+            if not eval_imported:
+                errors.append(f"{session_id}: failed to post eval metadata")
+
+            if exists and eval_imported:
+                enriched += 1
+                match_str = f" -> {target_session_id}" if matched_session_id else ""
+                click.echo(f"  ~ {session_id}{match_str}: evaluation metadata enriched")
+            elif trace_imported:
                 imported += 1
                 score_str = f"{meta['score']:.3f}" if meta["score"] is not None else "n/a"
-                click.echo(f"  + {session_id}  score={score_str}  task={meta['task_name']}")
+                match_str = f" -> {target_session_id}" if matched_session_id else ""
+                click.echo(
+                    f"  + {session_id}{match_str}  score={score_str}  task={meta['task_name']}"
+                )
             else:
                 skipped += 1
 
-    click.echo(f"\n{imported} imported, {skipped} skipped, {already_exist} already existed")
+    click.echo(
+        f"\n{imported} imported, {enriched} enriched, {skipped} skipped, "
+        f"{already_exist} already existed"
+    )
     if errors:
         for err in errors[:10]:
             click.echo(f"  ! {err}")

--- a/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
+++ b/packages/nooa-cli/src/nooa_cli/commands/import_harbor.py
@@ -100,7 +100,19 @@ def _find_harbor_traces(root: Path) -> list[Path]:
     """Find trace JSONL files within Harbor trials, independent of layout."""
     traces: set[Path] = set()
     for trial_dir in _trial_dirs(root):
-        traces.update(path for path in trial_dir.rglob("*.jsonl") if _is_trace_jsonl(path))
+        seen_contents: set[str] = set()
+        candidates = sorted(
+            trial_dir.rglob("*.jsonl"),
+            key=lambda path: (len(path.relative_to(trial_dir).parts), str(path)),
+        )
+        for path in candidates:
+            if not _is_trace_jsonl(path):
+                continue
+            content_hash = _trace_content_hash(path)
+            if content_hash is None or content_hash in seen_contents:
+                continue
+            seen_contents.add(content_hash)
+            traces.add(path)
     return sorted(traces)
 
 
@@ -127,6 +139,15 @@ def _is_trace_jsonl(path: Path) -> bool:
     except (OSError, UnicodeError):
         return False
     return False
+
+
+def _trace_content_hash(path: Path) -> str | None:
+    """Return a streaming digest used to deduplicate copies within one trial."""
+    try:
+        with path.open("rb") as stream:
+            return hashlib.file_digest(stream, "sha256").hexdigest()
+    except OSError:
+        return None
 
 
 def _read_json(path: Path) -> dict[str, Any]:

--- a/packages/nooa-cli/tests/test_import_harbor.py
+++ b/packages/nooa-cli/tests/test_import_harbor.py
@@ -143,12 +143,30 @@ def test_missing_primary_score_does_not_become_failure(tmp_path: Path) -> None:
     assert span["status"]["code"] == 1
 
 
+def test_trace_discovery_is_content_based_and_layout_independent(tmp_path: Path) -> None:
+    job_dir, trial_dir = _make_trial(tmp_path, {"rewards": {"progress": 0.5}})
+    nested_dir = trial_dir / "custom" / "deeply" / "nested"
+    nested_dir.mkdir(parents=True)
+    trace_path = nested_dir / "events.jsonl"
+    trace_path.write_text("not-json\n" + json.dumps(_trace_body()) + "\n")
+
+    unrelated = trial_dir / "agent" / "traces" / "messages.jsonl"
+    unrelated.write_text(json.dumps({"messages": ["not a trace"]}) + "\n")
+    outside_trial = job_dir / "other.jsonl"
+    outside_trial.write_text(json.dumps(_trace_body()) + "\n")
+
+    assert import_harbor._find_harbor_traces(job_dir) == [trace_path]
+    assert import_harbor._trial_dir_for_trace(trace_path) == trial_dir
+
+
 def test_regular_import_groups_trial_files_and_adds_one_eval_span(
     tmp_path: Path, monkeypatch
 ) -> None:
     job_dir, trial_dir = _make_trial(tmp_path, {"rewards": {"progress": 0.5}})
+    trace_dir = trial_dir / "custom" / "trace-output"
+    trace_dir.mkdir(parents=True)
     for name in ("first.jsonl", "second.jsonl"):
-        (trial_dir / "agent" / "traces" / name).write_text(json.dumps(_trace_body()) + "\n")
+        (trace_dir / name).write_text(json.dumps(_trace_body()) + "\n")
 
     posted: list[list[dict[str, Any]]] = []
     monkeypatch.setattr(import_harbor, "check_endpoint_reachable", lambda _endpoint: True)

--- a/packages/nooa-cli/tests/test_import_harbor.py
+++ b/packages/nooa-cli/tests/test_import_harbor.py
@@ -143,7 +143,9 @@ def test_missing_primary_score_does_not_become_failure(tmp_path: Path) -> None:
     assert span["status"]["code"] == 1
 
 
-def test_trace_discovery_is_content_based_and_layout_independent(tmp_path: Path) -> None:
+def test_trace_discovery_is_content_based_and_layout_independent(
+    tmp_path: Path, monkeypatch
+) -> None:
     job_dir, trial_dir = _make_trial(tmp_path, {"rewards": {"progress": 0.5}})
     nested_dir = trial_dir / "custom" / "deeply" / "nested"
     nested_dir.mkdir(parents=True)
@@ -154,13 +156,38 @@ def test_trace_discovery_is_content_based_and_layout_independent(tmp_path: Path)
     duplicate_path.parent.mkdir(parents=True)
     duplicate_path.write_bytes(trace_path.read_bytes())
 
+    unique_trace_path = trial_dir / "another" / "unique.jsonl"
+    unique_trace_path.parent.mkdir()
+    unique_trace_path.write_text(json.dumps(_trace_body()) + "\n\n")
+
     unrelated = trial_dir / "agent" / "traces" / "messages.jsonl"
     unrelated.write_text(json.dumps({"messages": ["not a trace"]}) + "\n")
     outside_trial = job_dir / "other.jsonl"
     outside_trial.write_text(json.dumps(_trace_body()) + "\n")
 
-    assert import_harbor._find_harbor_traces(job_dir) == [trace_path]
+    hashed_paths: list[Path] = []
+    original_hash = import_harbor._trace_content_hash
+
+    def record_hash(path: Path) -> str | None:
+        hashed_paths.append(path)
+        return original_hash(path)
+
+    monkeypatch.setattr(import_harbor, "_trace_content_hash", record_hash)
+
+    assert import_harbor._find_harbor_traces(job_dir) == [unique_trace_path, trace_path]
+    assert hashed_paths == [trace_path, duplicate_path]
     assert import_harbor._trial_dir_for_trace(trace_path) == trial_dir
+
+
+def test_trace_sniff_limits_malformed_and_blank_lines(tmp_path: Path) -> None:
+    path = tmp_path / "mostly-invalid.jsonl"
+    lines = [
+        "not-json" if index % 2 else "" for index in range(import_harbor.MAX_TRACE_SNIFF_RECORDS)
+    ]
+    lines.append(json.dumps(_trace_body()))
+    path.write_text("\n".join(lines) + "\n")
+
+    assert not import_harbor._is_trace_jsonl(path)
 
 
 def test_regular_import_groups_trial_files_and_adds_one_eval_span(

--- a/packages/nooa-cli/tests/test_import_harbor.py
+++ b/packages/nooa-cli/tests/test_import_harbor.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+from nooa_cli.commands import import_harbor
+
+
+def _attrs(items: list[dict[str, Any]]) -> dict[str, object]:
+    return {item["key"]: next(iter(item["value"].values())) for item in items}
+
+
+def _make_trial(tmp_path: Path, verifier_result: dict[str, Any]) -> tuple[Path, Path]:
+    job_dir = tmp_path / "harbor-job"
+    trial_dir = job_dir / "trial-dir"
+    (trial_dir / "verifier").mkdir(parents=True)
+    (trial_dir / "agent" / "traces").mkdir(parents=True)
+    (job_dir / "result.json").write_text(json.dumps({"stats": {"evals": {"suite": {}}}}))
+    (trial_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "trial_name": "trial-1",
+                "task_name": "task-1",
+                "started_at": "2026-08-27T14:00:00Z",
+                "finished_at": "2026-08-27T14:05:00Z",
+                "config": {"agent": {"model_name": "model-1"}},
+            }
+        )
+    )
+    (trial_dir / "verifier" / "result.json").write_text(json.dumps(verifier_result))
+    return job_dir, trial_dir
+
+
+def _trace_body() -> dict[str, Any]:
+    return {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "session.id", "value": {"stringValue": "original-session"}},
+                        {"key": "experiment", "value": {"stringValue": "default"}},
+                    ]
+                },
+                "scopeSpans": [
+                    {
+                        "spans": [
+                            {
+                                "traceId": "1" * 32,
+                                "spanId": "2" * 16,
+                                "name": "agent.run",
+                                "startTimeUnixNano": "1",
+                                "endTimeUnixNano": "2",
+                                "attributes": [],
+                            }
+                        ]
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_generic_verifier_result_is_flattened_and_preserved(tmp_path: Path) -> None:
+    _job_dir, trial_dir = _make_trial(
+        tmp_path,
+        {
+            "status": "scored",
+            "done": True,
+            "levels_beaten": 3,
+            "max_level": 10,
+            "rewards": {"progress": 0.3},
+            "details": {"api_calls": 18, "labels": ["not", "a", "column"]},
+        },
+    )
+
+    meta = import_harbor._trial_meta_from_dir(trial_dir)
+    attrs = import_harbor._harbor_resource_attrs(meta, "experiment", "batch")
+
+    assert meta["score"] == 0.3
+    assert attrs["eval.passed"] is False
+    assert attrs["eval.verifier.status"] == "scored"
+    assert attrs["eval.verifier.done"] is True
+    assert attrs["eval.verifier.levels_beaten"] == 3
+    assert attrs["eval.verifier.rewards.progress"] == 0.3
+    assert attrs["eval.verifier.details.api_calls"] == 18
+    assert "eval.verifier.details.labels" not in attrs
+
+    body = import_harbor._build_eval_only_body(attrs, meta)
+    resource_span = body["resourceSpans"][0]
+    span = resource_span["scopeSpans"][0]["spans"][0]
+    span_attrs = _attrs(span["attributes"])
+    serialized_output = span_attrs["eval.output"]
+    assert isinstance(serialized_output, str)
+    output = json.loads(serialized_output)
+
+    assert span["name"] == "eval"
+    assert span["startTimeUnixNano"] == "1787839200000000000"
+    assert span["endTimeUnixNano"] == "1787839500000000000"
+    assert output["details"]["labels"] == ["not", "a", "column"]
+    assert output["levels_beaten"] == 3
+
+
+def test_eval_span_ids_are_stable_and_include_job_identity(tmp_path: Path) -> None:
+    _job_dir, trial_dir = _make_trial(tmp_path, {"rewards": {"progress": 0.0}})
+    meta = import_harbor._trial_meta_from_dir(trial_dir)
+    first_attrs = import_harbor._harbor_resource_attrs(meta, "experiment", "batch-1")
+    second_attrs = import_harbor._harbor_resource_attrs(meta, "experiment", "batch-2")
+
+    first = import_harbor._build_eval_only_body(first_attrs, meta)
+    repeated = import_harbor._build_eval_only_body(first_attrs, meta)
+    second = import_harbor._build_eval_only_body(second_attrs, meta)
+
+    def ids(body: dict[str, Any]) -> tuple[str, str]:
+        span = body["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        return span["traceId"], span["spanId"]
+
+    assert meta["score"] == 0.0
+    assert ids(first) == ids(repeated)
+    assert ids(first) != ids(second)
+
+
+def test_missing_primary_score_does_not_become_failure(tmp_path: Path) -> None:
+    _job_dir, trial_dir = _make_trial(
+        tmp_path,
+        {
+            "status": "scored",
+            "rewards": {"levels_beaten": 3},
+            "metrics": {"precision": 2, "recall": 3},
+        },
+    )
+    meta = import_harbor._trial_meta_from_dir(trial_dir)
+    attrs = import_harbor._harbor_resource_attrs(meta, "experiment", "batch")
+    body = import_harbor._build_eval_only_body(attrs, meta)
+    span = body["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+    span_attrs = _attrs(span["attributes"])
+
+    assert meta["score"] is None
+    assert "eval.passed" not in attrs
+    assert "eval.passed" not in span_attrs
+    assert span["status"]["code"] == 1
+
+
+def test_regular_import_groups_trial_files_and_adds_one_eval_span(
+    tmp_path: Path, monkeypatch
+) -> None:
+    job_dir, trial_dir = _make_trial(tmp_path, {"rewards": {"progress": 0.5}})
+    for name in ("first.jsonl", "second.jsonl"):
+        (trial_dir / "agent" / "traces" / name).write_text(json.dumps(_trace_body()) + "\n")
+
+    posted: list[list[dict[str, Any]]] = []
+    monkeypatch.setattr(import_harbor, "check_endpoint_reachable", lambda _endpoint: True)
+    monkeypatch.setattr(
+        import_harbor, "_find_matching_live_session", lambda _endpoint, _meta, _exp: None
+    )
+    monkeypatch.setattr(import_harbor, "session_exists", lambda _endpoint, _session_id: False)
+    monkeypatch.setattr(
+        import_harbor,
+        "post_traces_batch",
+        lambda _endpoint, bodies: posted.append(bodies) or True,
+    )
+
+    result = CliRunner().invoke(
+        import_harbor.command,
+        [str(job_dir), "--endpoint", "http://viewer.invalid"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "2 trace file(s) across 1 Harbor trial(s)" in result.output
+    assert "1 imported" in result.output
+    spans = [
+        span
+        for bodies in posted
+        for body in bodies
+        for resource_span in body["resourceSpans"]
+        for scope_span in resource_span["scopeSpans"]
+        for span in scope_span["spans"]
+    ]
+    assert [span["name"] for span in spans].count("eval") == 1
+    assert [span["name"] for span in spans].count("agent.run") == 2
+
+    trace_resources = [
+        _attrs(resource_span["resource"]["attributes"])
+        for bodies in posted[:-1]
+        for body in bodies
+        for resource_span in body["resourceSpans"]
+    ]
+    assert all(resource["session.id"] == "trial-1" for resource in trace_resources)
+    assert all(resource["experiment"] == "harbor-job" for resource in trace_resources)
+    assert all("eval.verifier.rewards.progress" not in resource for resource in trace_resources)

--- a/packages/nooa-cli/tests/test_import_harbor.py
+++ b/packages/nooa-cli/tests/test_import_harbor.py
@@ -150,6 +150,10 @@ def test_trace_discovery_is_content_based_and_layout_independent(tmp_path: Path)
     trace_path = nested_dir / "events.jsonl"
     trace_path.write_text("not-json\n" + json.dumps(_trace_body()) + "\n")
 
+    duplicate_path = trial_dir / "artifacts" / "logs" / "artifacts" / "traces" / "events.jsonl"
+    duplicate_path.parent.mkdir(parents=True)
+    duplicate_path.write_bytes(trace_path.read_bytes())
+
     unrelated = trial_dir / "agent" / "traces" / "messages.jsonl"
     unrelated.write_text(json.dumps({"messages": ["not a trace"]}) + "\n")
     outside_trial = job_dir / "other.jsonl"
@@ -165,8 +169,10 @@ def test_regular_import_groups_trial_files_and_adds_one_eval_span(
     job_dir, trial_dir = _make_trial(tmp_path, {"rewards": {"progress": 0.5}})
     trace_dir = trial_dir / "custom" / "trace-output"
     trace_dir.mkdir(parents=True)
-    for name in ("first.jsonl", "second.jsonl"):
-        (trace_dir / name).write_text(json.dumps(_trace_body()) + "\n")
+    for name, span_id in (("first.jsonl", "2" * 16), ("second.jsonl", "3" * 16)):
+        body = _trace_body()
+        body["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["spanId"] = span_id
+        (trace_dir / name).write_text(json.dumps(body) + "\n")
 
     posted: list[list[dict[str, Any]]] = []
     monkeypatch.setattr(import_harbor, "check_endpoint_reachable", lambda _endpoint: True)

--- a/packages/nooa-cli/tests/test_import_traces.py
+++ b/packages/nooa-cli/tests/test_import_traces.py
@@ -214,6 +214,15 @@ def test_resource_attribute_injection_skips_malformed_entries():
     ]
 
 
+def test_resource_attribute_injection_encodes_ints_as_otlp_decimal_strings():
+    body = _otlp_body(1)
+
+    _otlp_helpers.inject_resource_attrs(body, {"large.counter": 2**60})
+
+    attrs = body["resourceSpans"][0]["resource"]["attributes"]
+    assert attrs == [{"key": "large.counter", "value": {"intValue": str(2**60)}}]
+
+
 def test_harbor_live_session_lookup_uses_configured_viewer_auth(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/src/nooa/viewer/otlp_store.py
+++ b/src/nooa/viewer/otlp_store.py
@@ -598,10 +598,9 @@ def _ingest_one(body: dict, db: sqlite3.Connection) -> dict[str, Any]:
                     )
                 )
 
-    span_count = len(span_rows)
-    # Compute total payload size for the spans in this batch.
-    # Each span_row tuple has: ..., attributes(10), resource(11), events(12)
-    batch_size = sum(len(r[10]) + len(r[11]) + len(r[12]) for r in span_rows)
+    is_harbor_eval = eval_meta.get("method") == "harbor" and any(
+        row[4] == "eval" for row in span_rows
+    )
 
     existing = db.execute(
         """SELECT span_count, total_size, experiment, resource_attrs, eval_metadata
@@ -609,15 +608,66 @@ def _ingest_one(body: dict, db: sqlite3.Connection) -> dict[str, Any]:
         (session_id,),
     ).fetchone()
 
+    # Synthetic post-run eval spans use deterministic IDs. Reposting one should
+    # refresh its verifier details, not append another eval card to the trace.
+    # Other span kinds retain the existing append semantics used by streaming.
+    updated_eval_rows: list[tuple[tuple, int]] = []
+    updated_size_delta = 0
+    if existing and span_rows:
+        stored_eval_rows = db.execute(
+            """SELECT id, trace_id, span_id, attributes, resource, events
+               FROM spans WHERE session_id = ? AND name = 'eval'""",
+            (session_id,),
+        ).fetchall()
+        stored_by_identity = {
+            (row["trace_id"], row["span_id"]): row
+            for row in stored_eval_rows
+            if row["trace_id"] and row["span_id"]
+        }
+        new_rows: list[tuple] = []
+        for row in span_rows:
+            stored = (
+                stored_by_identity.get((row[1], row[2]))
+                if row[4] == "eval" and row[1] and row[2]
+                else None
+            )
+            if stored is None:
+                new_rows.append(row)
+                continue
+            old_size = sum(len(stored[key] or "") for key in ("attributes", "resource", "events"))
+            new_size = len(row[10]) + len(row[11]) + len(row[12])
+            updated_size_delta += new_size - old_size
+            updated_eval_rows.append((row, stored["id"]))
+        span_rows = new_rows
+
+    span_count = len(span_rows)
+    # Compute total payload size for newly inserted spans plus changes to
+    # deterministic eval spans refreshed above.
+    batch_size = sum(len(r[10]) + len(r[11]) + len(r[12]) for r in span_rows) + updated_size_delta
+
     if existing:
         new_count = existing["span_count"] + span_count
-        new_size = (existing["total_size"] or 0) + batch_size
+        new_size = max(0, (existing["total_size"] or 0) + batch_size)
         merged_meta = {}
         if existing["eval_metadata"]:
             try:
                 merged_meta = json.loads(existing["eval_metadata"])
             except (json.JSONDecodeError, TypeError):
                 pass
+        if is_harbor_eval:
+            replaceable_keys = {
+                "error",
+                "has_exception",
+                "output",
+                "score",
+                "verifier_source",
+                "weighted_score",
+            }
+            merged_meta = {
+                key: value
+                for key, value in merged_meta.items()
+                if key not in replaceable_keys and not key.startswith("verifier.")
+            }
         merged_meta.update(eval_meta)
 
         updates: dict[str, Any] = {
@@ -647,6 +697,22 @@ def _ingest_one(body: dict, db: sqlite3.Connection) -> dict[str, Any]:
                         existing_resource_attrs = json.loads(existing["resource_attrs"])
                     except (json.JSONDecodeError, TypeError):
                         pass
+                if is_harbor_eval:
+                    replaceable_resource_keys = {
+                        "eval.error",
+                        "eval.has_exception",
+                        "eval.output",
+                        "eval.passed",
+                        "eval.score",
+                        "eval.verifier_source",
+                        "eval.weighted_score",
+                    }
+                    existing_resource_attrs = {
+                        key: value
+                        for key, value in existing_resource_attrs.items()
+                        if key not in replaceable_resource_keys
+                        and not key.startswith("eval.verifier.")
+                    }
                 existing_resource_attrs.update(new_resource_attrs)
                 updates["resource_attrs"] = json.dumps(
                     existing_resource_attrs, separators=(",", ":")
@@ -654,6 +720,8 @@ def _ingest_one(body: dict, db: sqlite3.Connection) -> dict[str, Any]:
 
         if eval_passed is not None:
             updates["eval_passed"] = eval_passed
+        elif is_harbor_eval:
+            updates["eval_passed"] = None
         if merged_meta:
             updates["eval_metadata"] = json.dumps(merged_meta, separators=(",", ":"))
 
@@ -709,6 +777,20 @@ def _ingest_one(body: dict, db: sqlite3.Connection) -> dict[str, Any]:
             ),
         )
 
+    for row, row_id in updated_eval_rows:
+        db.execute(
+            """UPDATE spans SET
+               trace_id = ?, span_id = ?, parent_span_id = ?, name = ?, kind = ?,
+               start_time_ns = ?, end_time_ns = ?, status_code = ?, status_message = ?,
+               attributes = ?, resource = ?, events = ?
+               WHERE id = ?""",
+            (*row[1:], row_id),
+        )
+        db.execute(
+            "DELETE FROM spans_fts WHERE session_id = ? AND span_id = ?",
+            (row[0], row[2]),
+        )
+
     if span_rows:
         db.executemany(
             """INSERT INTO spans
@@ -719,9 +801,11 @@ def _ingest_one(body: dict, db: sqlite3.Connection) -> dict[str, Any]:
             span_rows,
         )
 
-        # Populate FTS index with searchable content from each span
+    # Populate or refresh FTS content for inserted and deterministic eval spans.
+    indexed_rows = span_rows + [row for row, _row_id in updated_eval_rows]
+    if indexed_rows:
         fts_rows = []
-        for row in span_rows:
+        for row in indexed_rows:
             # row: (session_id, trace_id, span_id, parent_span_id, name, kind,
             #        start_time_ns, end_time_ns, status_code, status_message,
             #        attributes, resource, events)

--- a/src/nooa/viewer/otlp_store.py
+++ b/src/nooa/viewer/otlp_store.py
@@ -613,7 +613,8 @@ def _ingest_one(body: dict, db: sqlite3.Connection) -> dict[str, Any]:
     # Other span kinds retain the existing append semantics used by streaming.
     updated_eval_rows: list[tuple[tuple, int]] = []
     updated_size_delta = 0
-    if existing and span_rows:
+    has_deterministic_eval = any(row[4] == "eval" and row[1] and row[2] for row in span_rows)
+    if existing and has_deterministic_eval:
         stored_eval_rows = db.execute(
             """SELECT id, trace_id, span_id, attributes, resource, events
                FROM spans WHERE session_id = ? AND name = 'eval'""",

--- a/tests/viewer/test_otlp_store.py
+++ b/tests/viewer/test_otlp_store.py
@@ -482,6 +482,20 @@ class TestIngestReIngest:
         sessions = store.list_sessions()
         assert sessions[0]["span_count"] == 2
 
+    def test_reingesting_regular_spans_skips_eval_deduplication_query(self):
+        store.ingest(_make_body(session_id="s1"))
+        statements: list[str] = []
+        db = store._get_db()
+        db.set_trace_callback(statements.append)
+
+        store.ingest(_make_body(session_id="s1"))
+
+        db.set_trace_callback(None)
+        assert not any(
+            "FROM spans WHERE session_id" in statement and "name = 'eval'" in statement
+            for statement in statements
+        )
+
     def test_deterministic_eval_span_is_refreshed_without_duplication(self):
         def body(output: str, passed: bool | None) -> dict:
             attributes = [

--- a/tests/viewer/test_otlp_store.py
+++ b/tests/viewer/test_otlp_store.py
@@ -6,6 +6,7 @@ Tests are isolated via tmp_path: each test gets its own SQLite file so
 there is no shared state between test functions.
 """
 
+import json
 import sqlite3
 
 import pytest
@@ -480,6 +481,38 @@ class TestIngestReIngest:
         store.ingest(_make_body(session_id="s1"))
         sessions = store.list_sessions()
         assert sessions[0]["span_count"] == 2
+
+    def test_deterministic_eval_span_is_refreshed_without_duplication(self):
+        def body(output: str, passed: bool | None) -> dict:
+            attributes = [
+                {"key": "eval.method", "value": {"stringValue": "harbor"}},
+                {"key": "eval.output", "value": {"stringValue": output}},
+            ]
+            if passed is not None:
+                attributes.append({"key": "eval.passed", "value": {"boolValue": passed}})
+            span = {
+                "traceId": "eval-trace",
+                "spanId": "eval-span",
+                "name": "eval",
+                "kind": 1,
+                "startTimeUnixNano": "1",
+                "endTimeUnixNano": "2",
+                "attributes": attributes,
+            }
+            return _make_body(session_id="s1", spans=[span])
+
+        first = store.ingest(body('{"version":1}', True))
+        second = store.ingest(body('{"version":2}', None))
+
+        assert first["span_count"] == 1
+        assert second["span_count"] == 0
+        session = store.list_sessions()[0]
+        assert session["span_count"] == 1
+        assert session["eval"]["passed"] is None
+        assert session["eval"]["output"] == {"version": 2}
+        spans = store.get_session_spans("s1")
+        assert len(spans) == 1
+        assert store.otlp_attrs_to_dict(spans[0]["attributes"])["eval.output"] == ('{"version":2}')
 
     def test_eval_metadata_merges(self):
         body1 = _make_body(eval_attrs={"eval.model": "claude"})
@@ -1022,6 +1055,53 @@ class TestStartupLockCheck:
 
 
 class TestExistingSessionEvalEnrichment:
+    def test_generic_harbor_verifier_fields_are_visible_in_session_and_trace(self):
+        from nooa_cli.commands import import_harbor
+
+        outcome = import_harbor.HarborVerifierOutcome(
+            result={
+                "status": "scored",
+                "levels_beaten": 3,
+                "rewards": {"progress": 0.3},
+                "details": {"api_calls": 18},
+            },
+            embedded_result=None,
+            reward=None,
+            reward_text=None,
+            score=0.3,
+            passed=False,
+            error=None,
+            source="verifier/result.json",
+        )
+        meta = {
+            "trial_name": "trial-1",
+            "task_name": "task-1",
+            "model_name": "model-1",
+            "agent_type": "",
+            "agent_name": "",
+            "source": "suite",
+            "harbor_eval": "suite",
+            "started_at": "2026-08-27T14:00:00Z",
+            "finished_at": "2026-08-27T14:05:00Z",
+            "score": 0.3,
+            "verifier": outcome,
+        }
+        resource_attrs = import_harbor._harbor_resource_attrs(meta, "experiment", "batch")
+        store.ingest(import_harbor._build_eval_only_body(resource_attrs, meta))
+
+        session = store.list_sessions(experiment="experiment", eval_only=True)[0]
+        assert session["eval"]["verifier.status"] == "scored"
+        assert session["eval"]["verifier.levels_beaten"] == 3
+        assert session["eval"]["verifier.rewards.progress"] == 0.3
+        assert session["eval"]["verifier.details.api_calls"] == 18
+        assert session["eval"]["output"] == outcome.result
+
+        spans = store.get_session_spans("trial-1")
+        assert len(spans) == 1
+        assert spans[0]["name"] == "eval"
+        span_attrs = store.otlp_attrs_to_dict(spans[0]["attributes"])
+        assert json.loads(span_attrs["eval.output"]) == outcome.result
+
     def test_existing_default_session_can_be_grouped_into_eval_experiment(self):
         store.ingest(_make_body(session_id="trial-1", experiment="default"))
 


### PR DESCRIPTION
## What does this PR do?

Makes `nooa import-harbor` preserve arbitrary Harbor verifier results in both the experiment overview and trace detail views.

- Flattens bounded scalar verifier fields into dynamic `verifier.*` experiment metadata while retaining the full verifier JSON on a deterministic synthetic `eval` span.
- Reads standard Harbor result and reward artifact shapes without benchmark-specific adapters and conservatively derives normalized score/pass values.
- Discovers OTLP and Nooa journal JSONL files by content within Harbor trials, independent of their directory layout.
- Deduplicates byte-identical trace copies within a trial, as produced by mirrored Harbor artifact paths.
- Associates discovered traces with their enclosing trial and supports live-session enrichment and trial-level grouping.
- Refreshes deterministic eval spans on re-import instead of creating duplicate trace cards.

## Related issues

None.

## Validation

- `uv run pytest packages/nooa-cli/tests tests/viewer tests/tracing/test_journal_file_exporter.py -q` — 254 passed, 2 skipped, 2 deselected
- Repository pre-commit checks — Ruff, formatting, Pyright, conflict, SPDX, and file checks passed
- Live import — a real DiG-bench Harbor trial imported into an isolated viewer as one session with 151 spans (150 trace spans and one eval span); its verifier fields and full result JSON were visible through both trace and evaluation APIs

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests were added or updated and pass locally
- [x] User-facing CLI behavior and docstrings were updated
- [x] New source files contain SPDX headers

Signed-off-by: Severin Klingler <sklingler@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Harbor imports support varied trial layouts and automatically discover valid trace and journal files.
  * Verifier results, scores, pass status, errors, and output appear on evaluation spans.
  * Existing sessions can be enriched with imported evaluation data.
  * Resource attributes support floating-point values and selective per-key overwriting.

* **Bug Fixes**
  * Re-importing Harbor data refreshes evaluation spans without creating duplicates.
  * Imports deduplicate identical traces and handle missing or malformed result data more reliably.
  * Integer resource attributes are encoded correctly for OTLP ingestion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->