### PR TITLE
fix(libwriting): handle unset PYTHONPATH in tests

### DIFF
--- a/src/nooa/tools/library_writing_lib.py
+++ b/src/nooa/tools/library_writing_lib.py
@@ -320,7 +320,7 @@ class SkillWriting(Skill):
         shell = self._agent.shell
         tests_dir = self._path / lib_name / "tests"
         result = await shell.run(
-            f"PYTHONPATH={shlex.quote(str(self._path))}:$PYTHONPATH "
+            f"PYTHONPATH={shlex.quote(str(self._path))}${{PYTHONPATH:+:$PYTHONPATH}} "
             f"{shlex.quote(_sys.executable)} -m pytest {shlex.quote(str(tests_dir))} -v",
             timeout=60,
         )

--- a/tests/tools/test_library_writing_lib.py
+++ b/tests/tools/test_library_writing_lib.py
@@ -344,6 +344,52 @@ async def test_run_tests_passes(tmp_path: Path):
     assert "passed" in output.lower(), output
 
 
+@pytest.mark.asyncio
+async def test_run_tests_passes_when_pythonpath_is_unset_and_shell_uses_nounset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """run_tests() must not expand an unset PYTHONPATH under ``set -u``."""
+
+    class _NounsetShell(_FakeShell):
+        async def run(self, command, timeout=120.0):
+            import os
+            import subprocess
+
+            from nooa.tools._results import RunResult
+
+            env = os.environ.copy()
+            env.pop("PYTHONPATH", None)
+            result = subprocess.run(
+                ["bash", "-u", "-c", command],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env=env,
+            )
+            return RunResult(
+                stdout=result.stdout.strip(),
+                stderr=result.stderr.strip(),
+                returncode=result.returncode,
+            )
+
+    agent = _make_agent()
+    agent.shell = _NounsetShell()
+    libs = SkillWriting(agent, path=tmp_path)
+    await libs.create("rt_nounset", DESCRIPTION)
+    (tmp_path / "rt_nounset" / "rt_nounset.py").write_text(SIMPLE_SOURCE)
+    tests_dir = tmp_path / "rt_nounset" / "tests"
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    (tests_dir / "test_rt_nounset.py").write_text(
+        "from rt_nounset.rt_nounset import add\ndef test_add(): assert add(1, 2) == 3\n"
+    )
+
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    output = await libs.run_tests("rt_nounset")
+
+    assert "passed" in output.lower(), output
+    assert "unbound variable" not in output.lower(), output
+
+
 # ---------------------------------------------------------------------------
 # SkillWriting.reload — failure reporting
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- make `SkillWriting.run_tests()` safe when the invoking shell uses `set -u` and `PYTHONPATH` is unset
- preserve an existing non-empty `PYTHONPATH` without adding an empty path entry
- add a regression that executes the generated command through `bash -u` with `PYTHONPATH` removed

## Motivation

A real local-library test run failed before pytest with:

```
/bin/bash: PYTHONPATH: unbound variable
```

The shell session intentionally enables nounset. The current command expands `$PYTHONPATH` unconditionally.

## Verification

- `uv run pytest -q tests/tools/test_library_writing_lib.py` — 23 passed
- `uv run pytest -q tests/tools` — 299 passed on current `main`; 300 passed on the live PR-179 checkout
- Ruff check and format check — passed
- compileall and `git diff --check` — passed
- exact live repro: `await self.libs.run_tests("work_tracker")` with `PYTHONPATH` removed — 9 passed, no unbound-variable error
- independent read-only review — no blockers; manually checked unset, empty, non-empty, spaces, and metacharacter-containing values


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed test execution when `PYTHONPATH` is not set, preventing shell errors caused by an invalid environment path.
  - Preserved existing `PYTHONPATH` values when provided.

- **Tests**
  - Added regression coverage for running library tests under strict Bash settings without `PYTHONPATH`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->