### PR TITLE
TUI fullscreen follow-ups: perf, correctness, code sharing

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -562,6 +562,21 @@ class ModelCommand(Command):
                     )
                 )
             return CommandResult.err(f"Failed to switch model: {e}")
+        except BaseException as e:  # noqa: BLE001 — ownership must resolve on cancel too
+            # Cancellation is a BaseException in Python 3.13: if the probe is
+            # cancelled after _begin_model_validation took over the startup
+            # prompt ownership, nothing would ever reject or release the
+            # deferred prompts. Resolve ownership on the way out, then
+            # propagate the cancellation to the caller.
+            if model_validation_started:
+                self._mark_model_check_failed(
+                    HealthCheckResult(
+                        ok=False,
+                        error_message=f"Model validation cancelled: {e}",
+                        blocking=True,
+                    )
+                )
+            raise
         self.config.default_model = selected
         self._mark_model_ready(selected)
         try:

--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -511,7 +511,11 @@ class ModelCommand(Command):
                 TextOutput(f"Current model: {self.config.default_model}", "info")
             )
         selected = args[0]
-        model_validation_started = False
+        # Ownership of the deferred startup prompts needs resolving only
+        # while the probe is in flight. The switch phase below has already
+        # produced a healthy probe; cancelling THERE must not publish a
+        # failed health (the agent may already be on the new model).
+        probe_in_flight = False
         try:
             from nooa.interactive import apply_model_limits
             from nooa_cli.tui.config import UnresolvedModelError, get_llm_for_model
@@ -534,8 +538,9 @@ class ModelCommand(Command):
                     ],
                 )
             self._begin_model_validation()
-            model_validation_started = True
+            probe_in_flight = True
             health = await probe_llm(candidate)
+            probe_in_flight = False
             if not health.ok:
                 self._mark_model_check_failed(health)
                 outputs = [
@@ -553,7 +558,7 @@ class ModelCommand(Command):
 
             await self.agent_run_async(_switch)
         except Exception as e:
-            if model_validation_started:
+            if probe_in_flight:
                 self._mark_model_check_failed(
                     HealthCheckResult(
                         ok=False,
@@ -562,13 +567,23 @@ class ModelCommand(Command):
                     )
                 )
             return CommandResult.err(f"Failed to switch model: {e}")
-        except BaseException as e:  # noqa: BLE001 — ownership must resolve on cancel too
+        except asyncio.CancelledError as e:
             # Cancellation is a BaseException in Python 3.13: if the probe is
             # cancelled after _begin_model_validation took over the startup
             # prompt ownership, nothing would ever reject or release the
             # deferred prompts. Resolve ownership on the way out, then
             # propagate the cancellation to the caller.
-            if model_validation_started:
+            if probe_in_flight:
+                self._mark_model_check_failed(
+                    HealthCheckResult(
+                        ok=False,
+                        error_message=f"Model validation cancelled: {e}",
+                        blocking=True,
+                    )
+                )
+            raise
+        except BaseException as e:  # noqa: BLE001 — resolve ownership for Ctrl-C etc.
+            if probe_in_flight:
                 self._mark_model_check_failed(
                     HealthCheckResult(
                         ok=False,

--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -965,8 +965,35 @@ def _style_event_header_line(lines: list[str], width: int) -> list[str]:
     return styled
 
 
+# Cache entries hold the row itself alongside its lines so a recycled
+# ``id(row)`` can never alias a fresh row onto stale rendered lines
+# (EventExplorerRow is an eq-dataclass, so the row cannot key the dict).
+_STYLE_CACHE: dict[tuple[int, int], tuple[EventExplorerRow, list[str]]] = {}
+_STYLE_CACHE_MAX = 64
+
+
 def _styled_detail_lines(row: EventExplorerRow, width: int) -> list[str]:
-    """Return the detail pane's styled rendering (markdown or syntax colors)."""
+    """Return the memoized styled rendering (markdown or syntax colors).
+
+    Detail rendering walks the same markdown up to three times per paint
+    (match lines, occurrences, highlighted output) and again on measurement;
+    Rich renders of large event payloads dominate that cost. The rendering
+    is a pure function of (row, width) and rows are immutable, so cache it.
+    """
+    width = max(int(width), 20)
+    key = (id(row), width)
+    cached = _STYLE_CACHE.get(key)
+    if cached is not None and cached[0] is row:
+        return cached[1]
+    lines = _render_styled_detail_lines(row, width)
+    if len(_STYLE_CACHE) >= _STYLE_CACHE_MAX:
+        _STYLE_CACHE.clear()
+    _STYLE_CACHE[key] = (row, lines)
+    return lines
+
+
+def _render_styled_detail_lines(row: EventExplorerRow, width: int) -> list[str]:
+    """Render the detail pane's styled lines (uncached)."""
     width = max(int(width), 20)
     lines: list[str] = []
     if row.markdown is not None:

--- a/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/event_explorer.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import datetime
 import json
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
 
@@ -968,7 +969,11 @@ def _style_event_header_line(lines: list[str], width: int) -> list[str]:
 # Cache entries hold the row itself alongside its lines so a recycled
 # ``id(row)`` can never alias a fresh row onto stale rendered lines
 # (EventExplorerRow is an eq-dataclass, so the row cannot key the dict).
-_STYLE_CACHE: dict[tuple[int, int], tuple[EventExplorerRow, list[str]]] = {}
+# LRU memo: eviction drops only the least-recently-used entry (a full clear
+# at capacity would re-trigger render storms for the still-live keys), and
+# entries retain the row so a recycled ``id(row)`` can never alias a fresh
+# row onto stale lines.
+_STYLE_CACHE: OrderedDict[tuple[int, int], tuple[EventExplorerRow, list[str]]] = OrderedDict()
 _STYLE_CACHE_MAX = 64
 
 
@@ -984,10 +989,11 @@ def _styled_detail_lines(row: EventExplorerRow, width: int) -> list[str]:
     key = (id(row), width)
     cached = _STYLE_CACHE.get(key)
     if cached is not None and cached[0] is row:
+        _STYLE_CACHE.move_to_end(key)
         return cached[1]
     lines = _render_styled_detail_lines(row, width)
-    if len(_STYLE_CACHE) >= _STYLE_CACHE_MAX:
-        _STYLE_CACHE.clear()
+    while len(_STYLE_CACHE) >= _STYLE_CACHE_MAX:
+        _STYLE_CACHE.popitem(last=False)
     _STYLE_CACHE[key] = (row, lines)
     return lines
 

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -591,6 +591,12 @@ class ExplorerBrowser:
             list_height=self.explorer_list_height,
             floats=dropdown_floats,
         )
+        # Views with a timed confirmation gesture (the memory explorer's
+        # arm/confirm window) hook expiry to a repaint so the footer stops
+        # promising a confirm that no longer applies even without a keypress.
+        register_expiry = getattr(self.view, "on_confirm_expired", None)
+        if callable(register_expiry):
+            register_expiry(self.invalidate)
 
     def _create_list_control(self) -> Any:
         """Factory hook: the pane control rendering the list. Subclasses may override."""

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -502,7 +502,7 @@ class ExplorerBrowser:
                 else ""
             ),
         )
-        self.list_control = _BrowserPaneControl(self)
+        self.list_control = self._create_list_control()
         self.preview_control = SelectablePreviewControl(self)
         self.option_controls = [
             _BrowserOptionControl(self, index) for index in range(len(view.options))
@@ -512,14 +512,18 @@ class ExplorerBrowser:
         for index, control in enumerate(self.option_controls):
             if index:
                 option_windows.append(Window(FormattedTextControl(" "), width=1, height=1))
-            option_window = Window(control, width=Dimension(min=12, preferred=22), height=1)
+            option_window = Window(
+                control, width=self._option_window_width(index), height=1
+            )
             self.option_windows.append(option_window)
             option_windows.append(option_window)
+        self.search_label_control = FormattedTextControl(self._search_label)
+        self.search_close_control = FormattedTextControl(self._search_close)
         search = VSplit(
             [
-                Window(FormattedTextControl(self._search_label), width=9, height=1),
+                Window(self.search_label_control, width=9, height=1),
                 self.query_window,
-                Window(FormattedTextControl(self._search_close), width=1, height=1),
+                Window(self.search_close_control, width=1, height=1),
             ],
             padding=0,
         )
@@ -587,6 +591,14 @@ class ExplorerBrowser:
             list_height=self.explorer_list_height,
             floats=dropdown_floats,
         )
+
+    def _create_list_control(self) -> Any:
+        """Factory hook: the pane control rendering the list. Subclasses may override."""
+        return _BrowserPaneControl(self)
+
+    def _option_window_width(self, index: int) -> Dimension:
+        """Factory hook: one option button window's width. Subclasses may override."""
+        return Dimension(min=12, preferred=22)
 
     @property
     def active_dropdown(self) -> Any | None:
@@ -687,6 +699,8 @@ class ExplorerBrowser:
             self.preview_control,
             *self.dropdown_controls,
             *self.option_controls,
+            self.search_label_control,
+            self.search_close_control,
             self.title_control,
             self.help_control,
             self.list_header_control,

--- a/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
@@ -287,13 +287,17 @@ class MemoryExplorerView(ExplorerView):
         pending_action, row_id, armed_at = pending
         if pending_action != action or row_id != id(row):
             return False
-        return (time.time() - armed_at) <= self._CONFIRM_WINDOW_SECONDS
+        return (time.monotonic() - armed_at) <= self._CONFIRM_WINDOW_SECONDS
 
     def pending_confirmation_hint(self) -> str:
         pending = self._pending_confirm
         if pending is None:
             return ""
-        action, row_id, _armed_at = pending
+        action, row_id, armed_at = pending
+        # An expired arm cannot fire — the next press re-arms. Do not keep
+        # promising a confirm that no longer applies.
+        if time.monotonic() - armed_at > self._CONFIRM_WINDOW_SECONDS:
+            return ""
         row = next((row for row in self.model.rows if id(row) == row_id), None)
         if row is None:
             self._pending_confirm = None
@@ -307,7 +311,7 @@ class MemoryExplorerView(ExplorerView):
             return "ignored"
         if action == "text:f":
             if not self._consume_confirmation(action, row):
-                self._pending_confirm = (action, id(row), time.time())
+                self._pending_confirm = (action, id(row), time.monotonic())
                 return "handled"
             self._forget(row.id)
             self.model.rows.remove(row)
@@ -320,7 +324,7 @@ class MemoryExplorerView(ExplorerView):
                 self._pending_confirm = None
                 return "ignored"
             if not self._consume_confirmation(action, row):
-                self._pending_confirm = (action, id(row), time.time())
+                self._pending_confirm = (action, id(row), time.monotonic())
                 return "handled"
             self._mark_done(row.id)
             # The search tag mirrors the CURRENT status (todo:open / todo:dropped

--- a/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
@@ -160,9 +160,10 @@ class MemoryExplorerView(ExplorerView):
         self._forget = forget
         self._mark_done = mark_done
         # Destructive actions arm on the first press and fire on the second
-        # press of the same key on the same row, so no invisible pane/query
-        # state can trigger an unconfirmed forget or mark-done.
-        self._pending_confirm: tuple[str, str] | None = None
+        # press of the same key on the same row within the gesture window,
+        # so no invisible pane/query state — and no stale arm from minutes
+        # ago — can trigger an unconfirmed forget or mark-done.
+        self._pending_confirm: tuple[str, str, float] | None = None
         model = ExplorerModel(rows)
         title = "Memory Explorer"
         if last_reflection:
@@ -269,22 +270,30 @@ class MemoryExplorerView(ExplorerView):
                 lines.append(f"  → {target_id[:8]} {edge_type} ({weight:.2f})")
         return lines
 
+    _CONFIRM_WINDOW_SECONDS = 10.0
+
     def _consume_confirmation(self, action: str, row: Any) -> bool:
         """Return True when this press confirms the pending armed action.
 
         The first press of an action key arms it; the same key on the same
         row must follow within the gesture window to fire. Any other key
-        (including typing "f"/"d" into the search buffer) disarms.
+        (including typing "f"/"d" into the search buffer) disarms, and an
+        arm older than the window expires instead of firing.
         """
         pending = self._pending_confirm
         self._pending_confirm = None
-        return pending == (action, id(row))
+        if pending is None:
+            return False
+        pending_action, row_id, armed_at = pending
+        if pending_action != action or row_id != id(row):
+            return False
+        return (time.time() - armed_at) <= self._CONFIRM_WINDOW_SECONDS
 
     def pending_confirmation_hint(self) -> str:
         pending = self._pending_confirm
         if pending is None:
             return ""
-        action, row_id = pending
+        action, row_id, _armed_at = pending
         row = next((row for row in self.model.rows if id(row) == row_id), None)
         if row is None:
             self._pending_confirm = None
@@ -298,7 +307,7 @@ class MemoryExplorerView(ExplorerView):
             return "ignored"
         if action == "text:f":
             if not self._consume_confirmation(action, row):
-                self._pending_confirm = (action, id(row))
+                self._pending_confirm = (action, id(row), time.time())
                 return "handled"
             self._forget(row.id)
             self.model.rows.remove(row)
@@ -311,7 +320,7 @@ class MemoryExplorerView(ExplorerView):
                 self._pending_confirm = None
                 return "ignored"
             if not self._consume_confirmation(action, row):
-                self._pending_confirm = (action, id(row))
+                self._pending_confirm = (action, id(row), time.time())
                 return "handled"
             self._mark_done(row.id)
             # The search tag mirrors the CURRENT status (todo:open / todo:dropped

--- a/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/memory_explorer.py
@@ -162,8 +162,12 @@ class MemoryExplorerView(ExplorerView):
         # Destructive actions arm on the first press and fire on the second
         # press of the same key on the same row within the gesture window,
         # so no invisible pane/query state — and no stale arm from minutes
-        # ago — can trigger an unconfirmed forget or mark-done.
+        # ago — can trigger an unconfirmed forget or mark-done. The expiry
+        # timer clears the arm at the window edge and repaints via the
+        # browser's on_confirm_expired hook.
         self._pending_confirm: tuple[str, str, float] | None = None
+        self._confirm_expiry_timer = None
+        self._confirm_expired_callbacks: list[Callable[[], None]] = []
         model = ExplorerModel(rows)
         title = "Memory Explorer"
         if last_reflection:
@@ -272,6 +276,42 @@ class MemoryExplorerView(ExplorerView):
 
     _CONFIRM_WINDOW_SECONDS = 10.0
 
+    def on_confirm_expired(self, callback: Callable[[], None]) -> None:
+        """Register a repaint hook fired when the armed confirm expires.
+
+        The browser wires this to its invalidate so the footer stops
+        promising a confirm that no longer applies even when no key is
+        pressed during the window.
+        """
+        self._confirm_expired_callbacks.append(callback)
+
+    def _schedule_confirm_expiry(self, armed_at: float) -> None:
+        """Arm a deadline that clears the pending confirm at the window edge."""
+        self._cancel_confirm_expiry()
+        try:
+            import asyncio
+
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # Sync callers (unit tests) self-heal on the next render.
+        delay = max(0.0, self._CONFIRM_WINDOW_SECONDS - (time.monotonic() - armed_at))
+        self._confirm_expiry_timer = loop.call_later(delay, self._confirm_expired)
+
+    def _cancel_confirm_expiry(self) -> None:
+        if self._confirm_expiry_timer is not None:
+            self._confirm_expiry_timer.cancel()
+            self._confirm_expiry_timer = None
+
+    def _confirm_expired(self) -> None:
+        self._confirm_expiry_timer = None
+        if self._pending_confirm is None:
+            return
+        _action, _row_id, armed_at = self._pending_confirm
+        if time.monotonic() - armed_at > self._CONFIRM_WINDOW_SECONDS:
+            self._pending_confirm = None
+            for callback in self._confirm_expired_callbacks:
+                callback()
+
     def _consume_confirmation(self, action: str, row: Any) -> bool:
         """Return True when this press confirms the pending armed action.
 
@@ -280,6 +320,7 @@ class MemoryExplorerView(ExplorerView):
         (including typing "f"/"d" into the search buffer) disarms, and an
         arm older than the window expires instead of firing.
         """
+        self._cancel_confirm_expiry()
         pending = self._pending_confirm
         self._pending_confirm = None
         if pending is None:
@@ -300,6 +341,7 @@ class MemoryExplorerView(ExplorerView):
             return ""
         row = next((row for row in self.model.rows if id(row) == row_id), None)
         if row is None:
+            self._cancel_confirm_expiry()
             self._pending_confirm = None
             return ""
         verb = "forget" if action == "text:f" else "mark done"
@@ -312,6 +354,7 @@ class MemoryExplorerView(ExplorerView):
         if action == "text:f":
             if not self._consume_confirmation(action, row):
                 self._pending_confirm = (action, id(row), time.monotonic())
+                self._schedule_confirm_expiry(self._pending_confirm[2])
                 return "handled"
             self._forget(row.id)
             self.model.rows.remove(row)
@@ -321,10 +364,12 @@ class MemoryExplorerView(ExplorerView):
             if row.type != "todo" or row.status == "done":
                 # An action key that cannot apply still interrupts the armed
                 # gesture — the next f/d press must arm, not confirm.
+                self._cancel_confirm_expiry()
                 self._pending_confirm = None
                 return "ignored"
             if not self._consume_confirmation(action, row):
                 self._pending_confirm = (action, id(row), time.monotonic())
+                self._schedule_confirm_expiry(self._pending_confirm[2])
                 return "handled"
             self._mark_done(row.id)
             # The search tag mirrors the CURRENT status (todo:open / todo:dropped
@@ -335,5 +380,6 @@ class MemoryExplorerView(ExplorerView):
             row.search_text = row.search_text.replace(old_tag, "todo:done", 1)
             self.model.set_query(self.model.query)
             return "handled"
+        self._cancel_confirm_expiry()
         self._pending_confirm = None
         return "ignored"

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -244,23 +244,31 @@ class ResumePickerModel:
         self.selected = ids.index(previous_id) if previous_id in ids else 0
         self.list_offset = min(self.list_offset, self.selected)
 
+    def set_filter(self, value: Literal["detached", "attached", "all"]) -> None:
+        """Apply a filter value and restart the list from the top."""
+        self.state_filter = value
+        self.selected = self.list_offset = 0
+        self._rebuild_matches()
+
     def cycle_filter(self, delta: int = 1) -> None:
         filters: tuple[Literal["detached", "attached", "all"], ...] = (
             "detached",
             "attached",
             "all",
         )
-        self.state_filter = filters[(filters.index(self.state_filter) + delta) % len(filters)]
-        self.selected = self.list_offset = 0
-        self._rebuild_matches()
+        self.set_filter(filters[(filters.index(self.state_filter) + delta) % len(filters)])
 
     def toggle_filter(self) -> None:
         self.cycle_filter()
 
-    def toggle_sort(self) -> None:
-        self.sort_updated = not self.sort_updated
+    def set_sort(self, updated: bool) -> None:
+        """Apply a sort direction and restart the list from the top."""
+        self.sort_updated = updated
         self.selected = self.list_offset = 0
         self._rebuild_matches()
+
+    def toggle_sort(self) -> None:
+        self.set_sort(not self.sort_updated)
 
     def move(self, delta: int) -> None:
         if not self._matches or not delta:
@@ -602,9 +610,6 @@ class ResumePicker(ExplorerBrowser):
         self._preview_models: dict[tuple[str, int], Any] = {}
         self._preview_tasks: dict[tuple[str, int], Any] = {}
         self.native_selection = False
-        # The session list fills its pane like every other browser (the
-        # shell's compact five-row default capped it short of the divider).
-        self.picker_list_height = Dimension(min=1, preferred=5, weight=1)
         super().__init__(
             self._view_facade,
             app,
@@ -621,16 +626,12 @@ class ResumePicker(ExplorerBrowser):
         """
 
         def on_filter(value: str) -> None:
-            self.model.state_filter = value  # type: ignore[assignment]
-            self.model.selected = self.model.list_offset = 0
-            self.model._rebuild_matches()
+            self.model.set_filter(value)  # type: ignore[arg-type]
             self._prepare_current_preview()
             self.invalidate()
 
         def on_sort(value: str) -> None:
-            self.model.sort_updated = value == "updated"
-            self.model.selected = self.model.list_offset = 0
-            self.model._rebuild_matches()
+            self.model.set_sort(value == "updated")
             self._prepare_current_preview()
             self.invalidate()
 

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -283,6 +283,9 @@ class ResumePickerModel:
     def jump_end(self) -> None:
         if self._matches:
             self.selected = len(self._matches) - 1
+            # Keep the selection on screen: the list renders from
+            # list_offset, so End must scroll it into view too.
+            self.list_offset = max(0, len(self._matches) - 1)
 
     def select(self, index: int) -> None:
         if 0 <= index < len(self._matches) and index != self.selected:
@@ -629,11 +632,16 @@ class ResumePicker(ExplorerBrowser):
 
         def on_filter(value: str) -> None:
             self.model.set_filter(value)  # type: ignore[arg-type]
+            # A filter/sort change can select a different row: reset the
+            # (possibly cached) current preview's viewport so it follows the
+            # tail instead of keeping the previous scroll position.
+            self._reset_preview()
             self._prepare_current_preview()
             self.invalidate()
 
         def on_sort(value: str) -> None:
             self.model.set_sort(value == "updated")
+            self._reset_preview()
             self._prepare_current_preview()
             self.invalidate()
 

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -158,7 +158,6 @@ class ResumePickerModel:
         self.state_filter: Literal["detached", "attached", "all"] = "detached"
         self.sort_updated = True
         self.selected = self.list_offset = 0
-        self.preview_offset = 10**9
         self._query_matches: list[tuple[int, str, tuple[int, ...]] | None] = []
         self._matches: list[FieldMatch] = []
         self.set_query("")
@@ -250,7 +249,6 @@ class ResumePickerModel:
         ids = [match.row.id for match in self._matches]
         self.selected = ids.index(previous_id) if previous_id in ids else 0
         self.list_offset = min(self.list_offset, self.selected)
-        self.preview_offset = 10**9
 
     def cycle_filter(self, delta: int = 1) -> None:
         filters: tuple[Literal["detached", "attached", "all"], ...] = (
@@ -274,23 +272,19 @@ class ResumePickerModel:
         if not self._matches or not delta:
             return
         self.selected = (self.selected + delta) % len(self._matches)
-        self.preview_offset = 10**9
 
     def jump_home(self) -> None:
         if self._matches:
             self.selected = 0
             self.list_offset = 0
-            self.preview_offset = 10**9
 
     def jump_end(self) -> None:
         if self._matches:
             self.selected = len(self._matches) - 1
-            self.preview_offset = 10**9
 
     def select(self, index: int) -> None:
         if 0 <= index < len(self._matches) and index != self.selected:
             self.selected = index
-            self.preview_offset = 10**9
 
     def ensure_selection_visible(self, rows: int) -> None:
         rows = max(1, rows)
@@ -312,11 +306,6 @@ class ResumePickerModel:
         maximum = max(0, len(self._matches) - max(1, rows))
         self.list_offset = min(maximum, max(0, self.list_offset + delta))
 
-    def scroll_preview(self, delta: int, line_count: int, height: int) -> None:
-        maximum = max(0, line_count - max(1, height))
-        current = min(self.preview_offset, maximum)
-        self.preview_offset = min(maximum, max(0, current + delta))
-
 
 def _clip(text: str, width: int) -> str:
     width = max(0, width)
@@ -332,23 +321,6 @@ def _clip(text: str, width: int) -> str:
         kept.append(text[start:stop])
         used += cells
     return "".join(kept) + "…"
-
-
-def _wrap(text: str, width: int) -> list[str]:
-    """Wrap sanitized text by terminal cells while preserving grapheme clusters."""
-    width = max(1, width)
-    result: list[str] = []
-    for source in sanitize_live_text(text).splitlines() or [""]:
-        line, used = [], 0
-        for start, stop, cells in split_graphemes(source)[0]:
-            cluster = source[start:stop]
-            if line and used + cells > width:
-                result.append("".join(line))
-                line, used = [], 0
-            line.append(cluster)
-            used += cells
-        result.append("".join(line))
-    return result
 
 
 def _field_fragments(
@@ -481,41 +453,6 @@ def _row_fragments(
     ]
 
 
-def _preview_lines(row: ResumePickerRow | None, width: int) -> list[list[tuple[str, str]]]:
-    """Render transcript turns using the same visual language as live scrollback."""
-    if row is None:
-        return [[("class:fullscreen-browser.empty", "No session selected")]]
-    if not row.turns:
-        return [[("class:fullscreen-browser.empty", "No conversation preview")]]
-    lines: list[list[tuple[str, str]]] = []
-    width = max(1, width)
-    for turn in row.turns:
-        if turn.role == "user":
-            edge = "▔" * width
-            lines.append([("class:fullscreen-browser.preview-user-edge", edge)])
-            for index, text in enumerate(_wrap(turn.content, max(1, width - 4))):
-                prompt = "❯ " if index == 0 else "  "
-                content = _clip(f" {prompt}{text}", width)
-                lines.append(
-                    [
-                        (
-                            "class:fullscreen-browser.preview-user",
-                            content + " " * max(0, width - cell_len(content)),
-                        )
-                    ]
-                )
-            lines.append([("class:fullscreen-browser.preview-user-edge", "▁" * width)])
-        else:
-            lines.append([("class:fullscreen-browser.preview-agent", "OO:")])
-            lines.extend(
-                [("class:fullscreen-browser.preview", text)] for text in _wrap(turn.content, width)
-            )
-            lines.append([])
-    if lines and not lines[-1]:
-        lines.pop()
-    return lines
-
-
 def _semantic_preview_selection(text: str) -> str:
     """Remove conversation-preview chrome from selected text."""
     output: list[str] = []
@@ -537,59 +474,6 @@ def _semantic_preview_selection(text: str) -> str:
         elif stripped != "OO:":
             output.append(line)
     return "\n".join(output).strip("\n")
-
-
-def render_resume_picker(model: ResumePickerModel, width: int, height: int) -> str:
-    """Render a deterministic text snapshot used by unit tests and narrow fallbacks."""
-    if width < 48 or height < 13:
-        return f"Terminal too small\nNeed 48 x 13; now {width} x {height}"
-    separator = "─" * width
-    filt = {
-        "detached": "✓ Not attached",
-        "attached": "✗ Attached",
-        "all": "✓/✗ All",
-    }[model.state_filter]
-    sort = "Recent activity" if model.sort_updated else "Creation date"
-    lines = [
-        _clip(f"Resume a previous session · {len(model.matches)} sessions", width),
-        _clip(f"[Search: {model.query}] [Filter: {filt}] [Sort: {sort}]", width),
-        _clip(
-            "Tab/Shift-Tab focus · arrows navigate · Space/↵ activate · Esc cancel",
-            width,
-        ),
-        separator,
-    ]
-    list_height = min(5, max(1, height - 10))
-    model.ensure_selection_visible(list_height)
-    for index, match in model.visible(list_height):
-        lines.extend(
-            "".join(text for _, text in row)
-            for row in _row_fragments(
-                match, index == model.selected, width, sort_updated=model.sort_updated
-            )
-        )
-    lines.extend(
-        [
-            separator,
-            _clip(
-                f"Preview · {_single_line(model.current.title) if model.current else 'No selection'}",
-                width,
-            ),
-        ]
-    )
-    preview = _preview_lines(model.current, width)
-    preview_height = max(1, height - len(lines) - 2)
-    maximum = max(0, len(preview) - preview_height)
-    start = min(model.preview_offset, maximum)
-    lines.extend(
-        "".join(text for _, text in line) for line in preview[start : start + preview_height]
-    )
-    lines.extend(
-        [
-            separator,
-        ]
-    )
-    return "\n".join(lines[:height])
 
 
 class _PickerControl(FormattedTextControl):

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -10,8 +10,6 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Literal
 
-from prompt_toolkit.buffer import Buffer
-from prompt_toolkit.layout import VSplit, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.mouse_events import MouseButton, MouseEvent, MouseEventType, MouseModifier
@@ -20,10 +18,6 @@ from rich.cells import cell_len, split_graphemes
 from .explorer_base import ExplorerOption
 from .fullscreen_browser import (
     ExplorerBrowser,
-    SelectablePreviewControl,
-    _BrowserOptionControl,
-    _BrowserSearchControl,
-    build_fullscreen_browser,
 )
 from .terminal_safety import sanitize_live_text
 
@@ -541,11 +535,18 @@ class ResumePicker(ExplorerBrowser):
 
         config = SimpleNamespace(actions={})
         item_name = "session"
+        title = "Resume a previous session"
 
         def __init__(self, picker: ResumePicker, options: tuple[ExplorerOption, ...]) -> None:
             self._picker = picker
             self.options = options
             self.pending_input: str | None = None
+
+        @property
+        def model(self) -> ResumePickerModel:
+            # The shared construction seeds the search buffer from
+            # ``view.model.query``; the picker's model is the real one.
+            return self._picker.model
 
         def handle_key(self, _action: str, _value: str = "") -> str:
             return "handled"
@@ -562,6 +563,12 @@ class ResumePicker(ExplorerBrowser):
     def view(self) -> ResumePicker._ViewFacade:
         return self._view_facade
 
+    @view.setter
+    def view(self, value: ResumePicker._ViewFacade) -> None:
+        # The shared construction assigns the facade passed to
+        # super().__init__; keep it in the same slot the property reads.
+        self._view_facade = value
+
     @property
     def model(self) -> ResumePickerModel:
         return self._resume_model
@@ -569,6 +576,14 @@ class ResumePicker(ExplorerBrowser):
     @model.setter
     def model(self, value: ResumePickerModel) -> None:
         self._resume_model = value
+
+    def _create_list_control(self) -> Any:
+        # The picker's list renders its compact FieldMatch rows.
+        return _PickerControl(self)
+
+    def _option_window_width(self, index: int) -> Dimension:
+        widths = (Dimension(min=17, preferred=20), Dimension(min=10, preferred=18))
+        return widths[index]
 
     def __init__(
         self,
@@ -584,76 +599,17 @@ class ResumePicker(ExplorerBrowser):
         # options mode; their callbacks mirror the model's cycle/toggle
         # semantics (restart from the top, refresh the prepared preview).
         self._view_facade = ResumePicker._ViewFacade(self, self._build_view_options())
-        self._selection_copy_callback = selection_copy_callback
-        self._selection_status = selection_status
         self._preview_models: dict[tuple[str, int], Any] = {}
         self._preview_tasks: dict[tuple[str, int], Any] = {}
         self.native_selection = False
-        self.active_control = "list"
-        self.option_cursor: int | None = None
-        self.buffer = Buffer(multiline=False)
-        self.buffer.on_text_changed += lambda _: self._query_changed()
-        self.query_control = _BrowserSearchControl(self, self.buffer)
-        self.query_window = Window(
-            self.query_control,
-            width=Dimension(min=4, weight=1),
-            height=1,
-            style=lambda: (
-                "class:fullscreen-browser.control-focused"
-                if self.active_control == "list" and self.option_cursor is None
-                else ""
-            ),
-        )
-        self.option_controls = [_BrowserOptionControl(self, index) for index in range(2)]
-        self.search_label_control = FormattedTextControl(self._search_label)
-        self.search_close_control = FormattedTextControl(self._search_close)
-        search = VSplit(
-            [
-                Window(self.search_label_control, width=9, height=1),
-                self.query_window,
-                Window(self.search_close_control, width=1, height=1),
-            ],
-            padding=0,
-        )
-        selectors = VSplit(
-            [
-                Window(self.option_controls[0], width=Dimension(min=17, preferred=20), height=1),
-                Window(FormattedTextControl(" "), width=1, height=1),
-                Window(self.option_controls[1], width=Dimension(min=10, preferred=18), height=1),
-            ],
-            padding=0,
-        )
-        controls = VSplit(
-            [search, Window(FormattedTextControl(" "), width=1, height=1), selectors],
-            padding=0,
-        )
-        self.list_control = _PickerControl(self)
-        self.preview_control = SelectablePreviewControl(self)
-
-        self.title_control = FormattedTextControl(self._title)
-        self.list_header_control = FormattedTextControl(self._list_header)
-        self.preview_header_control = FormattedTextControl(self._preview_header)
-        self.small_control = FormattedTextControl(
-            [("class:fullscreen-browser.too-small", "Terminal too small")], focusable=True
-        )
         # The session list fills its pane like every other browser (the
         # shell's compact five-row default capped it short of the divider).
         self.picker_list_height = Dimension(min=1, preferred=5, weight=1)
-        self.container = build_fullscreen_browser(
-            app=self.app,
-            title_control=self.title_control,
-            help_control=FormattedTextControl(
-                self._help_text, style="class:fullscreen-browser.footer"
-            ),
-            controls=controls,
-            list_header_control=self.list_header_control,
-            list_control=self.list_control,
-            preview_header_control=self.preview_header_control,
-            preview_control=self.preview_control,
-            active_rail=self._active_rail,
-            small_control=self.small_control,
-            small_text=self._small_text,
-            list_height=self.picker_list_height,
+        super().__init__(
+            self._view_facade,
+            app,
+            selection_copy_callback=selection_copy_callback,
+            selection_status=selection_status,
         )
 
     def _build_view_options(self) -> tuple[ExplorerOption, ...]:
@@ -762,18 +718,6 @@ class ResumePicker(ExplorerBrowser):
                 ),
             )
         ]
-
-    def invalidate(self) -> None:
-        self.list_control._fragment_cache.clear()
-        self.preview_control._fragment_cache.clear()
-        for control in self.option_controls:
-            control._fragment_cache.clear()
-        self.search_label_control._fragment_cache.clear()
-        self.search_close_control._fragment_cache.clear()
-        self.title_control._fragment_cache.clear()
-        self.list_header_control._fragment_cache.clear()
-        self.preview_header_control._fragment_cache.clear()
-        self.app.invalidate()
 
     def navigate_vertical(self, delta: int) -> None:
         if self.option_cursor is not None:

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -591,7 +591,9 @@ class ResumePicker(ExplorerBrowser):
 
     def _option_window_width(self, index: int) -> Dimension:
         widths = (Dimension(min=17, preferred=20), Dimension(min=10, preferred=18))
-        return widths[index]
+        # Future option rows fall back to the shared default width rather
+        # than raising on the two-entry tuple.
+        return widths[index] if index < len(widths) else Dimension(min=12, preferred=22)
 
     def __init__(
         self,

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -668,6 +668,10 @@ class ResumePicker(ExplorerBrowser):
 
     def _query_changed(self) -> None:
         self.model.set_query(self.buffer.text)
+        # Typing a query can swap the selected row, exactly like the filter
+        # and sort handlers: reset the cached current preview so it follows
+        # the tail instead of keeping the previous row's scroll position.
+        self._reset_preview()
         self._prepare_current_preview()
         self.invalidate()
 

--- a/packages/nooa-cli/tests/tui/resume_picker_snapshot.py
+++ b/packages/nooa-cli/tests/tui/resume_picker_snapshot.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic text snapshot of the resume picker for unit tests.
+
+Migrated from ``nooa_cli.tui.resume_picker``: the renderer has no production
+callers (the picker renders through the shared browser), so it lives here as a
+test fixture. It snapshots the same model state the browser renders.
+"""
+
+from __future__ import annotations
+
+from nooa_cli.tui.resume_picker import (
+    ResumePickerModel,
+    ResumePickerRow,
+    _clip,
+    _row_fragments,
+    _single_line,
+)
+from nooa_cli.tui.terminal_safety import sanitize_live_text
+from rich.cells import cell_len, split_graphemes
+
+
+def _wrap(text: str, width: int) -> list[str]:
+    """Wrap sanitized text by terminal cells while preserving grapheme clusters."""
+    width = max(1, width)
+    result: list[str] = []
+    for source in sanitize_live_text(text).splitlines() or [""]:
+        line, used = [], 0
+        for start, stop, cells in split_graphemes(source)[0]:
+            cluster = source[start:stop]
+            if line and used + cells > width:
+                result.append("".join(line))
+                line, used = [], 0
+            line.append(cluster)
+            used += cells
+        result.append("".join(line))
+    return result
+
+
+def _preview_lines(row: ResumePickerRow | None, width: int) -> list[list[tuple[str, str]]]:
+    """Render transcript turns using the same visual language as live scrollback."""
+    if row is None:
+        return [[("class:fullscreen-browser.empty", "No session selected")]]
+    if not row.turns:
+        return [[("class:fullscreen-browser.empty", "No conversation preview")]]
+    lines: list[list[tuple[str, str]]] = []
+    width = max(1, width)
+    for turn in row.turns:
+        if turn.role == "user":
+            edge = "▔" * width
+            lines.append([("class:fullscreen-browser.preview-user-edge", edge)])
+            for index, text in enumerate(_wrap(turn.content, max(1, width - 4))):
+                prompt = "❯ " if index == 0 else "  "
+                content = _clip(f" {prompt}{text}", width)
+                lines.append(
+                    [
+                        (
+                            "class:fullscreen-browser.preview-user",
+                            content + " " * max(0, width - cell_len(content)),
+                        )
+                    ]
+                )
+            lines.append([("class:fullscreen-browser.preview-user-edge", "▁" * width)])
+        else:
+            lines.append([("class:fullscreen-browser.preview-agent", "OO:")])
+            lines.extend(
+                [("class:fullscreen-browser.preview", text)] for text in _wrap(turn.content, width)
+            )
+            lines.append([])
+    if lines and not lines[-1]:
+        lines.pop()
+    return lines
+
+
+def render_resume_picker(model: ResumePickerModel, width: int, height: int) -> str:
+    """Render a deterministic text snapshot used by unit tests and narrow fallbacks."""
+    if width < 48 or height < 13:
+        return f"Terminal too small\nNeed 48 x 13; now {width} x {height}"
+    separator = "─" * width
+    filt = {
+        "detached": "✓ Not attached",
+        "attached": "✗ Attached",
+        "all": "✓/✗ All",
+    }[model.state_filter]
+    sort = "Recent activity" if model.sort_updated else "Creation date"
+    lines = [
+        _clip(f"Resume a previous session · {len(model.matches)} sessions", width),
+        _clip(f"[Search: {model.query}] [Filter: {filt}] [Sort: {sort}]", width),
+        _clip(
+            "Tab/Shift-Tab focus · arrows navigate · Space/↵ activate · Esc cancel",
+            width,
+        ),
+        separator,
+    ]
+    list_height = min(5, max(1, height - 10))
+    model.ensure_selection_visible(list_height)
+    for index, match in model.visible(list_height):
+        lines.extend(
+            "".join(text for _, text in row)
+            for row in _row_fragments(
+                match, index == model.selected, width, sort_updated=model.sort_updated
+            )
+        )
+    lines.extend(
+        [
+            separator,
+            _clip(
+                f"Preview · {_single_line(model.current.title) if model.current else 'No selection'}",
+                width,
+            ),
+        ]
+    )
+    # The live browser keeps the preview viewport on the transcript; the
+    # snapshot renders from the start (deterministic for tests).
+    preview = _preview_lines(model.current, width)
+    preview_height = max(1, height - len(lines) - 2)
+    lines.extend(
+        "".join(text for _, text in line) for line in preview[:preview_height]
+    )
+    lines.extend(
+        [
+            separator,
+        ]
+    )
+    return "\n".join(lines[:height])

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -491,12 +491,23 @@ def test_styled_detail_lines_render_once_per_row_and_width(monkeypatch) -> None:
 
     first = ee._styled_detail_lines(row, 80)
     second = ee._styled_detail_lines(row, 80)
-    assert first is second
+    assert first == second
     assert calls["n"] == 1
     # A different width renders again (but only once more).
     ee._styled_detail_lines(row, 60)
     ee._styled_detail_lines(row, 60)
     assert calls["n"] == 2
+
+    # The id-recycling guard: a NEW row whose id() may reuse the evicted key's
+    # must never be served the evicted row's lines.
+    other = build_event_rows(
+        SimpleNamespace(items=lambda: [("2", _FakeEvent("TUIUserInput", text="different text"))])
+    )[0]
+    evicted = ee._styled_detail_lines(row, 80)
+    assert "hello world" in "\n".join(evicted)
+    fresh = ee._styled_detail_lines(other, 80)
+    assert "different text" in "\n".join(fresh)
+    assert "hello world" not in "\n".join(fresh)
 
 
 def test_event_search_text_excludes_markdown_chrome() -> None:

--- a/packages/nooa-cli/tests/tui/test_event_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_event_explorer.py
@@ -472,6 +472,33 @@ def test_event_explorer_view_highlights_selected_occurrence_on_same_line() -> No
     assert "".join(lines).count(f"{highlight_style_code(current=True)}alpha\x1b[0m") == 1
 
 
+def test_styled_detail_lines_render_once_per_row_and_width(monkeypatch) -> None:
+    """Detail rendering is memoized: the 3x search chain reuses one render."""
+    from nooa_cli.tui import event_explorer as ee
+
+    row = build_event_rows(
+        SimpleNamespace(items=lambda: [("1", _FakeEvent("TUIUserInput", text="hello world"))])
+    )[0]
+
+    calls = {"n": 0}
+    original = ee._render_styled_detail_lines
+
+    def counting(row, width):
+        calls["n"] += 1
+        return original(row, width)
+
+    monkeypatch.setattr(ee, "_render_styled_detail_lines", counting)
+
+    first = ee._styled_detail_lines(row, 80)
+    second = ee._styled_detail_lines(row, 80)
+    assert first is second
+    assert calls["n"] == 1
+    # A different width renders again (but only once more).
+    ee._styled_detail_lines(row, 60)
+    ee._styled_detail_lines(row, 60)
+    assert calls["n"] == 2
+
+
 def test_event_search_text_excludes_markdown_chrome() -> None:
     """Timestamps and ids in the markdown header/footer must not match."""
     from nooa_cli.tui.event_explorer import _event_markdown, _searchable_markdown

--- a/packages/nooa-cli/tests/tui/test_memory_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_memory_explorer.py
@@ -142,7 +142,7 @@ def test_invalid_action_disarms_the_pending_confirm() -> None:
     assert calls["forgot"] == [ids["skill"]]
 
 
-def test_stale_arm_expires_instead_of_firing() -> None:
+def test_stale_arm_expires_instead_of_firing(monkeypatch) -> None:
     """An arm older than the gesture window re-arms, never fires.
 
     The docstring always promised a gesture window; without one, an f armed
@@ -152,19 +152,25 @@ def test_stale_arm_expires_instead_of_firing() -> None:
     view, calls = _view(agent, mgr)
     skill = next(r for r in view.model.rows if r.id == ids["skill"])
 
-    # Arm, then simulate the window elapsing.
+    # Arm, then shrink the window to zero: the stale arm does not fire,
+    # it re-arms fresh.
     assert view.handle_action("text:f", skill) == "handled"
-    assert view._pending_confirm is not None
-    _action, _row_id, armed_at = view._pending_confirm
-    view._pending_confirm = (_action, _row_id, armed_at - view._CONFIRM_WINDOW_SECONDS - 1)
-
-    # The stale arm does not fire: it re-arms fresh.
+    monkeypatch.setattr(view, "_CONFIRM_WINDOW_SECONDS", 0.0)
     assert view.handle_action("text:f", skill) == "handled"
     assert calls["forgot"] == []
 
-    # A prompt second press (fresh window) fires.
+    # A prompt second press (fresh window restored) fires.
+    monkeypatch.setattr(view, "_CONFIRM_WINDOW_SECONDS", 10.0)
     assert view.handle_action("text:f", skill) == "handled"
     assert calls["forgot"] == [ids["skill"]]
+
+    # The boundary is inclusive: an arm exactly at the window edge still
+    # confirms.
+    todo = next(r for r in view.model.rows if r.id == ids["todo"])
+    assert view.handle_action("text:d", todo) == "handled"
+    monkeypatch.setattr(view, "_CONFIRM_WINDOW_SECONDS", 10.0)
+    assert view.handle_action("text:d", todo) == "handled"
+    assert calls["done"] == [ids["todo"]]
 
 
 def test_armed_confirm_does_not_leak_across_rows() -> None:

--- a/packages/nooa-cli/tests/tui/test_memory_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_memory_explorer.py
@@ -146,21 +146,28 @@ def test_stale_arm_expires_instead_of_firing(monkeypatch) -> None:
     """An arm older than the gesture window re-arms, never fires.
 
     The docstring always promised a gesture window; without one, an f armed
-    minutes earlier still fired on the next f.
+    minutes earlier still fired on the next f. A controllable monotonic
+    clock drives the elapsed time deterministically — a zero-second window
+    would still confirm when both reads are equal, and immediate presses
+    cannot prove the inclusive boundary.
     """
+    import time as time_module
+
     agent, mgr, ids = _seeded_manager()
     view, calls = _view(agent, mgr)
     skill = next(r for r in view.model.rows if r.id == ids["skill"])
 
-    # Arm, then shrink the window to zero: the stale arm does not fire,
+    clock = {"now": 100.0}
+    monkeypatch.setattr(time_module, "monotonic", lambda: clock["now"])
+
+    # Arm, then advance past the window: the stale arm does not fire,
     # it re-arms fresh.
     assert view.handle_action("text:f", skill) == "handled"
-    monkeypatch.setattr(view, "_CONFIRM_WINDOW_SECONDS", 0.0)
+    clock["now"] += view._CONFIRM_WINDOW_SECONDS + 1
     assert view.handle_action("text:f", skill) == "handled"
     assert calls["forgot"] == []
 
-    # A prompt second press (fresh window restored) fires.
-    monkeypatch.setattr(view, "_CONFIRM_WINDOW_SECONDS", 10.0)
+    # A prompt second press within the fresh arm's window fires.
     assert view.handle_action("text:f", skill) == "handled"
     assert calls["forgot"] == [ids["skill"]]
 
@@ -168,7 +175,7 @@ def test_stale_arm_expires_instead_of_firing(monkeypatch) -> None:
     # confirms.
     todo = next(r for r in view.model.rows if r.id == ids["todo"])
     assert view.handle_action("text:d", todo) == "handled"
-    monkeypatch.setattr(view, "_CONFIRM_WINDOW_SECONDS", 10.0)
+    clock["now"] += view._CONFIRM_WINDOW_SECONDS
     assert view.handle_action("text:d", todo) == "handled"
     assert calls["done"] == [ids["todo"]]
 

--- a/packages/nooa-cli/tests/tui/test_memory_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_memory_explorer.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import pytest
 from nooa_cli.tui.memory_explorer import (
     MemoryExplorerView,
     build_memory_rows,
@@ -178,6 +179,44 @@ def test_stale_arm_expires_instead_of_firing(monkeypatch) -> None:
     clock["now"] += view._CONFIRM_WINDOW_SECONDS
     assert view.handle_action("text:d", todo) == "handled"
     assert calls["done"] == [ids["todo"]]
+
+
+@pytest.mark.asyncio
+async def test_expiring_arm_clears_itself_and_fires_the_repaint_hook(
+    monkeypatch,
+) -> None:
+    """The armed hint disappears without a keypress once the window lapses.
+
+    The arm schedules a deadline that clears _pending_confirm and runs the
+    browser's repaint hook — a stale footer would otherwise keep promising
+    a confirm that can no longer fire. The window is shrunk to a few frames
+    so the test can simply sleep past it on the real clock (the deadline and
+    the expiry check both use time.monotonic, so no clock patching is safe
+    here: freezing it would stall asyncio itself).
+    """
+    import asyncio
+
+    agent, mgr, ids = _seeded_manager()
+    view, calls = _view(agent, mgr)
+    skill = next(r for r in view.model.rows if r.id == ids["skill"])
+    monkeypatch.setattr(view, "_CONFIRM_WINDOW_SECONDS", 0.05)
+
+    fired = []
+
+    def repaint() -> None:
+        fired.append(True)
+
+    view.on_confirm_expired(repaint)
+    # Arm inside the running loop so the deadline timer schedules.
+    assert view.handle_action("text:f", skill) == "handled"
+    assert view.pending_confirmation_hint() != ""
+    # No keypress: the window lapses and the deadline must fire on its own.
+    await asyncio.sleep(0.3)
+
+    assert view._pending_confirm is None
+    assert view.pending_confirmation_hint() == ""
+    assert fired == [True]
+    assert calls["forgot"] == []
 
 
 def test_armed_confirm_does_not_leak_across_rows() -> None:

--- a/packages/nooa-cli/tests/tui/test_memory_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_memory_explorer.py
@@ -142,6 +142,31 @@ def test_invalid_action_disarms_the_pending_confirm() -> None:
     assert calls["forgot"] == [ids["skill"]]
 
 
+def test_stale_arm_expires_instead_of_firing() -> None:
+    """An arm older than the gesture window re-arms, never fires.
+
+    The docstring always promised a gesture window; without one, an f armed
+    minutes earlier still fired on the next f.
+    """
+    agent, mgr, ids = _seeded_manager()
+    view, calls = _view(agent, mgr)
+    skill = next(r for r in view.model.rows if r.id == ids["skill"])
+
+    # Arm, then simulate the window elapsing.
+    assert view.handle_action("text:f", skill) == "handled"
+    assert view._pending_confirm is not None
+    _action, _row_id, armed_at = view._pending_confirm
+    view._pending_confirm = (_action, _row_id, armed_at - view._CONFIRM_WINDOW_SECONDS - 1)
+
+    # The stale arm does not fire: it re-arms fresh.
+    assert view.handle_action("text:f", skill) == "handled"
+    assert calls["forgot"] == []
+
+    # A prompt second press (fresh window) fires.
+    assert view.handle_action("text:f", skill) == "handled"
+    assert calls["forgot"] == [ids["skill"]]
+
+
 def test_armed_confirm_does_not_leak_across_rows() -> None:
     """Arming on row A must never fire on row B.
 

--- a/packages/nooa-cli/tests/tui/test_session_resume_picker.py
+++ b/packages/nooa-cli/tests/tui/test_session_resume_picker.py
@@ -398,9 +398,16 @@ def test_preview_scroll_is_independent_and_selection_resets_to_tail() -> None:
     selected = picker.model.selected
     picker.move(1)
     assert picker.model.selected != selected
-    # The new row's preview resets to the tail, not the scrolled position.
+    # Preload and scroll the new row's transcript, then leave and return:
+    # the reset must act on the CACHED viewport, not just a fresh
+    # tail-positioned one (a first-time transcript trivially follows the tail).
     transcript2 = picker._preview_model(60)
     assert transcript2 is not None
+    picker.scroll_preview(-3)
+    assert transcript2.top_row(width=60, height=5) > 0
+    picker.move(-1)
+    picker.move(1)
+    # The cached row's preview resets to the tail.
     assert transcript2.viewport.follows_tail is True
 
 

--- a/packages/nooa-cli/tests/tui/test_session_resume_picker.py
+++ b/packages/nooa-cli/tests/tui/test_session_resume_picker.py
@@ -398,6 +398,10 @@ def test_preview_scroll_is_independent_and_selection_resets_to_tail() -> None:
     selected = picker.model.selected
     picker.move(1)
     assert picker.model.selected != selected
+    # The new row's preview resets to the tail, not the scrolled position.
+    transcript2 = picker._preview_model(60)
+    assert transcript2 is not None
+    assert transcript2.viewport.follows_tail is True
 
 
 def test_mouse_wheel_routes_to_list_and_preview_separately() -> None:

--- a/packages/nooa-cli/tests/tui/test_session_resume_picker.py
+++ b/packages/nooa-cli/tests/tui/test_session_resume_picker.py
@@ -12,11 +12,12 @@ from nooa_cli.tui.resume_picker import (
     _clip,
     _row_fragments,
     _semantic_preview_selection,
-    render_resume_picker,
 )
 from prompt_toolkit.data_structures import Point
 from prompt_toolkit.mouse_events import MouseButton, MouseEvent, MouseEventType
 from rich.cells import cell_len
+
+from .resume_picker_snapshot import render_resume_picker
 
 
 def test_semantic_preview_selection_removes_user_and_agent_chrome() -> None:
@@ -370,16 +371,22 @@ def test_active_rail_marks_only_current_area() -> None:
 
 
 def test_preview_scroll_is_independent_and_selection_resets_to_tail() -> None:
+    """Preview scrolling lives on the transcript; moving rows resets it to the tail."""
+    app = MagicMock()
+    app.output.get_size.return_value = SimpleNamespace(columns=80, rows=24)
     turns = tuple(ResumePickerTurn("user", f"message {index}") for index in range(12))
-    model = ResumePickerModel([row("1", "one", turns=turns), row("2", "two", turns=turns)])
-    model.scroll_preview(-3, line_count=30, height=5)
-    assert model.preview_offset == 22
-    selected = model.selected
-    model.list_offset = 0
-    model.move(1)
-    assert model.selected != selected
-    assert model.preview_offset == 10**9
-    assert model.list_offset == 0
+    picker = ResumePicker([row("1", "one", turns=turns), row("2", "two", turns=turns)], app)
+    picker.preview_control.viewport = (60, 5)
+
+    transcript = picker._preview_model(60)
+    assert transcript is not None
+    picker.scroll_preview(-3)
+    top = transcript.top_row(width=60, height=5)
+    assert top > 0
+
+    selected = picker.model.selected
+    picker.move(1)
+    assert picker.model.selected != selected
 
 
 def test_mouse_wheel_routes_to_list_and_preview_separately() -> None:

--- a/packages/nooa-cli/tests/tui/test_session_resume_picker.py
+++ b/packages/nooa-cli/tests/tui/test_session_resume_picker.py
@@ -136,7 +136,7 @@ def test_filter_and_sort_reuse_cached_query_matches(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_resume_list_fills_its_pane_on_tall_terminals() -> None:
+async def test_resume_list_fills_its_pane_on_tall_terminals(monkeypatch) -> None:
     """The session list grows with the terminal instead of capping at 5."""
     from nooa_cli.tui import session_manager as sm
 
@@ -153,10 +153,21 @@ async def test_resume_list_fills_its_pane_on_tall_terminals() -> None:
         )
         for i in range(12)
     ]
-    sm.SessionManager.list_sessions = classmethod(lambda cls, limit=None: sessions)
-    sm.SessionManager.is_active = classmethod(lambda cls, value: False)
-    sm.SessionManager.load_turns = classmethod(
-        lambda cls, value, limit=12: [SimpleNamespace(role="agent", content="x")]
+    # Patch through monkeypatch: bare classmethod assignments leaked the
+    # fake sessions into every later test (the memory-sidecars test then
+    # saw s00000001... sessions that were never cleaned up).
+    monkeypatch.setattr(
+        sm.SessionManager, "list_sessions", classmethod(lambda cls, limit=None: sessions)
+    )
+    monkeypatch.setattr(
+        sm.SessionManager, "is_active", classmethod(lambda cls, value: False)
+    )
+    monkeypatch.setattr(
+        sm.SessionManager,
+        "load_turns",
+        classmethod(
+            lambda cls, value, limit=12: [SimpleNamespace(role="agent", content="x")]
+        ),
     )
 
     from .tui_app_harness import MutableRecordingOutput, TUIHarness

--- a/packages/nooa-cli/tests/tui/test_startup_latency.py
+++ b/packages/nooa-cli/tests/tui/test_startup_latency.py
@@ -490,6 +490,83 @@ async def test_model_switch_owns_deferred_prompts_before_old_probe_finishes(monk
     app.reject_deferred_messages.assert_not_called()
 
 
+async def test_cancelled_model_probe_still_resolves_deferred_prompt_ownership(monkeypatch):
+    """A cancelled /model probe must not strand deferred startup prompts.
+
+    Cancellation is a BaseException in Python 3.13; the old ``except
+    Exception`` let a cancelled probe skip _mark_model_check_failed after
+    _begin_model_validation had taken prompt ownership, so deferred prompts
+    waited forever.
+    """
+    import asyncio
+
+    from nooa_cli.tui.commands import ModelCommand
+    from nooa_cli.tui.health_check import HealthCheckResult
+    from nooa_cli.tui.session import Session
+
+    old_llm = SimpleNamespace(model="old/model")
+    candidate = SimpleNamespace(model="new/model")
+    agent = SimpleNamespace(
+        llm=old_llm,
+        set_llm=lambda llm: setattr(agent, "llm", llm),
+    )
+    registry = SimpleNamespace(
+        blocking_llm_health=HealthCheckResult(
+            ok=False,
+            error_message="Checking old model.",
+            blocking=True,
+            pending=True,
+        ),
+        llm_health_generation=0,
+        startup_info=SimpleNamespace(llm_ready=False, llm_status="checking"),
+    )
+    app = SimpleNamespace(
+        invalidate=Mock(),
+        set_llm_probe_status=Mock(),
+        release_deferred_messages=Mock(),
+        reject_deferred_messages=Mock(),
+        refresh_transcript_blocks=Mock(return_value=True),
+    )
+    session = Session.__new__(Session)
+    session.agent = agent
+    session.registry = registry
+    session.frontend = SimpleNamespace(render=AsyncMock())
+    session._app = app
+    session._background_tasks = set()
+
+    probe_gate = asyncio.Event()
+
+    async def hanging_probe(llm):
+        await probe_gate.wait()
+        return HealthCheckResult(ok=True)
+
+    monkeypatch.setattr("nooa_cli.tui.health_check.probe_llm", hanging_probe)
+    monkeypatch.setattr("nooa_cli.tui.config.get_llm_for_model", lambda _model: candidate)
+    monkeypatch.setattr("nooa.interactive.apply_model_limits", lambda _agent: None)
+
+    command = ModelCommand(
+        AsyncMock(),
+        SimpleNamespace(default_model="old/model"),
+        agent,
+        registry=registry,
+    )
+    command.frontend._app = app
+    command._persist_tui_setting = lambda _key, _value: Path("settings.yaml")
+    command._agent_run_async = lambda fn: asyncio.sleep(0, result=fn())
+
+    switch_task = asyncio.create_task(command.execute(["new/model"]))
+    await asyncio.sleep(0)
+    assert registry.llm_health_generation == 1  # ownership transferred
+
+    switch_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await switch_task
+
+    # Ownership resolved: deferred prompts were rejected, never stranded.
+    app.reject_deferred_messages.assert_called_once()
+    app.release_deferred_messages.assert_not_called()
+
+
 async def asyncio_wait_for_background_tasks(session) -> None:
     import asyncio
 

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -2850,10 +2850,13 @@ async def test_cancel_status_is_immediate_and_stays_until_agent_cleanup_ack() ->
         await h.wait_for(lambda: h.app.is_thinking())
         await asyncio.wait_for(step_started.wait(), timeout=1.0)
         assert h.app.request_agent_cancel(source="escape") is True
-        # Acknowledge the accepted key press synchronously, before the agent
-        # loop has even entered cancellation cleanup.
+        # Acknowledge the accepted key press synchronously: the status is
+        # set by the cancel request itself, not by the agent loop unwinding.
+        # (The old sibling assertion — cleanup not yet started at this
+        # point — was a load race: cancellation can legitimately begin
+        # before the test's next line runs. The contract is the synchronous
+        # status acknowledgement, not the scheduler's interleaving.)
         assert h.capture_status() == "· Interrupting agent turn"
-        assert cleanup_started.is_set() is False
         await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
         await h.wait_for(lambda: h.capture_status() == "• Interrupting agent turn")
         assert h.app.is_thinking() is True


### PR DESCRIPTION
# TUI fullscreen follow-ups

Follow-up backlog from the review rounds of the merged select-copy stack (#244, #245). Seven commits, each independently verified; full TUI suite **1428 passed** (previously flaky suite runs are now clean at the root).

## Performance
- **Event detail rendering memoized** (`_styled_detail_lines`): the search chain walked the same markdown up to six times per keystroke (match lines, occurrences, highlighted output, measurement, paint). One Rich render per `(row, width)`, with the row retained in the cache entry so a recycled `id` can never alias stale lines.

## Correctness
- **`/model` probe cancellation gap**: `except Exception` cannot catch `CancelledError` (a `BaseException` in Python 3.13). A cancelled probe after `_begin_model_validation` stranded deferred startup prompts forever. Ownership now resolves on cancellation before re-raising. Regression cancels a gated probe and asserts `reject_deferred_messages` fires.
- **Memory arm/confirm gesture window**: the docstring promised a window that never existed — an armed `f` from minutes earlier still fired. Arms now carry a timestamp and expire after 10s; a stale arm re-arms instead of firing.

## Code sharing
- **Test-only snapshot renderer retired**: `render_resume_picker`/`_preview_lines`/`_wrap` had no production callers (the picker renders through the shared browser). They moved into the test package as a deterministic fixture, and the superseded `ResumePickerModel.scroll_preview`/`preview_offset` scroll state went with them (−116 production lines).
- **Shared browser construction template-methoded**: `ExplorerBrowser.__init__` gained `_create_list_control`/`_option_window_width` factory hooks and shared search chrome; `ResumePicker.__init__` collapsed to its model, its view facade, and `super().__init__` (−42 net lines, ~85 duplicated construction lines gone). The duplicate `invalidate()` deleted — the base one covers every control.

## Test-suite stability (both flaky tests fixed at the root)
- **Cancel-status race**: the test asserted cleanup had not started between the cancel and the next line — a scheduler interleaving that only holds on an idle machine. The mid-flight ordering assertion is gone; the synchronous-acknowledgement contract assertions remain.
- **Fake-session leak**: `test_resume_list_fills_its_pane` assigned `SessionManager` classmethods with bare `classmethod` objects — no monkeypatch, no teardown — leaking 12 fabricated sessions (`s00000001…`) into every later test (why the memory-sidecars test failed intermittently in full-suite runs). Now patched through monkeypatch.

## Verification
- Full TUI suite: **1428 passed**, zero flakes across repeated runs
- Ruff clean
- Every commit replayed to GitHub via the Git Data API with trees verified identical to local


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cancelling model validation now correctly resolves pending prompts.
  - Expired confirmations no longer display misleading hints and require a fresh confirmation.
  - Resume-picker preview scrolling, filtering, sorting, and selection are more reliable.
  - Event details load more efficiently when revisiting content.
  - Search and close controls now update correctly when displayed options change.

- **Tests**
  - Added coverage for confirmation expiry, cancellation handling, event rendering and caching, and resume-picker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->