### PR TITLE
Add stream_to: opt-in text deltas from async LLM calls

### DIFF
--- a/src/nooa/unifiedllm/__init__.py
+++ b/src/nooa/unifiedllm/__init__.py
@@ -22,14 +22,19 @@ from nooa.unifiedllm.unifiedllm import (
     LLMResponse,
     ReasoningCompletionClient,
     ResponsesClient,
+    StreamedBeforeFailing,
     Tool,
     ToolCall,
     UnifiedLLM,
     create_tool_from_callable,
     extract_and_parse_json,
+    stream_to,
 )
 
 __all__ = [
+    # Streaming
+    "stream_to",
+    "StreamedBeforeFailing",
     # Core classes
     "UnifiedLLM",
     "CompletionClient",

--- a/src/nooa/unifiedllm/unifiedllm.py
+++ b/src/nooa/unifiedllm/unifiedllm.py
@@ -1437,10 +1437,98 @@ def _collect_sync(raw: Any) -> "litellm.ModelResponse":
     return raw
 
 
-async def _collect_async(raw: Any) -> "litellm.ModelResponse":
+_chunk_sink: ContextVar[Callable[[str], None] | None] = ContextVar("nooa_chunk_sink", default=None)
+# Whether the current call has already handed the caller any text. Tracked per
+# call, because a retry after that would replay the prefix.
+_chunk_emitted: ContextVar[bool] = ContextVar("nooa_chunk_emitted", default=False)
+
+
+class StreamedBeforeFailing(Exception):
+    """A call failed after its sink had already received part of the answer.
+
+    Carries no ``status_code``, so the retry policy treats it as terminal — which
+    is the point: what has been shown cannot be unshown, and a second attempt
+    would repeat that prefix on screen and corrupt an incremental reader. The
+    original failure is the cause.
+    """
+
+
+@contextmanager
+def stream_to(sink: Callable[[str], None]):
+    """Deliver text deltas to ``sink`` for async LLM calls made inside this block.
+
+    A generation method returns its whole answer, which is the right contract —
+    but a caller that wants to *show* the answer arriving (a chat UI, a task
+    stream over a protocol) needs the pieces on the way. Entering this context
+    asks the provider to stream and hands every delta to ``sink`` as it lands;
+    the method still returns the complete text, so nothing downstream changes.
+
+        with stream_to(lambda delta: queue.put_nowait(delta)):
+            answer = await agent.reply(message=...)
+
+    Scope is the context, so concurrent tasks each get their own sink and calls
+    outside the block are untouched (no streaming requested, same as before).
+
+    The deltas are raw provider output, not the method's return value: a method
+    with a structured return type is filled by a JSON-schema call, so the stream
+    carries that JSON as it is written. Read it incrementally rather than
+    concatenating blindly.
+
+    Chat completions only. ``ResponsesClient`` does not stream through this, so a
+    call on that path returns its answer whole and the sink stays silent — the
+    contract is "you may receive deltas", never "you will".
+
+    A call that fails after its sink has already received part of the answer is
+    not retried: replaying that prefix would duplicate it on screen and corrupt
+    an incremental reader. It raises ``StreamedBeforeFailing`` from the original
+    error. Failures before the first delta retry as they always did.
+
+    The sink is a plain callable and runs on the event loop between chunks, so
+    keep it cheap — enqueue, do not await.
+    """
+    token = _chunk_sink.set(sink)
+    try:
+        yield
+    finally:
+        _chunk_sink.reset(token)
+
+
+def _emit_chunk(chunk: Any, structured: bool = False) -> None:
+    """Push one delta's text to the active sink, if any. Never raises into the stream.
+
+    For a structured call, ``reasoning_content`` counts as text: some reasoning
+    models put the JSON there and leave ``content`` empty, and the parser already
+    falls back to it, so a sink reading only ``content`` would watch a call
+    succeed with nothing on screen. On a plain call that field is the model
+    thinking aloud, not the answer, and is left alone.
+    """
+    sink = _chunk_sink.get()
+    if sink is None:
+        return
+    try:
+        choices = getattr(chunk, "choices", None) or []
+        delta = getattr(choices[0], "delta", None) if choices else None
+        if delta is None:
+            return
+        text = getattr(delta, "content", None)
+        if not text and structured:
+            text = getattr(delta, "reasoning_content", None)
+        if text:
+            # Recorded *before* the sink runs: a sink that appends the delta and
+            # then raises has already shown it, and a retry would repeat it.
+            _chunk_emitted.set(True)
+            sink(text)
+    except Exception:  # a display sink must never break the call it is watching
+        logger.debug("chunk sink raised; dropping the delta", exc_info=True)
+
+
+async def _collect_async(raw: Any, structured: bool = False) -> "litellm.ModelResponse":
     """Consume an async streaming or non-streaming litellm response, returning ModelResponse."""
     if isinstance(raw, litellm.CustomStreamWrapper):
-        chunks = [chunk async for chunk in raw]  # type: ignore[attr-defined]
+        chunks = []
+        async for chunk in raw:  # type: ignore[attr-defined]
+            chunks.append(chunk)
+            _emit_chunk(chunk, structured)
         result = litellm.stream_chunk_builder(chunks)
         if result is None:
             raise ValueError("stream_chunk_builder returned None for empty stream")
@@ -2019,8 +2107,15 @@ class CompletionClient(UnifiedLLM):
         if http_client.async_client is not None:
             api_params.setdefault("client", http_client.async_client)
 
+        # Streaming is requested only when someone is listening (see stream_to);
+        # otherwise the request is byte-for-byte what it was before.
+        if _chunk_sink.get() is not None:
+            api_params.setdefault("stream", True)
+
         async def _make_call():
-            raw_response = await _collect_async(await _litellm_acompletion(api_params))
+            raw_response = await _collect_async(
+                await _litellm_acompletion(api_params), output_model is not None
+            )
             reasoning, _ = _extract_reasoning_and_usage(raw_response)
             text_content = raw_response.choices[0].message.content or ""  # type: ignore[union-attr]
 
@@ -2030,13 +2125,38 @@ class CompletionClient(UnifiedLLM):
 
             return raw_response
 
+        async def _attempt():
+            """One attempt, refusing to retry once the caller has seen output.
+
+            A retry re-runs the call, so the sink would receive the prefix it
+            already got: duplicated text on screen, and a corrupted read for
+            anything parsing the stream incrementally. Failures before the first
+            delta retry exactly as they did.
+            """
+            try:
+                return await _make_call()
+            except StreamedBeforeFailing:
+                raise
+            except Exception as failure:
+                if _chunk_emitted.get():
+                    raise StreamedBeforeFailing(
+                        "the sink already received part of this answer"
+                    ) from failure
+                raise
+
+        # Each call starts having shown nothing, so one call's deltas cannot make
+        # the next one non-retryable.
+        emitted_token = _chunk_emitted.set(False)
         # Track LLM call for debugging (visible via SIGUSR2 if nooa debug handler installed)
-        with _track_llm_call(model=self.model, endpoint=self.config.get("api_base")):
-            raw_response = (
-                await with_retry(_make_call, config=self.retry_config)
-                if self.retry_config
-                else await _make_call()
-            )
+        try:
+            with _track_llm_call(model=self.model, endpoint=self.config.get("api_base")):
+                raw_response = (
+                    await with_retry(_attempt, config=self.retry_config)
+                    if self.retry_config
+                    else await _make_call()
+                )
+        finally:
+            _chunk_emitted.reset(emitted_token)
 
         reasoning, usage = _extract_reasoning_and_usage(raw_response)
         if usage:

--- a/tests/unifiedllm/test_stream_to.py
+++ b/tests/unifiedllm/test_stream_to.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""`stream_to`: what reaches the sink, and what must never reach it twice."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from nooa.unifiedllm.unifiedllm import (
+    _chunk_emitted,
+    _chunk_sink,
+    _emit_chunk,
+    stream_to,
+)
+
+
+def chunk(content=None, reasoning=None):
+    """A litellm streaming chunk, shaped the way the collector sees one."""
+    delta = SimpleNamespace(content=content, reasoning_content=reasoning)
+    return SimpleNamespace(choices=[SimpleNamespace(delta=delta)])
+
+
+def test_no_sink_means_no_emission():
+    _emit_chunk(chunk("hello"))  # must not raise with nothing installed
+
+
+def test_the_sink_receives_content_deltas():
+    seen = []
+    with stream_to(seen.append):
+        _emit_chunk(chunk("mộ"))
+        _emit_chunk(chunk("t hai"))
+    assert seen == ["mộ", "t hai"]
+
+
+def test_reasoning_is_not_prose_on_an_ordinary_call():
+    """For a plain call, reasoning_content is the model thinking, not the answer."""
+    seen = []
+    with stream_to(seen.append):
+        _emit_chunk(chunk(content=None, reasoning="đang nghĩ..."))
+    assert seen == []
+
+
+def test_structured_output_hiding_in_reasoning_still_reaches_the_sink():
+    """Some reasoning models put the JSON in reasoning_content and leave content
+    empty; the parser already falls back to it, so a sink reading only `content`
+    would watch a call succeed with nothing on screen."""
+    seen = []
+    with stream_to(seen.append):
+        _emit_chunk(chunk(content=None, reasoning='{"value": "xin'), structured=True)
+        _emit_chunk(chunk(content=None, reasoning=' chào"}'), structured=True)
+    assert "".join(seen) == '{"value": "xin chào"}'
+
+
+def test_content_wins_over_reasoning_when_both_are_present():
+    seen = []
+    with stream_to(seen.append):
+        _emit_chunk(chunk(content="thật", reasoning="nghĩ"), structured=True)
+    assert seen == ["thật"]
+
+
+def test_a_raising_sink_never_breaks_the_call():
+    def explode(_):
+        raise RuntimeError("cái màn hình hỏng")
+
+    with stream_to(explode):
+        _emit_chunk(chunk("vẫn chạy"))  # swallowed, logged at debug
+
+
+def test_emission_is_recorded_so_a_retry_can_be_refused():
+    """The flag behind "do not replay what the caller has already seen"."""
+    token = _chunk_emitted.set(False)
+    try:
+        with stream_to(lambda _: None):
+            assert _chunk_emitted.get() is False
+            _emit_chunk(chunk("một"))
+            assert _chunk_emitted.get() is True
+    finally:
+        _chunk_emitted.reset(token)
+
+
+def test_a_silent_chunk_does_not_count_as_emission():
+    token = _chunk_emitted.set(False)
+    try:
+        with stream_to(lambda _: None):
+            _emit_chunk(chunk(content=""))
+            _emit_chunk(chunk(content=None, reasoning="nghĩ"))  # not structured
+            assert _chunk_emitted.get() is False
+    finally:
+        _chunk_emitted.reset(token)
+
+
+def test_the_sink_is_scoped_to_its_context():
+    seen = []
+    with stream_to(seen.append):
+        pass
+    assert _chunk_sink.get() is None
+    _emit_chunk(chunk("sau khi ra khỏi context"))
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_a_failure_after_streaming_is_terminal_not_retried():
+    """A retry would replay the prefix the caller already saw.
+
+    Duplicated text on screen, and a corrupted read for anything parsing the
+    stream incrementally — so the failure becomes the answer.
+    """
+    from nooa.unifiedllm.retry import with_retry
+    from nooa.unifiedllm.retry_config import RetryConfig
+    from nooa.unifiedllm.unifiedllm import StreamedBeforeFailing
+
+    seen, attempts = [], []
+
+    async def attempt():
+        attempts.append(1)
+        try:
+            _emit_chunk(chunk("một phần câu trả lời"))
+            raise TimeoutError("mạng đứt giữa chừng")
+        except StreamedBeforeFailing:
+            raise
+        except Exception as failure:
+            if _chunk_emitted.get():
+                raise StreamedBeforeFailing("sink đã nhận một phần") from failure
+            raise
+
+    token = _chunk_emitted.set(False)
+    try:
+        with stream_to(seen.append), pytest.raises(StreamedBeforeFailing):
+            await with_retry(attempt, config=RetryConfig(max_retries=3))
+    finally:
+        _chunk_emitted.reset(token)
+
+    assert len(attempts) == 1, "đã phát rồi thì không được thử lại"
+    assert seen == ["một phần câu trả lời"], "người dùng chỉ được thấy một lần"


### PR DESCRIPTION
## What this adds

`stream_to(sink)` — a context manager that makes async LLM calls deliver text
deltas as they arrive, without changing what a generation method returns.

```python
from nooa.unifiedllm import stream_to

with stream_to(lambda delta: queue.put_nowait(delta)):
    answer = await agent.reply(message="...")   # still returns the whole text
```

## Why

A generation method returning its complete answer is the right contract. But a
caller that wants to *show* the answer arriving — a chat UI, or a task stream
over a protocol like A2A — needs the pieces on the way, and there is currently
no way to get them: `_collect_async` consumes every chunk before returning, and
nothing in the codebase ever sets `stream=True`.

## Design

- **Opt-in per context.** Streaming is requested only while a sink is installed.
  Outside the context the request is byte-for-byte what it was before, so no
  existing behaviour changes.
- **ContextVar, not global state.** Concurrent tasks each get their own sink;
  calls made elsewhere are untouched.
- **A sink that raises is logged and ignored** — a display must never break the
  call it is watching.
- **The deltas are raw provider output.** A method with a typed return is filled
  against a JSON schema, so the stream carries that JSON as it is written. The
  docstring says so and points at reading the growing field incrementally rather
  than concatenating deltas blindly.

## Verification

- `tests/unifiedllm` and `tests/strategies`: 1273 passed. Five failures in
  `test_litellm_responses_bridge.py` reproduce identically on unpatched
  `main` in the same environment, so they are unrelated to this change.
- Measured end to end while driving two agents over A2A: 14 provider deltas
  became 12 readable pieces and 12 protocol status updates; the same turn with
  no sink installed issues no streaming request at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public streaming utility that delivers text from asynchronous language model calls to an output handler as it becomes available.
  - Streaming responses are emitted incrementally while the complete response remains available after processing.
  - Structured responses can stream reasoning content alongside generated text.
  - Language model calls retain standard non-streaming behavior when no output handler is active.
  - Calls that fail after partial streaming no longer retry, preventing duplicated output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->