### PR TITLE
fix(tools): preserve BashSession serialization during loop-change resets

### DIFF
--- a/src/nooa/tools/_bash_session.py
+++ b/src/nooa/tools/_bash_session.py
@@ -61,6 +61,7 @@ class BashSession:
         self._started = False
         self._started_on_loop: asyncio.AbstractEventLoop | None = None
         self._lock = asyncio.Lock()
+        self._lock_loop: asyncio.AbstractEventLoop | None = None
         self._last_successful_command: float | None = None
         self._last_command: str = ""
         self._start_count: int = 0
@@ -242,12 +243,17 @@ class BashSession:
         return f'eval "$(base64 -d <<<{blob})" </dev/null\n{protocol}'
 
     def _ensure_lock_on_current_loop(self) -> None:
-        """Recreate the lock if the event loop changed since it was created."""
-        if (
-            self._started_on_loop is not None
-            and self._started_on_loop is not asyncio.get_running_loop()
-        ):
+        """Recreate the lock if serialized commands move to another event loop.
+
+        Track the lock separately from the shell lifecycle so reset() cannot
+        replace a lock that a caller still holds.
+        """
+        loop = asyncio.get_running_loop()
+        if self._lock_loop is None:
+            self._lock_loop = loop
+        elif self._lock_loop is not loop:
             self._lock = asyncio.Lock()
+            self._lock_loop = loop
 
     async def run(self, command: str, timeout: float = 30.0) -> tuple[str, str, int]:
         """Run a command and return (stdout, stderr, exit_code).
@@ -687,4 +693,3 @@ class BashSession:
         self._process = None
         self._started = False
         self._started_on_loop = None
-        self._lock = asyncio.Lock()

--- a/src/nooa/tools/tests/test_bash_lock_loop.py
+++ b/src/nooa/tools/tests/test_bash_lock_loop.py
@@ -99,25 +99,30 @@ class TestLockLoopMismatch:
         await bash_session.run("echo start")
         original_lock = bash_session._lock
 
-        # Simulate a loop change by setting _started_on_loop to a different object
-        bash_session._started_on_loop = object()
+        # Simulate a loop change by setting _lock_loop to a different object
+        bash_session._lock_loop = object()
         bash_session._ensure_lock_on_current_loop()
         assert bash_session._lock is not original_lock
+        assert bash_session._lock_loop is asyncio.get_running_loop()
 
     def test_run_after_close_on_new_loop(self, bash_session):
-        """Lock is fresh after close(), so a new loop works without error."""
+        """close() preserves the lock until the next loop adopts a fresh one."""
 
         async def start_and_close(session):
             await session.run("echo first")
+            original_lock = session._lock
             await session.close()
+            assert session._lock is original_lock
+            return original_lock
 
         async def run_after_close(session):
             stdout, _, code = await session.run("echo second")
             return stdout.strip(), code
 
         # Start and close on loop A
-        asyncio.run(start_and_close(bash_session))
+        original_lock = asyncio.run(start_and_close(bash_session))
 
-        # Use on loop B — would fail without lock reset in close()
+        # Use on loop B — the public operation replaces the old loop's lock
         result = asyncio.run(run_after_close(bash_session))
         assert result == ("second", 0)
+        assert bash_session._lock is not original_lock

--- a/tests/tools/test_bash_cross_loop.py
+++ b/tests/tools/test_bash_cross_loop.py
@@ -119,6 +119,49 @@ class TestCrossLoopLockContention:
         finally:
             await session.close()
 
+    async def test_loop_change_reset_keeps_concurrent_runs_serialized(self, tmp_path, monkeypatch):
+        """A loop-change reset must not replace a lock held by run()."""
+        session = BashSession(cwd=tmp_path)
+        session._started = True
+        session._started_on_loop = object()
+
+        restart_started = asyncio.Event()
+        allow_restart = asyncio.Event()
+        command_started = asyncio.Event()
+        allow_command = asyncio.Event()
+
+        async def start():
+            session._started = True
+            session._started_on_loop = asyncio.get_running_loop()
+            restart_started.set()
+            await allow_restart.wait()
+
+        async def send_and_wait(_script, _sentinel, timeout):
+            command_started.set()
+            await allow_command.wait()
+            return ["0", str(tmp_path)], "", "", False
+
+        monkeypatch.setattr(session, "start", start)
+        monkeypatch.setattr(session, "_send_and_wait", send_and_wait)
+
+        first = asyncio.create_task(session.run("echo first"))
+        await asyncio.wait_for(restart_started.wait(), timeout=1)
+        second = asyncio.create_task(session.run("echo second"))
+
+        entered_during_reset = False
+        try:
+            await asyncio.sleep(0)
+            entered_during_reset = command_started.is_set()
+        finally:
+            allow_restart.set()
+            allow_command.set()
+            results = await asyncio.wait_for(
+                asyncio.gather(first, second, return_exceptions=True), timeout=1
+            )
+
+        assert not entered_during_reset
+        assert results == [("", "", 0), ("", "", 0)]
+
     async def test_shell_tools_survives_loop_restart(self, tmp_path):
         """ShellTools concurrent usage survives loop restart."""
         shell = ShellTools(cwd=tmp_path)


### PR DESCRIPTION
## What does this PR do?

Preserves `BashSession` command serialization when an event-loop change triggers a shell reset.

The command lock now tracks its event loop independently of the shell lifecycle. `close()` no longer replaces a lock that may still be held, while the next serialized command on a different event loop adopts a fresh lock. This prevents queued `run()` calls from bypassing the active lock while `reset()` is in progress.

Adds deterministic regression coverage for the race and updates the existing loop-reuse tests for the corrected lock lifecycle.

## Related issues

Closes #239

## Validation

- `uv run pytest -q src/nooa/tools/tests/test_bash_lock_loop.py tests/tools/test_bash*.py tests/tools/test_shell_tools_modern*.py` — 223 passed
- `uv run --isolated --python 3.12 pytest -q src/nooa/tools/tests/test_bash_lock_loop.py tests/tools/test_bash_cross_loop.py` — 11 passed
- `uv run pre-commit run --files src/nooa/tools/_bash_session.py src/nooa/tools/tests/test_bash_lock_loop.py tests/tools/test_bash_cross_loop.py` — passed
- `uv run pytest -q` — 6,949 passed, 8 skipped, 298 deselected, and 3 xfailed; one pre-existing order-dependent MCP HTTP transport timeout was reproduced unchanged on `origin/main` and passes in isolation
- CI-equivalent `uv build --no-sources` builds passed for `nooa`, `nooa-cli`, `nooa-acp`, `nooa-memory`, and `nooa-bench`

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [x] Docs updated if behavior or public APIs changed (not applicable; internal synchronization fix only)
- [x] New source files carry an SPDX license header (not applicable; no new source files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bash session reliability when commands run across different asynchronous execution contexts.
  * Prevented session resets and closures from disrupting commands currently in progress.
  * Ensured concurrent command execution remains coordinated during session restarts and session reuse.

* **Tests**
  * Added regression coverage for cross-context execution, session reuse, and concurrent operations during resets.
  * Verified that commands complete successfully when execution contexts change during an active session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->