### PR TITLE
fix(release): discover draft releases reliably

### DIFF
--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -220,11 +220,26 @@ def release_for_tag(tag: str) -> dict[str, Any] | None:
         die(f"could not inspect GitHub release {tag}: {detail}")
     try:
         metadata = json.loads(proc.stdout)
+        database_id = metadata["databaseId"]
+        draft = metadata["isDraft"]
+        target = metadata["targetCommitish"]
+        url = metadata["url"]
+        if (
+            not isinstance(database_id, int)
+            or isinstance(database_id, bool)
+            or database_id <= 0
+            or not isinstance(draft, bool)
+            or not isinstance(target, str)
+            or not target
+            or not isinstance(url, str)
+            or not url
+        ):
+            raise TypeError
         return {
-            "id": metadata["databaseId"],
-            "draft": metadata["isDraft"],
-            "target_commitish": metadata["targetCommitish"],
-            "html_url": metadata["url"],
+            "id": database_id,
+            "draft": draft,
+            "target_commitish": target,
+            "html_url": url,
         }
     except (json.JSONDecodeError, KeyError, TypeError):
         die(f"GitHub returned invalid release metadata for {tag}")

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -199,21 +199,35 @@ def validate_https_url(value: str, label: str) -> str:
 
 
 def release_for_tag(tag: str) -> dict[str, Any] | None:
-    """Return GitHub release metadata, including drafts, or None for 404."""
+    """Return draft-aware GitHub release metadata, or None when absent."""
     proc = run(
-        ["gh", "api", f"repos/{GITHUB_REPO}/releases/tags/{tag}"],
+        [
+            "gh",
+            "release",
+            "view",
+            tag,
+            "--repo",
+            GITHUB_REPO,
+            "--json",
+            "databaseId,isDraft,targetCommitish,url",
+        ],
         check=False,
     )
-    if proc.returncode == 0:
-        try:
-            return json.loads(proc.stdout)
-        except json.JSONDecodeError:
-            die(f"GitHub returned invalid release metadata for {tag}")
-    # gh uses exit 1 for HTTP 404. Do not turn authentication/server failures
-    # into "unused tag": its stderr contains the HTTP status, never a token.
-    if "404" in proc.stderr or "release not found" in proc.stderr.lower():
-        return None
-    die(f"could not inspect GitHub release {tag}: {proc.stderr.strip()}")
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout).strip()
+        if "release not found" in detail.lower():
+            return None
+        die(f"could not inspect GitHub release {tag}: {detail}")
+    try:
+        metadata = json.loads(proc.stdout)
+        return {
+            "id": metadata["databaseId"],
+            "draft": metadata["isDraft"],
+            "target_commitish": metadata["targetCommitish"],
+            "html_url": metadata["url"],
+        }
+    except (json.JSONDecodeError, KeyError, TypeError):
+        die(f"GitHub returned invalid release metadata for {tag}")
 
 
 def validate_existing_release(tag: str, sha: str) -> dict[str, Any] | None:

--- a/tests/test_make_release.py
+++ b/tests/test_make_release.py
@@ -412,6 +412,69 @@ def test_existing_release_must_be_matching_unpublished_draft(mr, monkeypatch):
         mr.validate_existing_release("v1.2.3", sha)
 
 
+def test_release_lookup_uses_draft_aware_gh_command(mr, monkeypatch):
+    metadata = {
+        "databaseId": 7,
+        "isDraft": True,
+        "targetCommitish": "a" * 40,
+        "url": "https://draft",
+    }
+    commands = []
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, json.dumps(metadata), "")
+
+    monkeypatch.setattr(mr, "run", fake_run)
+
+    assert mr.release_for_tag("v1.2.3") == {
+        "id": 7,
+        "draft": True,
+        "target_commitish": "a" * 40,
+        "html_url": "https://draft",
+    }
+    assert commands == [
+        [
+            "gh",
+            "release",
+            "view",
+            "v1.2.3",
+            "--repo",
+            mr.GITHUB_REPO,
+            "--json",
+            "databaseId,isDraft,targetCommitish,url",
+        ]
+    ]
+
+
+def test_release_lookup_returns_none_when_cli_reports_not_found(mr, monkeypatch):
+    monkeypatch.setattr(
+        mr,
+        "run",
+        lambda cmd, **_kwargs: subprocess.CompletedProcess(cmd, 1, "", "release not found"),
+    )
+
+    assert mr.release_for_tag("v1.2.3") is None
+
+
+def test_release_lookup_fails_closed_on_api_error_or_invalid_metadata(mr, monkeypatch):
+    monkeypatch.setattr(
+        mr,
+        "run",
+        lambda cmd, **_kwargs: subprocess.CompletedProcess(cmd, 1, "", "HTTP 403"),
+    )
+    with pytest.raises(mr.ReleaseError, match="HTTP 403"):
+        mr.release_for_tag("v1.2.3")
+
+    monkeypatch.setattr(
+        mr,
+        "run",
+        lambda cmd, **_kwargs: subprocess.CompletedProcess(cmd, 0, "not-json", ""),
+    )
+    with pytest.raises(mr.ReleaseError, match="invalid release metadata"):
+        mr.release_for_tag("v1.2.3")
+
+
 def test_strict_fast_checks_sync_all_public_ci_dependencies_first(mr, monkeypatch):
     commands = []
 

--- a/tests/test_make_release.py
+++ b/tests/test_make_release.py
@@ -475,6 +475,23 @@ def test_release_lookup_fails_closed_on_api_error_or_invalid_metadata(mr, monkey
         mr.release_for_tag("v1.2.3")
 
 
+def test_release_lookup_rejects_string_draft_state(mr, monkeypatch):
+    metadata = {
+        "databaseId": 7,
+        "isDraft": "false",
+        "targetCommitish": "a" * 40,
+        "url": "https://release",
+    }
+    monkeypatch.setattr(
+        mr,
+        "run",
+        lambda cmd, **_kwargs: subprocess.CompletedProcess(cmd, 0, json.dumps(metadata), ""),
+    )
+
+    with pytest.raises(mr.ReleaseError, match="invalid release metadata"):
+        mr.release_for_tag("v1.2.3")
+
+
 def test_strict_fast_checks_sync_all_public_ci_dependencies_first(mr, monkeypatch):
     commands = []
 


### PR DESCRIPTION
## Summary

- discover draft releases with `gh release view --json`
- retain exact-candidate and unpublished-release safeguards
- add regression coverage for the failed `v0.0.10` draft workflow

## Test

`pytest tests/test_make_release.py -q` (50 passed)

Signed-off-by: Severin Klingler <sklingler@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release lookups now accurately recognize draft releases and map their metadata.
  * Missing releases are reported distinctly from other lookup failures.
  * Invalid, incomplete, or malformed release information—including incorrectly typed draft status—is rejected with clear validation errors.
  * API, command, and invalid-response failures continue to block releases with explicit error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->