### PR TITLE
Fix JSON parser matching non-JSON Markdown fences

### DIFF
--- a/src/nooa/unifiedllm/unifiedllm.py
+++ b/src/nooa/unifiedllm/unifiedllm.py
@@ -343,8 +343,8 @@ def extract_and_parse_json(text: str) -> dict[str, Any]:
     original_text = text
     text = text.strip()
 
-    markdown_pattern = r"```(?:json)?\s*\n?(.*?)\n?```"
-    markdown_match = re.search(markdown_pattern, text, re.DOTALL)
+    markdown_pattern = r"```(?:json)?[ \t]*\r?\n(.*?)\r?\n?```"
+    markdown_match = re.fullmatch(markdown_pattern, text, re.DOTALL)
     if markdown_match:
         _record_llm_metric("json_fence_removed")
         text = markdown_match.group(1).strip()

--- a/tests/unifiedllm/test_json_parsing.py
+++ b/tests/unifiedllm/test_json_parsing.py
@@ -7,6 +7,7 @@ import json
 import pytest
 
 from nooa.unifiedllm import extract_and_parse_json
+from nooa.unifiedllm.unifiedllm import _llm_metrics_callback
 
 
 class TestExtractAndParseJson:
@@ -15,11 +16,48 @@ class TestExtractAndParseJson:
         result = extract_and_parse_json('{"answer": "42", "confidence": 0.9}')
         assert result == {"answer": "42", "confidence": 0.9}
 
-    def test_markdown_fenced_json(self):
-        """JSON inside markdown code fences is extracted and parsed."""
+    def test_full_response_json_fence(self):
+        """A full-response JSON fence is extracted, parsed, and recorded."""
         text = '```json\n{"answer": "42"}\n```'
+        events = []
+        token = _llm_metrics_callback.set(lambda event, detail: events.append(event))
+        try:
+            result = extract_and_parse_json(text)
+        finally:
+            _llm_metrics_callback.reset(token)
+
+        assert result == {"answer": "42"}
+        assert events == ["json_fence_removed"]
+
+    def test_full_response_bare_fence(self):
+        """A full-response bare fence is extracted and parsed."""
+        text = '```\n{"answer": "42"}\n```'
         result = extract_and_parse_json(text)
         assert result == {"answer": "42"}
+
+    def test_bash_fence_does_not_mask_later_json(self):
+        """A non-JSON fence in prose does not replace the complete response."""
+        text = """Run the example:
+
+```bash
+uv run python scripts/run_local.py
+```
+
+Result: {"answer": "42"}
+"""
+        result = extract_and_parse_json(text)
+        assert result == {"answer": "42"}
+
+    def test_full_response_bash_fence_raises_for_complete_input(self):
+        """A non-JSON fence is not mistaken for a JSON wrapper."""
+        text = """```bash
+uv run python scripts/run_local.py
+```"""
+        with pytest.raises(json.JSONDecodeError) as exc_info:
+            extract_and_parse_json(text)
+
+        assert exc_info.value.doc.startswith("```bash")
+        assert "uv run python scripts/run_local.py" in exc_info.value.doc
 
     def test_markdown_bold_prefix(self):
         """LLMs sometimes wrap JSON in markdown bold markers."""


### PR DESCRIPTION
## What does this PR do?

Restricts `extract_and_parse_json()` to unwrap Markdown fences only when the entire trimmed response is enclosed by a bare or explicit `json` fence. Non-JSON fences such as `bash` and `python` are left in the complete response, so they cannot mask valid JSON appearing later or produce errors based only on the fenced command.

### Where this came from

This surfaced when I asked OO to translate a Markdown file into another language. The document contained `bash`, `json`, and bare code blocks, and the JSON parser treated the first non-JSON fence as a JSON wrapper, causing havoc during translation.

### Design note

IMHO, we should not bend over backwards to accommodate models that do not return JSON when asked for JSON. Current models are capable of following that contract, and every additional recovery heuristic creates more ambiguous edge cases and a never-ending game of whack-a-mole. This PR is deliberately narrow: it fixes the incorrect fence match without adding new recovery behavior.

## Related issues

None.

## Validation

- `uv run pytest tests/unifiedllm/test_json_parsing.py` — 12 passed
- `uv run ruff check src/nooa/unifiedllm/unifiedllm.py tests/unifiedllm/test_json_parsing.py` — passed

## Checklist

- [x] Code follows the project style for the changed files
- [x] Tests added/updated and passing
- [x] No documentation changes needed; this narrows internal parser cleanup behavior
- [x] No new source files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON parsing for Markdown-fenced responses.
  * Fenced JSON is now recognized only when it constitutes the complete response, reducing accidental parsing of unrelated content.
  * Non-JSON fences embedded in prose no longer interfere with valid JSON found later.
  * Invalid complete fences now preserve the original content while reporting a parsing error.
  * Added clearer tracking for removed JSON fences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->