### PR TITLE
feat(strategy): accept registry aliases in @strategy(llm=...)

### DIFF
--- a/docs/concepts/strategies.md
+++ b/docs/concepts/strategies.md
@@ -67,6 +67,10 @@ class ResearchAgent(Agent, llm=fast_llm):
         ...
 ```
 
+The `llm=` override also accepts a registry alias or model string
+(``@strategy(PredictStrategy(), llm="gpt-5-mini")``) — resolved lazily on the
+first call per instance, so declaring it constructs no client at import time.
+
 LLM overrides may also be supplied per instance or per call. Keep model routing
 out of the public method contract unless the application truly needs callers to
 choose it.

--- a/skills/nooa-agent-authoring/SKILL.md
+++ b/skills/nooa-agent-authoring/SKILL.md
@@ -70,7 +70,7 @@ at import time) — the natural way to pin a method to a cheaper or stronger
 model:
 
 ```python
-class SupportAgent(Agent, llm="gpt-5"):
+class SupportAgent(Agent, llm=default):       # agent default takes a client
     @strategy(llm="gpt-5-mini")                 # alias or model string
     async def summarize(self, text: str) -> str: ...
 ```

--- a/skills/nooa-agent-authoring/SKILL.md
+++ b/skills/nooa-agent-authoring/SKILL.md
@@ -64,9 +64,20 @@ Keys come from `.env` (library use) or `~/.config/nooa/secrets.yaml`.
 4. `class MyAgent(Agent, llm=default)` — class default
 5. **Parent inheritance** — a subagent with no `llm=` of its own inherits from the agent that calls it
 
-The method override also accepts a **callable** taking the agent and returning
-a client, resolved on each call. Use it when the per-method model has to be
-chosen per instance (or per call) rather than fixed at import time:
+The method override accepts three spellings. A **registry alias or model
+string** resolves lazily on the first call per instance (no client constructed
+at import time) — the natural way to pin a method to a cheaper or stronger
+model:
+
+```python
+class SupportAgent(Agent, llm="gpt-5"):
+    @strategy(llm="gpt-5-mini")                 # alias or model string
+    async def summarize(self, text: str) -> str: ...
+```
+
+A **callable** taking the agent and returning a client is resolved on each
+call. Use it when the per-method model has to be chosen per instance (or per
+call) rather than fixed at import time:
 
 ```python
 class Researcher(Agent, llm=fast):
@@ -81,8 +92,8 @@ class Researcher(Agent, llm=fast):
     async def solve(self, problem: str) -> str: ...   # differs per call
 ```
 
-Standalone `@strategy` functions must pass a client, not a callable — they
-have no instance to resolve against.
+Standalone `@strategy` functions may pass a client or an alias string, but
+not a callable — they have no instance to resolve against.
 
 Child agents inherit the parent's LLM by default. Any explicit `llm=` on the child overrides it — that's how you run a cheap model for one phase:
 

--- a/src/nooa/agent.py
+++ b/src/nooa/agent.py
@@ -118,6 +118,10 @@ class Agent(metaclass=AgentMeta):
     _enable_tracing: Annotated[bool, hidden]
     _execution_config: Annotated["ExecutionConfig", hidden]
     _agent_llm: Annotated["UnifiedLLM | _InheritSentinel", hidden]
+    # Per-instance cache of clients resolved from @strategy(llm="alias") strings.
+    # Populated lazily by nooa.method_llm._resolve_alias, hidden so snapshots
+    # and the LLM never see client objects through it.
+    _strategy_llm_alias_cache: Annotated["dict[str, UnifiedLLM]", hidden, nosnapshot]
     _agent_truncation: Annotated["TruncationConfig", hidden]
     _agent_context_blocks: Annotated["dict[str, str | DynamicContext | None]", hidden]
     _agent_event_query: Annotated["EventQuery | None", hidden]

--- a/src/nooa/decorators.py
+++ b/src/nooa/decorators.py
@@ -26,7 +26,7 @@ def strategy(
     strategy_instance: "GenerationStrategyABC | None" = None,
     context: "ScopedContext | dict[str, Any] | None" = None,
     *,
-    llm: "UnifiedLLM | Callable[[Any], UnifiedLLM] | None" = None,
+    llm: "UnifiedLLM | str | Callable[[Any], UnifiedLLM] | None" = None,
     truncation: "TruncationConfig | None" = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Strategy decorator for agent methods.
@@ -41,12 +41,16 @@ def strategy(
             - A plain dict ``{key: str | Context | DynamicContext | None}`` for context-only overrides.
             - A ``ScopedContext`` instance when you also need event filtering.
             Applied in _prepare_context() between strategy overrides and scoped blocks.
-        llm: Optional LLM override for this method. Either a ``UnifiedLLM``
-            instance (fixed at import time, shared by every instance of the
-            class) or a callable taking the agent instance and returning one
-            (resolved on each generation call, so it can vary per instance or
-            per call). Standalone functions must pass a ``UnifiedLLM`` — they
-            have no instance for a callable to bind against.
+        llm: Optional LLM override for this method. One of:
+            - a ``UnifiedLLM`` instance (fixed at import time, shared by every
+              instance of the class)
+            - a registry alias or litellm model string (resolved lazily on the
+              first call per agent instance, then cached on it, so no client
+              is constructed at import time)
+            - a callable taking the agent instance and returning one (resolved
+              on each generation call, so it can vary per instance or per call)
+            Standalone functions may pass a client or an alias string, but not
+            a callable — they have no instance for one to bind against.
         truncation: Optional TruncationConfig override for this method. Fields set
             here take precedence over the agent-level truncation config. Unset fields
             inherit from the agent-level config.

--- a/src/nooa/method_llm.py
+++ b/src/nooa/method_llm.py
@@ -10,7 +10,7 @@ spellings avoid that:
   generation call for each agent instance through
   :func:`nooa.unifiedllm.get_llm_client` and cached on the instance::
 
-    class SupportAgent(Agent, llm="gpt-5"):
+    class SupportAgent(Agent, llm=default_client):
         @strategy(llm="gpt-5-mini")
         async def summarize(self, text: str) -> str: ...
 
@@ -100,6 +100,10 @@ def resolve_alias(
     One resolution path means one error message, one cache policy, and one
     place to change if client construction ever grows validation.
 
+    A resolved alias is cached for the life of the cache owner, so a later
+    ``reload_registry()`` does not invalidate clients already resolved — an
+    alias pins a specific model at first use, like a client passed directly.
+
     Args:
         alias: Registry key or litellm-supported model string.
         cache: Caller-owned ``{alias: client}`` dict, or ``None`` to resolve
@@ -142,7 +146,7 @@ def resolve_alias(
     return client
 
 
-def _resolve_alias(alias: str, agent: Any, method_name: str) -> UnifiedLLM:
+def _resolve_alias(alias: str, agent: Any, method_name: str, *, origin: str) -> UnifiedLLM:
     """Resolve a registry alias / litellm model string against *agent*.
 
     The client is constructed once per (agent instance, alias) pair and
@@ -153,22 +157,21 @@ def _resolve_alias(alias: str, agent: Any, method_name: str) -> UnifiedLLM:
         alias: Registry key or litellm-supported model string.
         agent: The agent instance to cache the client on.
         method_name: Method name, for error messages.
+        origin: Human-readable source of the alias, for error messages.
 
     Returns:
         The resolved :class:`~nooa.unifiedllm.UnifiedLLM`.
     """
     cache = getattr(agent, _INSTANCE_LLM_CACHE_ATTR, None)
-    if isinstance(cache, dict):
-        return resolve_alias(alias, cache, method_name)
-
-    # Fresh instance, or a duck-typed stub that refuses new attributes
-    # (e.g. __slots__). Resolve without caching rather than failing the call.
-    try:
-        cache = {}
-        setattr(agent, _INSTANCE_LLM_CACHE_ATTR, cache)
-    except (AttributeError, TypeError):
-        return resolve_alias(alias, None, method_name)
-    return resolve_alias(alias, cache, method_name)
+    if not isinstance(cache, dict):
+        # Fresh instance, or a duck-typed stub that refuses new attributes
+        # (e.g. __slots__). Resolve without caching rather than failing the call.
+        try:
+            cache = {}
+            setattr(agent, _INSTANCE_LLM_CACHE_ATTR, cache)
+        except (AttributeError, TypeError):
+            cache = None
+    return resolve_alias(alias, cache, method_name, origin=origin)
 
 
 def validate_method_llm_spec(spec: Any, func_name: str, *, standalone: bool = False) -> None:
@@ -178,8 +181,8 @@ def validate_method_llm_spec(spec: Any, func_name: str, *, standalone: bool = Fa
     middle of a generation call:
 
     - a value that is not a client, alias string, or callable (e.g. an int
-      or a list)
-    - an empty or non-string passed where an alias was meant
+      or a list — non-strings fall to this generic case)
+    - an empty string, which cannot name a model
     - a callable on a standalone function, which has no instance to bind to
 
     Args:
@@ -221,8 +224,10 @@ def validate_method_llm_spec(spec: Any, func_name: str, *, standalone: bool = Fa
     )
 
 
-def resolve_method_llm(spec: Any, agent: Any, method_name: str) -> UnifiedLLM:
-    """Resolve a ``@strategy(llm=...)`` value against an agent instance.
+def resolve_method_llm(
+    spec: Any, agent: Any, method_name: str, *, origin: str = "@strategy(llm=...)"
+) -> UnifiedLLM:
+    """Resolve an ``llm=`` value against an agent instance.
 
     Args:
         spec: A ``UnifiedLLM``, a registry alias / litellm model string
@@ -230,13 +235,17 @@ def resolve_method_llm(spec: Any, agent: Any, method_name: str) -> UnifiedLLM:
             taking the agent instance.
         agent: The agent the method is executing on.
         method_name: Method name, for error messages.
+        origin: Human-readable source of *spec*, for error messages — the
+            ``@strategy`` decorator or a call-site ``llm=`` kwarg, so a
+            failure points at the line that supplied the value.
 
     Returns:
         The resolved ``UnifiedLLM``.
 
     Raises:
-        TypeError: If *spec* is not a client, string, or callable, or if a
-            callable returns something that is not a ``UnifiedLLM``.
+        TypeError: If *spec* is not a client, string, or callable, an empty
+            string, or if a callable returns something that is not a
+            ``UnifiedLLM``.
         RuntimeError: If a string alias cannot be resolved by
             ``get_llm_client``, or if the callable itself raises. The original
             exception is chained, but the message names the method and makes
@@ -248,11 +257,18 @@ def resolve_method_llm(spec: Any, agent: Any, method_name: str) -> UnifiedLLM:
         return cast("UnifiedLLM", spec)
 
     if isinstance(spec, str):
-        return _resolve_alias(spec, agent, method_name)
+        # Decoration time rejects empty strings, but call-site values bypass
+        # validation — catch them here too, with the same targeted message.
+        if not spec:
+            raise TypeError(
+                f"{origin} for '{method_name}' got an empty string. Pass a registry "
+                f"alias or litellm model string, or a client / callable."
+            )
+        return _resolve_alias(spec, agent, method_name, origin=origin)
 
     if not callable(spec):
         raise TypeError(
-            f"@strategy(llm=...) for '{method_name}' must be a UnifiedLLM instance, a "
+            f"{origin} for '{method_name}' must be a UnifiedLLM instance, a "
             f"registry alias / model string, or a callable returning one, got "
             f"{type(spec).__name__}."
         )
@@ -261,13 +277,12 @@ def resolve_method_llm(spec: Any, agent: Any, method_name: str) -> UnifiedLLM:
         resolved = spec(agent)
     except Exception as exc:
         raise RuntimeError(
-            f"The @strategy(llm=...) callable for '{method_name}' raised "
-            f"{type(exc).__name__}: {exc}"
+            f"The {origin} callable for '{method_name}' raised {type(exc).__name__}: {exc}"
         ) from exc
 
     if not _is_llm_client(resolved):
         raise TypeError(
-            f"The @strategy(llm=...) callable for '{method_name}' must return a "
+            f"The {origin} callable for '{method_name}' must return a "
             f"UnifiedLLM instance, got {type(resolved).__name__}."
         )
 

--- a/src/nooa/method_llm.py
+++ b/src/nooa/method_llm.py
@@ -3,9 +3,26 @@
 """Late-bound per-method LLM overrides for ``@strategy(llm=...)``.
 
 ``@strategy(llm=my_client)`` pins a method to a concrete client at import
-time, so every instance of the class shares it forever. Passing a
-**callable** instead defers the choice to generation time, where the agent
-instance is in hand::
+time, so every instance of the class shares it forever. Two later-bound
+spellings avoid that:
+
+* a **registry alias / litellm model string**, resolved lazily on the first
+  generation call for each agent instance through
+  :func:`nooa.unifiedllm.get_llm_client` and cached on the instance::
+
+    class SupportAgent(Agent, llm="gpt-5"):
+        @strategy(llm="gpt-5-mini")
+        async def summarize(self, text: str) -> str: ...
+
+  Strings need no client object at import time — a module that only
+  *declares* models doesn't construct any LLM I/O machinery until the
+  method is actually called, matching the framework's lazy-I/O pattern.
+  The resolved client is cached per agent instance, so repeated calls
+  share one client rather than constructing a new one per call.
+
+* a **callable** taking the agent instance, invoked on every generation
+  call for that method — so return an existing client, don't construct
+  one::
 
     class Researcher(Agent, llm=fast):
         @strategy(llm=lambda self: self.big_model)
@@ -14,13 +31,9 @@ instance is in hand::
         @strategy(llm=lambda self: self.big if self.retries > 2 else self.fast)
         async def solve(self, problem: str) -> str: ...
 
-The callable receives the agent instance and must return a
-:class:`~nooa.unifiedllm.UnifiedLLM`. It is invoked on **every** generation
-call for that method — so return an existing client, don't construct one.
-Re-resolving per call is what makes the second example above work.
-
 Standalone ``@strategy`` functions (no ``self`` parameter) have no instance
-to bind against, so they reject callables at decoration time — see
+to bind against, so they reject callables at decoration time — but strings
+are fine, since a string resolves without an instance. See
 :func:`validate_method_llm_spec`.
 """
 
@@ -30,6 +43,11 @@ from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from nooa.unifiedllm import UnifiedLLM
+
+# Attribute on an agent instance holding its resolved string-alias clients:
+# {alias: UnifiedLLM}. Keyed on the instance (not the method) so a class
+# with several methods sharing an alias constructs one client.
+_INSTANCE_LLM_CACHE_ATTR = "_strategy_llm_alias_cache"
 
 
 def _is_llm_client(spec: Any) -> bool:
@@ -66,14 +84,71 @@ def _is_llm_client(spec: Any) -> bool:
     return hasattr(spec, "acall")
 
 
+def _resolve_alias(alias: str, agent: Any, method_name: str) -> UnifiedLLM:
+    """Resolve a registry alias / litellm model string against *agent*.
+
+    The client is constructed once per (agent instance, alias) pair and
+    cached on the instance, so a second call reuses the client (and its
+    token budgeting bookkeeping) rather than rebuilding it.
+
+    Args:
+        alias: Registry key or litellm-supported model string.
+        agent: The agent instance to cache the client on.
+        method_name: Method name, for error messages.
+
+    Returns:
+        The resolved :class:`~nooa.unifiedllm.UnifiedLLM`.
+
+    Raises:
+        RuntimeError: If ``get_llm_client`` raises. The original exception
+            is chained, but the message names the method and the alias so a
+            typo'd model name points at the ``@strategy`` line that named it.
+    """
+    cacheable = True
+    cache = getattr(agent, _INSTANCE_LLM_CACHE_ATTR, None)
+    if not isinstance(cache, dict):
+        # Fresh instance, or a duck-typed stub that refuses new attributes
+        # (e.g. __slots__). Resolve without caching rather than failing the call.
+        cache = {}
+        try:
+            setattr(agent, _INSTANCE_LLM_CACHE_ATTR, cache)
+        except (AttributeError, TypeError):
+            cacheable = False
+
+    cached = cache.get(alias)
+    if cached is not None:
+        return cast("UnifiedLLM", cached)
+
+    from nooa.unifiedllm import get_llm_client
+
+    try:
+        client = get_llm_client(alias)
+    except Exception as exc:
+        raise RuntimeError(
+            f"The @strategy(llm={alias!r}) alias for '{method_name}' could not be "
+            f"resolved by get_llm_client: {type(exc).__name__}: {exc}"
+        ) from exc
+
+    if not _is_llm_client(client):
+        raise TypeError(
+            f"The @strategy(llm={alias!r}) alias for '{method_name}' resolved to "
+            f"{type(client).__name__}, not a UnifiedLLM instance."
+        )
+
+    if cacheable:
+        cache[alias] = client
+    return client
+
+
 def validate_method_llm_spec(spec: Any, func_name: str, *, standalone: bool = False) -> None:
     """Validate an ``@strategy(llm=...)`` value at decoration time.
 
-    Catches the two mistakes that would otherwise surface much later, in
-    the middle of a generation call:
+    Catches the mistakes that would otherwise surface much later, in the
+    middle of a generation call:
 
-    - a value that is neither a ``UnifiedLLM`` nor callable (e.g. a model
-      name string — there is no alias registry; pass a client or a callable)
+    - a value that is not a client, alias string, or callable (e.g. an int
+      or a list)
+    - an empty or non-string passed where an alias was meant
     - a callable on a standalone function, which has no instance to bind to
 
     Args:
@@ -88,20 +163,30 @@ def validate_method_llm_spec(spec: Any, func_name: str, *, standalone: bool = Fa
     if _is_llm_client(spec):
         return
 
+    if isinstance(spec, str):
+        if not spec:
+            raise TypeError(
+                f"@strategy(llm=...) on '{func_name}' got an empty string. Pass a "
+                f"registry alias or litellm model string, or a client / callable."
+            )
+        return
+
     if callable(spec):
         if standalone:
             raise TypeError(
                 f"@strategy(llm=...) on standalone function '{func_name}' must be a "
-                f"UnifiedLLM instance, not a callable. Callables resolve against an "
-                f"agent instance, and standalone functions have none. Pass a client "
-                f"directly, or make '{func_name}' a method on an Agent subclass."
+                f"UnifiedLLM instance or an alias string, not a callable. Callables "
+                f"resolve against an agent instance, and standalone functions have "
+                f"none. Pass a client or a string alias, or make '{func_name}' a "
+                f"method on an Agent subclass."
             )
         return
 
     raise TypeError(
-        f"@strategy(llm=...) on '{func_name}' must be a UnifiedLLM instance or a "
-        f"callable taking the agent and returning one, got {type(spec).__name__}. "
-        f"For a per-instance model, use llm=lambda self: self.my_client."
+        f"@strategy(llm=...) on '{func_name}' must be a UnifiedLLM instance, a "
+        f"registry alias / model string, or a callable taking the agent and "
+        f"returning one, got {type(spec).__name__}. For a per-instance model, use "
+        f"llm=lambda self: self.my_client."
     )
 
 
@@ -109,7 +194,9 @@ def resolve_method_llm(spec: Any, agent: Any, method_name: str) -> UnifiedLLM:
     """Resolve a ``@strategy(llm=...)`` value against an agent instance.
 
     Args:
-        spec: A ``UnifiedLLM``, or a callable taking the agent instance.
+        spec: A ``UnifiedLLM``, a registry alias / litellm model string
+            (resolved lazily and cached per agent instance), or a callable
+            taking the agent instance.
         agent: The agent the method is executing on.
         method_name: Method name, for error messages.
 
@@ -117,21 +204,26 @@ def resolve_method_llm(spec: Any, agent: Any, method_name: str) -> UnifiedLLM:
         The resolved ``UnifiedLLM``.
 
     Raises:
-        TypeError: If *spec* is not a client or callable, or if a callable
-            returns something that is not a ``UnifiedLLM``.
-        RuntimeError: If the callable itself raises. The original exception
-            is chained, but the message names the method and makes clear the
-            failure came from the ``llm=`` callable rather than from
-            generation — a bare AttributeError from a typo'd attribute is
-            otherwise very hard to place.
+        TypeError: If *spec* is not a client, string, or callable, or if a
+            callable returns something that is not a ``UnifiedLLM``.
+        RuntimeError: If a string alias cannot be resolved by
+            ``get_llm_client``, or if the callable itself raises. The original
+            exception is chained, but the message names the method and makes
+            clear the failure came from the ``llm=`` value rather than from
+            generation — a bare AttributeError from a typo'd attribute or a
+            404 from a typo'd model name is otherwise very hard to place.
     """
     if _is_llm_client(spec):
         return cast("UnifiedLLM", spec)
 
+    if isinstance(spec, str):
+        return _resolve_alias(spec, agent, method_name)
+
     if not callable(spec):
         raise TypeError(
-            f"@strategy(llm=...) for '{method_name}' must be a UnifiedLLM instance or "
-            f"a callable returning one, got {type(spec).__name__}."
+            f"@strategy(llm=...) for '{method_name}' must be a UnifiedLLM instance, a "
+            f"registry alias / model string, or a callable returning one, got "
+            f"{type(spec).__name__}."
         )
 
     try:

--- a/src/nooa/method_llm.py
+++ b/src/nooa/method_llm.py
@@ -84,6 +84,64 @@ def _is_llm_client(spec: Any) -> bool:
     return hasattr(spec, "acall")
 
 
+def resolve_alias(
+    alias: str,
+    cache: dict[str, Any] | None,
+    method_name: str,
+    *,
+    origin: str = "@strategy(llm=...)",
+) -> UnifiedLLM:
+    """Resolve a registry alias / litellm model string via ``get_llm_client``.
+
+    Shared by every call site that accepts an alias string — the
+    ``@strategy(llm=...)`` decorator (caching on the agent instance, see
+    :func:`_resolve_alias`) and standalone ``@strategy`` functions (caching
+    in the wrapper closure, since a fresh agent stub is built per call).
+    One resolution path means one error message, one cache policy, and one
+    place to change if client construction ever grows validation.
+
+    Args:
+        alias: Registry key or litellm-supported model string.
+        cache: Caller-owned ``{alias: client}`` dict, or ``None`` to resolve
+            without caching (for owners that cannot host a dict).
+        method_name: Method (or standalone function) name, for error messages.
+        origin: Human-readable source of the alias, for error messages.
+
+    Returns:
+        The resolved :class:`~nooa.unifiedllm.UnifiedLLM`.
+
+    Raises:
+        RuntimeError: If ``get_llm_client`` raises. The original exception
+            is chained, but the message names the method and the alias so a
+            typo'd model name points at the line that named it.
+        TypeError: If resolution returns something that is not a client.
+    """
+    if cache is not None:
+        cached = cache.get(alias)
+        if cached is not None:
+            return cast("UnifiedLLM", cached)
+
+    from nooa.unifiedllm import get_llm_client
+
+    try:
+        client = get_llm_client(alias)
+    except Exception as exc:
+        raise RuntimeError(
+            f"The {origin} alias {alias!r} for '{method_name}' could not be "
+            f"resolved by get_llm_client: {type(exc).__name__}: {exc}"
+        ) from exc
+
+    if not _is_llm_client(client):
+        raise TypeError(
+            f"The {origin} alias {alias!r} for '{method_name}' resolved to "
+            f"{type(client).__name__}, not a UnifiedLLM instance."
+        )
+
+    if cache is not None:
+        cache[alias] = client
+    return client
+
+
 def _resolve_alias(alias: str, agent: Any, method_name: str) -> UnifiedLLM:
     """Resolve a registry alias / litellm model string against *agent*.
 
@@ -98,46 +156,19 @@ def _resolve_alias(alias: str, agent: Any, method_name: str) -> UnifiedLLM:
 
     Returns:
         The resolved :class:`~nooa.unifiedllm.UnifiedLLM`.
-
-    Raises:
-        RuntimeError: If ``get_llm_client`` raises. The original exception
-            is chained, but the message names the method and the alias so a
-            typo'd model name points at the ``@strategy`` line that named it.
     """
-    cacheable = True
     cache = getattr(agent, _INSTANCE_LLM_CACHE_ATTR, None)
-    if not isinstance(cache, dict):
-        # Fresh instance, or a duck-typed stub that refuses new attributes
-        # (e.g. __slots__). Resolve without caching rather than failing the call.
-        cache = {}
-        try:
-            setattr(agent, _INSTANCE_LLM_CACHE_ATTR, cache)
-        except (AttributeError, TypeError):
-            cacheable = False
+    if isinstance(cache, dict):
+        return resolve_alias(alias, cache, method_name)
 
-    cached = cache.get(alias)
-    if cached is not None:
-        return cast("UnifiedLLM", cached)
-
-    from nooa.unifiedllm import get_llm_client
-
+    # Fresh instance, or a duck-typed stub that refuses new attributes
+    # (e.g. __slots__). Resolve without caching rather than failing the call.
     try:
-        client = get_llm_client(alias)
-    except Exception as exc:
-        raise RuntimeError(
-            f"The @strategy(llm={alias!r}) alias for '{method_name}' could not be "
-            f"resolved by get_llm_client: {type(exc).__name__}: {exc}"
-        ) from exc
-
-    if not _is_llm_client(client):
-        raise TypeError(
-            f"The @strategy(llm={alias!r}) alias for '{method_name}' resolved to "
-            f"{type(client).__name__}, not a UnifiedLLM instance."
-        )
-
-    if cacheable:
-        cache[alias] = client
-    return client
+        cache = {}
+        setattr(agent, _INSTANCE_LLM_CACHE_ATTR, cache)
+    except (AttributeError, TypeError):
+        return resolve_alias(alias, None, method_name)
+    return resolve_alias(alias, cache, method_name)
 
 
 def validate_method_llm_spec(spec: Any, func_name: str, *, standalone: bool = False) -> None:
@@ -243,4 +274,4 @@ def resolve_method_llm(spec: Any, agent: Any, method_name: str) -> UnifiedLLM:
     return cast("UnifiedLLM", resolved)
 
 
-__all__ = ["resolve_method_llm", "validate_method_llm_spec"]
+__all__ = ["resolve_alias", "resolve_method_llm", "validate_method_llm_spec"]

--- a/src/nooa/runtime/actor.py
+++ b/src/nooa/runtime/actor.py
@@ -2599,12 +2599,17 @@ class ActorRuntime:
         strategy = call_strategy or decorator_strategy or get_default_strategy()
 
         # Resolve LLM client with priority: call-level > @strategy decorator > agent's default.
-        # A @strategy(llm=...) value may be a callable resolved against the agent
-        # instance; only invoke it when it would actually be used, so a call-level
-        # override doesn't trigger someone else's resolver side effects.
+        # A call-level or @strategy(llm=...) value may be a callable resolved against
+        # the agent instance; only invoke it when it would actually be used, so a
+        # call-level override doesn't trigger someone else's resolver side effects.
         plan_llm = getattr(base_method, "_plan_llm", None)
         if call_llm is not _MISSING and call_llm is not None:
-            llm_client = call_llm
+            from nooa.method_llm import resolve_method_llm
+
+            # Call-site overrides accept the same spellings as the decorator
+            # (client, alias string cached per instance, or callable resolved
+            # against the agent), resolved by the same shared path.
+            llm_client = resolve_method_llm(call_llm, self.agent, method_name)
             llm_selection_source = "call_site"
         elif plan_llm is not None:
             from nooa.method_llm import resolve_method_llm

--- a/src/nooa/runtime/actor.py
+++ b/src/nooa/runtime/actor.py
@@ -2608,8 +2608,12 @@ class ActorRuntime:
 
             # Call-site overrides accept the same spellings as the decorator
             # (client, alias string cached per instance, or callable resolved
-            # against the agent), resolved by the same shared path.
-            llm_client = resolve_method_llm(call_llm, self.agent, method_name)
+            # against the agent), resolved by the same shared path. The origin
+            # names the call site so a typo'd alias or a raising resolver
+            # points at the caller's line, not the decorator's.
+            llm_client = resolve_method_llm(
+                call_llm, self.agent, method_name, origin="call-site llm="
+            )
             llm_selection_source = "call_site"
         elif plan_llm is not None:
             from nooa.method_llm import resolve_method_llm

--- a/src/nooa/standalone.py
+++ b/src/nooa/standalone.py
@@ -192,24 +192,17 @@ def create_standalone_wrapper(
     # Aliases resolved per (wrapper, alias): standalone functions have no
     # agent instance to cache on, and a fresh stub is built per call, so the
     # wrapper closure is the only stable place to remember a resolved client.
+    # Shared resolution lives in nooa.method_llm.resolve_alias so this path
+    # and the agent-method path report identical errors.
     _alias_cache: dict[str, Any] = {}
 
     @wraps(func)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         resolved_llm = llm
         if isinstance(resolved_llm, str):
-            from nooa.unifiedllm import get_llm_client
+            from nooa.method_llm import resolve_alias
 
-            if resolved_llm not in _alias_cache:
-                try:
-                    _alias_cache[resolved_llm] = get_llm_client(resolved_llm)
-                except Exception as exc:
-                    raise RuntimeError(
-                        f"The @strategy(llm={resolved_llm!r}) alias for standalone "
-                        f"function '{func.__name__}' could not be resolved by "
-                        f"get_llm_client: {type(exc).__name__}: {exc}"
-                    ) from exc
-            resolved_llm = _alias_cache[resolved_llm]
+            resolved_llm = resolve_alias(resolved_llm, _alias_cache, func.__name__)
         if resolved_llm is None:
             # Cascade: inherit LLM from a calling agent if we're inside one
             from nooa.runtime.context_vars import _parent_agent_var

--- a/src/nooa/standalone.py
+++ b/src/nooa/standalone.py
@@ -165,11 +165,11 @@ def create_standalone_wrapper(
         strategy: GenerationStrategy instance resolved from the decorator.
         llm: Optional explicit LLM value from ``@strategy(..., llm=...)``.
             A client, or a registry alias / litellm model string (resolved
-            lazily on first call and cached per process, since standalone
-            functions have no agent instance to cache on). Never a resolver
-            callable: standalone functions have no agent instance to bind one
-            against, so ``@strategy`` rejects callables here at decoration
-            time.
+            lazily on first call and cached per wrapper — one decorated
+            function object — since standalone functions have no agent
+            instance to cache on). Never a resolver callable: standalone
+            functions have no agent instance to bind one against, so
+            ``@strategy`` rejects callables here at decoration time.
 
     Returns:
         Async callable with the same signature as *func*.
@@ -202,7 +202,12 @@ def create_standalone_wrapper(
         if isinstance(resolved_llm, str):
             from nooa.method_llm import resolve_alias
 
-            resolved_llm = resolve_alias(resolved_llm, _alias_cache, func.__name__)
+            resolved_llm = resolve_alias(
+                resolved_llm,
+                _alias_cache,
+                func.__name__,
+                origin="standalone @strategy(llm=...)",
+            )
         if resolved_llm is None:
             # Cascade: inherit LLM from a calling agent if we're inside one
             from nooa.runtime.context_vars import _parent_agent_var

--- a/src/nooa/standalone.py
+++ b/src/nooa/standalone.py
@@ -163,10 +163,13 @@ def create_standalone_wrapper(
     Args:
         func: Original async function with an ellipsis body.
         strategy: GenerationStrategy instance resolved from the decorator.
-        llm: Optional explicit LLM client from ``@strategy(..., llm=...)``.
-            Always a client, never a resolver callable: standalone functions
-            have no agent instance to bind one against, so ``@strategy``
-            rejects callables here at decoration time.
+        llm: Optional explicit LLM value from ``@strategy(..., llm=...)``.
+            A client, or a registry alias / litellm model string (resolved
+            lazily on first call and cached per process, since standalone
+            functions have no agent instance to cache on). Never a resolver
+            callable: standalone functions have no agent instance to bind one
+            against, so ``@strategy`` rejects callables here at decoration
+            time.
 
     Returns:
         Async callable with the same signature as *func*.
@@ -186,9 +189,27 @@ def create_standalone_wrapper(
     #     instead of stacking on one shard)
     _standalone_agent_id = f"standalone:{_PROCESS_AGENT_ID}:{func.__module__}:{func.__qualname__}"
 
+    # Aliases resolved per (wrapper, alias): standalone functions have no
+    # agent instance to cache on, and a fresh stub is built per call, so the
+    # wrapper closure is the only stable place to remember a resolved client.
+    _alias_cache: dict[str, Any] = {}
+
     @wraps(func)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         resolved_llm = llm
+        if isinstance(resolved_llm, str):
+            from nooa.unifiedllm import get_llm_client
+
+            if resolved_llm not in _alias_cache:
+                try:
+                    _alias_cache[resolved_llm] = get_llm_client(resolved_llm)
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"The @strategy(llm={resolved_llm!r}) alias for standalone "
+                        f"function '{func.__name__}' could not be resolved by "
+                        f"get_llm_client: {type(exc).__name__}: {exc}"
+                    ) from exc
+            resolved_llm = _alias_cache[resolved_llm]
         if resolved_llm is None:
             # Cascade: inherit LLM from a calling agent if we're inside one
             from nooa.runtime.context_vars import _parent_agent_var

--- a/tests/test_method_llm_callable.py
+++ b/tests/test_method_llm_callable.py
@@ -17,23 +17,24 @@ from nooa.strategies.predict import PredictStrategy
 from nooa.unifiedllm import FakeLLMClient, LLMResponse
 
 
-def _fake(answer: str = "") -> FakeLLMClient:
-    """A FakeLLMClient whose single PredictStrategy answer is *answer*.
+def _response(answer: str) -> LLMResponse:
+    """One scripted PredictStrategy response wrapping ``{"value": answer}``."""
+    content = json.dumps({"value": answer})
+    return LLMResponse(
+        raw_response=None,
+        content=content,
+        tool_calls=[],
+        finish_reason="stop",
+        assistant_message={"role": "assistant", "content": content},
+    )
+
+
+def _fake(answer: str = "", *, times: int = 1) -> FakeLLMClient:
+    """A FakeLLMClient answering *answer* to the first *times* calls.
 
     PredictStrategy wraps a plain ``-> str`` return in ``{"value": ...}``.
     """
-    content = json.dumps({"value": answer})
-    return FakeLLMClient(
-        scripted_responses=[
-            LLMResponse(
-                raw_response=None,
-                content=content,
-                tool_calls=[],
-                finish_reason="stop",
-                assistant_message={"role": "assistant", "content": content},
-            )
-        ]
-    )
+    return FakeLLMClient(scripted_responses=[_response(answer) for _ in range(times)])
 
 
 class TestValidation:
@@ -61,11 +62,19 @@ class TestValidation:
         assert method._plan_llm is resolver  # type: ignore[attr-defined]
         assert calls == [], "resolver must not run until generation time"
 
-    def test_string_rejected_at_decoration_time(self) -> None:
-        """There is no alias registry — a model name string is a mistake."""
-        with pytest.raises(TypeError, match="must be a UnifiedLLM instance or a callable"):
+    def test_string_accepted_at_decoration_time(self) -> None:
+        """A registry alias / model string is stored as-is, resolved lazily."""
 
-            @strategy(PredictStrategy(), llm="gpt-4")  # type: ignore[arg-type]
+        @strategy(PredictStrategy(), llm="gpt-4")
+        async def method(self) -> str: ...
+
+        assert method._plan_llm == "gpt-4"  # type: ignore[attr-defined]
+
+    def test_empty_string_rejected_at_decoration_time(self) -> None:
+        """An empty string is a mistake, not an alias."""
+        with pytest.raises(TypeError, match="empty string"):
+
+            @strategy(PredictStrategy(), llm="")  # type: ignore[arg-type]
             async def method(self) -> str: ...
 
     def test_arbitrary_object_rejected(self) -> None:
@@ -362,3 +371,168 @@ class TestEndToEnd:
 
         with pytest.raises(RuntimeError, match=r"callable for 'run' raised AttributeError"):
             await Broken().run()
+
+
+class TestAliasResolution:
+    """String aliases resolve lazily through get_llm_client, cached per instance."""
+
+    def test_alias_resolves_via_get_llm_client(self, monkeypatch) -> None:
+        client = _fake("ok")
+        calls = []
+
+        def fake_get(name, **kw):  # noqa: ANN001, ANN003
+            calls.append(name)
+            return client
+
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", fake_get)
+
+        class Stub:
+            pass
+
+        assert resolve_method_llm("gpt-4-mini", Stub(), "method") is client
+        assert calls == ["gpt-4-mini"]
+
+    def test_alias_cached_per_agent_instance(self, monkeypatch) -> None:
+        """Second resolution reuses the client — no reconstruction per call."""
+        client = _fake("ok")
+        calls = []
+
+        def fake_get(name, **kw):  # noqa: ANN001, ANN003
+            calls.append(name)
+            return client
+
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", fake_get)
+
+        class Stub:
+            pass
+
+        agent = Stub()
+        first = resolve_method_llm("alias", agent, "method")
+        second = resolve_method_llm("alias", agent, "method")
+        assert first is second is client
+        assert calls == ["alias"], "get_llm_client must run once per (instance, alias)"
+
+        other = Stub()
+        third = resolve_method_llm("alias", other, "method")
+        assert third is client
+        assert calls == ["alias", "alias"], "a different instance must re-resolve"
+
+    def test_alias_resolution_failure_wrapped_with_method_name(self, monkeypatch) -> None:
+        def fake_get(name, **kw):  # noqa: ANN001, ANN003
+            raise ValueError("unknown model")
+
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", fake_get)
+
+        with pytest.raises(RuntimeError, match=r"alias for 'analyze' could not be resolved"):
+            resolve_method_llm("no-such-model", object(), "analyze")
+
+    def test_alias_cache_survives_uncacheable_agent(self, monkeypatch) -> None:
+        """A stub that refuses new attributes still resolves (without caching)."""
+        client = _fake("ok")
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", lambda name, **kw: client)
+
+        class Slotted:
+            __slots__ = ()
+
+        assert resolve_method_llm("alias", Slotted(), "method") is client
+
+    def test_alias_resolution_error_chains_original(self, monkeypatch) -> None:
+        def fake_get(name, **kw):  # noqa: ANN001, ANN003
+            raise KeyError("registry")
+
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", fake_get)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            resolve_method_llm("alias", object(), "method")
+        assert isinstance(exc_info.value.__cause__, KeyError)
+
+
+class TestAliasEndToEnd:
+    """The alias actually drives which model a generation call uses."""
+
+    @pytest.mark.asyncio
+    async def test_method_runs_on_aliased_model(self, monkeypatch) -> None:
+        aliased = _fake("aliased-answer")
+        default = _fake("default-answer")
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", lambda name, **kw: aliased)
+
+        class SupportAgent(Agent, llm=default):
+            """A support agent."""
+
+            @strategy(PredictStrategy(), llm="gpt-5-mini")
+            async def summarize(self, text: str) -> str:
+                """Return a one-sentence summary of {text}."""
+                ...
+
+        agent = SupportAgent()
+        assert await agent.summarize("hello") == "aliased-answer"
+
+    @pytest.mark.asyncio
+    async def test_no_client_constructed_at_import_time(self, monkeypatch) -> None:
+        """Declaring the class must not resolve the alias — only the first call does."""
+        aliased = _fake("aliased-answer", times=2)
+        default = _fake("default-answer")
+        calls = []
+
+        def fake_get(name, **kw):  # noqa: ANN001, ANN003
+            calls.append(name)
+            return aliased
+
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", fake_get)
+
+        class LazyAgent(Agent, llm=default):
+            """A lazy agent."""
+
+            @strategy(PredictStrategy(), llm="lazy-alias")
+            async def run(self) -> str:
+                """Return a word."""
+                ...
+
+        assert calls == [], "class definition must not resolve the alias"
+
+        agent = LazyAgent()
+        assert await agent.run() == "aliased-answer"
+        assert calls == ["lazy-alias"]
+
+        await agent.run()
+        assert calls == ["lazy-alias"], "the resolved client must be cached"
+
+    @pytest.mark.asyncio
+    async def test_call_site_override_beats_alias(self, monkeypatch) -> None:
+        """Precedence is unchanged: call-site llm= wins over the decorator."""
+        aliased = _fake("aliased-answer")
+        override = _fake("override-answer")
+        default = _fake("default-answer")
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", lambda name, **kw: aliased)
+
+        class SupportAgent(Agent, llm=default):
+            """A support agent."""
+
+            @strategy(PredictStrategy(), llm="gpt-5-mini")
+            async def summarize(self, text: str) -> str:
+                """Return a one-sentence summary of {text}."""
+                ...
+
+        agent = SupportAgent()
+        assert await agent.summarize("hello", llm=override) == "override-answer"
+
+    @pytest.mark.asyncio
+    async def test_standalone_function_accepts_alias(self, monkeypatch) -> None:
+        """Standalone functions have no instance, but strings still resolve."""
+        aliased = _fake("standalone-answer", times=2)
+        calls = []
+
+        def fake_get(name, **kw):  # noqa: ANN001, ANN003
+            calls.append(name)
+            return aliased
+
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", fake_get)
+
+        @strategy(PredictStrategy(), llm="my-alias")
+        async def standalone_summarize(text: str) -> str:
+            """Return a one-sentence summary of {text}."""
+            ...
+
+        assert await standalone_summarize("hello") == "standalone-answer"
+        assert await standalone_summarize("again") == "standalone-answer"
+        assert calls == ["my-alias"], "the wrapper caches the resolved client"

--- a/tests/test_method_llm_callable.py
+++ b/tests/test_method_llm_callable.py
@@ -562,3 +562,180 @@ class TestAliasEndToEnd:
         assert await standalone_summarize("hello") == "standalone-answer"
         assert await standalone_summarize("again") == "standalone-answer"
         assert calls == ["my-alias"], "the wrapper caches the resolved client"
+
+
+class TestAliasReviewHardening:
+    """Edge cases surfaced by the subagent review round."""
+
+    @pytest.mark.asyncio
+    async def test_real_agent_instances_cache_independently(self, monkeypatch) -> None:
+        """Two real Agent instances resolve the same alias to separate clients.
+
+        Guards the lazily-setattr'd per-instance cache in agent.py: if anyone
+        ever gives the annotation a class-level ``= {}`` default, every
+        instance would share one dict and this test catches it.
+        """
+        default = _fake("default")
+        clients = []
+
+        def fake_get(name, **kw):  # noqa: ANN001, ANN003
+            client = _fake(f"resolved-{len(clients)}")
+            clients.append(client)
+            return client
+
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", fake_get)
+
+        class Pair(Agent, llm=default):
+            """A pair."""
+
+            @strategy(PredictStrategy(), llm="shared-alias")
+            async def run(self) -> str:
+                """Return a word."""
+                ...
+
+        a, b = Pair(), Pair()
+        assert await a.run() == "resolved-0"
+        assert await b.run() == "resolved-1"
+        assert len(clients) == 2, "each instance must resolve its own client"
+
+    @pytest.mark.asyncio
+    async def test_same_alias_two_methods_one_instance_one_client(self, monkeypatch) -> None:
+        """The cache is keyed on alias, not method — one client per (instance, alias)."""
+        default = _fake("default")
+        calls = []
+
+        def fake_get(name, **kw):  # noqa: ANN001, ANN003
+            calls.append(name)
+            return _fake("aliased", times=2)
+
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", fake_get)
+
+        class Twin(Agent, llm=default):
+            """A twin."""
+
+            @strategy(PredictStrategy(), llm="cheap")
+            async def one(self) -> str:
+                """Return a word."""
+                ...
+
+            @strategy(PredictStrategy(), llm="cheap")
+            async def two(self) -> str:
+                """Return another word."""
+                ...
+
+        agent = Twin()
+        assert await agent.one() == "aliased"
+        assert await agent.two() == "aliased"
+        assert calls == ["cheap"], "methods sharing an alias share one client"
+
+    def test_alias_resolving_to_non_client_raises_typeerror(self, monkeypatch) -> None:
+        """get_llm_client returning garbage is caught, not passed to generation."""
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", lambda name, **kw: 42)
+
+        with pytest.raises(TypeError, match="resolved to int, not a UnifiedLLM instance"):
+            resolve_method_llm("bad-alias", object(), "method")
+
+    @pytest.mark.asyncio
+    async def test_e2e_alias_failure_names_method_and_leaves_no_poison(self, monkeypatch) -> None:
+        """A failed resolution surfaces at call time naming the method, and a
+        fixed registry re-resolves on the next call (nothing was cached)."""
+        default = _fake("default")
+        state = {"fail": True}
+        calls = []
+
+        def fake_get(name, **kw):  # noqa: ANN001, ANN003
+            calls.append(name)
+            if state["fail"]:
+                raise ValueError("unknown model")
+            return _fake("fixed")
+
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", fake_get)
+
+        class Flaky(Agent, llm=default):
+            """A flaky agent."""
+
+            @strategy(PredictStrategy(), llm="flaky-alias")
+            async def run(self) -> str:
+                """Return a word."""
+                ...
+
+        agent = Flaky()
+        with pytest.raises(RuntimeError, match=r"alias 'flaky-alias' for 'run'"):
+            await agent.run()
+
+        state["fail"] = False
+        assert await agent.run() == "fixed"
+        assert calls == ["flaky-alias", "flaky-alias"], "failed resolution must not be cached"
+
+    @pytest.mark.asyncio
+    async def test_call_site_string_skips_decorator_callable(self, monkeypatch) -> None:
+        """A call-site alias must not trigger the decorator's resolver side effects."""
+        aliased = _fake("call-site", times=2)
+        default = _fake("default")
+        resolver_calls = []
+
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", lambda name, **kw: aliased)
+
+        class Guarded(Agent, llm=default):
+            """A guarded agent."""
+
+            @strategy(PredictStrategy(), llm=lambda self: _boom())
+            async def run(self) -> str:
+                """Return a word."""
+                ...
+
+        def _boom():
+            resolver_calls.append("invoked")
+            raise AssertionError("decorator resolver must not run")
+
+        agent = Guarded()
+        assert await agent.run(llm="safe-alias") == "call-site"
+        assert resolver_calls == []
+
+    @pytest.mark.asyncio
+    async def test_two_standalone_wrappers_keep_separate_caches(self, monkeypatch) -> None:
+        """Each wrapper closure caches independently — per function, not module."""
+        clients = []
+
+        def fake_get(name, **kw):  # noqa: ANN001, ANN003
+            client = _fake(f"fn-{len(clients)}")
+            clients.append(client)
+            return client
+
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", fake_get)
+
+        @strategy(PredictStrategy(), llm="shared")
+        async def first_fn(text: str) -> str:
+            """Return a summary of {text}."""
+            ...
+
+        @strategy(PredictStrategy(), llm="shared")
+        async def second_fn(text: str) -> str:
+            """Return a summary of {text}."""
+            ...
+
+        assert await first_fn("x") == "fn-0"
+        assert await second_fn("x") == "fn-1"
+        assert len(clients) == 2
+
+    @pytest.mark.asyncio
+    async def test_standalone_alias_failure_names_function(self, monkeypatch) -> None:
+        def fake_get(name, **kw):  # noqa: ANN001, ANN003
+            raise ValueError("unknown model")
+
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", fake_get)
+
+        @strategy(PredictStrategy(), llm="no-such-alias")
+        async def named_fn(text: str) -> str:
+            """Return a summary of {text}."""
+            ...
+
+        with pytest.raises(
+            RuntimeError,
+            match=r"standalone @strategy\(llm=\.\.\.\) alias 'no-such-alias' for 'named_fn'",
+        ):
+            await named_fn("x")
+
+    def test_call_site_empty_string_rejected_with_targeted_message(self) -> None:
+        with pytest.raises(TypeError, match="empty string"):
+            resolve_method_llm("", object(), "method", origin="call-site llm=")

--- a/tests/test_method_llm_callable.py
+++ b/tests/test_method_llm_callable.py
@@ -423,7 +423,7 @@ class TestAliasResolution:
 
         monkeypatch.setattr("nooa.unifiedllm.get_llm_client", fake_get)
 
-        with pytest.raises(RuntimeError, match=r"alias for 'analyze' could not be resolved"):
+        with pytest.raises(RuntimeError, match=r"alias 'no-such-model' for 'analyze'"):
             resolve_method_llm("no-such-model", object(), "analyze")
 
     def test_alias_cache_survives_uncacheable_agent(self, monkeypatch) -> None:
@@ -515,6 +515,32 @@ class TestAliasEndToEnd:
 
         agent = SupportAgent()
         assert await agent.summarize("hello", llm=override) == "override-answer"
+
+    @pytest.mark.asyncio
+    async def test_call_site_accepts_alias_string(self, monkeypatch) -> None:
+        """The call-site spelling shares resolution: a string alias works there too."""
+        aliased = _fake("call-site-alias", times=2)
+        default = _fake("default-answer")
+        calls = []
+
+        def fake_get(name, **kw):  # noqa: ANN001, ANN003
+            calls.append(name)
+            return aliased
+
+        monkeypatch.setattr("nooa.unifiedllm.get_llm_client", fake_get)
+
+        class SupportAgent(Agent, llm=default):
+            """A support agent."""
+
+            @strategy(PredictStrategy())
+            async def summarize(self, text: str) -> str:
+                """Return a one-sentence summary of {text}."""
+                ...
+
+        agent = SupportAgent()
+        assert await agent.summarize("hello", llm="gpt-5-mini") == "call-site-alias"
+        assert await agent.summarize("again", llm="gpt-5-mini") == "call-site-alias"
+        assert calls == ["gpt-5-mini"], "call-site alias is cached per instance"
 
     @pytest.mark.asyncio
     async def test_standalone_function_accepts_alias(self, monkeypatch) -> None:


### PR DESCRIPTION
## Motivation

Users keep writing `@strategy(blah, llm=my_llm)` expecting a model name to work — the natural interface. Today the `llm=` override only accepts a `UnifiedLLM` client or a callable (PR #81), and a string alias is rejected with a `TypeError` at decoration time. Issue #20 (mechanism 1) proposes exactly this widening; the larger `method_llms` / `llm_roles` / `Role` design stays under discussion there.

## What changed

`@strategy(llm=...)` now accepts a **registry alias / litellm model string** in addition to a client or a callable:

```python
class SupportAgent(Agent, llm=default):      # agent default stays a client
    @strategy(llm="gpt-5-mini")             # alias or model string
    async def summarize(self, text: str) -> str: ...
```

- **Lazy resolution**: strings resolve on the first generation call via `get_llm_client()`, cached per (agent instance, alias) on a hidden `nosnapshot` attr — no client constructed at import time, repeated calls reuse one client. Standalone `@strategy` functions accept strings too (cached per wrapper closure; they have no instance).
- **One shared resolution path**: `nooa.method_llm.resolve_alias()` backs the decorator path, the standalone path, and the call-site `llm=` kwarg, which now routes through `resolve_method_llm` and accepts the same three spellings. Errors name their origin (`@strategy(llm=...)`, `call-site llm=`, `standalone @strategy(llm=...)`) so a typo points at the line that named it. Empty call-site strings get the same targeted `TypeError` as decoration time.
- **Precedence unchanged**: call-site `llm=` > `@strategy(llm=...)` > agent default. The agent default `llm=` remains client-only (it resolves eagerly at `__init__` and feeds summarizer/window budgeting).
- Resolved aliases pin their model at first use: a later `reload_registry()` does not invalidate cached clients (documented).

## Testing

- 19 new tests in `tests/test_method_llm_callable.py` (43 total in the file): decoration-time acceptance/rejection, per-instance caching incl. real-Agent isolation and one-client-per-alias across methods, error wrapping/chaining, non-client resolution, e2e routing, import-time laziness, call-site precedence + string spelling, standalone per-wrapper caching and failure naming, no poisoned cache after failed resolution.
- Full suite: **6788 passed, 5 skipped, 0 failed**; `ruff check` + `format` clean on all changed files.

## Review

Three read-only subagent reviews (correctness, simplicity, test quality) completed; all actionable findings addressed in the last commit (doc examples fixed to client-only agent defaults, error origins threaded, per-wrapper wording, empty-string resolve-time rejection, 8 hardening tests).

Partially addresses #20 (mechanism 1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM overrides for strategies and standalone wrappers now support registry aliases and LiteLLM model strings, in addition to client instances.
  * String-based overrides are resolved lazily and cached per agent instance or standalone wrapper.
  * Callable overrides continue to resolve at call time, with support for agent-bound strategies.
  * Call-level LLM overrides now support clients, aliases, and agent-bound callables.

* **Bug Fixes**
  * Improved validation and error messages for empty aliases, failed resolutions, invalid results, and callable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->