### PR TITLE
fix(release): support GitHub CLI 2.23

### DIFF
--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -243,7 +243,7 @@ def release_for_tag(tag: str) -> dict[str, Any] | None:
             "target_commitish": target,
             "html_url": url,
         }
-    except (json.JSONDecodeError, KeyError, TypeError):
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
         die(f"GitHub returned invalid release metadata for {tag}")
 
 

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -209,7 +209,7 @@ def release_for_tag(tag: str) -> dict[str, Any] | None:
             "--repo",
             GITHUB_REPO,
             "--json",
-            "databaseId,isDraft,targetCommitish,url",
+            "apiUrl,isDraft,targetCommitish,url",
         ],
         check=False,
     )
@@ -220,14 +220,12 @@ def release_for_tag(tag: str) -> dict[str, Any] | None:
         die(f"could not inspect GitHub release {tag}: {detail}")
     try:
         metadata = json.loads(proc.stdout)
-        database_id = metadata["databaseId"]
+        api_url = metadata["apiUrl"]
         draft = metadata["isDraft"]
         target = metadata["targetCommitish"]
         url = metadata["url"]
         if (
-            not isinstance(database_id, int)
-            or isinstance(database_id, bool)
-            or database_id <= 0
+            not isinstance(api_url, str)
             or not isinstance(draft, bool)
             or not isinstance(target, str)
             or not target
@@ -235,8 +233,12 @@ def release_for_tag(tag: str) -> dict[str, Any] | None:
             or not url
         ):
             raise TypeError
+        api_prefix = f"https://api.github.com/repos/{GITHUB_REPO}/releases/"
+        database_id_match = re.fullmatch(rf"{re.escape(api_prefix)}([1-9]\d*)", api_url)
+        if database_id_match is None:
+            raise TypeError
         return {
-            "id": database_id,
+            "id": int(database_id_match.group(1)),
             "draft": draft,
             "target_commitish": target,
             "html_url": url,

--- a/tests/test_make_release.py
+++ b/tests/test_make_release.py
@@ -414,7 +414,7 @@ def test_existing_release_must_be_matching_unpublished_draft(mr, monkeypatch):
 
 def test_release_lookup_uses_draft_aware_gh_command(mr, monkeypatch):
     metadata = {
-        "databaseId": 7,
+        "apiUrl": f"https://api.github.com/repos/{mr.GITHUB_REPO}/releases/7",
         "isDraft": True,
         "targetCommitish": "a" * 40,
         "url": "https://draft",
@@ -442,7 +442,7 @@ def test_release_lookup_uses_draft_aware_gh_command(mr, monkeypatch):
             "--repo",
             mr.GITHUB_REPO,
             "--json",
-            "databaseId,isDraft,targetCommitish,url",
+            "apiUrl,isDraft,targetCommitish,url",
         ]
     ]
 
@@ -477,8 +477,33 @@ def test_release_lookup_fails_closed_on_api_error_or_invalid_metadata(mr, monkey
 
 def test_release_lookup_rejects_string_draft_state(mr, monkeypatch):
     metadata = {
-        "databaseId": 7,
+        "apiUrl": f"https://api.github.com/repos/{mr.GITHUB_REPO}/releases/7",
         "isDraft": "false",
+        "targetCommitish": "a" * 40,
+        "url": "https://release",
+    }
+    monkeypatch.setattr(
+        mr,
+        "run",
+        lambda cmd, **_kwargs: subprocess.CompletedProcess(cmd, 0, json.dumps(metadata), ""),
+    )
+
+    with pytest.raises(mr.ReleaseError, match="invalid release metadata"):
+        mr.release_for_tag("v1.2.3")
+
+
+@pytest.mark.parametrize(
+    "api_url",
+    [
+        "https://api.github.com/repos/NVIDIA-NeMo/labs-OO-Agents/releases/0",
+        "https://api.github.com/repos/NVIDIA-NeMo/labs-OO-Agents/releases/not-an-id",
+        "https://example.com/repos/NVIDIA-NeMo/labs-OO-Agents/releases/7",
+    ],
+)
+def test_release_lookup_rejects_invalid_api_url(mr, monkeypatch, api_url):
+    metadata = {
+        "apiUrl": api_url,
+        "isDraft": True,
         "targetCommitish": "a" * 40,
         "url": "https://release",
     }

--- a/tests/test_make_release.py
+++ b/tests/test_make_release.py
@@ -497,7 +497,9 @@ def test_release_lookup_rejects_string_draft_state(mr, monkeypatch):
     [
         "https://api.github.com/repos/NVIDIA-NeMo/labs-OO-Agents/releases/0",
         "https://api.github.com/repos/NVIDIA-NeMo/labs-OO-Agents/releases/not-an-id",
+        "https://api.github.com/repos/other/repo/releases/7",
         "https://example.com/repos/NVIDIA-NeMo/labs-OO-Agents/releases/7",
+        f"https://api.github.com/repos/NVIDIA-NeMo/labs-OO-Agents/releases/1{'0' * 5000}",
     ],
 )
 def test_release_lookup_rejects_invalid_api_url(mr, monkeypatch, api_url):


### PR DESCRIPTION
## Summary

- use the `apiUrl` field supported by the release runner's GitHub CLI 2.23.0
- derive and validate the numeric release database ID from that URL
- add regression coverage for invalid release API URLs

## Validation

- exact pinned GitLab release image with Debian `gh 2.23.0`
- live lookup of published `v0.0.9` and absent `v0.0.10`
- Python 3.12 frozen sync: 54 release tests passed
- Ruff 0.15.20 lint and format checks passed

Signed-off-by: Severin Klingler <sklingler@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GitHub release metadata handling by using the canonical API URL to identify releases.
  - Added validation to reject invalid repository URLs, non-GitHub URLs, zero or nonnumeric release IDs, and oversized numeric IDs.
  - Existing checks for valid types and non-empty metadata remain supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->