### PR TITLE
fix(unifiedllm): keep context window out of requests

### DIFF
--- a/src/nooa/unifiedllm/unifiedllm.py
+++ b/src/nooa/unifiedllm/unifiedllm.py
@@ -1153,9 +1153,10 @@ def _update_token_calibration(
 class UnifiedLLM(ABC):
     _registry_config: dict[str, Any] | None
 
-    def __init__(self, model: str, **config):
+    def __init__(self, model: str, context_window: int | None = None, **config: Any) -> None:
         self.model = model
         self.config = config
+        self._context_window = context_window
         self._registry_config = None
         # Cache control injection — shared by CompletionClient and ResponsesClient
         self.cache_control_injection_points: list[dict[str, Any]] = (
@@ -1329,7 +1330,7 @@ class UnifiedLLM(ABC):
         """Get context window size (max input tokens).
 
         Resolution order:
-        1. Explicit ``context_window`` config passed to the client constructor
+        1. Explicit ``context_window`` passed to the client constructor
         2. Registry config (if created via get_llm_client())
         3. Registry lookup by model name or model_name field
         4. litellm model info (for known models)
@@ -1338,10 +1339,10 @@ class UnifiedLLM(ABC):
         Returns:
             Maximum input tokens for this model, or None if unknown.
         """
-        # First, honor explicit direct-client config.
-        cw = self.config.get("context_window")
-        if cw is not None:
-            return cw
+        # First, honor explicit direct-client metadata. This is stored outside
+        # self.config so it cannot be serialized into provider API requests.
+        if self._context_window is not None:
+            return self._context_window
 
         # Then check registry config (set by get_llm_client()).
         if self._registry_config is not None:
@@ -1744,6 +1745,7 @@ class CompletionClient(UnifiedLLM):
         http_config: HttpConfig | None = None,
         # use system as default for cache_control_injection_points
         cache_control_injection_points: list[dict[str, Any]] | None = None,
+        context_window: int | None = None,
         **config,
     ):
         """
@@ -1768,9 +1770,11 @@ class CompletionClient(UnifiedLLM):
                 enable prompt caching (for example: {"role": "system"} or
                 {"role": "tool", "position": "last"}). Applied to all calls.
                 Note: Do NOT manually add cache_control to message content when using this.
+            context_window: Optional model context-window metadata used for local
+                context budgeting. It is never sent to the inference API.
             **config: Additional configuration passed to litellm (api_key, api_base, etc.)
         """
-        super().__init__(model, **config)
+        super().__init__(model, context_window=context_window, **config)
         self.retry_config = retry_config or RetryConfig()
         self._http_config = http_config or HttpConfig()
         self._http = _ClientHttp.for_completion(self.model, self.config, self._http_config)
@@ -2247,6 +2251,7 @@ class ResponsesClient(UnifiedLLM):
         retry_config: RetryConfig | None = None,
         http_config: HttpConfig | None = None,
         cache_control_injection_points: list[dict[str, Any]] | None = None,
+        context_window: int | None = None,
         **config,
     ):
         """
@@ -2272,9 +2277,11 @@ class ResponsesClient(UnifiedLLM):
             cache_control_injection_points: Optional list of role/position rules to
                 enable prompt caching (for example: {"role": "system"} or
                 {"role": "tool", "position": "last"}). Applied to all calls.
+            context_window: Optional model context-window metadata used for local
+                context budgeting. It is never sent to the inference API.
             **config: Additional configuration passed to litellm (api_key, api_base, etc.)
         """
-        super().__init__(model, **config)
+        super().__init__(model, context_window=context_window, **config)
         self.retry_config = retry_config or RetryConfig()
         self._http_config = http_config or HttpConfig()
         self._http = _ClientHttp.for_responses(self.model, self.config, self._http_config)

--- a/tests/unifiedllm/test_context_window.py
+++ b/tests/unifiedllm/test_context_window.py
@@ -1,13 +1,37 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from nooa.unifiedllm import CompletionClient
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import litellm
+import pytest
+
+from nooa.unifiedllm import CompletionClient, ResponsesClient, get_llm_client
+
+
+def _completion_response() -> litellm.ModelResponse:
+    message = litellm.Message(content="ok", role="assistant")
+    choice = litellm.Choices(message=message, index=0, finish_reason="stop")
+    return litellm.ModelResponse(choices=[choice], model="test-model")
+
+
+def _responses_response() -> SimpleNamespace:
+    return SimpleNamespace(output=[], usage=None, status="completed", incomplete_details=None)
 
 
 def test_completion_client_context_window_config_is_honored():
     client = CompletionClient(model="unknown/context-window-model", context_window=262144)
 
     assert client.context_window == 262144
+    assert "context_window" not in client.config
+
+
+def test_responses_client_context_window_config_is_honored():
+    client = ResponsesClient(model="unknown/context-window-model", context_window=262144)
+
+    assert client.context_window == 262144
+    assert "context_window" not in client.config
 
 
 def test_context_window_config_overrides_registry_config():
@@ -15,3 +39,84 @@ def test_context_window_config_overrides_registry_config():
     client._registry_config = {"context_window": 131072}
 
     assert client.context_window == 262144
+
+
+def test_zero_context_window_remains_an_explicit_override():
+    client = CompletionClient(model="unknown/context-window-model", context_window=0)
+    client._registry_config = {"context_window": 131072}
+
+    assert client.context_window == 0
+    assert "context_window" not in client.config
+
+
+def test_none_context_window_falls_through_to_registry_config():
+    client = CompletionClient(model="unknown/context-window-model", context_window=None)
+    client._registry_config = {"context_window": 131072}
+
+    assert client.context_window == 131072
+    assert "context_window" not in client.config
+
+
+def test_registry_only_context_window_still_resolves():
+    client = CompletionClient(model="unknown/context-window-model")
+    client._registry_config = {"context_window": 131072}
+
+    assert client.context_window == 131072
+
+
+def test_get_llm_client_override_is_metadata_not_request_config(monkeypatch):
+    from nooa.unifiedllm import registry
+
+    monkeypatch.setattr(registry, "_loaded", True)
+    monkeypatch.setitem(
+        registry.MODELS,
+        "context-window-alias",
+        {"model_name": "unknown/context-window-model", "context_window": 131072},
+    )
+
+    client = get_llm_client("context-window-alias", context_window=262144)
+
+    assert client.context_window == 262144
+    assert "context_window" not in client.config
+
+
+def test_completion_sync_request_omits_context_window():
+    client = CompletionClient(model="test-model", context_window=262144)
+
+    with patch("litellm.completion", return_value=_completion_response()) as completion:
+        client.call([{"role": "user", "content": "hello"}])
+
+    assert "context_window" not in completion.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_completion_async_request_omits_context_window():
+    client = CompletionClient(model="test-model", context_window=262144)
+
+    with patch(
+        "litellm.acompletion", new_callable=AsyncMock, return_value=_completion_response()
+    ) as completion:
+        await client.acall([{"role": "user", "content": "hello"}])
+
+    assert "context_window" not in completion.call_args.kwargs
+
+
+def test_responses_sync_request_omits_context_window():
+    client = ResponsesClient(model="test-model", context_window=262144)
+
+    with patch("litellm.responses", return_value=_responses_response()) as responses:
+        client.call([{"role": "user", "content": "hello"}])
+
+    assert "context_window" not in responses.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_responses_async_request_omits_context_window():
+    client = ResponsesClient(model="test-model", context_window=262144)
+
+    with patch(
+        "litellm.aresponses", new_callable=AsyncMock, return_value=_responses_response()
+    ) as responses:
+        await client.acall([{"role": "user", "content": "hello"}])
+
+    assert "context_window" not in responses.call_args.kwargs


### PR DESCRIPTION
## Summary

- store explicit `context_window` as NOOA-side client metadata instead of LiteLLM request configuration
- preserve explicit, registry, registry-lookup, and LiteLLM model-info resolution precedence
- cover direct and registry-created clients plus sync and async request serialization for both client types

Fixes https://github.com/NVIDIA-NeMo/labs-OO-Agents/issues/240

## Verification

- `uv run pytest tests/unifiedllm -q` (361 passed, 5 deselected)
- `uv run ruff check src/nooa/unifiedllm/unifiedllm.py tests/unifiedllm/test_context_window.py`
- `uv run ruff format --check src/nooa/unifiedllm/unifiedllm.py tests/unifiedllm/test_context_window.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional context-window setting for unified language model clients.
  * Explicit context-window values now take precedence over provider defaults.
  * Context-window metadata is kept separate from inference requests, preventing it from being sent to model APIs.

* **Bug Fixes**
  * Improved handling of zero and unset context-window values.
  * Ensured consistent behavior for synchronous and asynchronous requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->