### PR TITLE
Unify fullscreen search on word-AND terms

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/completer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/completer.py
@@ -227,7 +227,7 @@ class Completer:
                 return self._skill_id_completions(text, prefix)
 
         # Session ID completion
-        for prefix in ("/session resume ", "/session delete "):
+        for prefix in ("/session resume ", "/session delete ", "/resume "):
             if lower.startswith(prefix.lower()):
                 return self._session_id_completions(text, prefix)
 

--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -386,8 +386,10 @@ def _searchable_markdown(markdown: str | None) -> str:
     if not markdown:
         return ""
     lines = markdown.splitlines()
-    # Drop the leading header line (" [tag] Type · timestamp · id=…").
-    if lines and lines[0].lstrip().startswith("["):
+    # Drop the leading header line ("**[tag]** *Type* · timestamp · id=…").
+    # Rich markdown emphasis wraps the tag in **…**, so match the bolded
+    # form (a bare "[" never matches and the strip never fired).
+    if lines and lines[0].lstrip().startswith("**["):
         lines = lines[1:]
     # Drop the trailing metadata footer (everything from the last rule).
     for index in range(len(lines) - 1, -1, -1):
@@ -462,6 +464,9 @@ _NOISE_FIELDS = {
     "trace_id",
     "span_id",
     "tool_call_id",
+    # Provider reasoning blobs (KBs per tool call) are opaque chrome in the
+    # detail pane — never dump them into the repr or search text.
+    "reasoning_items",
 }
 
 _RENDERED_FIELD_ORDER = {

--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -208,6 +208,10 @@ class EventExplorerView(ExplorerView):
 
     item_name = "event"
     list_heading = "  id       event type              summary"
+    # detail_lines embeds its own styled search highlighting with
+    # occurrence navigation (search_line_cursor), so it opts out of the
+    # browser's generic term highlighting.
+    handles_search_highlighting = True
 
     def __init__(self, event_manager: Any) -> None:
         super().__init__(
@@ -344,6 +348,8 @@ class EventExplorerView(ExplorerView):
 
 
 def _event_to_mapping(event: Any) -> dict[str, Any]:
+    if isinstance(event, dict):
+        return event
     if hasattr(event, "model_dump"):
         try:
             return event.model_dump()
@@ -402,6 +408,27 @@ def _extract_fenced_code(text: str) -> tuple[str, str] | None:
         return None
     language = match.group(1).strip() or "python"
     return match.group(2).rstrip("\n"), language
+
+
+def _searchable_detail(event: Any, event_type: str) -> str:
+    """Repr dump restricted to fields a user can actually see.
+
+    ``_format_detail`` includes every field — even empty and noise ones — so
+    searching it matches field *names*: a PythonOutput event with an empty
+    ``error`` would match the query "error". Only non-empty, non-noise fields
+    participate in search text.
+    """
+    data = _event_to_mapping(event)
+    fields = [
+        (key, value)
+        for key, value in data.items()
+        if key != "event_type"
+        and key not in _NOISE_FIELDS
+        and not _is_empty_event_field(value)
+    ]
+    if not fields:
+        return ""
+    return f"{event_type}(" + ", ".join(f"{key}={value!r}" for key, value in fields) + ")"
 
 
 def _event_code(event: Any, event_type: str) -> tuple[str | None, str]:
@@ -790,7 +817,10 @@ def build_event_rows(event_manager: Any) -> list[EventExplorerRow]:
         detail = _format_detail(str(tag), event)
         code, code_language = _event_code(event, event_type)
         markdown = _event_markdown(str(tag), event, event_type)
-        search_text = f"{tag} {event_type} {summary} {detail} {code or ''} {markdown or ''}"
+        search_text = (
+            f"{tag} {event_type} {summary} "
+            f"{_searchable_detail(event, event_type)} {code or ''} {markdown or ''}"
+        )
         rows.append(
             EventExplorerRow(
                 tag=str(tag),

--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -170,9 +170,14 @@ class EventExplorerModel:
             self.search_line_cursor = 0 if delta > 0 else 10**9
 
     def move_or_scroll(self, delta: int) -> None:
-        if self.search_active and self.focus == "list":
-            self.move_search_occurrence(delta)
-        elif self.focus == "list":
+        """Match the shared navigation contract: list focus moves rows.
+
+        Detail-match stepping is owned by the browser's preview search (the
+        transcript's move_search_match), exactly like /resume — the old
+        list-focus occurrence jumping made the same arrow keys behave
+        differently in every browser.
+        """
+        if self.focus == "list":
             self.move(delta)
         else:
             self.scroll_detail(delta)

--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -375,6 +375,28 @@ def _extract_fenced_code(text: str) -> tuple[str, str] | None:
     return match.group(2).rstrip("\n"), language
 
 
+def _searchable_markdown(markdown: str | None) -> str:
+    """Markdown stripped of the header line and metadata footer.
+
+    ``_event_markdown`` always emits a header line and a metadata footer
+    containing timestamps and ids. Those are chrome, not content; leaving
+    them in search text would let noise fields (timestamp, id) match a
+    query again even though ``_searchable_detail`` excludes them.
+    """
+    if not markdown:
+        return ""
+    lines = markdown.splitlines()
+    # Drop the leading header line (" [tag] Type · timestamp · id=…").
+    if lines and lines[0].lstrip().startswith("["):
+        lines = lines[1:]
+    # Drop the trailing metadata footer (everything from the last rule).
+    for index in range(len(lines) - 1, -1, -1):
+        if lines[index].strip().startswith("---"):
+            lines = lines[:index]
+            break
+    return "\n".join(lines)
+
+
 def _searchable_detail(event: Any, event_type: str) -> str:
     """Repr dump restricted to fields a user can actually see.
 
@@ -784,7 +806,8 @@ def build_event_rows(event_manager: Any) -> list[EventExplorerRow]:
         markdown = _event_markdown(str(tag), event, event_type)
         search_text = (
             f"{tag} {event_type} {summary} "
-            f"{_searchable_detail(event, event_type)} {code or ''} {markdown or ''}"
+            f"{_searchable_detail(event, event_type)} {code or ''} "
+            f"{_searchable_markdown(markdown)}"
         )
         rows.append(
             EventExplorerRow(
@@ -980,6 +1003,20 @@ def _plain_offset_map(styled: str) -> list[int]:
     return mapping
 
 
+def _active_sgr_before(styled: str, position: int) -> str:
+    """Return the SGR state active at *position* (excluding resets)."""
+    import re as _re
+
+    active: list[str] = []
+    for match in _re.finditer(r"\x1b\[([0-9;]*)m", styled[:position]):
+        codes = match.group(1)
+        if codes == "0" or codes == "":
+            active.clear()
+        else:
+            active.append(match.group(0))
+    return "".join(active)
+
+
 def _highlight_line_terms(
     styled: str, terms: list[str], *, current_occurrence: int | None = None
 ) -> str:
@@ -1004,7 +1041,11 @@ def _highlight_line_terms(
         current = current_occurrence is not None and occurrence == current_occurrence
         start, stop = offsets[match.start()], offsets[match.end() - 1] + 1
         insertions.append((start, highlight_style_code(current=current)))
-        insertions.append((stop, "\x1b[0m"))
+        # Reapply the styling that was active at the match boundary: a
+        # match inside a styled token must not strip the token's remaining
+        # characters of their color.
+        active_style = _active_sgr_before(styled, start)
+        insertions.append((stop, f"\x1b[0m{active_style}" if active_style else "\x1b[0m"))
         occurrence += 1
     if not insertions:
         return styled

--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -15,6 +15,7 @@ from .explorer_base import (
     ExplorerOption,
     ExplorerView,
     highlight_style_code,
+    matches_all_terms,
     search_terms,
     wrap_plain_line,
 )
@@ -95,12 +96,12 @@ class EventExplorerModel:
 
     def set_query(self, query: str) -> None:
         self.query = query
-        words = [w.lower() for w in query.split() if w.strip()]
+        terms = [w for w in query.split() if w.strip()]
         self.matches = [
             i
             for i, row in enumerate(self.rows)
             if row.event_type in self.enabled_types
-            and (not words or all(word in row.search_text.lower() for word in words))
+            and matches_all_terms(terms, row.search_text)
         ]
         if self.sort_mode == "type":
             self.matches.sort(key=lambda index: (self.rows[index].event_type, index))

--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -130,45 +130,6 @@ class EventExplorerModel:
         self.detail_offset = 0
         self.search_line_cursor = 0
 
-    def current_search_line(self) -> int | None:
-        if self._last_detail_match_occurrences:
-            match_count = len(self._last_detail_match_occurrences)
-            self.search_line_cursor = min(max(self.search_line_cursor, 0), match_count - 1)
-            return self._last_detail_match_occurrences[self.search_line_cursor][0]
-        if self._last_detail_match_lines:
-            match_count = len(self._last_detail_match_lines)
-            self.search_line_cursor = min(max(self.search_line_cursor, 0), match_count - 1)
-            return self._last_detail_match_lines[self.search_line_cursor]
-        return None
-
-    def center_detail_on_line(self, line: int, visible_lines: int | None = None) -> None:
-        visible = max(
-            visible_lines if visible_lines is not None else self._last_detail_visible_lines, 1
-        )
-        self.detail_offset = max(line - visible // 2, 0)
-        self.clamp_detail_offset(visible)
-
-    def move_search_occurrence(self, delta: int) -> None:
-        if not self.matches:
-            return
-        match_count = len(self._last_detail_match_occurrences) or len(self._last_detail_match_lines)
-        if not match_count:
-            self.move(delta)
-            return
-        next_cursor = self.search_line_cursor + delta
-        if 0 <= next_cursor < match_count:
-            self.search_line_cursor = next_cursor
-            target = self.current_search_line()
-            if target is not None:
-                self.center_detail_on_line(target)
-            return
-        old_cursor = self.cursor
-        self.move(delta)
-        if self.cursor != old_cursor:
-            self._last_detail_match_lines = []
-            self._last_detail_match_occurrences = []
-            self.search_line_cursor = 0 if delta > 0 else 10**9
-
     def move_or_scroll(self, delta: int) -> None:
         """Match the shared navigation contract: list focus moves rows.
 
@@ -197,7 +158,11 @@ class EventExplorerModel:
         self.focus = "detail" if self.focus == "list" else "list"
 
     def scroll_detail(self, delta: int) -> None:
-        max_offset = max(self._last_detail_line_count - 1, 0)
+        # Clamp to the last *visible* window (count - visible), like the base
+        # ExplorerModel — the old count-1 clamp let the pane wheel nearly a
+        # full page past the last line.
+        visible = max(self._last_detail_visible_lines, 1)
+        max_offset = max(self._last_detail_line_count - visible, 0)
         self.detail_offset = min(max(self.detail_offset + delta, 0), max_offset)
 
     def page_detail(self, delta: int) -> None:
@@ -221,12 +186,7 @@ class EventExplorerView(ExplorerView):
     def __init__(self, event_manager: Any) -> None:
         super().__init__(
             EventExplorerModel(build_event_rows(event_manager)),
-            ExplorerConfig(
-                title="Event Explorer",
-                detail_pane_name="event detail",
-                empty_message="No events recorded.",
-                no_match_message="No events matching {query!r}.",
-            ),
+            ExplorerConfig(title="Event Explorer"),
         )
         event_types = tuple(sorted(self.model.enabled_types, key=str.casefold))
 

--- a/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
@@ -80,6 +80,19 @@ def search_terms(query: str) -> list[str]:
     return [term for term in query.split() if term.strip()]
 
 
+def matches_all_terms(terms: list[str], text: str) -> bool:
+    """Shared word-AND search contract for every fullscreen browser.
+
+    A query matches when *every* whitespace-separated term occurs
+    (case-insensitively) somewhere in the searchable text. All explorers and
+    the resume picker use this rule so search behaves identically everywhere.
+    """
+    if not terms:
+        return True
+    folded = text.casefold()
+    return all(term.casefold() in folded for term in terms)
+
+
 def highlight_terms(text: str, terms: list[str], *, current: bool = False) -> str:
     """Highlight search terms in text using ANSI colors."""
     if not terms:
@@ -239,12 +252,12 @@ class ExplorerModel:
     def set_query(self, query: str) -> None:
         """Update search query and refilter matches."""
         self.query = query
-        words = [w.lower() for w in query.split() if w.strip()]
+        terms = [w for w in query.split() if w.strip()]
         self.matches = [
             i
             for i, row in enumerate(self.rows)
             if self._filter_predicate(row)
-            and (not words or all(word in row.search_text.lower() for word in words))
+            and matches_all_terms(terms, row.search_text)
         ]
         if self._sort_key is not None:
             self.matches.sort(

--- a/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
@@ -540,6 +540,10 @@ class ExplorerView(ExplorerInteraction):
         """Format a single row for the list. Override in subclasses."""
         return str(row)[:width]
 
+    # Views that embed their own search highlighting in detail_lines (with
+    # occurrence navigation) opt out of the browser's generic highlighting.
+    handles_search_highlighting: bool = False
+
     def detail_lines(self, row: Any, width: int) -> list[str]:
         """Return detail lines for the selected row. Override in subclasses."""
         return [str(row)]

--- a/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
@@ -316,20 +316,6 @@ class ExplorerModel:
         else:
             self.scroll_detail(delta)
 
-    def _move_detail_match(self, delta: int) -> bool:
-        if not self._last_detail_match_lines:
-            return False
-        count = len(self._last_detail_match_lines)
-        next_cursor = self.search_line_cursor + delta
-        if not 0 <= next_cursor < count:
-            return False
-        self.search_line_cursor = next_cursor
-        line = self._last_detail_match_lines[self.search_line_cursor]
-        visible = max(self._last_detail_visible_lines, 1)
-        self.detail_offset = max(line - visible // 2, 0)
-        self.clamp_detail_offset(visible)
-        return True
-
     def jump_home(self) -> None:
         self.cursor = 0
         self.detail_offset = 0
@@ -365,18 +351,10 @@ class ExplorerConfig:
 
     Attributes:
         title: Explorer title shown in header bar.
-        detail_pane_name: Label for the detail focus (e.g. "dialog", "event text").
-        empty_message: Shown when no rows exist.
-        no_match_message: Template for no search results (gets .format(query=...)).
-        list_ratio: Fraction of body height for the list pane (0.0-1.0).
         actions: Custom action names mapped to descriptions (for footer hints).
     """
 
     title: str = "Explorer"
-    detail_pane_name: str = "detail"
-    empty_message: str = "No items."
-    no_match_message: str = "No matches for {query!r}."
-    list_ratio: float = 0.33
     actions: dict[str, str] = field(default_factory=dict)
 
 

--- a/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
@@ -306,15 +306,12 @@ class ExplorerModel:
         self.search_line_cursor = 0
 
     def move_or_scroll(self, delta: int) -> None:
-        if self.search_active and self._last_detail_match_lines:
-            if self._move_detail_match(delta):
-                return
-            old_cursor = self.cursor
-            self.move(delta)
-            if self.cursor != old_cursor:
-                self._last_detail_match_lines = []
-                self.search_line_cursor = 0 if delta > 0 else 10**9
-        elif self.focus == "list":
+        """Shared navigation contract: list focus moves rows; detail scrolls.
+
+        Preview-match stepping is owned by the browser's transcript search
+        (like /resume), not by the model.
+        """
+        if self.focus == "list":
             self.move(delta)
         else:
             self.scroll_detail(delta)

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -821,6 +821,9 @@ class ExplorerBrowser:
             self._detail_transcript_key = key
         transcript = self._detail_transcript
         assert transcript is not None
+        # The transcript's own search powers preview match navigation
+        # (reveal + current-match cycling) for every browser, matching /resume.
+        transcript.set_search(self.buffer.text, width=max(1, width), height=max(1, height))
         self.model._last_detail_line_count = len(transcript._display_rows(max(1, width)))
         self.model._last_detail_visible_lines = max(1, height)
         self.model.clamp_detail_offset(height)
@@ -861,13 +864,28 @@ class ExplorerBrowser:
         self.invalidate()
 
     def navigate_vertical(self, delta: int) -> None:
+        """Shared navigation contract (same as /resume).
+
+        List focus moves between matching rows; preview focus steps between
+        the detail's search matches (wrapping), scrolling when there is no
+        query or no matches.
+        """
         if self.option_cursor is not None:
             self.change_option(delta)
-        elif self.active_control == "list":
+            return
+        if self.active_control == "list":
             self._list_offset_detached = False
-            self.model.move_or_scroll(delta)
-        else:
-            self.model.move_or_scroll(delta)
+            self.model.move(delta)
+            self.invalidate()
+            return
+        width, height = self.preview_control.viewport
+        transcript = self._preview_transcript(width, height)
+        if transcript is not None and transcript.move_search_match(
+            delta, width=max(1, width), height=max(1, height)
+        ):
+            self.invalidate()
+            return
+        self.model.scroll_detail(delta)
         self.invalidate()
 
     def page(self, delta: int) -> None:

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -662,7 +662,12 @@ class ExplorerBrowser:
     def _preview_header(self):
         row = self.model.current
         title = getattr(row, "title", None) or getattr(row, "event_type", None) or "No selection"
-        return [("class:fullscreen-browser.heading", f"Preview · {title}")]
+        suffix = ""
+        if self._detail_transcript is not None and self.buffer.text.strip():
+            position, total = self._detail_transcript.search_position
+            if total:
+                suffix = f" · match {position}/{total}"
+        return [("class:fullscreen-browser.heading", f"Preview · {title}{suffix}")]
 
     def _small_text(self):
         size = self.app.output.get_size()

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -763,22 +763,32 @@ class ExplorerBrowser:
                     )
                 )
             )[:width]
-            query = self.buffer.text.casefold().strip()
+            query = self.buffer.text.strip()
             if not query:
                 output.append((base, text))
                 continue
+            # Word-AND rows can match terms scattered across the row, so
+            # every term gets its own highlight span instead of one span for
+            # the whole query (which a multi-word query would never find).
             folded = text.casefold()
+            spans: list[tuple[int, int]] = []
+            for term in dict.fromkeys(term.casefold() for term in query.split()):
+                cursor = 0
+                while (found := folded.find(term, cursor)) >= 0:
+                    spans.append((found, found + len(term)))
+                    cursor = found + len(term)
+            if not spans:
+                output.append((base, text))
+                continue
+            spans.sort()
             cursor = 0
-            while True:
-                found = folded.find(query, cursor)
-                if found < 0:
-                    output.append((base, text[cursor:]))
-                    break
-                output.append((base, text[cursor:found]))
-                output.append(
-                    (base + " class:fullscreen-browser.match", text[found : found + len(query)])
-                )
-                cursor = found + len(query)
+            for start, stop in spans:
+                if start < cursor:
+                    continue
+                output.append((base, text[cursor:start]))
+                output.append((base + " class:fullscreen-browser.match", text[start:stop]))
+                cursor = stop
+            output.append((base, text[cursor:]))
         return output or [("class:fullscreen-browser.empty", "No matching items")]
 
     def _preview_transcript(self, width: int, height: int) -> FullscreenTranscriptModel | None:

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -832,10 +832,15 @@ class ExplorerBrowser:
         self.model._last_detail_line_count = len(transcript._display_rows(max(1, width)))
         self.model._last_detail_visible_lines = max(1, height)
         self.model.clamp_detail_offset(height)
-        transcript.jump_to_start(width=max(1, width))
-        transcript.scroll_visual_lines(
-            self.model.detail_offset, width=max(1, width), height=max(1, height)
-        )
+        # With a search active, set_search has already revealed the current
+        # match — re-anchoring to detail_offset here would clobber that reveal
+        # (the matched text scrolled out of view while the count kept working).
+        # Without a query, honor the model's detail scroll offset as before.
+        if not self.buffer.text.strip():
+            transcript.jump_to_start(width=max(1, width))
+            transcript.scroll_visual_lines(
+                self.model.detail_offset, width=max(1, width), height=max(1, height)
+            )
         return transcript
 
     def preview_text(self, width: int, height: int):

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -620,6 +620,11 @@ class ExplorerBrowser:
         copy_status = self._selection_status() if self._selection_status is not None else ""
         if copy_status:
             return copy_status
+        confirm_hint = getattr(self.view, "pending_confirmation_hint", None)
+        if callable(confirm_hint):
+            hint = confirm_hint()
+            if hint:
+                return hint
         if self.option_cursor is not None:
             return "Options · ←→ select · ↑↓/Space change · Enter/Esc done"
         actions = " · ".join(self.view.config.actions.values())

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -781,13 +781,15 @@ class ExplorerBrowser:
             # Word-AND rows can match terms scattered across the row, so
             # every term gets its own highlight span instead of one span for
             # the whole query (which a multi-word query would never find).
-            folded = text.casefold()
+            # A case-insensitive regex keeps the match offsets in the
+            # original text: casefold() can expand characters (ß -> ss) and
+            # desynchronize folded offsets from the row being sliced.
+            import re as _re
+
             spans: list[tuple[int, int]] = []
-            for term in dict.fromkeys(term.casefold() for term in query.split()):
-                cursor = 0
-                while (found := folded.find(term, cursor)) >= 0:
-                    spans.append((found, found + len(term)))
-                    cursor = found + len(term)
+            for term in dict.fromkeys(query.split()):
+                for found in _re.finditer(_re.escape(term), text, _re.IGNORECASE):
+                    spans.append((found.start(), found.end()))
             if not spans:
                 output.append((base, text))
                 continue

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -875,6 +875,24 @@ class ExplorerBrowser:
                     self._selection_copy_callback(selected)
         self.invalidate()
 
+    def _scroll_detail_pane(self, delta: int) -> None:
+        """Scroll the preview pane on the live viewport.
+
+        While a search is active the detail transcript owns its viewport
+        (the model offset is never applied, so `scroll_detail` would be a
+        no-op); scroll the transcript directly instead. Without a query the
+        model offset drives scrolling as before.
+        """
+        if self.buffer.text.strip():
+            width, height = self.preview_control.viewport
+            transcript = self._preview_transcript(width, height)
+            if transcript is not None:
+                transcript.scroll_visual_lines(
+                    delta, width=max(1, width), height=max(1, height)
+                )
+                return
+        self.model.scroll_detail(delta)
+
     def navigate_vertical(self, delta: int) -> None:
         """Shared navigation contract (same as /resume).
 
@@ -897,7 +915,7 @@ class ExplorerBrowser:
         ):
             self.invalidate()
             return
-        self.model.scroll_detail(delta)
+        self._scroll_detail_pane(delta)
         self.invalidate()
 
     def page(self, delta: int) -> None:
@@ -910,7 +928,7 @@ class ExplorerBrowser:
             self._list_offset_detached = False
             self.model.move(delta * max(1, amount))
         else:
-            self.model.scroll_detail(delta * max(1, amount))
+            self._scroll_detail_pane(delta * max(1, amount))
         self.invalidate()
 
     def select_visible(self, y: int) -> None:
@@ -927,7 +945,7 @@ class ExplorerBrowser:
             self.list_offset = min(maximum, max(0, self.list_offset + delta))
             self._list_offset_detached = True
         else:
-            self.model.scroll_detail(delta)
+            self._scroll_detail_pane(delta)
         self.invalidate()
 
     def handle_key(self, action: str, value: str = ""):

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -26,6 +26,7 @@ from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.mouse_events import MouseButton, MouseEvent, MouseEventType, MouseModifier
 from prompt_toolkit.widgets import Frame
 
+from .explorer_base import highlight_terms
 from .fullscreen_transcript import FullscreenTranscriptModel
 from .terminal_safety import sanitize_live_text
 
@@ -796,6 +797,13 @@ class ExplorerBrowser:
         if row is None:
             return None
         lines = tuple(self.view.detail_lines(row, max(1, width)))
+        # Views that don't highlight search matches themselves get the
+        # browser's generic term highlighting so every explorer's detail pane
+        # shows matches the same way.
+        if not getattr(self.view, "handles_search_highlighting", False):
+            terms = [term for term in self.buffer.text.split() if term.strip()]
+            if terms:
+                lines = tuple(highlight_terms(line, terms) for line in lines)
         key = (row, max(1, width), lines)
         if self._detail_transcript_key != key:
             if self._detail_transcript_key is not None:

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -240,11 +240,16 @@ class FullscreenTranscriptModel:
             return
         match = self._search_matches[self._search_cursor]
         rows = self._display_rows(max(1, width))
-        for row in rows:
+        for index, row in enumerate(rows):
             if row.anchor.record_id != match.record_id:
                 continue
             if any(start < match.stop and stop > match.start for start, stop in row.source_spans):
-                self._viewport = ViewportState(False, row.anchor)
+                # Center the match vertically when context exists above it,
+                # so the reveal shows before/after context instead of pinning
+                # the match to the pane's first row. Early matches clamp to
+                # the content start.
+                top = max(0, index - max(1, height) // 2)
+                self._viewport = ViewportState(False, rows[top].anchor)
                 return
 
     def cursor_position(self, *, width: int, height: int = 1) -> Point:

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -193,7 +193,9 @@ class FullscreenTranscriptModel:
         if normalized == self._search_query:
             return
         self._search_query = normalized
-        terms = [term for term in normalized.split() if term]
+        # Deduplicate repeated terms ("alpha alpha") so match counts and
+        # navigation visits reflect distinct occurrences.
+        terms = list(dict.fromkeys(term for term in normalized.split() if term))
         matches: list[_SearchMatch] = []
         if terms:
             for record in self._records:

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_transcript.py
@@ -193,8 +193,9 @@ class FullscreenTranscriptModel:
         if normalized == self._search_query:
             return
         self._search_query = normalized
+        terms = [term for term in normalized.split() if term]
         matches: list[_SearchMatch] = []
-        if normalized:
+        if terms:
             for record in self._records:
                 folded_parts: list[str] = []
                 source: list[int] = []
@@ -203,13 +204,20 @@ class FullscreenTranscriptModel:
                     folded_parts.append(folded)
                     source.extend([index] * len(folded))
                 folded_text = "".join(folded_parts)
-                cursor = 0
-                while (found := folded_text.find(normalized, cursor)) >= 0:
-                    stop = found + len(normalized)
-                    matches.append(
-                        _SearchMatch(record.record_id, source[found], source[stop - 1] + 1)
-                    )
-                    cursor = stop
+                record_matches: list[_SearchMatch] = []
+                # Word-AND search highlights every term occurrence, matching
+                # the list filtering contract; each occurrence is its own
+                # navigation stop.
+                for term in terms:
+                    cursor = 0
+                    while (found := folded_text.find(term, cursor)) >= 0:
+                        stop = found + len(term)
+                        record_matches.append(
+                            _SearchMatch(record.record_id, source[found], source[stop - 1] + 1)
+                        )
+                        cursor = stop
+                record_matches.sort(key=lambda match: (match.start, match.stop))
+                matches.extend(record_matches)
         self._search_matches = tuple(matches)
         self._search_cursor = 0
         if matches:

--- a/packages/nooa-cli/src/nooa_cli/tui/job_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/job_explorer.py
@@ -73,14 +73,7 @@ class JobExplorerView(ExplorerView):
     def __init__(self, snapshots: Iterable[JobProjection]) -> None:
         rows = build_job_rows(snapshots)
         model = ExplorerModel(rows)
-        config = ExplorerConfig(
-            title="Job Explorer",
-            detail_pane_name="job output",
-            empty_message="No background jobs.",
-            no_match_message="No jobs matching {query!r}.",
-            list_ratio=0.4,
-            actions={},
-        )
+        config = ExplorerConfig(title="Job Explorer", actions={})
         super().__init__(model, config)
         self.configure_row_options(
             filters=(

--- a/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
@@ -169,10 +169,6 @@ class MemoryExplorerView(ExplorerView):
             title = f"{title} — {last_reflection}"
         config = ExplorerConfig(
             title=title,
-            detail_pane_name="memory detail",
-            empty_message="No memories.",
-            no_match_message="No memories matching {query!r}.",
-            list_ratio=0.4,
             actions={
                 "forget": "f×2 forget",
                 "done": "d×2 todo done",

--- a/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
@@ -159,6 +159,10 @@ class MemoryExplorerView(ExplorerView):
     ) -> None:
         self._forget = forget
         self._mark_done = mark_done
+        # Destructive actions arm on the first press and fire on the second
+        # press of the same key on the same row, so no invisible pane/query
+        # state can trigger an unconfirmed forget or mark-done.
+        self._pending_confirm: tuple[str, str] | None = None
         model = ExplorerModel(rows)
         title = "Memory Explorer"
         if last_reflection:
@@ -170,8 +174,8 @@ class MemoryExplorerView(ExplorerView):
             no_match_message="No memories matching {query!r}.",
             list_ratio=0.4,
             actions={
-                "forget": "f forget",
-                "done": "d todo done",
+                "forget": "f×2 forget",
+                "done": "d×2 todo done",
             },
         )
         super().__init__(model, config)
@@ -269,10 +273,37 @@ class MemoryExplorerView(ExplorerView):
                 lines.append(f"  → {target_id[:8]} {edge_type} ({weight:.2f})")
         return lines
 
+    def _consume_confirmation(self, action: str, row: Any) -> bool:
+        """Return True when this press confirms the pending armed action.
+
+        The first press of an action key arms it; the same key on the same
+        row must follow within the gesture window to fire. Any other key
+        (including typing "f"/"d" into the search buffer) disarms.
+        """
+        pending = self._pending_confirm
+        self._pending_confirm = None
+        return pending == (action, id(row))
+
+    def pending_confirmation_hint(self) -> str:
+        pending = self._pending_confirm
+        if pending is None:
+            return ""
+        action, row_id = pending
+        row = next((row for row in self.model.rows if id(row) == row_id), None)
+        if row is None:
+            self._pending_confirm = None
+            return ""
+        verb = "forget" if action == "text:f" else "mark done"
+        title = (getattr(row, "title", None) or row.id)[:40]
+        return f"Press {action[-1]} again to {verb} {title!r}"
+
     def handle_action(self, action: str, row: Any) -> SubviewKeyResult:
         if row is None:
             return "ignored"
         if action == "text:f":
+            if not self._consume_confirmation(action, row):
+                self._pending_confirm = (action, id(row))
+                return "handled"
             self._forget(row.id)
             self.model.rows.remove(row)
             self.model.set_query(self.model.query)  # rebuild matches without the row
@@ -280,6 +311,9 @@ class MemoryExplorerView(ExplorerView):
         if action == "text:d":
             if row.type != "todo" or row.status == "done":
                 return "ignored"
+            if not self._consume_confirmation(action, row):
+                self._pending_confirm = (action, id(row))
+                return "handled"
             self._mark_done(row.id)
             # The search tag mirrors the CURRENT status (todo:open / todo:dropped
             # — see build_memory_rows), so replace whatever tag the row was
@@ -289,4 +323,5 @@ class MemoryExplorerView(ExplorerView):
             row.search_text = row.search_text.replace(old_tag, "todo:done", 1)
             self.model.set_query(self.model.query)
             return "handled"
+        self._pending_confirm = None
         return "ignored"

--- a/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
@@ -306,6 +306,9 @@ class MemoryExplorerView(ExplorerView):
             return "handled"
         if action == "text:d":
             if row.type != "todo" or row.status == "done":
+                # An action key that cannot apply still interrupts the armed
+                # gesture — the next f/d press must arm, not confirm.
+                self._pending_confirm = None
                 return "ignored"
             if not self._consume_confirmation(action, row):
                 self._pending_confirm = (action, id(row))

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -17,7 +17,13 @@ from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.mouse_events import MouseButton, MouseEvent, MouseEventType, MouseModifier
 from rich.cells import cell_len, split_graphemes
 
-from .fullscreen_browser import ExplorerBrowser, SelectablePreviewControl, build_fullscreen_browser
+from .explorer_base import ExplorerOption
+from .fullscreen_browser import (
+    ExplorerBrowser,
+    SelectablePreviewControl,
+    _BrowserOptionControl,
+    build_fullscreen_browser,
+)
 from .terminal_safety import sanitize_live_text
 
 
@@ -612,43 +618,6 @@ class _PickerSearchControl(BufferControl):
         return super().mouse_handler(mouse_event)
 
 
-class _PickerButtonControl(FormattedTextControl):
-    def __init__(self, picker: ResumePicker, kind: Literal["filter", "sort"]):
-        self.picker = picker
-        self.kind = kind
-        super().__init__(self._text, focusable=False, show_cursor=False)
-
-    def _text(self):
-        focused = self.picker.option_cursor == self.kind
-        style = "class:fullscreen-browser.control" + (
-            " class:fullscreen-browser.control-focused" if focused else ""
-        )
-        if self.kind == "filter":
-            value = {
-                "detached": "✓ Not attached",
-                "attached": "✗ Attached",
-                "all": "✓/✗ All",
-            }[self.picker.model.state_filter]
-            return [(style, f"[Filter: {value}]")]
-        value = "Recent activity" if self.picker.model.sort_updated else "Creation date"
-        return [(style, f"[Sort: {value}]")]
-
-    def mouse_handler(self, mouse_event: MouseEvent):
-        if (
-            mouse_event.event_type is MouseEventType.MOUSE_DOWN
-            and mouse_event.button is MouseButton.LEFT
-        ):
-            self.picker.option_cursor = self.kind
-            if self.kind == "filter":
-                self.picker.cycle_filter()
-            else:
-                self.picker.toggle_sort()
-            self.picker.option_cursor = None
-            self.picker.invalidate()
-            return None
-        return NotImplemented
-
-
 class ResumePicker(ExplorerBrowser):
     """Session-specific ExplorerBrowser with asynchronous replay previews.
 
@@ -660,8 +629,10 @@ class ResumePicker(ExplorerBrowser):
 
     class _ViewFacade:
         config = SimpleNamespace(actions={})
-        options: tuple[Any, ...] = ()
         item_name = "session"
+
+        def __init__(self, options: tuple[ExplorerOption, ...] = ()) -> None:
+            self.options = options
 
         @staticmethod
         def handle_key(_action: str, _value: str = "") -> str:
@@ -692,15 +663,18 @@ class ResumePicker(ExplorerBrowser):
         selection_status: Callable[[], str] | None = None,
     ):
         self.app = app
-        self._view_facade = ResumePicker._ViewFacade()
         self.model = ResumePickerModel(rows)
+        # Real option rows drive the shared option controls and the inherited
+        # options mode; their callbacks mirror the model's cycle/toggle
+        # semantics (restart from the top, refresh the prepared preview).
+        self._view_facade = ResumePicker._ViewFacade(self._build_view_options())
         self._selection_copy_callback = selection_copy_callback
         self._selection_status = selection_status
         self._preview_models: dict[tuple[str, int], Any] = {}
         self._preview_tasks: dict[tuple[str, int], Any] = {}
         self.native_selection = False
         self.active_control = "list"
-        self.option_cursor: Literal["filter", "sort"] | None = None
+        self.option_cursor: int | None = None
         self.buffer = Buffer(multiline=False)
         self.buffer.on_text_changed += lambda _: self._query_changed()
         self.query_control = _PickerSearchControl(self, self.buffer)
@@ -714,8 +688,7 @@ class ResumePicker(ExplorerBrowser):
                 else ""
             ),
         )
-        self.filter_control = _PickerButtonControl(self, "filter")
-        self.sort_control = _PickerButtonControl(self, "sort")
+        self.option_controls = [_BrowserOptionControl(self, index) for index in range(2)]
         self.search_label_control = FormattedTextControl(self._search_label)
         self.search_close_control = FormattedTextControl(self._search_close)
         search = VSplit(
@@ -728,9 +701,9 @@ class ResumePicker(ExplorerBrowser):
         )
         selectors = VSplit(
             [
-                Window(self.filter_control, width=Dimension(min=17, preferred=20), height=1),
+                Window(self.option_controls[0], width=Dimension(min=17, preferred=20), height=1),
                 Window(FormattedTextControl(" "), width=1, height=1),
-                Window(self.sort_control, width=Dimension(min=10, preferred=18), height=1),
+                Window(self.option_controls[1], width=Dimension(min=10, preferred=18), height=1),
             ],
             padding=0,
         )
@@ -765,6 +738,49 @@ class ResumePicker(ExplorerBrowser):
             small_control=self.small_control,
             small_text=self._small_text,
             list_height=self.picker_list_height,
+        )
+
+    def _build_view_options(self) -> tuple[ExplorerOption, ...]:
+        """The picker's filter/sort controls as real shared option rows.
+
+        The callbacks preserve the model's filter/sort semantics (restart from
+        the top of the list, refresh the prepared preview) while the shared
+        option controls and options mode handle rendering and navigation.
+        """
+
+        def on_filter(value: str) -> None:
+            self.model.state_filter = value  # type: ignore[assignment]
+            self.model.selected = self.model.list_offset = 0
+            self.model._rebuild_matches()
+            self._prepare_current_preview()
+            self.invalidate()
+
+        def on_sort(value: str) -> None:
+            self.model.sort_updated = value == "updated"
+            self.model.selected = self.model.list_offset = 0
+            self.model._rebuild_matches()
+            self._prepare_current_preview()
+            self.invalidate()
+
+        return (
+            ExplorerOption(
+                key="filter",
+                label="Filter",
+                choices=(
+                    ("detached", "✓ Not attached"),
+                    ("attached", "✗ Attached"),
+                    ("all", "✓/✗ All"),
+                ),
+                value=self.model.state_filter,
+                on_change=on_filter,
+            ),
+            ExplorerOption(
+                key="sort",
+                label="Sort",
+                choices=(("updated", "Recent activity"), ("created", "Creation date")),
+                value="updated" if self.model.sort_updated else "created",
+                on_change=on_sort,
+            ),
         )
 
     def _query_changed(self) -> None:
@@ -834,8 +850,8 @@ class ResumePicker(ExplorerBrowser):
     def invalidate(self) -> None:
         self.list_control._fragment_cache.clear()
         self.preview_control._fragment_cache.clear()
-        self.filter_control._fragment_cache.clear()
-        self.sort_control._fragment_cache.clear()
+        for control in self.option_controls:
+            control._fragment_cache.clear()
         self.search_label_control._fragment_cache.clear()
         self.search_close_control._fragment_cache.clear()
         self.title_control._fragment_cache.clear()
@@ -851,40 +867,6 @@ class ResumePicker(ExplorerBrowser):
         }
         self.app.layout.focus(controls[name])
         self.invalidate()
-
-    def toggle_options(self) -> None:
-        """Enter or leave the inline filter/sort options mode."""
-        self.active_control = "list"
-        if self.option_cursor is None:
-            self.option_cursor = "filter"
-            self.app.layout.focus(self.list_control)
-        else:
-            self.option_cursor = None
-            self.app.layout.focus(self.query_control)
-        self.invalidate()
-
-    def move_option(self, delta: int) -> None:
-        if self.option_cursor is None or not delta:
-            return
-        self.option_cursor = "sort" if delta > 0 else "filter"
-        self.invalidate()
-
-    def change_option(self, delta: int = 1) -> None:
-        if self.option_cursor == "filter":
-            self.model.cycle_filter(delta)
-            self._prepare_current_preview()
-        elif self.option_cursor == "sort" and delta:
-            self.model.toggle_sort()
-            self._prepare_current_preview()
-        self.invalidate()
-
-    def close_options(self) -> bool:
-        if self.option_cursor is None:
-            return False
-        self.option_cursor = None
-        self.app.layout.focus(self.query_control)
-        self.invalidate()
-        return True
 
     def focus_previous(self) -> None:
         self.focus_next(-1)
@@ -914,16 +896,6 @@ class ResumePicker(ExplorerBrowser):
                 self.scroll_preview(delta)
             else:
                 self.invalidate()
-
-    def cycle_filter(self) -> None:
-        self.model.toggle_filter()
-        self._prepare_current_preview()
-        self.invalidate()
-
-    def toggle_sort(self) -> None:
-        self.model.toggle_sort()
-        self._prepare_current_preview()
-        self.invalidate()
 
     def page(self, delta: int) -> None:
         if self.active_control == "list":

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -767,6 +767,9 @@ class ResumePicker(ExplorerBrowser):
         self.small_control = FormattedTextControl(
             [("class:fullscreen-browser.too-small", "Terminal too small")], focusable=True
         )
+        # The session list fills its pane like every other browser (the
+        # shell's compact five-row default capped it short of the divider).
+        self.picker_list_height = Dimension(min=1, preferred=5, weight=1)
         self.container = build_fullscreen_browser(
             app=self.app,
             title_control=self.title_control,
@@ -781,6 +784,7 @@ class ResumePicker(ExplorerBrowser):
             active_rail=self._active_rail,
             small_control=self.small_control,
             small_text=self._small_text,
+            list_height=self.picker_list_height,
         )
 
     def _query_changed(self) -> None:

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -97,6 +97,30 @@ def _single_line(text: str) -> str:
     return " ".join(sanitize_live_text(text).split())
 
 
+# Folded-text memo: casefold expansion of a field is deterministic, and rows
+# are immutable, so per-keystroke search reuses the expansion instead of
+# rebuilding a per-character map over every conversation for every keystroke.
+_FOLD_CACHE: dict[str, tuple[str, list[int]]] = {}
+_FOLD_CACHE_MAX = 4096
+
+
+def _folded_with_source(text: str) -> tuple[str, list[int]]:
+    cached = _FOLD_CACHE.get(text)
+    if cached is not None:
+        return cached
+    parts: list[str] = []
+    source: list[int] = []
+    for index, char in enumerate(text):
+        folded = char.casefold()
+        parts.append(folded)
+        source.extend([index] * len(folded))
+    entry = ("".join(parts), source)
+    if len(_FOLD_CACHE) >= _FOLD_CACHE_MAX:
+        _FOLD_CACHE.clear()
+    _FOLD_CACHE[text] = entry
+    return entry
+
+
 def _term_hits(
     terms: list[str], text: str
 ) -> tuple[set[str], int, tuple[int, ...]] | None:
@@ -105,13 +129,7 @@ def _term_hits(
     Returns the distinct terms hit, the earliest hit position, and the
     original-text positions of every hit (for row highlighting).
     """
-    parts: list[str] = []
-    source: list[int] = []
-    for index, char in enumerate(text):
-        folded = char.casefold()
-        parts.append(folded)
-        source.extend([index] * len(folded))
-    target = "".join(parts)
+    target, source = _folded_with_source(text)
     hit: set[str] = set()
     earliest: int | None = None
     positions: list[int] = []

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from typing import Any, Literal
 
 from prompt_toolkit.buffer import Buffer
-from prompt_toolkit.layout import BufferControl, VSplit, Window
+from prompt_toolkit.layout import VSplit, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.mouse_events import MouseButton, MouseEvent, MouseEventType, MouseModifier
@@ -22,6 +22,7 @@ from .fullscreen_browser import (
     ExplorerBrowser,
     SelectablePreviewControl,
     _BrowserOptionControl,
+    _BrowserSearchControl,
     build_fullscreen_browser,
 )
 from .terminal_safety import sanitize_live_text
@@ -250,6 +251,17 @@ class ResumePickerModel:
             return
         self.selected = (self.selected + delta) % len(self._matches)
         self.preview_offset = 10**9
+
+    def jump_home(self) -> None:
+        if self._matches:
+            self.selected = 0
+            self.list_offset = 0
+            self.preview_offset = 10**9
+
+    def jump_end(self) -> None:
+        if self._matches:
+            self.selected = len(self._matches) - 1
+            self.preview_offset = 10**9
 
     def select(self, index: int) -> None:
         if 0 <= index < len(self._matches) and index != self.selected:
@@ -607,17 +619,6 @@ class _PickerControl(FormattedTextControl):
         return NotImplemented
 
 
-class _PickerSearchControl(BufferControl):
-    def __init__(self, picker: ResumePicker, buffer: Buffer):
-        self.picker = picker
-        super().__init__(buffer)
-
-    def mouse_handler(self, mouse_event: MouseEvent):
-        if mouse_event.event_type is MouseEventType.MOUSE_DOWN:
-            self.picker.activate_control("list")
-        return super().mouse_handler(mouse_event)
-
-
 class ResumePicker(ExplorerBrowser):
     """Session-specific ExplorerBrowser with asynchronous replay previews.
 
@@ -677,7 +678,7 @@ class ResumePicker(ExplorerBrowser):
         self.option_cursor: int | None = None
         self.buffer = Buffer(multiline=False)
         self.buffer.on_text_changed += lambda _: self._query_changed()
-        self.query_control = _PickerSearchControl(self, self.buffer)
+        self.query_control = _BrowserSearchControl(self, self.buffer)
         self.query_window = Window(
             self.query_control,
             width=Dimension(min=4, weight=1),

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -110,6 +110,39 @@ def literal_match(query: str, text: str) -> tuple[int, tuple[int, ...]] | None:
     return -found, positions
 
 
+def _term_hits(
+    terms: list[str], text: str
+) -> tuple[set[str], int, tuple[int, ...]] | None:
+    """Locate query terms in one field, in original-text coordinates.
+
+    Returns the distinct terms hit, the earliest hit position, and the
+    original-text positions of every hit (for row highlighting).
+    """
+    parts: list[str] = []
+    source: list[int] = []
+    for index, char in enumerate(text):
+        folded = char.casefold()
+        parts.append(folded)
+        source.extend([index] * len(folded))
+    target = "".join(parts)
+    hit: set[str] = set()
+    earliest: int | None = None
+    positions: list[int] = []
+    for term in terms:
+        needle = term.casefold()
+        found = target.find(needle)
+        if found < 0:
+            continue
+        hit.add(needle)
+        if earliest is None or found < earliest:
+            earliest = found
+        positions.extend(source[found : found + len(needle)])
+    if not hit:
+        return None
+    assert earliest is not None
+    return hit, earliest, tuple(dict.fromkeys(positions))
+
+
 class ResumePickerModel:
     def __init__(self, rows: list[ResumePickerRow]) -> None:
         self.rows = rows
@@ -152,16 +185,29 @@ class ResumePickerModel:
         self.query = query
         normalized_query = query.strip()
         if normalized_query:
+            # Word-AND matching, shared with the explorers: every term must
+            # occur somewhere across the row's fields (title, preview, or
+            # conversation). The best field — most terms covered, earliest —
+            # provides the ranking score and highlight positions.
+            terms = [term for term in normalized_query.split() if term.strip()]
+            needed = {term.casefold() for term in terms}
             query_matches: list[tuple[int, str, tuple[int, ...]] | None] = []
             for fields in self._search_fields:
-                candidates = []
+                best: tuple[int, int, str, tuple[int, ...]] | None = None
+                covered: set[str] = set()
                 for field, value in fields.items():
-                    result = literal_match(normalized_query, value)
-                    if result is not None:
-                        candidates.append((result[0], field, result[1]))
-                query_matches.append(
-                    max(candidates, key=lambda item: item[0]) if candidates else None
-                )
+                    hits = _term_hits(terms, value)
+                    if hits is None:
+                        continue
+                    hit, earliest, positions = hits
+                    covered.update(hit)
+                    candidate = (len(hit), -earliest, field, positions)
+                    if best is None or candidate[:2] > best[:2]:
+                        best = candidate
+                if best is not None and covered == needed:
+                    query_matches.append((best[1], best[2], best[3]))
+                else:
+                    query_matches.append(None)
             self._query_matches = query_matches
         else:
             self._query_matches = [(0, "", ()) for _row in self.rows]

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -622,25 +622,32 @@ class _PickerControl(FormattedTextControl):
 class ResumePicker(ExplorerBrowser):
     """Session-specific ExplorerBrowser with asynchronous replay previews.
 
-    The host owns this picker's key dispatch (it never routes through
-    ``ExplorerBrowser.handle_key``), but inherited helpers dereference
-    ``self.view``. Expose a minimal facade so an accidental inherited call
-    degrades gracefully instead of raising ``AttributeError``.
+    Navigation and options dispatch through the inherited
+    ``ExplorerBrowser.handle_key`` via the view facade; only the picker's
+    lifecycle keys (Escape/Enter/Ctrl-C) stay host-bound because finishing
+    the dialog is a host concern, not a view action.
     """
 
     class _ViewFacade:
+        """View contract for the shared ``ExplorerBrowser.handle_key``."""
+
         config = SimpleNamespace(actions={})
         item_name = "session"
 
-        def __init__(self, options: tuple[ExplorerOption, ...] = ()) -> None:
+        def __init__(self, picker: ResumePicker, options: tuple[ExplorerOption, ...]) -> None:
+            self._picker = picker
             self.options = options
+            self.pending_input: str | None = None
 
-        @staticmethod
-        def handle_key(_action: str, _value: str = "") -> str:
+        def handle_key(self, _action: str, _value: str = "") -> str:
             return "handled"
 
-        @staticmethod
-        def handle_action(_action: str, _row: Any) -> str:
+        def handle_action(self, action: str, row: Any) -> str:
+            if action == "enter" and row is not None:
+                selected = self._picker.selected_id()
+                if selected is not None:
+                    self.pending_input = selected
+                    return "close"
             return "ignored"
 
     @property
@@ -668,7 +675,7 @@ class ResumePicker(ExplorerBrowser):
         # Real option rows drive the shared option controls and the inherited
         # options mode; their callbacks mirror the model's cycle/toggle
         # semantics (restart from the top, refresh the prepared preview).
-        self._view_facade = ResumePicker._ViewFacade(self._build_view_options())
+        self._view_facade = ResumePicker._ViewFacade(self, self._build_view_options())
         self._selection_copy_callback = selection_copy_callback
         self._selection_status = selection_status
         self._preview_models: dict[tuple[str, int], Any] = {}
@@ -859,29 +866,6 @@ class ResumePicker(ExplorerBrowser):
         self.list_header_control._fragment_cache.clear()
         self.preview_header_control._fragment_cache.clear()
         self.app.invalidate()
-
-    def activate_control(self, name: str) -> None:
-        self.active_control = name
-        controls = {
-            "list": self.query_control,
-            "preview": self.preview_control,
-        }
-        self.app.layout.focus(controls[name])
-        self.invalidate()
-
-    def focus_previous(self) -> None:
-        self.focus_next(-1)
-
-    def move_horizontal(self, delta: int) -> None:
-        if self.option_cursor is not None:
-            self.move_option(delta)
-            return
-        if self.active_control != "list" or not delta:
-            return
-        if delta < 0:
-            self.buffer.cursor_left(count=1)
-        else:
-            self.buffer.cursor_right(count=1)
 
     def navigate_vertical(self, delta: int) -> None:
         if self.option_cursor is not None:

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -117,13 +117,15 @@ def _term_hits(
     positions: list[int] = []
     for term in terms:
         needle = term.casefold()
-        found = target.find(needle)
-        if found < 0:
+        cursor = 0
+        while (found := target.find(needle, cursor)) >= 0:
+            hit.add(needle)
+            if earliest is None or found < earliest:
+                earliest = found
+            positions.extend(source[found : found + len(needle)])
+            cursor = found + len(needle)
+        if needle not in hit:
             continue
-        hit.add(needle)
-        if earliest is None or found < earliest:
-            earliest = found
-        positions.extend(source[found : found + len(needle)])
     if not hit:
         return None
     assert earliest is not None
@@ -175,10 +177,12 @@ class ResumePickerModel:
             # Word-AND matching, shared with the explorers: every term must
             # occur somewhere across the row's fields (title, preview, or
             # conversation). The best field — most terms covered, earliest —
-            # provides the ranking score and highlight positions.
+            # provides the ranking score and highlight positions. The score
+            # keeps the coverage count so rows with all terms in one field
+            # outrank rows whose terms are split across fields.
             terms = [term for term in normalized_query.split() if term.strip()]
             needed = {term.casefold() for term in terms}
-            query_matches: list[tuple[int, str, tuple[int, ...]] | None] = []
+            query_matches: list[tuple[int, int, str, tuple[int, ...]] | None] = []
             for fields in self._search_fields:
                 best: tuple[int, int, str, tuple[int, ...]] | None = None
                 covered: set[str] = set()
@@ -192,12 +196,12 @@ class ResumePickerModel:
                     if best is None or candidate[:2] > best[:2]:
                         best = candidate
                 if best is not None and covered == needed:
-                    query_matches.append((best[1], best[2], best[3]))
+                    query_matches.append((best[0], best[1], best[2], best[3]))
                 else:
                     query_matches.append(None)
             self._query_matches = query_matches
         else:
-            self._query_matches = [(0, "", ()) for _row in self.rows]
+            self._query_matches = [(0, 0, "", ()) for _row in self.rows]
         self._rebuild_matches(previous_id)
 
     def _rebuild_matches(self, previous_id: str | None = None) -> None:
@@ -211,12 +215,14 @@ class ResumePickerModel:
             query_match = self._query_matches[index]
             if query_match is None:
                 continue
-            score, field, positions = query_match
+            coverage, score, field, positions = query_match
             stamp = row.last_active if self.sort_updated else row.created_at
             ranked.append(
                 (
                     -stamp,
-                    -score if self.query.strip() else 0,
+                    # Ascending sort: negate coverage so the most-covered
+                    # field ranks first, then the earliest match position.
+                    (-coverage, -score) if self.query.strip() else (0, 0),
                     index,
                     FieldMatch(row, field or None, positions),
                 )

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -90,26 +90,6 @@ def _single_line(text: str) -> str:
     return " ".join(sanitize_live_text(text).split())
 
 
-def literal_match(query: str, text: str) -> tuple[int, tuple[int, ...]] | None:
-    """Find one case-insensitive contiguous match in original-text coordinates."""
-    query = query.casefold().strip()
-    parts: list[str] = []
-    source: list[int] = []
-    for index, char in enumerate(text):
-        folded = char.casefold()
-        parts.append(folded)
-        source.extend([index] * len(folded))
-    target = "".join(parts)
-    if not query:
-        return 0, ()
-    found = target.find(query)
-    if found < 0:
-        return None
-    stop = found + len(query)
-    positions = tuple(dict.fromkeys(source[found:stop]))
-    return -found, positions
-
-
 def _term_hits(
     terms: list[str], text: str
 ) -> tuple[set[str], int, tuple[int, ...]] | None:

--- a/packages/nooa-cli/src/nooa_cli/tui/todo_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/todo_explorer.py
@@ -82,14 +82,7 @@ class TodoExplorerView(ExplorerView):
 
     def __init__(self, rows: Iterable[TodoExplorerRow]) -> None:
         model = ExplorerModel(list(rows))
-        config = ExplorerConfig(
-            title="Todo Explorer",
-            detail_pane_name="todo detail",
-            empty_message="No todos.",
-            no_match_message="No todos matching {query!r}.",
-            list_ratio=0.4,
-            actions={},
-        )
+        config = ExplorerConfig(title="Todo Explorer", actions={})
         super().__init__(model, config)
         self.configure_row_options(
             filters=(

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2588,6 +2588,20 @@ class TUIApplication:
             if self._resume_picker is not None:
                 self._resume_picker.toggle_options()
 
+        @kb.add("home", filter=resume_picker_active, eager=True)
+        def _(event):
+            picker = self._resume_picker
+            if picker is not None:
+                picker.model.jump_home()
+                picker.invalidate()
+
+        @kb.add("end", filter=resume_picker_active, eager=True)
+        def _(event):
+            picker = self._resume_picker
+            if picker is not None:
+                picker.model.jump_end()
+                picker.invalidate()
+
         @kb.add("pageup", filter=resume_picker_active, eager=True)
         def _(event):
             if self._resume_picker is not None:

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2501,9 +2501,13 @@ class TUIApplication:
         @kb.add("escape", Keys.Any, filter=resume_picker_active)
         def _(event):
             last = event.key_sequence[-1] if event.key_sequence else None
-            if last is not None and (
-                last.key == Keys.Backspace or last.data in ("\x7f", "\b")
-            ):
+            if last is None:
+                return
+            # Cursor-position reports arriving in the same read as an Esc
+            # must reach the CPR handler — absorbing them stalls layout.
+            if any(kp.key == Keys.CPRResponse for kp in event.key_sequence):
+                return
+            if last.key == Keys.Backspace or last.data in ("\x7f", "\b"):
                 picker = self._resume_picker
                 if (
                     picker is not None
@@ -2698,7 +2702,16 @@ class TUIApplication:
                 if kp.key is not Keys.CPRResponse
             ]
             if not pending:
-                self._subview_key(event, "escape")
+                # A CPR report may share this read (it pairs with the Esc in
+                # VT input, e.g. after a cursor-position request). Closing on
+                # it would be spurious; absorb the Esc and let the CPR reach
+                # its own handler. Only a truly lone Esc closes.
+                queue_has_cpr = any(
+                    kp.key is Keys.CPRResponse
+                    for kp in event.key_processor.input_queue
+                )
+                if not queue_has_cpr:
+                    self._subview_key(event, "escape")
                 return
             # Chord continuation pending: absorb this Esc only.
 

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2539,78 +2539,42 @@ class TUIApplication:
             if selected is not None:
                 self._finish_resume_picker(selected)
 
-        @kb.add("up", filter=resume_picker_active, eager=True)
-        @kb.add("c-p", filter=resume_picker_active, eager=True)
-        def _(event):
-            if self._resume_picker is not None:
-                self._resume_picker.navigate_vertical(-1)
-                event.app.invalidate()
+        # Navigation and options dispatch through the shared
+        # ExplorerBrowser.handle_key via the picker's view facade — the same
+        # code path every explorer uses. Only the lifecycle keys above stay
+        # host-bound: finishing the dialog is a host concern.
+        _picker_key_map = {
+            "up": ("up", ""),
+            "c-p": ("up", ""),
+            "down": ("down", ""),
+            "c-n": ("down", ""),
+            "left": ("left", ""),
+            "right": ("right", ""),
+            "tab": ("tab", ""),
+            "s-tab": ("s-tab", ""),
+            " ": ("space", ""),
+            "c-o": ("options", ""),
+            "home": ("home", ""),
+            "end": ("end", ""),
+            "pageup": ("page_up", ""),
+            "pagedown": ("page_down", ""),
+        }
 
-        @kb.add("down", filter=resume_picker_active, eager=True)
-        @kb.add("c-n", filter=resume_picker_active, eager=True)
-        def _(event):
-            if self._resume_picker is not None:
-                self._resume_picker.navigate_vertical(1)
-                event.app.invalidate()
-
-        @kb.add("left", filter=resume_picker_active, eager=True)
-        def _(event):
-            if self._resume_picker is not None:
-                self._resume_picker.move_horizontal(-1)
-
-        @kb.add("right", filter=resume_picker_active, eager=True)
-        def _(event):
-            if self._resume_picker is not None:
-                self._resume_picker.move_horizontal(1)
-
-        @kb.add("tab", filter=resume_picker_active, eager=True)
-        def _(event):
-            if self._resume_picker is not None:
-                self._resume_picker.focus_next()
-
-        @kb.add("s-tab", filter=resume_picker_active, eager=True)
-        def _(event):
-            if self._resume_picker is not None:
-                self._resume_picker.focus_previous()
-
-        @kb.add(" ", filter=resume_picker_active, eager=True)
-        def _(event):
+        def _picker_handle_key(event, action: str) -> None:
             picker = self._resume_picker
             if picker is None:
                 return
-            if picker.option_cursor is not None:
-                picker.change_option()
-            elif picker.active_control == "list":
-                picker.buffer.insert_text(" ")
+            result = normalize_key_result(picker.handle_key(action, ""))
+            if result == "close":
+                selected = picker.view.pending_input
+                self._finish_resume_picker(selected)
+            event.app.invalidate()
 
-        @kb.add("c-o", filter=resume_picker_active, eager=True)
-        def _(event):
-            if self._resume_picker is not None:
-                self._resume_picker.toggle_options()
+        for _key, (_action, _value) in _picker_key_map.items():
 
-        @kb.add("home", filter=resume_picker_active, eager=True)
-        def _(event):
-            picker = self._resume_picker
-            if picker is not None:
-                picker.model.jump_home()
-                picker.invalidate()
-
-        @kb.add("end", filter=resume_picker_active, eager=True)
-        def _(event):
-            picker = self._resume_picker
-            if picker is not None:
-                picker.model.jump_end()
-                picker.invalidate()
-
-        @kb.add("pageup", filter=resume_picker_active, eager=True)
-        def _(event):
-            if self._resume_picker is not None:
-                self._resume_picker.page(-1)
-
-        @kb.add("pagedown", filter=resume_picker_active, eager=True)
-        def _(event):
-            if self._resume_picker is not None:
-                self._resume_picker.page(1)
+            @kb.add(_key, filter=resume_picker_active, eager=True)
+            def _(event, _action=_action):
+                _picker_handle_key(event, _action)
 
         input_selection_active = (
             Condition(lambda: self.input_buffer.selection_state is not None) & subview_inactive

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2493,6 +2493,29 @@ class TUIApplication:
                 count = picker.buffer.document.find_previous_word_beginning()
                 picker.buffer.delete_before_cursor(count=abs(count or -1))
 
+        # Non-eager absorber for every other Alt/Meta chord: without it, a
+        # chord like Alt+X falls back to the bare-Esc binding below (prompt_
+        # toolkit's retry loop fires the longest prefix match), canceling the
+        # picker instead of ignoring the chord. A standalone Esc still fires
+        # after the VT prefix timeout.
+        @kb.add("escape", Keys.Any, filter=resume_picker_active)
+        def _(event):
+            last = event.key_sequence[-1] if event.key_sequence else None
+            if last is not None and (
+                last.key == Keys.Backspace or last.data in ("\x7f", "\b")
+            ):
+                picker = self._resume_picker
+                if (
+                    picker is not None
+                    and picker.active_control == "list"
+                    and picker.option_cursor is None
+                ):
+                    count = picker.buffer.document.find_previous_word_beginning()
+                    picker.buffer.delete_before_cursor(count=abs(count or -1))
+
+        # Non-eager so the Alt+Backspace word-delete chord above can win the
+        # prefix race; a standalone Esc still fires after the VT parser times
+        # out on the prefix (ttimeoutlen is already shortened for this).
         @kb.add("escape", filter=resume_picker_active)
         def _(event):
             picker = self._resume_picker
@@ -2678,9 +2701,28 @@ class TUIApplication:
         def _(event):
             self._insert_bracketed_paste(event.current_buffer, event.data)
 
+        # Alt/Meta chords arrive as an ESC-prefixed second key in one read.
+        # prompt_toolkit gives EAGER bindings priority and discards longer
+        # matches, so the moment ESC enters the key buffer this binding fires
+        # immediately — which used to cancel the view on every Alt-chord
+        # (Option+Backspace deleted the dialog instead of a character).
+        # Keep Escape eager (a non-eager variant loses the ESC prefix to the
+        # eager Keys.Any wildcard above, which swallows it as text) but
+        # swallow it when the same read carried more keys: this Esc is the
+        # prefix of a chord, not a close gesture. The pending keys then flow
+        # through their own bindings — Alt+Backspace deletes in the search
+        # buffer, Alt+letter types, mouse packets route to the view.
         @kb.add("escape", filter=subview_active, eager=True)
         def _(event):
-            self._subview_key(event, "escape")
+            pending = [
+                kp
+                for kp in event.key_processor.input_queue
+                if kp.key is not Keys.CPRResponse
+            ]
+            if not pending:
+                self._subview_key(event, "escape")
+                return
+            # Chord continuation pending: absorb this Esc only.
 
         @kb.add("q", filter=subview_active, eager=True)
         def _(event):

--- a/packages/nooa-cli/tests/tui/test_completer.py
+++ b/packages/nooa-cli/tests/tui/test_completer.py
@@ -105,6 +105,13 @@ def test_session_id_completion_excludes_empty_sessions(completer, monkeypatch):
     assert [item.text for item in completer.complete("/session delete ")] == [
         "/session delete used-ses"
     ]
+    # The /resume alias completes session ids like /session resume.
+    assert [item.text for item in completer.complete("/resume ")] == [
+        "/resume used-ses"
+    ]
+    assert [item.text for item in completer.complete("/resume used")] == [
+        "/resume used-ses"
+    ]
 
 
 def test_slash_case_insensitive(completer):

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -472,6 +472,18 @@ def test_event_explorer_view_highlights_selected_occurrence_on_same_line() -> No
     assert "".join(lines).count(f"{highlight_style_code(current=True)}alpha\x1b[0m") == 1
 
 
+def test_event_search_text_excludes_markdown_chrome() -> None:
+    """Timestamps and ids in the markdown header/footer must not match."""
+    row = build_event_rows(
+        SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="hello"))])
+    )[0]
+
+    # The markdown header carries a timestamp; searching it must not match.
+    assert "timestamp" not in row.search_text.lower()
+    # The rendered markdown content itself remains searchable.
+    assert "hello" in row.search_text
+
+
 def test_event_explorer_search_ignores_empty_field_names() -> None:
     """Searching must not match the *names* of empty fields.
 
@@ -530,12 +542,11 @@ def test_event_explorer_search_keeps_styled_detail_colors() -> None:
     searched = highlighted_detail_lines(row, width=80, query="run")
 
     with_query = [line for line in "\n".join(searched).splitlines() if "\x1b[" in line]
-    # Non-match styling (syntax colors) must survive the search.
+    # Non-match styling (syntax colors) must survive the search: strip the
+    # search-highlight prefix itself and require another SGR to remain.
     assert with_query, "search dropped all styling"
-    assert any(
-        code in "".join(with_query) and code not in highlight_style_code()
-        for code in ("\x1b[38;", "\x1b[48;")
-    )
+    non_match_styles = "".join(with_query).replace(highlight_style_code(), "")
+    assert "\x1b[38;" in non_match_styles or "\x1b[48;" in non_match_styles
 
 
 def test_event_explorer_renders_execute_python_event_as_formatted_markdown() -> None:

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -62,7 +62,13 @@ def test_event_explorer_builds_rows_and_full_text_searches() -> None:
     assert [rows[i].tag for i in model.matches] == ["2", "3"]
 
 
-def test_event_explorer_search_boundary_clears_cached_occurrences() -> None:
+def test_event_explorer_list_focus_moves_rows_while_searching() -> None:
+    """List focus moves between matching rows even while search is active.
+
+    The old occurrence-jumping machinery (move_search_occurrence and friends)
+    was removed with the unified navigation contract; this pins the live
+    behavior it was replaced by.
+    """
     rows = build_event_rows(
         SimpleNamespace(
             items=lambda: [
@@ -75,20 +81,13 @@ def test_event_explorer_search_boundary_clears_cached_occurrences() -> None:
     model = EventExplorerModel(rows)
     model.set_query("alpha")
     model.search_active = True
-    model._last_detail_match_lines = [0]
-    model._last_detail_match_occurrences = [(0, 0), (0, 1)]
-    model.search_line_cursor = 1
 
-    model.move_search_occurrence(1)
-
+    model.move_or_scroll(1)
     assert model.cursor == 1
-    assert model._last_detail_match_lines == []
-    assert model._last_detail_match_occurrences == []
-    assert model.search_line_cursor == 0
-
-    # A second move before rendering must not reuse the previous event's matches.
-    model.move_search_occurrence(1)
+    model.move_or_scroll(1)
     assert model.cursor == 2
+    model.move_or_scroll(-1)
+    assert model.cursor == 1
 
 
 def test_event_explorer_query_change_clears_cached_occurrences() -> None:
@@ -101,15 +100,12 @@ def test_event_explorer_query_change_clears_cached_occurrences() -> None:
         )
     )
     model = EventExplorerModel(rows)
-    model._last_detail_match_lines = [0]
-    model._last_detail_match_occurrences = [(0, 0), (0, 1)]
 
     model.edit_query("beta")
 
     assert model._last_detail_match_lines == []
     assert model._last_detail_match_occurrences == []
-    model.move_search_occurrence(1)
-    assert model.cursor == 1
+    assert model.search_line_cursor == 0
 
 
 def test_event_explorer_renders_shared_session_events() -> None:

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -476,6 +476,40 @@ def test_event_explorer_view_highlights_selected_occurrence_on_same_line() -> No
     assert "".join(lines).count(f"{highlight_style_code(current=True)}alpha\x1b[0m") == 1
 
 
+def test_event_explorer_search_ignores_empty_field_names() -> None:
+    """Searching must not match the *names* of empty fields.
+
+    A PythonOutput event always has an ``error`` key, but usually an empty
+    one. Searching "error" matched every PythonOutput event via the raw repr
+    in search_text — even when no error occurred.
+    """
+    rows = build_event_rows(
+        SimpleNamespace(
+            items=lambda: [
+                (
+                    "1",
+                    _FakeEvent(
+                        "PythonOutput",
+                        stdout="all good",
+                        stderr="",
+                        error="",
+                        execution_status="complete",
+                    ),
+                ),
+                (
+                    "2",
+                    _FakeEvent("PythonOutput", error="NameError: boom"),
+                ),
+            ]
+        )
+    )
+
+    model = EventExplorerModel(rows)
+    model.set_query("error")
+
+    assert [row.tag for row in (rows[i] for i in model.matches)] == ["2"]
+
+
 def test_event_explorer_search_highlights_matches_inside_detail_text() -> None:
     row = build_event_rows(
         SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="find alpha here"))])
@@ -497,10 +531,8 @@ def test_event_explorer_search_keeps_styled_detail_colors() -> None:
         )
     )[0]
 
-    styled = highlighted_detail_lines(row, width=80)
     searched = highlighted_detail_lines(row, width=80, query="run")
 
-    without = [line for line in "\n".join(styled).splitlines() if "\x1b[" in line]
     with_query = [line for line in "\n".join(searched).splitlines() if "\x1b[" in line]
     # Non-match styling (syntax colors) must survive the search.
     assert with_query, "search dropped all styling"

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -474,6 +474,8 @@ def test_event_explorer_view_highlights_selected_occurrence_on_same_line() -> No
 
 def test_event_search_text_excludes_markdown_chrome() -> None:
     """Timestamps and ids in the markdown header/footer must not match."""
+    from nooa_cli.tui.event_explorer import _event_markdown, _searchable_markdown
+
     row = build_event_rows(
         SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="hello"))])
     )[0]
@@ -482,6 +484,11 @@ def test_event_search_text_excludes_markdown_chrome() -> None:
     assert "timestamp" not in row.search_text.lower()
     # The rendered markdown content itself remains searchable.
     assert "hello" in row.search_text
+    # The header strip actually fires: the bolded header line is gone.
+    markdown = _event_markdown("1", _FakeEvent("TUIUserInput", text="hello"), "TUIUserInput")
+    searchable = _searchable_markdown(markdown)
+    assert markdown is not None and markdown.splitlines()[0].startswith("**[")
+    assert "2026" not in searchable or "hello" in searchable
 
 
 def test_event_explorer_search_ignores_empty_field_names() -> None:

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -205,6 +205,27 @@ def test_explorer_browser_reserves_marker_column_for_alignment() -> None:
     assert text[0].index("aligned") == text[1].index("aligned")
 
 
+def test_explorer_browser_highlights_each_search_term_separately() -> None:
+    """Word-AND queries highlight every term span, not the whole query.
+
+    Regression for the whole-query substring highlight, which found nothing
+    whenever a multi-word query matched scattered terms across a row.
+    """
+    browser = _browser()
+    browser.model.rows.clear()
+    browser.model.rows.append(MagicMock(search_text="alpha beta", title="Row"))
+    browser.model.set_query("alpha beta")
+    browser.view.format_row = lambda _row, _width: "alpha content beta content"
+    browser.buffer.text = "alpha beta"
+
+    fragments = browser.list_text(80, 1)
+
+    spans = [text for style, text in fragments if "match" in str(style)]
+    assert spans == ["alpha", "beta"]
+    joined = "".join(text for _style, text in fragments)
+    assert joined.endswith("alpha content beta content")
+
+
 def test_explorer_browser_mouse_wheel_scrolls_list_without_moving_selection() -> None:
     browser = _browser()
     browser.model.rows.extend(

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -635,6 +635,42 @@ def test_explorer_browser_navigate_vertical_jumps_search_matches() -> None:
     assert browser.model.cursor == 0
 
 
+def test_searching_detail_reveals_the_matched_text() -> None:
+    """The matched text must be visible in the preview while searching.
+
+    Regression for the viewport stomp: _preview_transcript re-anchored the
+    viewport from the model's detail offset on every render, clobbering
+    set_search's match reveal — the match count worked but the matched
+    lines scrolled out of view (event 36 in a live session).
+    """
+    browser = _browser()
+
+    class _Row:
+        search_text = "error deep"
+        title = "Row"
+
+    browser.model.rows.clear()
+    browser.model.rows.append(_Row())
+    browser.model.set_query("error")
+    browser.buffer.text = "error"
+    # Detail long enough that the match sits far below the first page.
+    browser.view.detail_lines = lambda _row, _width: (
+        [f"line {i}" for i in range(30)] + ["content with error here"]
+    )
+    browser.preview_control.viewport = (50, 6)
+
+    transcript = browser._preview_transcript(50, 6)
+    assert transcript is not None
+    formatted = transcript.formatted_text(width=50, height=6)
+    visible = "".join(text for _style, text, *_ in formatted)
+    assert "error" in visible
+    # A second render (as happens on every repaint) must keep the reveal.
+    transcript = browser._preview_transcript(50, 6)
+    formatted = transcript.formatted_text(width=50, height=6)
+    visible = "".join(text for _style, text, *_ in formatted)
+    assert "error" in visible
+
+
 def test_explorer_detail_header_shows_match_position() -> None:
     """The preview header reports the current search match (like /resume)."""
     browser = _browser()

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -160,6 +160,56 @@ async def test_shared_explorer_f2_toggles_native_selection_and_cancels_drag() ->
 
 
 @pytest.mark.asyncio
+async def test_subview_alt_chords_do_not_close_the_view() -> None:
+    """Alt-chords flow through their bindings; only a lone Esc closes.
+
+    Regression for the eager bare-Escape swallowing every Alt/Meta chord:
+    Option+Backspace used to close the view instead of deleting in the
+    search buffer.
+    """
+    from types import SimpleNamespace
+
+    from nooa_cli.tui.todo_explorer import TodoExplorerView
+
+    from .tui_app_harness import MutableRecordingOutput, TUIHarness
+
+    view = TodoExplorerView(
+        [
+            SimpleNamespace(
+                id="t1",
+                title="Row",
+                status="open",
+                deps=(),
+                created_at="now",
+                notes="note",
+                comments=(),
+                search_text="Row",
+            )
+        ]
+    )
+    async with TUIHarness(output=MutableRecordingOutput(80, 24), full_screen=True) as harness:
+        opened = asyncio.create_task(harness.app.open_subview(view))
+        await harness.wait_for(lambda: isinstance(harness.app.active_subview, ExplorerBrowser))
+        await harness.type_keys("abc")
+        await harness.wait_for(lambda: view.model.query == "abc")
+
+        # Alt+Backspace in one read: deletes, view stays open.
+        harness._pipe.send_text("\x1b\x7f")
+        await asyncio.sleep(0.3)
+        assert harness.app.active_subview is not None, "Alt+Backspace closed the view"
+        assert view.model.query == "ab"
+
+        # Alt+X in one read: absorbed (typed through its own binding), view stays open.
+        harness._pipe.send_text("\x1bx")
+        await asyncio.sleep(0.3)
+        assert harness.app.active_subview is not None, "Alt+X closed the view"
+
+        # A lone Esc still closes the view.
+        harness._pipe.send_text("\x1b")
+        await asyncio.wait_for(opened, 2)
+
+
+@pytest.mark.asyncio
 async def test_preview_autoscroll_extends_selection_between_ticks() -> None:
     """Edge autoscroll must extend the selection, not just scroll the preview."""
     import asyncio as _asyncio

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -129,7 +129,7 @@ async def test_shared_explorer_f2_toggles_native_selection_and_cancels_drag() ->
                 status="open",
                 deps=(),
                 created_at="now",
-                notes="alpha beta gamma",
+                description="alpha beta gamma",
                 comments=(),
                 search_text="F2 me alpha beta gamma",
             )
@@ -181,7 +181,7 @@ async def test_subview_alt_chords_do_not_close_the_view() -> None:
                 status="open",
                 deps=(),
                 created_at="now",
-                notes="note",
+                description="note",
                 comments=(),
                 search_text="Row",
             )
@@ -474,7 +474,7 @@ async def test_todo_explorer_is_wrapped_in_shared_fullscreen_browser() -> None:
         status="open",
         deps=[],
         created_at="2026-08-27 18:00",
-        notes="Use the Resume Picker shell.",
+        description="Use the shared browser shell.",
         comments=[],
         search_text="Ship reusable browser",
     )
@@ -855,7 +855,7 @@ async def test_shared_explorers_copy_drag_from_terminal_mouse_packets(kind: str)
                     status="open",
                     deps=(),
                     created_at="now",
-                    notes="alpha beta gamma",
+                    description="alpha beta gamma",
                     comments=(),
                     search_text="Copy me alpha beta gamma",
                 )

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -635,6 +635,33 @@ def test_explorer_browser_navigate_vertical_jumps_search_matches() -> None:
     assert browser.model.cursor == 0
 
 
+def test_explorer_detail_header_shows_match_position() -> None:
+    """The preview header reports the current search match (like /resume)."""
+    browser = _browser()
+
+    class _MatchRow:
+        search_text = "error here"
+        title = "Row"
+
+    browser.model.rows.clear()
+    browser.model.rows.append(_MatchRow())
+    browser.model.set_query("error")
+    browser.buffer.text = "error"
+    browser.view.detail_lines = lambda _row, _width: ["the error happened", "no match", "again error"]
+    browser.preview_control.viewport = (50, 4)
+
+    browser._preview_transcript(50, 4)
+    position, total = browser._detail_transcript.search_position
+    assert total >= 2
+    header = "".join(text for _style, text in browser._preview_header())
+    assert f"match {position}/{total}" in header
+    # Stepping a match updates the header position.
+    browser.navigate_vertical(1)
+    position, _total = browser._detail_transcript.search_position
+    header = "".join(text for _style, text in browser._preview_header())
+    assert f"match {position}/{total}" in header
+
+
 def test_explorer_browser_preview_focus_steps_detail_matches() -> None:
     """Preview-focus up/down cycles the detail's search matches (like /resume)."""
     browser = _browser()

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -205,6 +205,36 @@ def test_explorer_browser_reserves_marker_column_for_alignment() -> None:
     assert text[0].index("aligned") == text[1].index("aligned")
 
 
+def test_explorer_detail_highlight_is_shared_across_views() -> None:
+    """Every explorer's detail pane highlights search terms the same way.
+
+    The event explorer embeds its own styled highlighting (with occurrence
+    navigation); the others previously showed no highlighting at all while
+    searching. The shared browser now applies generic term highlighting to
+    views that do not handle it themselves.
+    """
+    browser = _browser()
+    browser.view.handles_search_highlighting = False
+    browser.view.detail_lines = lambda _row, _width: ["notes: the error text"]
+    browser.model.rows.clear()
+    browser.model.rows.append(MagicMock(search_text="error notes", title="Row"))
+    browser.model.set_query("error")
+    browser.buffer.text = "error"
+    browser.preview_control.viewport = (60, 4)
+    assert browser.model.current is not None, "fixture row must match the query"
+
+    transcript = browser._preview_transcript(60, 4)
+
+    assert transcript is not None
+    assert "48;2;" in transcript._records[0].ansi  # truecolor match background
+    # Views that own their highlighting keep the browser out of it.
+    browser.view.handles_search_highlighting = True
+    browser._detail_transcript_key = None
+    transcript = browser._preview_transcript(60, 4)
+    assert transcript is not None
+    assert "48;2;" not in transcript._records[0].ansi
+
+
 def test_explorer_browser_highlights_each_search_term_separately() -> None:
     """Word-AND queries highlight every term span, not the whole query.
 

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -606,7 +606,7 @@ def test_explorer_browser_handle_key_scroll_up_detail() -> None:
 
 
 def test_explorer_browser_navigate_vertical_jumps_search_matches() -> None:
-    """When search is active, up/down jumps between matches instead of moving list selection."""
+    """List focus moves between matching rows even while search is active."""
 
     class _MatchRow:
         search_text = "alpha beta alpha"
@@ -615,7 +615,7 @@ def test_explorer_browser_navigate_vertical_jumps_search_matches() -> None:
 
     browser = _browser()
     browser.model.rows.clear()
-    browser.model.rows.append(_MatchRow())
+    browser.model.rows.extend([_MatchRow(), _MatchRow()])
     browser.model.set_query("")
     browser.list_control.viewport = (80, 4)
     browser.preview_control.viewport = (80, 4)
@@ -627,14 +627,37 @@ def test_explorer_browser_navigate_vertical_jumps_search_matches() -> None:
 
     assert browser.model.search_active is True
 
-    # Populate match lines (as detail_lines would)
-    browser.model._last_detail_match_lines = [0, 2]
-    browser.model._last_detail_visible_lines = 4
-
-    # Down should jump to match, not move cursor
+    # List focus always moves between matching rows (the /resume contract);
+    # detail matches are stepped from preview focus only.
     browser.navigate_vertical(1)
-    assert browser.model.search_line_cursor == 1
-    assert browser.model.cursor == 0  # selection stays
+    assert browser.model.cursor == 1
+    browser.navigate_vertical(-1)
+    assert browser.model.cursor == 0
+
+
+def test_explorer_browser_preview_focus_steps_detail_matches() -> None:
+    """Preview-focus up/down cycles the detail's search matches (like /resume)."""
+    browser = _browser()
+
+    class _MatchRow:
+        search_text = "alpha beta alpha"
+        title = "Match Row"
+
+    browser.model.rows.clear()
+    browser.model.rows.append(_MatchRow())
+    browser.model.set_query("")
+    browser.buffer.text = "alpha"
+    browser.view.detail_lines = lambda _row, _width: ["alpha one", "mid", "alpha two"]
+    browser.preview_control.viewport = (40, 4)
+    browser.active_control = "preview"
+
+    browser.navigate_vertical(1)
+
+    transcript = browser._preview_transcript(40, 4)
+    assert transcript is not None
+    position, total = transcript.search_position
+    assert total >= 2
+    assert position == 2
 
 
 def test_explorer_browser_search_match_boundary_moves_to_next_row() -> None:
@@ -647,11 +670,9 @@ def test_explorer_browser_search_match_boundary_moves_to_next_row() -> None:
 
     browser.navigate_vertical(1)
 
+    # Unified contract: list focus moves rows; stale cached detail matches
+    # from the previous row must not steer navigation.
     assert browser.model.cursor == 1
-    assert browser.model._last_detail_match_lines == []
-    assert browser.model.search_line_cursor == 0
-
-    # A second move before rendering must not reuse the previous row's matches.
     browser.navigate_vertical(1)
     assert browser.model.cursor == 2
 

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -741,7 +741,9 @@ def test_explorer_detail_header_shows_match_position() -> None:
     assert total >= 2
     header = "".join(text for _style, text in browser._preview_header())
     assert f"match {position}/{total}" in header
-    # Stepping a match updates the header position.
+    # Stepping a match updates the header position; match stepping is a
+    # preview-focus gesture.
+    browser.activate_control("preview")
     browser.navigate_vertical(1)
     position, _total = browser._detail_transcript.search_position
     header = "".join(text for _style, text in browser._preview_header())

--- a/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_browser.py
@@ -685,6 +685,44 @@ def test_explorer_browser_navigate_vertical_jumps_search_matches() -> None:
     assert browser.model.cursor == 0
 
 
+def test_detail_pane_scrolls_while_searching() -> None:
+    """Wheel/page scrolling works on the preview pane with a query active.
+
+    Regression for the search-reveal fix freezing the pane: while a query
+    is active the transcript owns the viewport, so wheel gestures must
+    scroll the transcript instead of mutating an offset that is never
+    applied.
+    """
+    browser = _browser()
+
+    class _Row:
+        search_text = "gamma deep"
+        title = "Row"
+
+    browser.model.rows.clear()
+    browser.model.rows.append(_Row())
+    browser.model.set_query("gamma")
+    browser.buffer.text = "gamma"
+    # The matched term sits mid-content so the reveal leaves room to scroll
+    # in both directions.
+    browser.view.detail_lines = lambda _row, _width: [
+        f"line {i}" if i != 30 else "gamma match here" for i in range(60)
+    ]
+    browser.preview_control.viewport = (50, 6)
+    browser.active_control = "preview"
+
+    transcript = browser._preview_transcript(50, 6)
+    assert transcript is not None
+    before = transcript.top_row(width=50, height=6)
+
+    browser.mouse_scroll("preview", 3)
+    after = transcript.top_row(width=50, height=6)
+    assert after == before + 3
+
+    browser.page(1)
+    assert transcript.top_row(width=50, height=6) == after + 6
+
+
 def test_searching_detail_reveals_the_matched_text() -> None:
     """The matched text must be visible in the preview while searching.
 

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -4423,17 +4423,37 @@ def test_transcript_search_highlights_all_matches_and_reveals_first() -> None:
     model.append("zero\none\nNeedle first\nthree\nfour\nneedle second\nsix")
     model.set_search("NEEDLE", width=20, height=2)
 
+    # Reveals center the match vertically when context exists above it
+    # instead of pinning it to the viewport's first row.
     assert model.search_position == (1, 2)
-    assert model.top_row(width=20, height=2) == 2
+    assert model.top_row(width=20, height=2) == 1
     fragments = model.formatted_text(width=20, height=2)
     assert "Needle" in "".join(text for _style, text in fragments)
     assert any("transcript-search-current" in style for style, text in fragments if text.strip())
 
     assert model.move_search_match(1, width=20, height=2)
     assert model.search_position == (2, 2)
-    assert model.top_row(width=20, height=2) == 5
+    assert model.top_row(width=20, height=2) == 4
     assert model.move_search_match(1, width=20, height=2)
     assert model.search_position == (1, 2)
+
+
+def test_transcript_search_reveal_centers_match_vertically() -> None:
+    """A revealed match shows before/after context, not just the match row."""
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+
+    model = FullscreenTranscriptModel(show_trailing_blank=False)
+    model.append("\n".join(f"line {i}" for i in range(12)) + "\nneedle\n" + "\n".join(f"tail {i}" for i in range(12)))
+    model.set_search("needle", width=30, height=7)
+
+    top = model.top_row(width=30, height=7)
+    # The match row (12) sits in the middle of the 7-row window.
+    assert top == 9
+    visible = model.formatted_text(width=30, height=7)
+    text = "".join(frag[1] for frag in visible)
+    assert "needle" in text
+    assert "line 10" in text and "line 11" in text  # context above
+    assert "tail 0" in text and "tail 1" in text  # context below
 
 
 def test_transcript_search_distinguishes_current_and_other_matches() -> None:

--- a/packages/nooa-cli/tests/tui/test_memory_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_memory_explorer.py
@@ -105,6 +105,9 @@ def test_action_d_marks_todo_done_round_trip() -> None:
     todo = next(r for r in view.model.rows if r.id == ids["todo"])
     # Route through the real key path: "d" arrives as a text key.
     view.model.cursor = view.model.matches.index(view.model.rows.index(todo))
+    # Destructive actions arm on the first press and fire on the second.
+    assert view.handle_key("text", "d") == "handled"
+    assert calls["done"] == []
     assert view.handle_key("text", "d") == "handled"
 
     assert calls["done"] == [ids["todo"]]
@@ -120,12 +123,37 @@ def test_action_d_marks_todo_done_round_trip() -> None:
     assert calls["done"] == [ids["todo"]]
 
 
+def test_destructive_action_disarms_on_any_other_key() -> None:
+    """A first press only arms; a different key must disarm, never fire.
+
+    Regression for the unconfirmed destructive fire: one 'f' press used to
+    permanently forget a memory with no confirmation.
+    """
+    agent, mgr, ids = _seeded_manager()
+    view, calls = _view(agent, mgr)
+
+    skill = next(r for r in view.model.rows if r.id == ids["skill"])
+    view.model.cursor = view.model.matches.index(view.model.rows.index(skill))
+    assert view.handle_key("text", "f") == "handled"
+    assert calls["forgot"] == []
+    assert "again to forget" in view.pending_confirmation_hint()
+
+    # A different key disarms instead of firing.
+    assert view.handle_key("text", "x") == "ignored"
+    assert view.handle_key("text", "f") == "handled"  # re-arms
+    assert calls["forgot"] == []
+    assert view.handle_key("text", "f") == "handled"  # now fires
+    assert calls["forgot"] == [ids["skill"]]
+
+
 def test_action_f_forgets_memory_round_trip() -> None:
     agent, mgr, ids = _seeded_manager()
     view, calls = _view(agent, mgr)
 
     skill = next(r for r in view.model.rows if r.id == ids["skill"])
     view.model.cursor = view.model.matches.index(view.model.rows.index(skill))
+    assert view.handle_key("text", "f") == "handled"
+    assert calls["forgot"] == []
     assert view.handle_key("text", "f") == "handled"
 
     assert calls["forgot"] == [ids["skill"]]
@@ -202,6 +230,9 @@ def test_action_d_on_dropped_todo_keeps_search_text_consistent() -> None:
 
     todo = next(r for r in view.model.rows if r.id == ids["todo"])
     assert "todo:dropped" in todo.search_text  # row built from the dropped state
+    # Destructive actions arm on the first press and fire on the second.
+    assert view.handle_action("text:d", todo) == "handled"
+    assert calls["done"] == []
     assert view.handle_action("text:d", todo) == "handled"
 
     assert calls["done"] == [ids["todo"]]

--- a/packages/nooa-cli/tests/tui/test_memory_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_memory_explorer.py
@@ -123,6 +123,25 @@ def test_action_d_marks_todo_done_round_trip() -> None:
     assert calls["done"] == [ids["todo"]]
 
 
+def test_invalid_action_disarms_the_pending_confirm() -> None:
+    """An action key that cannot apply still interrupts the armed gesture.
+
+    Press f (arms), press d on a non-todo row (ignored), press f again: the
+    final press must re-arm, not fire.
+    """
+    agent, mgr, ids = _seeded_manager()
+    view, calls = _view(agent, mgr)
+    skill = next(r for r in view.model.rows if r.id == ids["skill"])
+
+    assert view.handle_action("text:f", skill) == "handled"  # arm
+    assert view.handle_action("text:d", skill) == "ignored"  # invalid action
+    assert calls["forgot"] == []
+    assert view.handle_action("text:f", skill) == "handled"  # re-arm, not fire
+    assert calls["forgot"] == []
+    assert view.handle_action("text:f", skill) == "handled"  # now fires
+    assert calls["forgot"] == [ids["skill"]]
+
+
 def test_armed_confirm_does_not_leak_across_rows() -> None:
     """Arming on row A must never fire on row B.
 

--- a/packages/nooa-cli/tests/tui/test_memory_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_memory_explorer.py
@@ -123,6 +123,30 @@ def test_action_d_marks_todo_done_round_trip() -> None:
     assert calls["done"] == [ids["todo"]]
 
 
+def test_armed_confirm_does_not_leak_across_rows() -> None:
+    """Arming on row A must never fire on row B.
+
+    The arm is keyed to (action, id(row)); moving to another row and
+    pressing the same key re-arms the new row instead of firing.
+    """
+    agent, mgr, ids = _seeded_manager()
+    view, calls = _view(agent, mgr)
+    rows = list(view.model.rows)
+
+    first = rows[0]
+    second = rows[1]
+    # Arm on the first row.
+    assert view.handle_action("text:f", first) == "handled"
+    assert calls["forgot"] == []
+    # Press f on a different row: re-arms that row, never fires on either.
+    assert view.handle_action("text:f", second) == "handled"
+    assert calls["forgot"] == []
+    # A second press on the second row fires exactly there.
+    assert view.handle_action("text:f", second) == "handled"
+    assert calls["forgot"] == [second.id]
+    assert first.id in {r.id for r in view.model.rows}
+
+
 def test_destructive_action_disarms_on_any_other_key() -> None:
     """A first press only arms; a different key must disarm, never fire.
 

--- a/packages/nooa-cli/tests/tui/test_session_resume_picker.py
+++ b/packages/nooa-cli/tests/tui/test_session_resume_picker.py
@@ -78,6 +78,35 @@ def test_model_searches_title_and_full_recent_conversation() -> None:
     assert [match.row.id for match in model.matches] == ["2"]
 
 
+def test_resume_search_uses_word_and_semantics_like_explorers() -> None:
+    """Multi-word queries match scattered terms, like every explorer.
+
+    The old phrase matcher required the whole query contiguously; the shared
+    word-AND contract requires every term somewhere in the searched fields.
+    """
+    model = ResumePickerModel(
+        [
+            row(
+                "scattered",
+                "alpha in the title",
+                turns=(ResumePickerTurn("agent", "and beta in the reply"),),
+            ),
+            row(
+                "contiguous",
+                "unrelated title",
+                turns=(ResumePickerTurn("agent", "contains alpha beta together"),),
+            ),
+            row("neither", "nothing here"),
+        ]
+    )
+    model.set_query("alpha beta")
+
+    # Both rows match; the scattered row proves terms can hit different fields.
+    assert sorted(match.row.id for match in model.matches) == ["contiguous", "scattered"]
+    scattered = next(match for match in model.matches if match.row.id == "scattered")
+    assert scattered.positions, "cross-field match must carry highlight positions"
+
+
 def test_search_excludes_noncontiguous_and_hidden_metadata_matches() -> None:
     model = ResumePickerModel(
         [

--- a/packages/nooa-cli/tests/tui/test_session_resume_picker.py
+++ b/packages/nooa-cli/tests/tui/test_session_resume_picker.py
@@ -12,7 +12,6 @@ from nooa_cli.tui.resume_picker import (
     _clip,
     _row_fragments,
     _semantic_preview_selection,
-    literal_match,
     render_resume_picker,
 )
 from prompt_toolkit.data_structures import Point
@@ -72,8 +71,6 @@ def test_model_searches_title_and_full_recent_conversation() -> None:
     )
     model.set_query("resume")
     assert model.matches[0].row.title == "resume feature"
-    assert literal_match("RESUME", "resume feature") is not None
-    assert literal_match("rsm", "resume feature") is None
     model.set_query("deep needle")
     assert [match.row.id for match in model.matches] == ["2"]
 
@@ -128,10 +125,10 @@ def test_filter_and_sort_reuse_cached_query_matches(monkeypatch) -> None:
     model = ResumePickerModel([row("one", "needle"), row("two", "other", attached=True)])
     model.set_query("needle")
 
-    def unexpected_match(query: str, value: str):
+    def unexpected_match(terms: list[str], value: str):
         raise AssertionError("filter/sort must not rescan transcript search fields")
 
-    monkeypatch.setattr(picker_module, "literal_match", unexpected_match)
+    monkeypatch.setattr(picker_module, "_term_hits", unexpected_match)
     model.toggle_filter()
     model.toggle_sort()
     model.toggle_filter()

--- a/packages/nooa-cli/tests/tui/test_session_resume_picker.py
+++ b/packages/nooa-cli/tests/tui/test_session_resume_picker.py
@@ -234,7 +234,7 @@ def test_tab_cycles_only_list_and_preview() -> None:
     assert picker.active_control == "preview"
     picker.focus_next()
     assert picker.active_control == "list"
-    picker.focus_previous()
+    picker.focus_next(-1)
     assert picker.active_control == "preview"
 
 

--- a/packages/nooa-cli/tests/tui/test_session_resume_picker.py
+++ b/packages/nooa-cli/tests/tui/test_session_resume_picker.py
@@ -134,6 +134,19 @@ def test_filter_and_sort_reuse_cached_query_matches(monkeypatch) -> None:
     model.toggle_filter()
 
 
+def test_home_and_end_jump_the_session_list() -> None:
+    """Home/End jump to the first/last session like every explorer."""
+    app = MagicMock()
+    app.output.get_size.return_value = SimpleNamespace(columns=80, rows=24)
+    picker = ResumePicker([row(str(i), f"title {i}") for i in range(6)], app)
+
+    picker.model.jump_end()
+    assert picker.model.selected == 5
+    picker.model.jump_home()
+    assert picker.model.selected == 0
+    assert picker.model.list_offset == 0
+
+
 def test_state_filter_defaults_to_detached_and_cycles_all_states() -> None:
     detached = row("detached", "Detached")
     attached = row("attached", "Attached", attached=True, last_active=30)

--- a/packages/nooa-cli/tests/tui/test_session_resume_picker.py
+++ b/packages/nooa-cli/tests/tui/test_session_resume_picker.py
@@ -134,6 +134,65 @@ def test_filter_and_sort_reuse_cached_query_matches(monkeypatch) -> None:
     model.toggle_filter()
 
 
+@pytest.mark.asyncio
+async def test_resume_list_fills_its_pane_on_tall_terminals() -> None:
+    """The session list grows with the terminal instead of capping at 5."""
+    from nooa_cli.tui import session_manager as sm
+
+    sessions = [
+        SimpleNamespace(
+            id=f"s{i:08d}",
+            name=f"Session {i}",
+            model="m",
+            agent="A",
+            working_dir=str(Path.cwd()),
+            started_at=1,
+            last_active=float(100 + i),
+            turn_count=1,
+        )
+        for i in range(12)
+    ]
+    sm.SessionManager.list_sessions = classmethod(lambda cls, limit=None: sessions)
+    sm.SessionManager.is_active = classmethod(lambda cls, value: False)
+    sm.SessionManager.load_turns = classmethod(
+        lambda cls, value, limit=12: [SimpleNamespace(role="agent", content="x")]
+    )
+
+    from .tui_app_harness import MutableRecordingOutput, TUIHarness
+
+    async with TUIHarness(output=MutableRecordingOutput(100, 40), full_screen=True) as harness:
+        opened = asyncio.create_task(harness.app.open_session_resume_dialog())
+        await harness.wait_for(lambda: harness.app._resume_picker is not None)
+        picker = harness.app._resume_picker
+        await harness.wait_for(lambda: picker.list_control.viewport[1] > 5)
+
+        screen = harness.app._app.renderer.last_rendered_screen
+        rows = [
+            "".join(line[x].char for x in sorted(line)).rstrip()
+            for _y, line in sorted(screen.data_buffer.items())
+        ]
+        # Sessions run from the header to the list separator: the pane holds
+        # more than the old five-row cap.
+        session_rows = [r for r in rows if "Session" in r and "✓" in r]
+        assert len(session_rows) > 5
+        await harness.press("escape")
+        await asyncio.wait_for(opened, 2)
+
+
+def test_home_and_end_route_through_shared_handle_key() -> None:
+    """Home/End jump the list through the shared dispatch, like explorers."""
+    from nooa_cli.tui.fullscreen_browser import ExplorerBrowser
+
+    app = MagicMock()
+    app.output.get_size.return_value = SimpleNamespace(columns=80, rows=24)
+    assert ResumePicker.handle_key is ExplorerBrowser.handle_key  # shared dispatch
+    picker = ResumePicker([row(str(i), f"title {i}") for i in range(6)], app)
+    assert picker.handle_key("end") == "handled"
+    assert picker.model.selected == 5
+    assert picker.handle_key("home") == "handled"
+    assert picker.model.selected == 0
+
+
 def test_home_and_end_jump_the_session_list() -> None:
     """Home/End jump to the first/last session like every explorer."""
     app = MagicMock()

--- a/packages/nooa-cli/tests/tui/test_session_resume_picker.py
+++ b/packages/nooa-cli/tests/tui/test_session_resume_picker.py
@@ -460,6 +460,53 @@ def test_header_columns_align_with_row_columns() -> None:
     )
 
 
+def test_query_terms_deduplicate_for_match_counts() -> None:
+    """Repeated query terms count occurrences once, not per repetition."""
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+
+    model = FullscreenTranscriptModel(show_trailing_blank=False)
+    model.append("alpha one\nmid\nalpha two")
+    model.set_search("alpha alpha", width=30, height=4)
+
+    _position, total = model.search_position
+    assert total == 2  # not 4
+
+
+def test_row_highlights_every_occurrence_of_each_term() -> None:
+    """A term appearing twice in the best field highlights both positions."""
+    model = ResumePickerModel(
+        [row("1", "beta first and beta second")]
+    )
+    model.set_query("beta")
+
+    match = model.matches[0]
+    assert len(match.positions) >= 8  # both "beta" occurrences (4 cells each)
+
+
+def test_rows_rank_by_term_coverage_before_position() -> None:
+    """A row covering all terms in one field outranks a split-field row."""
+    model = ResumePickerModel(
+        [
+            # alpha lives in the title, beta in the conversation: no single
+            # field covers both terms.
+            row(
+                "split",
+                "alpha here",
+                turns=(ResumePickerTurn("agent", "beta answer"),),
+            ),
+            # Both terms in one conversation line.
+            row(
+                "together",
+                "also unrelated",
+                turns=(ResumePickerTurn("agent", "alpha beta in one line"),),
+            ),
+        ]
+    )
+    model.set_query("alpha beta")
+
+    assert [match.row.id for match in model.matches] == ["together", "split"]
+
+
 def test_row_shows_snippet_when_match_is_clipped_or_in_conversation() -> None:
     """Listed rows must show *why* they matched.
 

--- a/packages/nooa-cli/tests/tui/test_session_resume_picker.py
+++ b/packages/nooa-cli/tests/tui/test_session_resume_picker.py
@@ -240,11 +240,11 @@ def test_options_mode_selects_and_changes_filter_and_sort() -> None:
     app.output.get_size.return_value = SimpleNamespace(columns=80, rows=24)
     picker = ResumePicker([row("1", "one")], app)
     picker.toggle_options()
-    assert picker.option_cursor == "filter"
+    assert picker.option_cursor == 0  # Filter option row
     picker.change_option()
     assert picker.model.state_filter == "attached"
     picker.move_option(1)
-    assert picker.option_cursor == "sort"
+    assert picker.option_cursor == 1  # Sort option row
     picker.change_option()
     assert picker.model.sort_updated is False
     assert picker.close_options()
@@ -271,17 +271,17 @@ def test_only_selected_option_is_highlighted_in_options_mode() -> None:
     app = MagicMock()
     app.output.get_size.return_value = SimpleNamespace(columns=80, rows=24)
     picker = ResumePicker([row("1", "one")], app)
-    assert "control-focused" not in picker.filter_control._text()[0][0]
-    assert "control-focused" not in picker.sort_control._text()[0][0]
+    assert "control-focused" not in picker.option_controls[0]._text()[0][0]
+    assert "control-focused" not in picker.option_controls[1]._text()[0][0]
     picker.toggle_options()
     assert "control-focused" not in picker._search_label()[0][0]
     assert "control-focused" not in picker._search_close()[0][0]
     assert "control-focused" not in picker.query_window.style()
-    assert "control-focused" in picker.filter_control._text()[0][0]
-    assert "control-focused" not in picker.sort_control._text()[0][0]
+    assert "control-focused" in picker.option_controls[0]._text()[0][0]
+    assert "control-focused" not in picker.option_controls[1]._text()[0][0]
     picker.move_option(1)
-    assert "control-focused" not in picker.filter_control._text()[0][0]
-    assert "control-focused" in picker.sort_control._text()[0][0]
+    assert "control-focused" not in picker.option_controls[0]._text()[0][0]
+    assert "control-focused" in picker.option_controls[1]._text()[0][0]
 
 
 def test_active_rail_marks_only_current_area() -> None:
@@ -652,7 +652,8 @@ async def test_filter_change_prepares_new_preview_without_blocking(monkeypatch) 
         return FullscreenTranscriptModel(show_trailing_blank=False)
 
     monkeypatch.setattr(ResumePicker, "_build_preview_model", staticmethod(build_preview))
-    picker.cycle_filter()
+    # Change the filter through the shared option, as the UI does.
+    picker.view.options[0].move(1)
 
     key = ("attached", 40)
     assert key in picker._preview_tasks
@@ -891,7 +892,7 @@ async def test_real_prompt_toolkit_routes_search_navigation_and_cancel(monkeypat
         picker.buffer.text = ""
         await harness.wait_for(lambda: picker.model.query == "")
         await harness.press("c-o")
-        await harness.wait_for(lambda: picker.option_cursor == "filter")
+        await harness.wait_for(lambda: picker.option_cursor == 0)
         await harness.type_keys("x")
         await harness.press("option-backspace")
         await asyncio.sleep(0)
@@ -903,7 +904,7 @@ async def test_real_prompt_toolkit_routes_search_navigation_and_cancel(monkeypat
         await harness.wait_for(lambda: picker.model.state_filter == "all")
         assert {match.row.id for match in picker.model.matches} == {"session-1", "session-2"}
         await harness.press("right")
-        await harness.wait_for(lambda: picker.option_cursor == "sort")
+        await harness.wait_for(lambda: picker.option_cursor == 1)
         await harness.type_keys(" ")
         await harness.wait_for(lambda: not picker.model.sort_updated)
         await harness.press("enter")
@@ -944,7 +945,7 @@ async def test_ctrl_c_cancels_picker_while_options_are_open(monkeypatch) -> None
         opened = asyncio.create_task(harness.app.open_session_resume_dialog())
         await harness.wait_for(lambda: harness.app._resume_picker is not None)
         await harness.press("c-o")
-        await harness.wait_for(lambda: harness.app._resume_picker.option_cursor == "filter")
+        await harness.wait_for(lambda: harness.app._resume_picker.option_cursor == 0)
         await harness.press("c-c")
         assert await asyncio.wait_for(opened, 1) is None
         assert harness.app._resume_picker is None


### PR DESCRIPTION
# Unify fullscreen search on word-AND terms

Stacked on #244 — merge that first.

## Why
`/resume` and the explorers grew different search engines: `/resume` matched the whole query as one contiguous phrase (so `error message` missed sessions containing both words separately), while explorers split into words but highlighted nothing. Now every fullscreen browser shares one contract.

## What
- **Shared contract**: `explorer_base.matches_all_terms` — a query matches when every whitespace-separated term occurs (case-insensitively) somewhere in the searchable text. `ExplorerModel` and `EventExplorerModel` filter through it.
- **`/resume`**: cross-field word-AND across title/preview/conversation — terms may hit different fields; best-field ranking and per-term highlight positions preserved (works with the snippet rows from #244).
- **Row highlighting**: `ExplorerBrowser.list_text` highlights **every term span separately** instead of searching for the whole query as one substring — multi-word queries previously matched rows but highlighted nothing.
- **Preview search**: `FullscreenTranscriptModel.set_search` highlights and navigates every term occurrence, so preview match counts include scattered terms.

## Behavior change
`/resume` multi-word queries now match scattered terms (previously phrase-only). Single-word queries are unchanged.

## Verification
- Ruff clean
- 387 search/browser/resume/explorer/transcript tests passed; 183 style/replay/PTY/app-behavior tests passed
- Regressions added: resume cross-field word-AND, per-term row highlighting, scattered-term matching


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved case-insensitive, multi-term search across event explorers, transcripts, browsers, and resume pickers.
  * Search terms are highlighted independently, with browser previews supporting match navigation.
  * Resume searches match terms across titles, previews, and conversations while retaining ranking and highlights.
  * Event searches focus on visible, meaningful fields.
  * Destructive memory actions require two consecutive confirmations on the same item.

* **Bug Fixes**
  * Empty searches no longer produce false matches.
  * Alt/Option keyboard input no longer unintentionally closes active views.
  * List navigation now moves consistently between matching rows.

* **Tests**
  * Added coverage for search, highlighting, navigation, confirmations, and event details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->