### PR TITLE
feat(tui): add accessible extensible themes

### DIFF
--- a/packages/nooa-cli/README.md
+++ b/packages/nooa-cli/README.md
@@ -196,6 +196,14 @@ idle consolidation without deleting stored memories. Project memory lives at
 `.nooa/memory/memory.sqlite` by default; session memory lives beside the
 session database. Both choices are persisted per agent in `settings.yaml`.
 
+### Themes
+
+Use `/theme` for a full-screen browser with live previews, or `/theme <id>` to
+switch directly. Custom Base16/Base24 YAML themes
+can be installed in `~/.config/nooa/themes/` or `<project>/.nooa/themes/`. See
+[`docs/themes.md`](docs/themes.md) for the schema, semantic color roles, and
+validation rules.
+
 ### MCP servers
 
 Use the TUI commands for the common lifecycle:

--- a/packages/nooa-cli/docs/themes.md
+++ b/packages/nooa-cli/docs/themes.md
@@ -1,0 +1,91 @@
+# TUI themes
+
+NOOA ships four themes: `mocha`, `latte`, `vsdark`, and `vslight`.
+
+Use `/theme` with no arguments to open the full-screen theme browser. Moving through the list previews the complete theme immediately, including syntax-highlighted code and a unified diff. **Enter** applies and saves it, while **Esc** or **q** closes the browser and restores the theme that was active when it opened. `/theme <id>` remains the scriptable shortcut.
+
+## Semantic color roles
+
+Theme consumers should prefer these semantic roles instead of choosing a palette hue directly:
+
+| Role | Used for |
+|---|---|
+| `text_primary`, `text_muted`, `text_subtle` | primary and secondary copy |
+| `surface_raised`, `border_default` | panels and separators |
+| `feedback_success`, `feedback_error`, `feedback_warning`, `feedback_info` | status feedback |
+| `selection_fg`, `selection_bg` | selected text, rows, and focused controls |
+| `search_match_fg`, `search_match_bg` | ordinary search matches |
+| `search_current_fg`, `search_current_bg` | current search occurrence |
+| `focus_accent` | active-pane rail |
+| `user_message_fg`, `user_message_bg` | user-message bars |
+| `inline_code_fg`, `inline_code_bg` | Markdown inline-code chips |
+| `code_path`, `code_number` | technical values |
+| `diff_added`, `diff_removed` | added and removed diff lines |
+
+The legacy Catppuccin-named palette keys remain available as source swatches and for compatibility. New UI code should consume semantic roles. The Rich, prompt-toolkit, and ANSI adapters all resolve selection, search, focus, user-message, inline-code, and diff styles from these semantic roles.
+
+Built-in and installed themes use the same catalog parser, semantic-role expansion, contrast validation, and rendering path. The built-ins are Base24 definitions with semantic overrides; downloaded Base16/Base24 schemes follow the identical loading path.
+
+## Installing a theme
+
+Place `.yaml` or `.yml` files in either directory:
+
+- User-wide: `~/.config/nooa/themes/`
+- Project-local: `<project>/.nooa/themes/`
+
+Project themes override user themes with the same ID. Invalid files are skipped with a warning rather than preventing startup. Opening `/theme` reloads both directories, so adding a file does not require restarting the TUI.
+
+To install a theme downloaded from the internet, choose a Base16/Base24 YAML scheme (for example, from the [Tinted Theming schemes collection](https://github.com/tinted-theming/schemes)), copy its **raw** file URL, and save it in the user directory:
+
+```bash
+mkdir -p ~/.config/nooa/themes
+curl -L "$RAW_THEME_URL" -o ~/.config/nooa/themes/my-theme.yaml
+```
+
+Review downloaded files before using them. The filename becomes the theme ID when the file does not declare `slug` or `id`; open `/theme` to reload and preview it.
+
+To create a theme, the simplest route is to copy the Base16 example below to `~/.config/nooa/themes/my-theme.yaml`, change its `scheme`, `slug`, and colors, then run `/theme`. Add optional semantic-role keys at the top level when you need exact control over selection, inline code, or diff colors.
+
+### Base16 and Base24
+
+Standard Base16 YAML files are accepted directly. A minimal example:
+
+```yaml
+scheme: Ocean
+slug: ocean
+variant: dark
+base00: 2b303b
+base01: 343d46
+base02: 4f5b66
+base03: 65737e
+base04: a7adba
+base05: c0c5ce
+base06: dfe1e8
+base07: eff1f5
+base08: bf616a
+base09: d08770
+base0A: ebcb8b
+base0B: a3be8c
+base0C: 96b5b4
+base0D: 8fa1b3
+base0E: b48ead
+base0F: ab7967
+```
+
+Base24 files are accepted when all extension keys `base10` through `base17` are present. NOOA maps Base16 swatches to semantic UI roles and rejects required text/highlight combinations below the configured contrast thresholds.
+
+### Semantic overrides
+
+Base16 and Base24 files may override any semantic role listed above at the top level. For example:
+
+```yaml
+# Include base00 through base0F as shown above, then optionally add:
+inline_code_fg: '#ffffff'
+inline_code_bg: '#005fb8'
+selection_fg: '#ffffff'
+selection_bg: '#264f78'
+diff_added: '#287a1f'
+diff_removed: '#b42318'
+```
+
+Only six-digit RGB values are accepted. `syntax_theme` must name an installed Pygments style.

--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -1106,8 +1106,6 @@ class ReasoningCommand(Command):
 class ThemeCommand(Command):
     """Switch the color theme."""
 
-    THEMES = ("mocha", "latte", "vsdark", "vslight")
-
     @property
     def name(self) -> str:
         return "theme"
@@ -1117,25 +1115,31 @@ class ThemeCommand(Command):
 
         current = theme_module.get_theme() if hasattr(self, "config") else "?"
         return {
-            "/theme [name]": f"Switch theme (currently {current})",
+            "/theme [name]": f"Browse or switch themes (currently {current})",
         }
 
     def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
+        from .theme import reload_themes
+
+        names = reload_themes()
         if len(args) > 1:
-            return False, f"Usage: /theme [{'|'.join(self.THEMES)}]"
-        if len(args) == 1 and args[0].lower() not in self.THEMES:
-            return False, f"Theme must be one of: {', '.join(self.THEMES)}"
+            return False, f"Usage: /theme [{'|'.join(names)}]"
+        if len(args) == 1 and args[0].lower() not in names:
+            return False, f"Theme must be one of: {', '.join(names)}"
         return True, None
 
     async def execute(self, args: list[str]) -> "CommandResult":
         from . import theme as theme_module
 
         if not args:
-            current = theme_module.get_theme()
-            others = ", ".join(t for t in self.THEMES if t != current)
-            return CommandResult.ok(
-                TextOutput(f"Current theme: {current}  (available: {others})", "info")
-            )
+            open_browser = getattr(self.frontend, "open_theme_explorer", None)
+            if not callable(open_browser):
+                return CommandResult.err("The theme browser requires the terminal TUI.")
+            try:
+                await open_browser()
+            except Exception as exc:
+                return CommandResult.err(f"Theme browser failed: {exc}")
+            return CommandResult.ok(TextOutput("Theme browser closed.", "status"))
 
         name = args[0].lower()
         theme_module.set_theme(name)

--- a/packages/nooa-cli/src/nooa_cli/tui/completer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/completer.py
@@ -303,12 +303,12 @@ class Completer:
     # ------------------------------------------------------------------
 
     def _theme_completions(self, text: str) -> list[CompletionItem]:
-        from .theme import THEMES
+        from .theme import theme_names
 
         prefix = "/theme "
         partial = text[len(prefix) :]
         items = []
-        for name in THEMES:
+        for name in theme_names():
             if name.startswith(partial.lower()):
                 items.append(
                     CompletionItem(

--- a/packages/nooa-cli/src/nooa_cli/tui/config.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/config.py
@@ -105,7 +105,19 @@ class TUIConfig(BaseModel):
     trace_dir: Path | None = None
 
     # Color theme selected by ``/theme`` and restored on the next launch.
-    theme: Literal["mocha", "latte", "vsdark", "vslight"] = "mocha"
+    theme: str = "mocha"
+
+    @field_validator("theme")
+    @classmethod
+    def _validate_theme(cls, value: str) -> str:
+        from .theme import THEMES, reload_themes
+
+        name = str(value).lower()
+        if name not in THEMES:
+            reload_themes()
+        if name not in THEMES:
+            raise ValueError(f"Unknown theme {value!r}. Choose from: {', '.join(THEMES)}")
+        return name
 
     # Vi keybindings in prompt_toolkit input
     vi_mode: bool = False

--- a/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/explorer_base.py
@@ -44,8 +44,8 @@ def bar_style_code() -> str:
 
 def highlight_style_code(*, current: bool = False) -> str:
     """Return search-match colors for the active TUI theme."""
-    background = COLORS["sky"] if current else COLORS["yellow"]
-    return f"\x1b[38;2;{_rgb(COLORS['crust'])};48;2;{_rgb(background)}m"
+    role = "search_current" if current else "search_match"
+    return f"\x1b[38;2;{_rgb(COLORS[f'{role}_fg'])};48;2;{_rgb(COLORS[f'{role}_bg'])}m"
 
 
 def style_bar(text: str, *, ansi: bool) -> str:
@@ -256,8 +256,7 @@ class ExplorerModel:
         self.matches = [
             i
             for i, row in enumerate(self.rows)
-            if self._filter_predicate(row)
-            and matches_all_terms(terms, row.search_text)
+            if self._filter_predicate(row) and matches_all_terms(terms, row.search_text)
         ]
         if self._sort_key is not None:
             self.matches.sort(
@@ -364,6 +363,7 @@ class ExplorerInteraction:
     use_fullscreen_browser = True
     detail_focus = "detail"
     native_selection = False
+    quit_from_list = False
     options: tuple[ExplorerOptionItem, ...] = ()
     option_cursor: int | None = None
     _options_y = 1
@@ -456,6 +456,7 @@ class ExplorerInteraction:
             self.model.scroll_detail(delta)
         return "handled"
 
+
 class ExplorerView(ExplorerInteraction):
     """Generic in-app explorer subview.
 
@@ -526,6 +527,9 @@ class ExplorerView(ExplorerInteraction):
     def handle_action(self, action: str, row: Any) -> SubviewKeyResult:
         """Handle a custom action on the current row. Override for custom behavior."""
         return "ignored"
+
+    def on_selection_changed(self) -> None:
+        """React after the browser changes the selected row."""
 
     def handle_key(self, action: str, value: str = "") -> SubviewKeyResult:
         model = self.model

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -178,6 +178,10 @@ class Frontend(Protocol):
         """
         ...
 
+    async def open_theme_explorer(self) -> None:
+        """Open the full-screen theme browser."""
+        ...
+
     async def prompt_sensitive(
         self, title: str, message: str, *, link_url: str | None = None
     ) -> str:
@@ -287,6 +291,11 @@ class TerminalFrontend:
         if self._app is None:
             raise RuntimeError("TUI application is not ready.")
         await self._app.open_memory_explorer()
+
+    async def open_theme_explorer(self) -> None:
+        if self._app is None:
+            raise RuntimeError("TUI application is not ready.")
+        await self._app.open_theme_explorer(refresh=self.refresh_theme)
 
     async def open_activity_overlay(self, outputs: list[Output]) -> None:
         if self._app is None:
@@ -701,7 +710,7 @@ class TerminalFrontend:
     def _render_startup_to_string(self, info: StartupInfo, width: int) -> str:
         from rich.console import Console as RichConsole
 
-        from .theme import CATPPUCCIN_THEME
+        from .theme import create_theme
 
         buf = io.StringIO()
         render_width = max(int(width), 1)
@@ -711,7 +720,7 @@ class TerminalFrontend:
             highlight=False,
             force_terminal=True,
             color_system="256",
-            theme=CATPPUCCIN_THEME,
+            theme=create_theme(),
             _environ={"COLUMNS": str(render_width), "LINES": "25"},
         )
         self._print_startup(info, console)

--- a/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/fullscreen_browser.py
@@ -104,6 +104,7 @@ def build_fullscreen_browser(
     small_control: UIControl,
     small_text: Callable[[], Any],
     list_height: Dimension | None = None,
+    list_area_height: Dimension | None = None,
     floats: list[Float] | None = None,
 ) -> DynamicContainer:
     """Build the shared Resume-style title/search/list/preview browser shell."""
@@ -111,7 +112,7 @@ def build_fullscreen_browser(
     def separator() -> Window:
         return Window(char="─", height=1, style="class:fullscreen-browser.separator")
 
-    def area(name: str, body: Any) -> VSplit:
+    def area(name: str, body: Any, *, height: Dimension | None = None) -> VSplit:
         return VSplit(
             [
                 Window(
@@ -122,6 +123,7 @@ def build_fullscreen_browser(
                 body,
             ],
             padding=0,
+            height=height,
         )
 
     main_body = HSplit(
@@ -144,6 +146,7 @@ def build_fullscreen_browser(
                     ],
                     padding=0,
                 ),
+                height=list_area_height,
             ),
             separator(),
             area(
@@ -512,9 +515,7 @@ class ExplorerBrowser:
         for index, control in enumerate(self.option_controls):
             if index:
                 option_windows.append(Window(FormattedTextControl(" "), width=1, height=1))
-            option_window = Window(
-                control, width=self._option_window_width(index), height=1
-            )
+            option_window = Window(control, width=self._option_window_width(index), height=1)
             self.option_windows.append(option_window)
             option_windows.append(option_window)
         self.search_label_control = FormattedTextControl(self._search_label)
@@ -573,7 +574,24 @@ class ExplorerBrowser:
         self.small_control = FormattedTextControl(
             [("class:fullscreen-browser.too-small", "Terminal too small")], focusable=True
         )
-        self.explorer_list_height = Dimension(min=1, preferred=5, weight=1)
+        requested_list_height = getattr(view, "list_height", None)
+        self.explorer_list_height = (
+            Dimension(min=1, preferred=requested_list_height, max=requested_list_height)
+            if requested_list_height is not None
+            else Dimension(min=1, preferred=5, weight=1)
+        )
+        # The pane also contains search, heading, and separator rows. Constrain
+        # the wrapping VSplit because its rail window is otherwise flexible and
+        # lets the pane consume the remaining screen despite a fixed row list.
+        self.explorer_list_area_height = (
+            Dimension(
+                min=requested_list_height + 3,
+                preferred=requested_list_height + 3,
+                max=requested_list_height + 3,
+            )
+            if requested_list_height is not None
+            else None
+        )
         self.container = build_fullscreen_browser(
             app=app,
             title_control=self.title_control,
@@ -589,6 +607,7 @@ class ExplorerBrowser:
             # Explorer lists should consume the full list pane. The Resume
             # Picker keeps the shell's compact five-row default.
             list_height=self.explorer_list_height,
+            list_area_height=self.explorer_list_area_height,
             floats=dropdown_floats,
         )
         # Views with a timed confirmation gesture (the memory explorer's
@@ -617,11 +636,17 @@ class ExplorerBrowser:
     def model(self) -> Any:
         return self.view.model
 
+    def _selection_changed(self) -> None:
+        callback = getattr(self.view, "on_selection_changed", None)
+        if callable(callback):
+            callback()
+
     def _query_changed(self) -> None:
         self.model.edit_query(self.buffer.text)
         self.model.search_active = bool(self.buffer.text.strip())
         self.list_offset = 0
         self._list_offset_detached = False
+        self._selection_changed()
         self.invalidate()
 
     def _title(self):
@@ -907,9 +932,7 @@ class ExplorerBrowser:
             width, height = self.preview_control.viewport
             transcript = self._preview_transcript(width, height)
             if transcript is not None:
-                transcript.scroll_visual_lines(
-                    delta, width=max(1, width), height=max(1, height)
-                )
+                transcript.scroll_visual_lines(delta, width=max(1, width), height=max(1, height))
                 return
         self.model.scroll_detail(delta)
 
@@ -926,6 +949,7 @@ class ExplorerBrowser:
         if self.active_control == "list":
             self._list_offset_detached = False
             self.model.move(delta)
+            self._selection_changed()
             self.invalidate()
             return
         width, height = self.preview_control.viewport
@@ -947,6 +971,7 @@ class ExplorerBrowser:
         if self.active_control == "list":
             self._list_offset_detached = False
             self.model.move(delta * max(1, amount))
+            self._selection_changed()
         else:
             self._scroll_detail_pane(delta * max(1, amount))
         self.invalidate()
@@ -957,6 +982,7 @@ class ExplorerBrowser:
             self.model.cursor = index
             self.model.detail_offset = 0
             self._list_offset_detached = False
+            self._selection_changed()
             self.invalidate()
 
     def mouse_scroll(self, pane: str, delta: int) -> None:
@@ -1026,9 +1052,11 @@ class ExplorerBrowser:
             self.page(-1)
         elif action == "home":
             self.model.jump_home()
+            self._selection_changed()
             self.invalidate()
         elif action == "end":
             self.model.jump_end()
+            self._selection_changed()
             self.invalidate()
         elif action in {"scroll_down", "scroll_up"}:
             delta = 3 if action == "scroll_down" else -3
@@ -1038,6 +1066,8 @@ class ExplorerBrowser:
                 self.buffer.delete_before_cursor()
         elif action in {"quit", "resume", "slash", "j", "k"}:
             text = {"quit": "q", "resume": "r", "slash": "/", "j": "j", "k": "k"}[action]
+            if action == "quit" and getattr(self.view, "quit_from_list", False):
+                return "close"
             if self.active_control == "list":
                 self.buffer.insert_text(text)
             elif action == "quit":

--- a/packages/nooa-cli/src/nooa_cli/tui/highlight_preview.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/highlight_preview.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Interactive true-color preview for Markdown inline-code palettes."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from typing import TextIO
+
+RESET = "\x1b[0m"
+CLEAR = "\x1b[2J\x1b[H"
+HIDE_CURSOR = "\x1b[?25l"
+SHOW_CURSOR = "\x1b[?25h"
+
+
+@dataclass(frozen=True)
+class InlineCodePalette:
+    """One inline-code foreground/background candidate."""
+
+    name: str
+    description: str
+    foreground: str
+    background: str
+
+
+CANDIDATES: dict[str, tuple[InlineCodePalette, ...]] = {
+    "mocha": (
+        InlineCodePalette("Balanced", "blue chip", "#11111b", "#89b4fa"),
+        InlineCodePalette("Cool", "teal chip", "#11111b", "#94e2d5"),
+        InlineCodePalette("Warm", "peach chip", "#11111b", "#fab387"),
+    ),
+    "latte": (
+        InlineCodePalette("Balanced", "blue chip", "#ffffff", "#1e66f5"),
+        InlineCodePalette("Cool", "teal chip", "#ffffff", "#007b83"),
+        InlineCodePalette("Warm", "rose chip", "#ffffff", "#a83f55"),
+    ),
+    "vsdark": (
+        InlineCodePalette("Balanced", "blue chip", "#1e1e1e", "#9cdcfe"),
+        InlineCodePalette("Cool", "teal chip", "#1e1e1e", "#4ec9b0"),
+        InlineCodePalette("Warm", "peach chip", "#1e1e1e", "#ce9178"),
+    ),
+    "vslight": (
+        InlineCodePalette("Balanced", "blue chip", "#ffffff", "#005fb8"),
+        InlineCodePalette("Cool", "green chip", "#ffffff", "#107c10"),
+        InlineCodePalette("Warm", "red chip", "#ffffff", "#a31515"),
+    ),
+}
+
+
+def _luminance(color: str) -> float:
+    channels = [int(color[index : index + 2], 16) / 255 for index in (1, 3, 5)]
+    linear = [
+        channel / 12.92 if channel <= 0.04045 else ((channel + 0.055) / 1.055) ** 2.4
+        for channel in channels
+    ]
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+
+def contrast_ratio(foreground: str, background: str) -> float:
+    """Return the WCAG contrast ratio for two ``#rrggbb`` colors."""
+    lighter, darker = sorted((_luminance(foreground), _luminance(background)), reverse=True)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _paint(text: str, candidate: InlineCodePalette, *, enabled: bool) -> str:
+    if not enabled:
+        return text
+    fg = tuple(int(candidate.foreground[index : index + 2], 16) for index in (1, 3, 5))
+    bg = tuple(int(candidate.background[index : index + 2], 16) for index in (1, 3, 5))
+    return f"\x1b[38;2;{fg[0]};{fg[1]};{fg[2]};48;2;{bg[0]};{bg[1]};{bg[2]}m{text}{RESET}"
+
+
+def render(theme: str, selected: int = 0, *, color: bool = True) -> str:
+    """Render three inline-code choices for one theme."""
+    lines = [
+        f"NOOA INLINE-CODE LAB  ·  theme: {theme}",
+        "The actual `inline code` chip is previewed below for every option.",
+        "",
+    ]
+    for index, candidate in enumerate(CANDIDATES[theme]):
+        marker = "❯" if index == selected else " "
+        sample = _paint(" inline code ", candidate, enabled=color)
+        command = _paint("uv run pytest", candidate, enabled=color)
+        path = _paint("theme.py", candidate, enabled=color)
+        lines.extend(
+            [
+                f"{marker} {index + 1}. {candidate.name} — {candidate.description}",
+                f"   Use {sample} inside prose; run {command} after editing {path}.",
+                f"   {candidate.foreground} on {candidate.background}  "
+                f"contrast {contrast_ratio(candidate.foreground, candidate.background):.2f}:1",
+                "",
+            ]
+        )
+    lines.append(
+        "←/→ or h/l: theme   ↑/↓ or j/k: choice   1–3: choice   Enter: print choice   q: quit"
+    )
+    return "\n".join(lines)
+
+
+def _read_key() -> str:
+    if os.name == "nt":  # pragma: no cover - Windows-only fallback
+        import msvcrt
+
+        key = msvcrt.getwch()
+        if key in {"\x00", "\xe0"}:
+            scan_code = msvcrt.getwch()
+            return {
+                "H": "\x1b[A",
+                "P": "\x1b[B",
+                "K": "\x1b[D",
+                "M": "\x1b[C",
+            }.get(scan_code, key + scan_code)
+        return key
+    import termios
+    import tty
+
+    descriptor = sys.stdin.fileno()
+    old = termios.tcgetattr(descriptor)
+    try:
+        tty.setraw(descriptor)
+        first = sys.stdin.read(1)
+        return first + sys.stdin.read(2) if first == "\x1b" else first
+    finally:
+        termios.tcsetattr(descriptor, termios.TCSADRAIN, old)
+
+
+def run_interactive(theme: str, *, output: TextIO = sys.stdout) -> int:
+    """Run the keyboard-driven preview and print the selected candidate."""
+    names = list(CANDIDATES)
+    theme_index = names.index(theme)
+    selected = 0
+    output.write(HIDE_CURSOR)
+    try:
+        while True:
+            current_theme = names[theme_index]
+            output.write(CLEAR + render(current_theme, selected) + "\n")
+            output.flush()
+            key = _read_key()
+            if key in {"q", "Q", "\x03"}:
+                return 0
+            if key in {"\x1b[D", "h", "H"}:
+                theme_index = (theme_index - 1) % len(names)
+            elif key in {"\x1b[C", "l", "L"}:
+                theme_index = (theme_index + 1) % len(names)
+            elif key in {"\x1b[A", "k", "K"}:
+                selected = (selected - 1) % 3
+            elif key in {"\x1b[B", "j", "J"}:
+                selected = (selected + 1) % 3
+            elif key in {"1", "2", "3"}:
+                selected = int(key) - 1
+            elif key in {"\r", "\n"}:
+                choice = CANDIDATES[current_theme][selected]
+                output.write(
+                    CLEAR
+                    + f"Selected: {current_theme} / {choice.name}\n"
+                    + f"inline code: {choice.foreground} on {choice.background}\n"
+                )
+                return 0
+    finally:
+        output.write(SHOW_CURSOR)
+        output.flush()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compare NOOA inline-code highlight palettes")
+    parser.add_argument("--theme", choices=CANDIDATES, default="mocha")
+    parser.add_argument("--plain", action="store_true", help="print without color or controls")
+    args = parser.parse_args(argv)
+    if args.plain:
+        print("\n\n".join(render(name, color=False) for name in CANDIDATES))
+        return 0
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        parser.error("interactive preview requires a terminal; use --plain for text output")
+    return run_interactive(args.theme)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/packages/nooa-cli/src/nooa_cli/tui/input_handler.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/input_handler.py
@@ -241,7 +241,7 @@ def create_key_bindings(vi_mode: bool = False) -> KeyBindings:
 
 
 def create_prompt_style() -> Style:
-    """Create prompt_toolkit style using Catppuccin colors."""
+    """Create a prompt_toolkit style from the active semantic palette."""
     return Style.from_dict(
         {
             # Prompt
@@ -249,9 +249,9 @@ def create_prompt_style() -> Style:
             "prompt.continuation": COLORS["overlay1"],
             "input-area": COLORS["text"],
             "paste-attachment": f"bg:{COLORS['surface0']} {COLORS['subtext1']} italic",
-            "selected": f"bg:{COLORS['surface2']} {COLORS['text']}",
-            "transcript-search-match": f"bg:{COLORS['surface1']} {COLORS['yellow']}",
-            "transcript-search-current": f"bg:{COLORS['yellow']} {COLORS['base']} bold",
+            "selected": f"bg:{COLORS['selection_bg']} {COLORS['selection_fg']}",
+            "transcript-search-match": f"bg:{COLORS['search_match_bg']} {COLORS['search_match_fg']}",
+            "transcript-search-current": f"bg:{COLORS['search_current_bg']} {COLORS['search_current_fg']} bold",
             "return-to-tail": f"bg:{COLORS['surface1']} {COLORS['blue']} bold",
             # Full-screen browsers inherit the terminal's default foreground
             # for ordinary text — the same color scrollback agent messages
@@ -259,29 +259,23 @@ def create_prompt_style() -> Style:
             # and state.
             "fullscreen-browser.title": "bold",
             "fullscreen-browser.row": "",
-            "fullscreen-browser.selected": f"bg:{COLORS['surface2']}",
-
+            "fullscreen-browser.selected": f"bg:{COLORS['selection_bg']} {COLORS['selection_fg']}",
             "fullscreen-browser.unavailable": f"{COLORS['overlay1']} italic",
             "fullscreen-browser.current": COLORS["blue"],
             "fullscreen-browser.attached": COLORS["peach"],
-            "fullscreen-browser.match": f"{COLORS['yellow']} bold underline",
+            "fullscreen-browser.match": f"bg:{COLORS['search_match_bg']} {COLORS['search_match_fg']} bold underline",
             "fullscreen-browser.meta": "",
             "fullscreen-browser.detail": "",
             "fullscreen-browser.search-label": "bold",
             "fullscreen-browser.control": "",
             "fullscreen-browser.dropdown": f"bg:{COLORS['surface0']} {COLORS['text']}",
             "fullscreen-browser.dropdown-frame": f"bg:{COLORS['surface0']} {COLORS['surface2']}",
-            "fullscreen-browser.control-focused": f"bg:{COLORS['surface2']}",
-
+            "fullscreen-browser.control-focused": f"bg:{COLORS['selection_bg']} {COLORS['selection_fg']}",
             "fullscreen-browser.heading": "bold",
-
             "fullscreen-browser.separator": COLORS["surface2"],
             "fullscreen-browser.active-rail": COLORS["surface1"],
-            # The active pane's rail is the one deliberate accent in the
-            # browser: the theme's highlight color (lavender on mocha),
-            # switching with the active palette.
-            "fullscreen-browser.active-rail-active": f"{COLORS['lavender']} bold",
-
+            # The active pane rail uses the theme's semantic focus accent.
+            "fullscreen-browser.active-rail-active": f"{COLORS['focus_accent']} bold",
             "fullscreen-browser.preview": "",
             "fullscreen-browser.preview-user": f"bg:{COLORS['surface2']}",
             "fullscreen-browser.preview-user-edge": COLORS["surface2"],

--- a/packages/nooa-cli/src/nooa_cli/tui/settings.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/settings.py
@@ -69,11 +69,13 @@ def _coerce_display_mode(value: Any) -> Any:
 
 
 def _coerce_theme(value: Any) -> str:
-    from .theme import THEMES
+    from .theme import THEMES, reload_themes
 
+    reload_themes()
     name = str(value).lower()
     if name not in THEMES:
-        raise ValueError(f"Unknown theme {value!r}. Choose from: {', '.join(THEMES)}")
+        logger.warning("Unknown persisted theme %r; falling back to mocha", value)
+        return "mocha"
     return name
 
 
@@ -281,8 +283,9 @@ tui:
   # LLM model alias (from the unifiedllm registry) or a litellm model name.
   # default_model: {default_model}
 
-  # Color palette. Prefer /theme <name> so the choice is applied and saved.
-  # theme: mocha               # mocha | latte | vsdark | vslight
+  # Color palette. Use /theme to browse; /theme <id> applies directly.
+  # Custom Base16/Base24 YAML themes load from user/project .nooa/themes/.
+  # theme: mocha
 
   # Show the agent's Python execution panels.
   # show_python: false

--- a/packages/nooa-cli/src/nooa_cli/tui/theme.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Theme system for the NOOA TUI.
 
-Four built-in palettes — all use the same Catppuccin key names so every
-consumer (frontend.py, console.py, splash.py) works without changes:
+Four built-in palettes provide a shared base palette plus documented semantic
+UI roles. Compatible native and Base16 YAML themes are discovered at startup:
 
   mocha   — Catppuccin Mocha (dark)         [default]
   latte   — Catppuccin Latte (light)
@@ -17,9 +17,13 @@ Usage::
     console._theme = create_theme()
 """
 
+from pygments.token import Generic
 from rich.console import Console, ConsoleOptions, RenderResult
-from rich.syntax import Syntax
+from rich.style import Style
+from rich.syntax import PygmentsSyntaxTheme, Syntax, SyntaxTheme
 from rich.theme import Theme
+
+from .theme_catalog import SEMANTIC_KEYS, ThemeRecord, load_user_themes, parse_theme
 
 # ---------------------------------------------------------------------------
 # Palettes — all share the same key names (Catppuccin semantic roles)
@@ -52,6 +56,8 @@ _MOCHA: dict[str, str] = {
     "base": "#1e1e2e",
     "mantle": "#181825",
     "crust": "#11111b",
+    "inline_code_fg": "#11111b",
+    "inline_code_bg": "#89b4fa",
 }
 
 _LATTE: dict[str, str] = {
@@ -81,6 +87,8 @@ _LATTE: dict[str, str] = {
     "base": "#eff1f5",
     "mantle": "#e6e9ef",
     "crust": "#dce0e8",
+    "inline_code_fg": "#ffffff",
+    "inline_code_bg": "#1e66f5",
 }
 
 # VS Code Dark+ — keys mapped to Catppuccin semantic roles
@@ -111,6 +119,8 @@ _VS_DARK: dict[str, str] = {
     "base": "#1e1e1e",
     "mantle": "#181818",
     "crust": "#111111",
+    "inline_code_fg": "#1e1e1e",
+    "inline_code_bg": "#9cdcfe",
 }
 
 # VS Code Light — keys mapped to Catppuccin semantic roles
@@ -141,31 +151,167 @@ _VS_LIGHT: dict[str, str] = {
     "base": "#ffffff",
     "mantle": "#f8f8f8",
     "crust": "#ececec",
+    "inline_code_fg": "#ffffff",
+    "inline_code_bg": "#005fb8",
 }
 
+_BUILTIN_SEMANTICS = {
+    "mocha": {
+        "selection_fg": "#cdd6f4",
+        "selection_bg": "#585b70",
+        "user_message_fg": "#cdd6f4",
+        "user_message_bg": "#585b70",
+        "search_match_fg": "#11111b",
+        "search_match_bg": "#f9e2af",
+        "search_current_fg": "#11111b",
+        "search_current_bg": "#89dceb",
+        "focus_accent": "#b4befe",
+    },
+    "latte": {
+        "selection_fg": "#4c4f69",
+        "selection_bg": "#c8d8f4",
+        "user_message_fg": "#4c4f69",
+        "user_message_bg": "#c8d8f4",
+        "search_match_fg": "#4c4f69",
+        "search_match_bg": "#f1dfb8",
+        "search_current_fg": "#20233a",
+        "search_current_bg": "#7aa2e8",
+        "focus_accent": "#1e66f5",
+        "feedback_success": "#287a1f",
+        "feedback_warning": "#765000",
+        "feedback_info": "#1858c7",
+    },
+    "vsdark": {
+        "selection_fg": "#d4d4d4",
+        "selection_bg": "#264f78",
+        "user_message_fg": "#d4d4d4",
+        "user_message_bg": "#264f78",
+        "search_match_fg": "#f5e6b3",
+        "search_match_bg": "#4b4632",
+        "search_current_fg": "#ffffff",
+        "search_current_bg": "#365f86",
+        "focus_accent": "#569cd6",
+    },
+    "vslight": {
+        "selection_fg": "#000000",
+        "selection_bg": "#add6ff",
+        "user_message_fg": "#000000",
+        "user_message_bg": "#add6ff",
+        "search_match_fg": "#3b2f1d",
+        "search_match_bg": "#f4ddb5",
+        "search_current_fg": "#101820",
+        "search_current_bg": "#75b8f5",
+        "focus_accent": "#005fb8",
+    },
+}
+for _theme_id, _overrides in _BUILTIN_SEMANTICS.items():
+    _BUILTIN_PALETTE = {"mocha": _MOCHA, "latte": _LATTE, "vsdark": _VS_DARK, "vslight": _VS_LIGHT}[
+        _theme_id
+    ]
+    _BUILTIN_PALETTE.update(_overrides)
+
+
+_BUILTIN_THEME_METADATA = {
+    "mocha": ("Catppuccin Mocha", "dark", "monokai", "Catppuccin's dark palette"),
+    "latte": ("Catppuccin Latte", "light", "gruvbox-light", "Catppuccin's light palette"),
+    "vsdark": ("Visual Studio Dark+", "dark", "github-dark", "Visual Studio Code Dark+"),
+    "vslight": ("Visual Studio Light", "light", "vs", "Visual Studio Code Light"),
+}
+_BUILTIN_PALETTES = {"mocha": _MOCHA, "latte": _LATTE, "vsdark": _VS_DARK, "vslight": _VS_LIGHT}
+
+
+def _base24_scheme(theme_id: str) -> dict[str, str]:
+    """Express a built-in palette through the public Base24 theme schema."""
+    palette = _BUILTIN_PALETTES[theme_id]
+    metadata = _BUILTIN_THEME_METADATA[theme_id]
+    scheme = {
+        "id": theme_id,
+        "name": metadata[0],
+        "variant": metadata[1],
+        "syntax_theme": metadata[2],
+        "description": metadata[3],
+        "base00": palette["base"],
+        "base01": palette["surface0"],
+        "base02": palette["surface1"],
+        "base03": palette["surface2"],
+        "base04": palette["subtext1"],
+        "base05": palette["text"],
+        "base06": palette["rosewater"],
+        "base07": palette["text"],
+        "base08": palette["red"],
+        "base09": palette["peach"],
+        "base0A": palette["yellow"],
+        "base0B": palette["green"],
+        "base0C": palette["teal"],
+        "base0D": palette["blue"],
+        "base0E": palette["mauve"],
+        "base0F": palette["flamingo"],
+        "base10": palette["crust"],
+        "base11": palette["red"],
+        "base12": palette["green"],
+        "base13": palette["yellow"],
+        "base14": palette["blue"],
+        "base15": palette["pink"],
+        "base16": palette["sky"],
+        "base17": palette["lavender"],
+    }
+    scheme.update({key: palette[key] for key in SEMANTIC_KEYS if key in palette})
+    return scheme
+
+
+_BUILTIN_RECORDS = {
+    theme_id: parse_theme(_base24_scheme(theme_id), fallback_id=theme_id, source="builtin")
+    for theme_id in _BUILTIN_THEME_METADATA
+}
+THEME_RECORDS, THEME_DIAGNOSTICS = load_user_themes(_BUILTIN_RECORDS)
 THEMES: dict[str, dict[str, str]] = {
-    "mocha": _MOCHA,
-    "latte": _LATTE,
-    "vsdark": _VS_DARK,
-    "vslight": _VS_LIGHT,
+    theme_id: record.palette for theme_id, record in THEME_RECORDS.items()
+}
+SYNTAX_THEMES: dict[str, str] = {
+    theme_id: record.syntax_theme for theme_id, record in THEME_RECORDS.items()
 }
 
-# Pygments styles selected to match each UI palette. Syntax renderers keep
-# their existing transparent/default background policy; this mapping only
-# changes token colours.
-SYNTAX_THEMES: dict[str, str] = {
-    "mocha": "monokai",
-    "latte": "gruvbox-light",
-    "vsdark": "github-dark",
-    "vslight": "vs",
-}
+
+def reload_themes() -> tuple[str, ...]:
+    """Reload user/project theme files while preserving shared mapping identity."""
+    global THEME_DIAGNOSTICS, _active_name
+    records, diagnostics = load_user_themes(_BUILTIN_RECORDS)
+    THEME_RECORDS.clear()
+    THEME_RECORDS.update(records)
+    THEMES.clear()
+    THEMES.update((theme_id, record.palette) for theme_id, record in records.items())
+    SYNTAX_THEMES.clear()
+    SYNTAX_THEMES.update((theme_id, record.syntax_theme) for theme_id, record in records.items())
+    THEME_DIAGNOSTICS = diagnostics
+    if _active_name not in THEMES:
+        _active_name = "mocha"
+    COLORS.clear()
+    COLORS.update(THEMES[_active_name])
+    return tuple(THEME_RECORDS)
+
+
+def theme_names() -> tuple[str, ...]:
+    """Return all discovered theme IDs in deterministic display order."""
+    return tuple(THEME_RECORDS)
+
+
+def get_theme_record(name: str | None = None) -> ThemeRecord:
+    """Return metadata and semantic colors for one discovered theme."""
+    selected = _active_name if name is None else name
+    try:
+        return THEME_RECORDS[selected]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown theme {selected!r}. Choose from: {', '.join(THEME_RECORDS)}"
+        ) from exc
+
 
 # ---------------------------------------------------------------------------
 # Active palette — a mutable dict updated in-place so that callers who did
 # `from .theme import COLORS` keep a live reference after set_theme().
 # ---------------------------------------------------------------------------
 
-COLORS: dict[str, str] = dict(_MOCHA)
+COLORS: dict[str, str] = dict(THEMES["mocha"])
 _active_name: str = "mocha"
 
 
@@ -175,12 +321,36 @@ def get_theme() -> str:
 
 
 def get_syntax_theme(name: str | None = None) -> str:
-    """Return the Pygments style paired with a built-in UI theme."""
+    """Return the Pygments style paired with a discovered UI theme."""
     selected = _active_name if name is None else name
     try:
         return SYNTAX_THEMES[selected]
     except KeyError as exc:
         raise ValueError(f"Unknown theme {selected!r}. Choose from: {', '.join(THEMES)}") from exc
+
+
+class SemanticSyntaxTheme(SyntaxTheme):
+    """Pygments syntax colors with semantic added/removed diff colors."""
+
+    def __init__(self, syntax_theme: str, palette: dict[str, str]) -> None:
+        self._base = PygmentsSyntaxTheme(syntax_theme)
+        self._palette = palette
+
+    def get_style_for_token(self, token_type: object) -> Style:
+        if token_type in Generic.Inserted:
+            return Style(color=self._palette["diff_added"])
+        if token_type in Generic.Deleted:
+            return Style(color=self._palette["diff_removed"])
+        return self._base.get_style_for_token(token_type)  # type: ignore[arg-type]
+
+    def get_background_style(self) -> Style:
+        return self._base.get_background_style()
+
+
+def create_syntax_theme(name: str | None = None) -> SemanticSyntaxTheme:
+    """Create syntax colors for a discovered theme, including semantic diffs."""
+    selected = get_theme() if name is None else name
+    return SemanticSyntaxTheme(get_syntax_theme(selected), THEMES[selected])
 
 
 class ThemeSyntax(Syntax):
@@ -189,12 +359,12 @@ class ThemeSyntax(Syntax):
     def __init__(self, code: str, lexer: object, **kwargs: object) -> None:
         self._uses_active_theme = "theme" not in kwargs
         if self._uses_active_theme:
-            kwargs["theme"] = get_syntax_theme()
+            kwargs["theme"] = create_syntax_theme()
         super().__init__(code, lexer, **kwargs)  # type: ignore[arg-type]
 
     def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
         if self._uses_active_theme:
-            self._theme = self.get_theme(get_syntax_theme())
+            self._theme = create_syntax_theme()
         yield from super().__rich_console__(console, options)
 
 
@@ -202,7 +372,7 @@ def set_theme(name: str) -> None:
     """Switch the active theme.  Updates COLORS in-place.
 
     Args:
-        name: One of ``mocha``, ``latte``, ``vsdark``, ``vslight``.
+        name: A built-in or discovered user theme ID.
 
     Raises:
         ValueError: If *name* is not a known theme.
@@ -229,11 +399,11 @@ def create_theme() -> Theme:
             "agent": f"bold {c['mauve']}",
             "agent.response": c["text"],
             # Status messages
-            "status": c["overlay1"],
-            "success": f"bold {c['green']}",
-            "error": f"bold {c['red']}",
-            "warning": f"bold {c['yellow']}",
-            "info": f"bold {c['blue']}",
+            "status": c["text_subtle"],
+            "success": f"bold {c['feedback_success']}",
+            "error": f"bold {c['feedback_error']}",
+            "warning": f"bold {c['feedback_warning']}",
+            "info": f"bold {c['feedback_info']}",
             # Panels and borders
             "panel.border": c["mauve"],
             "panel.title": f"bold {c['mauve']}",
@@ -248,13 +418,11 @@ def create_theme() -> Theme:
             "spinner.text": c["subtext1"],
             # Code/technical
             "code": c["peach"],
-            # Rich's default inline code span (``like this``) is cyan on a
-            # black background, which ignores the palette and disappears on
-            # light themes. Use the active surface/peach so the chip reads
-            # correctly on dark and light palettes alike.
-            "markdown.code": f"on {c['surface0']} {c['peach']}",
-            "path": c["teal"],
-            "number": c["peach"],
+            # Inline-code chips have dedicated colors: their compact filled
+            # shape needs different contrast than syntax tokens or panels.
+            "markdown.code": f"{c['inline_code_fg']} on {c['inline_code_bg']}",
+            "path": c["code_path"],
+            "number": c["code_number"],
             # History tags
             "tag": c["blue"],
             "tag.summary": c["yellow"],

--- a/packages/nooa-cli/src/nooa_cli/tui/theme_catalog.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme_catalog.py
@@ -1,0 +1,308 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Discovery and validation for built-in, native, and Base16 TUI themes."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+from pygments.styles import get_style_by_name
+
+logger = logging.getLogger(__name__)
+_HEX = re.compile(r"^#[0-9a-fA-F]{6}$")
+_MAX_THEME_BYTES = 64 * 1024
+_MAX_THEME_FILES = 64
+
+SEMANTIC_KEYS = (
+    "text_primary",
+    "text_muted",
+    "text_subtle",
+    "surface_raised",
+    "border_default",
+    "feedback_success",
+    "feedback_error",
+    "feedback_warning",
+    "feedback_info",
+    "selection_fg",
+    "selection_bg",
+    "search_match_fg",
+    "search_match_bg",
+    "search_current_fg",
+    "search_current_bg",
+    "focus_accent",
+    "user_message_fg",
+    "user_message_bg",
+    "inline_code_fg",
+    "inline_code_bg",
+    "code_path",
+    "code_number",
+    "diff_added",
+    "diff_removed",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ThemeRecord:
+    id: str
+    name: str
+    palette: dict[str, str]
+    syntax_theme: str
+    variant: str
+    source: str
+    description: str = ""
+    author: str = ""
+
+
+def normalize_color(value: object) -> str:
+    """Normalize a six-digit RGB value and reject style-string injection."""
+    text = str(value).strip()
+    if not text.startswith("#"):
+        text = "#" + text
+    if not _HEX.fullmatch(text):
+        raise ValueError(f"Expected six-digit RGB color, got {value!r}")
+    return text.lower()
+
+
+def semanticize(palette: dict[str, str]) -> dict[str, str]:
+    """Fill documented semantic UI roles from one normalized base palette."""
+    result = dict(palette)
+    defaults = {
+        "text_primary": result["text"],
+        "text_muted": result["subtext1"],
+        "text_subtle": result["overlay1"],
+        "surface_raised": result["surface0"],
+        "border_default": result["surface2"],
+        "feedback_success": result["green"],
+        "feedback_error": result["red"],
+        "feedback_warning": result["yellow"],
+        "feedback_info": result["blue"],
+        "selection_fg": result["text"],
+        "selection_bg": result["surface2"],
+        "search_match_fg": result["crust"],
+        "search_match_bg": result["yellow"],
+        "search_current_fg": result["crust"],
+        "search_current_bg": result["sky"],
+        "focus_accent": result["lavender"],
+        "user_message_fg": result["text"],
+        "user_message_bg": result["surface2"],
+        "inline_code_fg": result["text"],
+        "inline_code_bg": result["surface0"],
+        "code_path": result["teal"],
+        "code_number": result["peach"],
+    }
+    for key, value in defaults.items():
+        result.setdefault(key, value)
+    result.setdefault("diff_added", result["feedback_success"])
+    result.setdefault("diff_removed", result["feedback_error"])
+    return result
+
+
+def _base16_palette(data: dict[str, Any]) -> dict[str, str]:
+    folded = {str(key).lower(): value for key, value in data.items()}
+    bases = {f"base{index:02X}": normalize_color(folded[f"base{index:02x}"]) for index in range(16)}
+    palette = semanticize(
+        {
+            "base": bases["base00"],
+            "mantle": bases["base01"],
+            "crust": bases["base00"],
+            "surface0": bases["base01"],
+            "surface1": bases["base02"],
+            "surface2": bases["base03"],
+            "overlay0": bases["base03"],
+            "overlay1": bases["base04"],
+            "overlay2": bases["base04"],
+            "text": bases["base05"],
+            "subtext1": bases["base04"],
+            "subtext0": bases["base03"],
+            "red": bases["base08"],
+            "maroon": bases["base08"],
+            "peach": bases["base09"],
+            "yellow": bases["base0A"],
+            "green": bases["base0B"],
+            "teal": bases["base0C"],
+            "sky": bases["base0C"],
+            "sapphire": bases["base0D"],
+            "blue": bases["base0D"],
+            "lavender": bases["base0D"],
+            "mauve": bases["base0E"],
+            "pink": bases["base0E"],
+            "rosewater": bases["base0F"],
+            "flamingo": bases["base0F"],
+        }
+    )
+    dark, light = bases["base00"], bases["base07"]
+    for role, background in (
+        ("selection", bases["base02"]),
+        ("search_match", bases["base0A"]),
+        ("search_current", bases["base0D"]),
+        ("inline_code", bases["base0D"]),
+    ):
+        foreground = _contrast_foreground(background, dark, light)
+        if contrast_ratio(foreground, background) < 4.5:
+            foreground, background = palette["text_primary"], palette["surface_raised"]
+        if role == "inline_code" and contrast_ratio(background, palette["base"]) < 3:
+            candidates = (
+                bases["base0A"],
+                bases["base0B"],
+                bases["base0C"],
+                bases["base04"],
+                bases["base05"],
+                bases["base06"],
+                bases["base07"],
+            )
+            for candidate in candidates:
+                candidate_foreground = _contrast_foreground(candidate, dark, light)
+                if (
+                    contrast_ratio(candidate_foreground, candidate) >= 4.5
+                    and contrast_ratio(candidate, palette["base"]) >= 3
+                ):
+                    foreground, background = candidate_foreground, candidate
+                    break
+        palette[f"{role}_fg"] = foreground
+        palette[f"{role}_bg"] = background
+    palette["user_message_fg"] = palette["selection_fg"]
+    palette["user_message_bg"] = palette["selection_bg"]
+    base24_keys = {f"base{index:02x}" for index in range(16, 24)}
+    focus_candidates = [bases["base0D"], bases["base0B"], bases["base0A"]]
+    if base24_keys <= folded.keys():
+        palette.update(
+            feedback_error=normalize_color(folded["base11"]),
+            feedback_success=normalize_color(folded["base12"]),
+            feedback_warning=normalize_color(folded["base13"]),
+            feedback_info=normalize_color(folded["base14"]),
+        )
+        focus_candidates.append(normalize_color(folded["base14"]))
+    for role in ("success", "error", "warning", "info"):
+        key = f"feedback_{role}"
+        if contrast_ratio(palette[key], palette["base"]) < 4.5:
+            palette[key] = palette["text_primary"]
+    palette["diff_added"] = palette["feedback_success"]
+    palette["diff_removed"] = palette["feedback_error"]
+    palette["focus_accent"] = max(
+        focus_candidates,
+        key=lambda color: contrast_ratio(color, palette["base"]),
+    )
+    return palette
+
+
+def parse_theme(data: dict[str, Any], *, fallback_id: str, source: str) -> ThemeRecord:
+    """Parse a Base16/Base24 YAML mapping with optional semantic overrides."""
+    theme_id = str(data.get("id") or data.get("slug") or fallback_id).strip().lower()
+    if not re.fullmatch(r"[a-z0-9][a-z0-9._-]*", theme_id):
+        raise ValueError(f"Invalid theme id {theme_id!r}")
+    variant_value = data.get("variant")
+    variant = str(variant_value) if variant_value is not None else ""
+    if variant and variant not in {"dark", "light"}:
+        raise ValueError("variant must be dark or light")
+    folded_keys = {str(key).lower() for key in data}
+    base24 = {f"base{index:02x}" for index in range(16, 24)}
+    present_base24 = base24 & folded_keys
+    if present_base24 and present_base24 != base24:
+        raise ValueError("Base24 extensions must include every key from base10 through base17")
+
+    missing = [f"base{index:02X}" for index in range(16) if f"base{index:02x}" not in folded_keys]
+    if missing:
+        raise ValueError("theme must contain all Base16 base00..base0F colors")
+    palette = _base16_palette(data)
+    for key in SEMANTIC_KEYS:
+        if key in data:
+            palette[key] = normalize_color(data[key])
+    if not variant:
+        variant = "dark" if _luminance(palette["base"]) < 0.5 else "light"
+    syntax = str(data.get("syntax_theme") or ("github-dark" if variant == "dark" else "vs"))
+    get_style_by_name(syntax)
+    validate_palette(palette)
+    return ThemeRecord(
+        theme_id,
+        str(data.get("name") or data.get("scheme") or theme_id),
+        palette,
+        syntax,
+        variant,
+        source,
+        str(data.get("description") or ""),
+        str(data.get("author") or ""),
+    )
+
+
+def _luminance(color: str) -> float:
+    channels = [int(color[i : i + 2], 16) / 255 for i in (1, 3, 5)]
+    linear = [c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4 for c in channels]
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+
+def contrast_ratio(foreground: str, background: str) -> float:
+    """Return the WCAG contrast ratio for two normalized RGB colors."""
+    lighter, darker = sorted((_luminance(foreground), _luminance(background)), reverse=True)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _contrast_foreground(background: str, dark: str, light: str) -> str:
+    """Choose whichever supplied foreground is more readable on *background*."""
+    return max((dark, light), key=lambda color: contrast_ratio(color, background))
+
+
+def validate_palette(palette: dict[str, str]) -> None:
+    """Reject themes whose required text/highlight pairs are not accessible."""
+    text_pairs = {
+        "primary text": (palette["text_primary"], palette["base"]),
+        "selection": (palette["selection_fg"], palette["selection_bg"]),
+        "user message": (palette["user_message_fg"], palette["user_message_bg"]),
+        "search match": (palette["search_match_fg"], palette["search_match_bg"]),
+        "current search match": (palette["search_current_fg"], palette["search_current_bg"]),
+        "inline code": (palette["inline_code_fg"], palette["inline_code_bg"]),
+        "success": (palette["feedback_success"], palette["base"]),
+        "error": (palette["feedback_error"], palette["base"]),
+        "warning": (palette["feedback_warning"], palette["base"]),
+        "info": (palette["feedback_info"], palette["base"]),
+        "diff added": (palette["diff_added"], palette["base"]),
+        "diff removed": (palette["diff_removed"], palette["base"]),
+    }
+    failures = [
+        f"{role} ({contrast_ratio(foreground, background):.2f}:1)"
+        for role, (foreground, background) in text_pairs.items()
+        if contrast_ratio(foreground, background) < 4.5
+    ]
+    accents = {
+        "focus accent": palette["focus_accent"],
+        "inline-code surface": palette["inline_code_bg"],
+    }
+    failures.extend(
+        f"{role} ({contrast_ratio(color, palette['base']):.2f}:1)"
+        for role, color in accents.items()
+        if contrast_ratio(color, palette["base"]) < 3
+    )
+    if failures:
+        raise ValueError("insufficient contrast: " + ", ".join(failures))
+
+
+def load_user_themes(builtins: dict[str, ThemeRecord]) -> tuple[dict[str, ThemeRecord], list[str]]:
+    """Overlay user then project theme files; malformed files become diagnostics."""
+    from nooa.paths import get_project_dir, get_user_dir
+
+    records = dict(builtins)
+    diagnostics: list[str] = []
+    for label, directory in (
+        ("user", get_user_dir("themes")),
+        ("project", get_project_dir("themes")),
+    ):
+        if not directory.is_dir():
+            continue
+        paths = sorted((*directory.glob("*.yaml"), *directory.glob("*.yml")))[:_MAX_THEME_FILES]
+        for path in paths:
+            try:
+                if not path.is_file() or path.stat().st_size > _MAX_THEME_BYTES:
+                    raise ValueError("theme file is not regular or exceeds 64 KiB")
+                data = yaml.safe_load(path.read_text(encoding="utf-8"))
+                if not isinstance(data, dict):
+                    raise ValueError("theme document must be a mapping")
+                record = parse_theme(data, fallback_id=path.stem, source=f"{label}:{path}")
+                records[record.id] = record
+            except Exception as exc:
+                message = f"Skipped theme {path}: {exc}"
+                diagnostics.append(message)
+                logger.warning(message)
+    return records, diagnostics

--- a/packages/nooa-cli/src/nooa_cli/tui/theme_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme_explorer.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Full-screen browser for discovered TUI themes."""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from rich.console import Console
+from rich.syntax import Syntax
+
+from . import theme
+from .explorer_base import ExplorerConfig, ExplorerModel, ExplorerView
+from .theme import create_syntax_theme, get_theme, set_theme
+from .theme_catalog import ThemeRecord
+
+
+def _rgb(color: str) -> str:
+    value = color.lstrip("#")
+    return ";".join(str(int(value[index : index + 2], 16)) for index in (0, 2, 4))
+
+
+def _style(text: str, foreground: str, background: str | None = None) -> str:
+    code = f"38;2;{_rgb(foreground)}"
+    if background is not None:
+        code += f";48;2;{_rgb(background)}"
+    return f"\x1b[{code}m{text}\x1b[0m"
+
+
+def _syntax_lines(code: str, lexer: str, *, theme_id: str, width: int) -> list[str]:
+    """Render a compact syntax sample with the same Pygments theme as the TUI."""
+    output = io.StringIO()
+    console = Console(
+        file=output,
+        force_terminal=True,
+        color_system="truecolor",
+        width=max(20, width),
+    )
+    console.print(
+        Syntax(
+            code,
+            lexer,
+            theme=create_syntax_theme(theme_id),
+            background_color="default",
+            word_wrap=True,
+            padding=0,
+        )
+    )
+    return output.getvalue().rstrip("\n").splitlines()
+
+
+@dataclass(frozen=True, slots=True)
+class ThemeExplorerRow:
+    """One discovered theme and its source metadata."""
+
+    id: str
+    title: str
+    variant: str
+    source: str
+    description: str
+    record: ThemeRecord = field(compare=False, hash=False)
+    search_text: str = ""
+
+
+def build_theme_rows(records: dict[str, ThemeRecord] | None = None) -> list[ThemeExplorerRow]:
+    """Build searchable rows from the active theme catalog."""
+    catalog = theme.THEME_RECORDS if records is None else records
+    return [
+        ThemeExplorerRow(
+            record.id,
+            record.name,
+            record.variant,
+            record.source,
+            record.description,
+            record,
+            "\n".join(
+                (
+                    record.id,
+                    record.name,
+                    record.variant,
+                    record.source,
+                    record.description,
+                    record.author,
+                )
+            ),
+        )
+        for record in catalog.values()
+    ]
+
+
+class ThemeExplorerView(ExplorerView):
+    """Preview discovered themes; Enter commits and q restores the opening theme."""
+
+    item_name = "theme"
+    list_heading = "  id               variant  source"
+    list_height = 4
+    quit_from_list = True
+
+    def __init__(
+        self,
+        rows: list[ThemeExplorerRow] | None = None,
+        *,
+        refresh: Callable[[], None] | None = None,
+        persist: Callable[[str], None] | None = None,
+    ) -> None:
+        if rows is None:
+            theme.reload_themes()
+            values = build_theme_rows()
+        else:
+            values = rows
+        model = ExplorerModel(values)
+        if values:
+            active = next((i for i, row in enumerate(values) if row.id == get_theme()), 0)
+            model.cursor = active
+        skipped = len(theme.THEME_DIAGNOSTICS) if rows is None else 0
+        title = "Theme Browser" + (f" · {skipped} invalid skipped" if skipped else "")
+        super().__init__(model, ExplorerConfig(title=title, actions={"enter": "Apply"}))
+        self._opening_theme = get_theme()
+        self._previewed_theme = self._opening_theme
+        self._committed = False
+        self._refresh = refresh or (lambda: None)
+        self._persist = persist or (lambda _name: None)
+
+    def format_row(self, row: ThemeExplorerRow, width: int) -> str:
+        state = "active" if row.id == get_theme() else ""
+        return f"{row.id:<16} {row.variant:<7}  {row.source:<12} {state}"[:width]
+
+    def detail_lines(self, row: ThemeExplorerRow, width: int) -> list[str]:
+        p = row.record.palette
+        swatches = "  ".join(
+            _style(f" {label} ", fg, bg)
+            for label, fg, bg in (
+                ("inline code", p["inline_code_fg"], p["inline_code_bg"]),
+                ("selected", p["selection_fg"], p["selection_bg"]),
+                ("match", p["search_match_fg"], p["search_match_bg"]),
+                ("current", p["search_current_fg"], p["search_current_bg"]),
+            )
+        )
+        feedback = "  ".join(
+            _style(label, p[key])
+            for label, key in (
+                ("success", "feedback_success"),
+                ("warning", "feedback_warning"),
+                ("error", "feedback_error"),
+                ("info", "feedback_info"),
+            )
+        )
+        return [
+            f"{row.title} ({row.id})",
+            f"Variant: {row.variant}    Source: {row.source}",
+            f"Syntax: {row.record.syntax_theme}",
+            row.description,
+            "",
+            "Semantic highlights",
+            swatches,
+            "",
+            "Feedback and accents",
+            feedback,
+            "",
+            _style(" Primary text ", p["text_primary"], p["base"]),
+            _style(" Muted text ", p["text_muted"], p["surface_raised"]),
+            "",
+            "Syntax-highlighted code",
+            *_syntax_lines(
+                'def greet(name: str) -> str:\n    return f"Hello, {name}!"',
+                "python",
+                theme_id=row.id,
+                width=width,
+            ),
+            "",
+            "Unified diff",
+            *_syntax_lines(
+                "@@ -1,2 +1,2 @@\n-old_value = 1\n+new_value = 2",
+                "diff",
+                theme_id=row.id,
+                width=width,
+            ),
+            "",
+            "Enter applies and saves this theme. Esc or q closes and restores the opening theme.",
+        ]
+
+    def _preview_current(self) -> None:
+        row = self.model.current
+        if row is None or row.id == self._previewed_theme:
+            return
+        set_theme(row.id)
+        self._previewed_theme = row.id
+        self._refresh()
+
+    def on_selection_changed(self) -> None:
+        self._preview_current()
+
+    def handle_action(self, action: str, row: ThemeExplorerRow | None) -> str:
+        if action != "enter" or row is None:
+            return "ignored"
+        set_theme(row.id)
+        self._previewed_theme = row.id
+        self._persist(row.id)
+        self._committed = True
+        self._refresh()
+        return "close"
+
+    def on_open(self) -> None:
+        self._preview_current()
+
+    def on_close(self) -> None:
+        if not self._committed and get_theme() != self._opening_theme:
+            set_theme(self._opening_theme)
+            self._refresh()

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2050,6 +2050,22 @@ class TUIApplication:
             view = await view
         await self.open_subview(view)
 
+    async def open_theme_explorer(self, *, refresh: Callable[[], None] | None = None) -> None:
+        """Open the discovered-theme browser with live preview and saved apply."""
+        from .settings import write_settings_updates
+        from .theme_explorer import ThemeExplorerView
+
+        tui_config = getattr(self._config, "tui", self._config)
+
+        def persist(name: str) -> None:
+            write_settings_updates({("tui", "theme"): name})
+            if tui_config is not None:
+                tui_config.theme = name
+
+        await self.open_subview(
+            ThemeExplorerView(refresh=refresh or self.refresh_style, persist=persist)
+        )
+
     async def open_memory_explorer(self) -> None:
         """Open the host-provided memory explorer view."""
         if self._host_services.open_memory_view is None:
@@ -2638,12 +2654,12 @@ class TUIApplication:
             event.app.invalidate()
 
         mouse_bindings = load_mouse_bindings()
-        vt100_mouse_handler = mouse_bindings.get_bindings_for_keys(
-            (Keys.Vt100MouseEvent,)
-        )[0].handler
-        windows_mouse_handler = mouse_bindings.get_bindings_for_keys(
-            (Keys.WindowsMouseEvent,)
-        )[0].handler
+        vt100_mouse_handler = mouse_bindings.get_bindings_for_keys((Keys.Vt100MouseEvent,))[
+            0
+        ].handler
+        windows_mouse_handler = mouse_bindings.get_bindings_for_keys((Keys.WindowsMouseEvent,))[
+            0
+        ].handler
 
         @kb.add(Keys.Vt100MouseEvent, filter=subview_active, eager=True)
         def _(event):
@@ -2700,9 +2716,7 @@ class TUIApplication:
         @kb.add("escape", filter=subview_active, eager=True)
         def _(event):
             pending = [
-                kp
-                for kp in event.key_processor.input_queue
-                if kp.key is not Keys.CPRResponse
+                kp for kp in event.key_processor.input_queue if kp.key is not Keys.CPRResponse
             ]
             if not pending:
                 # A CPR report may share this read (it pairs with the Esc in
@@ -2710,8 +2724,7 @@ class TUIApplication:
                 # it would be spurious; absorb the Esc and let the CPR reach
                 # its own handler. Only a truly lone Esc closes.
                 queue_has_cpr = any(
-                    kp.key is Keys.CPRResponse
-                    for kp in event.key_processor.input_queue
+                    kp.key is Keys.CPRResponse for kp in event.key_processor.input_queue
                 )
                 if not queue_has_cpr:
                     self._subview_key(event, "escape")

--- a/packages/nooa-cli/src/nooa_cli/tui/user_message.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/user_message.py
@@ -85,8 +85,8 @@ def _hex_to_ansi256(hex_color: str) -> int:
 def render_user_bar(text: str, cols: int, colors: dict[str, str]) -> str:
     """Render one live or resumed user message with highlighted breathing room."""
     width = max(int(cols), 1)
-    foreground = _hex_to_ansi256(colors["text"])
-    background = _hex_to_ansi256(colors["surface2"])
+    foreground = _hex_to_ansi256(colors.get("user_message_fg", colors["text"]))
+    background = _hex_to_ansi256(colors.get("user_message_bg", colors["surface2"]))
     style_on = f"\x1b[38;5;{foreground};48;5;{background}m"
     # Reverse the bar color over SGR's semantic default background. After
     # reversal, the glyph uses the terminal's real background while the rest

--- a/packages/nooa-cli/tests/tui/test_completer.py
+++ b/packages/nooa-cli/tests/tui/test_completer.py
@@ -106,12 +106,16 @@ def test_session_id_completion_excludes_empty_sessions(completer, monkeypatch):
         "/session delete used-ses"
     ]
     # The /resume alias completes session ids like /session resume.
-    assert [item.text for item in completer.complete("/resume ")] == [
-        "/resume used-ses"
-    ]
-    assert [item.text for item in completer.complete("/resume used")] == [
-        "/resume used-ses"
-    ]
+    assert [item.text for item in completer.complete("/resume ")] == ["/resume used-ses"]
+    assert [item.text for item in completer.complete("/resume used")] == ["/resume used-ses"]
+
+
+def test_theme_completion_uses_discovered_theme_ids(completer, monkeypatch) -> None:
+    from nooa_cli.tui import theme
+
+    monkeypatch.setattr(theme, "theme_names", lambda: ("mocha", "custom-night"))
+
+    assert [item.text for item in completer.complete("/theme custom")] == ["/theme custom-night"]
 
 
 def test_slash_case_insensitive(completer):

--- a/packages/nooa-cli/tests/tui/test_highlight_preview.py
+++ b/packages/nooa-cli/tests/tui/test_highlight_preview.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the standalone inline-code palette preview."""
+
+from nooa_cli.tui import theme
+from nooa_cli.tui.highlight_preview import CANDIDATES, _read_key, contrast_ratio, main, render
+
+
+def test_preview_offers_three_accessible_candidates_per_theme() -> None:
+    assert CANDIDATES.keys() == theme.THEMES.keys()
+    for theme_name, candidates in CANDIDATES.items():
+        assert len(candidates) == 3
+        assert candidates[0].name == "Balanced"
+        for candidate in candidates:
+            assert contrast_ratio(candidate.foreground, candidate.background) >= 4.5
+            assert contrast_ratio(candidate.background, theme.THEMES[theme_name]["base"]) >= 3
+
+
+def test_balanced_candidate_matches_live_inline_code_palette() -> None:
+    for name, candidates in CANDIDATES.items():
+        balanced = candidates[0]
+        palette = theme.THEMES[name]
+        assert balanced.foreground == palette["inline_code_fg"]
+        assert balanced.background == palette["inline_code_bg"]
+
+
+def test_plain_preview_shows_inline_code_choices_without_ansi() -> None:
+    output = render("latte", selected=2, color=False)
+
+    assert "theme: latte" in output
+    assert "1. Balanced" in output
+    assert "2. Cool" in output
+    assert "❯ 3. Warm" in output
+    assert "inline code" in output
+    assert "uv run pytest" in output
+    assert "\x1b[" not in output
+
+
+def test_plain_cli_prints_every_theme(capsys) -> None:
+    assert main(["--plain"]) == 0
+    output = capsys.readouterr().out
+    for theme_name in CANDIDATES:
+        assert f"theme: {theme_name}" in output
+
+
+def test_windows_arrow_key_sequence_is_normalized(monkeypatch) -> None:
+    import sys
+    from types import SimpleNamespace
+
+    keys = iter(["\xe0", "H"])
+    monkeypatch.setattr("nooa_cli.tui.highlight_preview.os.name", "nt")
+    monkeypatch.setitem(sys.modules, "msvcrt", SimpleNamespace(getwch=lambda: next(keys)))
+
+    assert _read_key() == "\x1b[A"

--- a/packages/nooa-cli/tests/tui/test_input_style.py
+++ b/packages/nooa-cli/tests/tui/test_input_style.py
@@ -46,7 +46,6 @@ def test_input_uses_terminal_background_across_themes() -> None:
         "fullscreen-browser.preview-user",
         "fullscreen-browser.preview-agent",
         "fullscreen-browser.footer",
-        "fullscreen-browser.control-focused",
     ],
 )
 def test_fullscreen_browser_standard_text_uses_terminal_default_foreground(style_name: str) -> None:
@@ -110,18 +109,112 @@ def test_inline_code_spans_follow_the_active_theme() -> None:
     original = theme.get_theme()
     bodies = {}
     try:
-        for name in ("mocha", "latte"):
+        for name in theme.THEMES:
             theme.set_theme(name)
             frontend._console.refresh_theme()
             rendered = frontend._render_output_to_ansi(AgentMessage("see `chip` here"), 40)
-            bodies[name] = next(line for line in rendered.splitlines() if "chip" in line)
-        for name, body in bodies.items():
+            body = next(line for line in rendered.splitlines() if "chip" in line)
+            bodies[name] = body
+            style = frontend._console.console.get_style("markdown.code")
+            assert style.color is not None
+            assert style.bgcolor is not None
+            assert style.color.triplet == tuple(
+                int(theme.COLORS["inline_code_fg"][index : index + 2], 16) for index in (1, 3, 5)
+            )
+            assert style.bgcolor.triplet == tuple(
+                int(theme.COLORS["inline_code_bg"][index : index + 2], 16) for index in (1, 3, 5)
+            )
             assert "\x1b[40m" not in body, (name, body)
             assert "chip" in body
-        assert bodies["mocha"] != bodies["latte"]
+        assert len(set(bodies.values())) == len(theme.THEMES)
     finally:
         theme.set_theme(original)
         frontend._console.refresh_theme()
+
+
+def _relative_luminance(color: str) -> float:
+    channels = [int(color[index : index + 2], 16) / 255 for index in (1, 3, 5)]
+    linear = [
+        channel / 12.92 if channel <= 0.04045 else ((channel + 0.055) / 1.055) ** 2.4
+        for channel in channels
+    ]
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+
+def _contrast_ratio(foreground: str, background: str) -> float:
+    lighter, darker = sorted(
+        (_relative_luminance(foreground), _relative_luminance(background)), reverse=True
+    )
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+@pytest.mark.parametrize("name", theme.THEMES)
+def test_each_theme_has_accessible_inline_code_colors(name: str) -> None:
+    palette = theme.THEMES[name]
+    assert _contrast_ratio(palette["inline_code_fg"], palette["inline_code_bg"]) >= 4.5
+    assert _contrast_ratio(palette["inline_code_bg"], palette["base"]) >= 3
+
+
+@pytest.mark.parametrize("name", theme.THEMES)
+def test_semantic_highlight_roles_reach_prompt_toolkit(name: str) -> None:
+    original = theme.get_theme()
+    try:
+        theme.set_theme(name)
+        app = TUIApplication()
+        style = app._app.style
+        palette = theme.THEMES[name]
+
+        selected = style.get_attrs_for_style_str("class:fullscreen-browser.selected")
+        match = style.get_attrs_for_style_str("class:transcript-search-match")
+        current = style.get_attrs_for_style_str("class:transcript-search-current")
+        rail = style.get_attrs_for_style_str("class:fullscreen-browser.active-rail-active")
+
+        assert selected.color == palette["selection_fg"].lstrip("#")
+        assert selected.bgcolor == palette["selection_bg"].lstrip("#")
+        assert match.color == palette["search_match_fg"].lstrip("#")
+        assert match.bgcolor == palette["search_match_bg"].lstrip("#")
+        assert current.color == palette["search_current_fg"].lstrip("#")
+        assert current.bgcolor == palette["search_current_bg"].lstrip("#")
+        assert rail.color == palette["focus_accent"].lstrip("#")
+    finally:
+        theme.set_theme(original)
+
+
+@pytest.mark.parametrize("name", theme.THEMES)
+def test_feedback_roles_reach_rich_theme(name: str) -> None:
+    original = theme.get_theme()
+    try:
+        theme.set_theme(name)
+        rich_theme = theme.create_theme()
+        palette = theme.THEMES[name]
+        for style_name, role in (
+            ("success", "feedback_success"),
+            ("error", "feedback_error"),
+            ("warning", "feedback_warning"),
+            ("info", "feedback_info"),
+        ):
+            color = rich_theme.styles[style_name].color
+            assert color is not None
+            assert color.triplet == tuple(
+                int(palette[role][index : index + 2], 16) for index in (1, 3, 5)
+            )
+    finally:
+        theme.set_theme(original)
+
+
+@pytest.mark.parametrize("name", theme.THEMES)
+def test_semantic_diff_colors_override_pygments_theme(name: str) -> None:
+    from pygments.token import Generic
+
+    palette = theme.THEMES[name]
+    syntax_theme = theme.create_syntax_theme(name)
+
+    assert syntax_theme.get_style_for_token(Generic.Inserted).color.triplet == tuple(
+        int(palette["diff_added"][index : index + 2], 16) for index in (1, 3, 5)
+    )
+    assert syntax_theme.get_style_for_token(Generic.Deleted).color.triplet == tuple(
+        int(palette["diff_removed"][index : index + 2], 16) for index in (1, 3, 5)
+    )
 
 
 def test_active_pane_rail_uses_theme_highlight_color() -> None:
@@ -129,15 +222,17 @@ def test_active_pane_rail_uses_theme_highlight_color() -> None:
     app = TUIApplication()
 
     def rail_color() -> str:
-        attrs = app._app.style.get_attrs_for_style_str("class:fullscreen-browser.active-rail-active")
+        attrs = app._app.style.get_attrs_for_style_str(
+            "class:fullscreen-browser.active-rail-active"
+        )
         return attrs.color or ""
 
     original = theme.get_theme()
     try:
-        assert rail_color() == theme.COLORS["lavender"].lstrip("#")
+        assert rail_color() == theme.COLORS["focus_accent"].lstrip("#")
         theme.set_theme("latte")
         app.refresh_style()
-        assert rail_color() == theme.COLORS["lavender"].lstrip("#")
+        assert rail_color() == theme.COLORS["focus_accent"].lstrip("#")
     finally:
         theme.set_theme(original)
         app.refresh_style()

--- a/packages/nooa-cli/tests/tui/test_settings.py
+++ b/packages/nooa-cli/tests/tui/test_settings.py
@@ -103,11 +103,48 @@ class TestLayering:
         # null removed the key from the merged dict → field keeps its default.
         assert loaded.tui.agent_spec is None
 
-    def test_invalid_theme_fails_clearly(self, user_dir, project_dir):
+    def test_custom_theme_id_is_valid_after_catalog_reload(
+        self, user_dir, project_dir, monkeypatch
+    ):
+        from nooa_cli.tui import theme
+
+        theme_dir = project_dir / "themes"
+        theme_dir.mkdir()
+        values = {
+            "base00": "181818",
+            "base01": "282828",
+            "base02": "383838",
+            "base03": "585858",
+            "base04": "b8b8b8",
+            "base05": "d8d8d8",
+            "base06": "e8e8e8",
+            "base07": "f8f8f8",
+            "base08": "ab4642",
+            "base09": "dc9656",
+            "base0A": "f7ca88",
+            "base0B": "a1b56c",
+            "base0C": "86c1b9",
+            "base0D": "7cafc2",
+            "base0E": "ba8baf",
+            "base0F": "a16946",
+        }
+        (theme_dir / "ocean.yaml").write_text(yaml.safe_dump({"scheme": "Ocean", **values}))
+        (project_dir / "settings.yaml").write_text("tui:\n  theme: ocean\n")
+        try:
+            theme.reload_themes()
+            assert load_settings(Config()).tui.theme == "ocean"
+        finally:
+            monkeypatch.undo()
+            theme.reload_themes()
+            theme.set_theme("mocha")
+
+    def test_unknown_persisted_theme_falls_back_to_mocha(self, user_dir, project_dir, caplog):
         (project_dir / "settings.yaml").write_text("tui:\n  theme: ultraviolet\n")
 
-        with pytest.raises(ValueError, match="ultraviolet"):
-            load_settings(Config())
+        loaded = load_settings(Config())
+
+        assert loaded.tui.theme == "mocha"
+        assert "Unknown persisted theme 'ultraviolet'" in caplog.text
 
     def test_path_coercion(self, user_dir, project_dir):
         (user_dir / "settings.yaml").write_text(

--- a/packages/nooa-cli/tests/tui/test_theme_catalog.py
+++ b/packages/nooa-cli/tests/tui/test_theme_catalog.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Theme catalog validation and discovery tests."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+from nooa_cli.tui.theme_catalog import (
+    ThemeRecord,
+    contrast_ratio,
+    load_user_themes,
+    normalize_color,
+    parse_theme,
+    validate_palette,
+)
+
+
+def _base16(**extra):
+    data = {
+        "base00": "181818",
+        "base01": "282828",
+        "base02": "383838",
+        "base03": "585858",
+        "base04": "b8b8b8",
+        "base05": "d8d8d8",
+        "base06": "e8e8e8",
+        "base07": "f8f8f8",
+        "base08": "ab4642",
+        "base09": "dc9656",
+        "base0A": "f7ca88",
+        "base0B": "a1b56c",
+        "base0C": "86c1b9",
+        "base0D": "7cafc2",
+        "base0E": "ba8baf",
+        "base0F": "a16946",
+    }
+    return {"scheme": "Test Scheme", "slug": "test-scheme", **data, **extra}
+
+
+def test_normalize_color_accepts_hashless_rgb_and_rejects_style_strings() -> None:
+    assert normalize_color("AABBCC") == "#aabbcc"
+    with pytest.raises(ValueError, match="six-digit RGB"):
+        normalize_color("bold red")
+
+
+def test_base16_theme_maps_standard_colors_to_nooa_roles() -> None:
+    record = parse_theme(_base16(variant="dark"), fallback_id="unused", source="test")
+
+    assert record.id == "test-scheme"
+    assert record.name == "Test Scheme"
+    assert record.palette["base"] == "#181818"
+    assert record.palette["text"] == "#d8d8d8"
+    assert record.palette["red"] == "#ab4642"
+    assert record.palette["green"] == "#a1b56c"
+    assert record.palette["blue"] == "#7cafc2"
+    assert record.palette["selection_bg"] == "#383838"
+
+
+def test_standard_solarized_theme_gets_accessible_derived_highlights() -> None:
+    data = {
+        "scheme": "Solarized Dark",
+        "slug": "solarized-dark",
+        "variant": "dark",
+        "base00": "002b36",
+        "base01": "073642",
+        "base02": "586e75",
+        "base03": "657b83",
+        "base04": "839496",
+        "base05": "93a1a1",
+        "base06": "eee8d5",
+        "base07": "fdf6e3",
+        "base08": "dc322f",
+        "base09": "cb4b16",
+        "base0A": "b58900",
+        "base0B": "859900",
+        "base0C": "2aa198",
+        "base0D": "268bd2",
+        "base0E": "6c71c4",
+        "base0F": "d33682",
+    }
+
+    record = parse_theme(data, fallback_id="solarized-dark", source="test")
+
+    for role in ("search_current", "inline_code"):
+        assert contrast_ratio(record.palette[f"{role}_fg"], record.palette[f"{role}_bg"]) >= 4.5
+    assert contrast_ratio(record.palette["inline_code_bg"], record.palette["base"]) >= 3
+
+
+def test_base16_theme_accepts_semantic_overrides() -> None:
+    record = parse_theme(
+        _base16(
+            id="custom",
+            variant="dark",
+            inline_code_fg="#11111b",
+            inline_code_bg="#89b4fa",
+            search_match_fg="#11111b",
+            search_current_fg="#11111b",
+            diff_added="#a6e3a1",
+            diff_removed="#f38ba8",
+        ),
+        fallback_id="unused",
+        source="test",
+    )
+
+    assert record.id == "custom"
+    assert record.palette["inline_code_bg"] == "#89b4fa"
+    assert record.palette["diff_added"] == "#a6e3a1"
+    assert record.source == "test"
+
+
+def test_layered_theme_discovery_prefers_project_and_isolates_bad_files(
+    tmp_path, monkeypatch
+) -> None:
+    user = tmp_path / "user"
+    project = tmp_path / "project"
+    (user / "themes").mkdir(parents=True)
+    (project / "themes").mkdir(parents=True)
+    (user / "themes" / "shared.yaml").write_text(
+        textwrap.dedent(
+            """
+            scheme: User copy
+            slug: shared
+            variant: dark
+            base00: '000000'
+            base01: '010101'
+            base02: '020202'
+            base03: '030303'
+            base04: '808080'
+            base05: 'eeeeee'
+            base06: 'f0f0f0'
+            base07: 'ffffff'
+            base08: 'ff0000'
+            base09: 'ff8800'
+            base0A: 'ffff00'
+            base0B: '00ff00'
+            base0C: '00ffff'
+            base0D: '0088ff'
+            base0E: 'ff00ff'
+            base0F: '884400'
+            syntax_theme: monokai
+            """
+        )
+    )
+    (project / "themes" / "shared.yaml").write_text(
+        (user / "themes" / "shared.yaml").read_text().replace("User copy", "Prøject copy")
+    )
+    (project / "themes" / "bad.yaml").write_text("palette: [not, a, mapping]\n")
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(user))
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project))
+    builtin = ThemeRecord("builtin", "Builtin", {}, "monokai", "dark", "builtin")
+
+    records, diagnostics = load_user_themes({"builtin": builtin})
+
+    assert records["shared"].name == "Prøject copy"
+    assert records["shared"].source.startswith("project:")
+    assert len(diagnostics) == 1
+    assert "bad.yaml" in diagnostics[0]
+
+
+def test_partial_base24_extension_is_rejected() -> None:
+    data = _base16(base10="ffffff")
+    with pytest.raises(ValueError, match="base10 through base17"):
+        parse_theme(data, fallback_id="partial", source="test")
+
+
+def test_unreadable_base16_theme_is_rejected() -> None:
+    data = _base16(**{f"base{index:02X}": "777777" for index in range(16)})
+    with pytest.raises(ValueError, match="insufficient contrast"):
+        parse_theme(data, fallback_id="unreadable", source="test")
+
+
+def test_complete_base24_extension_is_accepted() -> None:
+    data = _base16(
+        variant="dark",
+        **{f"base{index:02X}": "ffffff" for index in range(16, 24)},
+    )
+    record = parse_theme(data, fallback_id="base24", source="test")
+    assert record.id == "test-scheme"
+    assert record.palette["feedback_success"] == "#ffffff"
+
+
+def test_feedback_text_requires_wcag_aa_contrast() -> None:
+    from nooa_cli.tui import theme
+
+    palette = dict(theme.THEMES["mocha"])
+    palette["feedback_info"] = "#777777"
+    palette["base"] = "#222222"
+    with pytest.raises(ValueError, match=r"info \(3\.[0-9]+:1\)"):
+        validate_palette(palette)
+
+
+def test_builtins_define_valid_semantic_roles() -> None:
+    from nooa_cli.tui.theme import THEME_RECORDS
+
+    for record in THEME_RECORDS.values():
+        validate_palette(record.palette)
+
+
+def test_builtins_expose_every_semantic_role() -> None:
+    from nooa_cli.tui.theme import THEME_RECORDS
+    from nooa_cli.tui.theme_catalog import SEMANTIC_KEYS
+
+    for record in THEME_RECORDS.values():
+        assert set(SEMANTIC_KEYS) <= record.palette.keys()
+        validate_palette(record.palette)

--- a/packages/nooa-cli/tests/tui/test_theme_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_theme_explorer.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the full-screen theme browser."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from nooa_cli.tui import theme
+from nooa_cli.tui.commands import ThemeCommand
+from nooa_cli.tui.fullscreen_browser import ExplorerBrowser
+from nooa_cli.tui.output import TextOutput
+from nooa_cli.tui.terminal_safety import strip_safe_ansi
+from nooa_cli.tui.theme_explorer import ThemeExplorerView, build_theme_rows
+from prompt_toolkit.application import Application
+from prompt_toolkit.data_structures import Size
+from prompt_toolkit.output import DummyOutput
+
+
+def test_theme_rows_expose_metadata_and_semantic_preview() -> None:
+    rows = build_theme_rows()
+
+    assert [row.id for row in rows[:4]] == ["mocha", "latte", "vsdark", "vslight"]
+    assert "Catppuccin" in rows[0].title
+    assert "builtin" in rows[0].search_text
+    rendered = "\n".join(ThemeExplorerView(rows).detail_lines(rows[0], 100))
+    plain = strip_safe_ansi(rendered)
+    assert "Semantic highlights" in rendered
+    assert "inline code" in rendered
+    assert "success" in rendered and "error" in rendered
+    assert "Syntax-highlighted code" in rendered
+    assert "def greet" in plain and "return" in plain
+    assert "Unified diff" in rendered
+    assert "-old_value = 1" in plain and "+new_value = 2" in plain
+    assert "\x1b[38;2;" in rendered
+
+
+@pytest.mark.parametrize("name", ["latte", "vslight"])
+def test_light_theme_diff_preview_uses_distinct_semantic_colors(name: str) -> None:
+    row = next(row for row in build_theme_rows() if row.id == name)
+    rendered = "\n".join(ThemeExplorerView([row]).detail_lines(row, 100))
+    palette = row.record.palette
+
+    for role in ("diff_added", "diff_removed"):
+        color = palette[role].lstrip("#")
+        rgb = ";".join(str(int(color[index : index + 2], 16)) for index in (0, 2, 4))
+        assert f"38;2;{rgb}" in rendered
+    assert palette["diff_added"] != palette["diff_removed"]
+
+
+def test_theme_browser_live_previews_and_rolls_back_on_close() -> None:
+    original = theme.get_theme()
+    refreshed: list[str] = []
+    try:
+        theme.set_theme("mocha")
+        view = ThemeExplorerView(refresh=lambda: refreshed.append(theme.get_theme()))
+        output = DummyOutput()
+        output.get_size = lambda: Size(rows=24, columns=100)  # type: ignore[method-assign]
+        app = Application(output=output, full_screen=True)
+        browser = ExplorerBrowser(view, app)
+        app.layout = app.layout.__class__(browser.container)
+        browser.handle_key("down")
+        assert theme.get_theme() == "latte"
+        browser.on_close()
+        assert theme.get_theme() == "mocha"
+        assert refreshed == ["latte", "mocha"]
+    finally:
+        theme.set_theme(original)
+
+
+def test_theme_browser_q_closes_from_initial_list_focus() -> None:
+    view = ThemeExplorerView(build_theme_rows())
+    output = DummyOutput()
+    output.get_size = lambda: Size(rows=24, columns=100)  # type: ignore[method-assign]
+    app = Application(output=output, full_screen=True)
+    browser = ExplorerBrowser(view, app)
+    app.layout = app.layout.__class__(browser.container)
+
+    assert browser.active_control == "list"
+    main = browser.container._get_container()
+    assert browser.explorer_list_height.preferred == 4
+    assert browser.explorer_list_height.max == 4
+    list_area = main.content.children[3]
+    assert list_area.height.min == 7
+    assert list_area.height.preferred == 7
+    assert list_area.height.max == 7
+    assert browser.handle_key("quit") == "close"
+    assert browser.buffer.text == ""
+
+
+def test_theme_rows_do_not_shift_when_active_theme_changes() -> None:
+    original = theme.get_theme()
+    rows = build_theme_rows()
+    view = ThemeExplorerView(rows)
+    try:
+        theme.set_theme("mocha")
+        mocha = view.format_row(rows[0], 100)
+        latte_before = view.format_row(rows[1], 100)
+        theme.set_theme("latte")
+        mocha_after = view.format_row(rows[0], 100)
+        latte = view.format_row(rows[1], 100)
+
+        assert mocha.index("mocha") == mocha_after.index("mocha")
+        assert latte.index("latte") == latte_before.index("latte")
+        assert "●" not in mocha + latte
+    finally:
+        theme.set_theme(original)
+
+
+def test_theme_browser_surfaces_skipped_theme_count(monkeypatch) -> None:
+    monkeypatch.setattr(theme, "reload_themes", lambda: theme.theme_names())
+    monkeypatch.setattr(theme, "THEME_DIAGNOSTICS", ["bad one", "bad two"])
+
+    view = ThemeExplorerView()
+
+    assert "2 invalid skipped" in view.title
+
+
+def test_theme_browser_enter_commits_current_theme() -> None:
+    original = theme.get_theme()
+    persisted: list[str] = []
+    try:
+        theme.set_theme("mocha")
+        view = ThemeExplorerView(refresh=lambda: None, persist=persisted.append)
+        view.model.move(1)
+        view.on_selection_changed()
+        assert view.handle_action("enter", view.model.current) == "close"
+        view.on_close()
+        assert theme.get_theme() == "latte"
+        assert persisted == ["latte"]
+    finally:
+        theme.set_theme(original)
+
+
+@pytest.mark.asyncio
+async def test_theme_command_without_args_opens_browser() -> None:
+    frontend = MagicMock()
+    frontend.open_theme_explorer = AsyncMock()
+    command = ThemeCommand(frontend, MagicMock(), MagicMock())
+
+    result = await command.execute([])
+
+    assert result.success is True
+    assert isinstance(result.outputs[0], TextOutput)
+    frontend.open_theme_explorer.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_tui_application_builds_theme_browser_with_persistence(tmp_path, monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    import yaml
+    from nooa_cli.tui.config import TUIConfig
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(tmp_path / ".nooa"))
+    app = object.__new__(TUIApplication)
+    app._config = SimpleNamespace(tui=TUIConfig())
+    app.open_subview = AsyncMock()
+    refresh = MagicMock()
+
+    await app.open_theme_explorer(refresh=refresh)
+    view = app.open_subview.await_args.args[0]
+    target = next(row for row in view.model.rows if row.id == "latte")
+    assert view.handle_action("enter", target) == "close"
+
+    assert app._config.tui.theme == "latte"
+    saved = yaml.safe_load((tmp_path / ".nooa" / "settings.yaml").read_text())
+    assert saved["tui"]["theme"] == "latte"
+
+
+@pytest.mark.asyncio
+async def test_theme_browser_does_not_mutate_runtime_config_when_save_fails(
+    monkeypatch,
+) -> None:
+    from types import SimpleNamespace
+
+    from nooa_cli.tui.config import TUIConfig
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    app = object.__new__(TUIApplication)
+    app._config = SimpleNamespace(tui=TUIConfig())
+    app.open_subview = AsyncMock()
+
+    def fail_write(_updates) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("nooa_cli.tui.settings.write_settings_updates", fail_write)
+    await app.open_theme_explorer(refresh=MagicMock())
+    view = app.open_subview.await_args.args[0]
+    target = next(row for row in view.model.rows if row.id == "latte")
+
+    with pytest.raises(OSError, match="disk full"):
+        view.handle_action("enter", target)
+
+    assert app._config.tui.theme == "mocha"
+    view.on_close()
+
+
+@pytest.mark.asyncio
+async def test_theme_command_accepts_discovered_theme(monkeypatch) -> None:
+    original = theme.get_theme()
+    custom = theme.ThemeRecord(
+        "custom-night",
+        "Custom Night",
+        dict(theme.THEMES["mocha"]),
+        "monokai",
+        "dark",
+        "test",
+    )
+    monkeypatch.setitem(theme.THEME_RECORDS, custom.id, custom)
+    monkeypatch.setitem(theme.THEMES, custom.id, custom.palette)
+    monkeypatch.setitem(theme.SYNTAX_THEMES, custom.id, custom.syntax_theme)
+    monkeypatch.setattr(theme, "reload_themes", lambda: theme.theme_names())
+    frontend = MagicMock()
+    config = MagicMock()
+    command = ThemeCommand(frontend, config, MagicMock())
+    monkeypatch.setattr(command, "_persist_tui_setting", lambda *_args: "settings.yaml")
+    try:
+        assert command.validate_args([custom.id]) == (True, None)
+        result = await command.execute([custom.id])
+        assert result.success is True
+        assert theme.get_theme() == custom.id
+        frontend.refresh_theme.assert_called_once_with()
+    finally:
+        theme.set_theme(original)
+
+
+@pytest.mark.asyncio
+async def test_terminal_frontend_delegates_theme_browser_with_full_refresh() -> None:
+    from nooa_cli.tui.config import Config
+    from nooa_cli.tui.frontend import TerminalFrontend
+
+    frontend = TerminalFrontend(Config())
+    frontend._app = MagicMock()
+    frontend._app.open_theme_explorer = AsyncMock()
+
+    await frontend.open_theme_explorer()
+
+    frontend._app.open_theme_explorer.assert_awaited_once_with(refresh=frontend.refresh_theme)
+
+
+@pytest.mark.asyncio
+async def test_full_application_theme_browser_previews_and_rolls_back() -> None:
+    from .tui_app_harness import MutableRecordingOutput, TUIHarness
+
+    original = theme.get_theme()
+    theme.set_theme("mocha")
+    try:
+        async with TUIHarness(output=MutableRecordingOutput(100, 24), full_screen=True) as harness:
+            opened = asyncio.create_task(harness.app.open_theme_explorer())
+            await harness.wait_for(lambda: isinstance(harness.app.active_subview, ExplorerBrowser))
+            await harness.press("down")
+            await harness.wait_for(lambda: theme.get_theme() == "latte")
+            await harness.press("escape")
+            await asyncio.wait_for(opened, 2)
+            assert theme.get_theme() == "mocha"
+    finally:
+        theme.set_theme(original)


### PR DESCRIPTION
## Summary

- introduce semantic TUI color roles for text, surfaces, feedback, selection, search, focus, user messages, Markdown inline code, and diff additions/removals
- tune Mocha, Latte, VS Dark, and VS Light for readable, visually distinct highlights
- make `/theme` with no arguments open a compact full-screen picker with live whole-theme preview; keep `/theme <id>` as the direct/scriptable form
- preview semantic UI colors, syntax-highlighted Python, and a unified diff; Enter applies and persists, while Esc or q restores the opening theme
- discover custom Base16/Base24 YAML themes from user and project theme directories, with bounded loading, validation, project overrides, and invalid-theme diagnostics
- document how to create a theme or install a downloaded raw Base16/Base24 YAML file

## Theme locations

- user: `~/.config/nooa/themes/`
- project: `<project>/.nooa/themes/`

Project themes override user themes with the same ID. Opening `/theme` reloads the catalog.

## Accessibility

- required text pairs, including semantic added/removed diff colors, must meet WCAG AA contrast of at least 4.5:1
- focus and decorative surface accents must meet at least 3:1 against the base surface
- all four built-in themes are covered by contrast tests
- semantic diff colors override Pygments defaults, fixing indistinguishable additions/removals in Latte and VS Light

## Preview

```bash
uv run python -m nooa_cli.tui.highlight_preview
```

The standalone palette lab includes Balanced, Cool, and Warm candidates for each built-in theme and supports arrow keys or `hjkl` (including normalized Windows console arrow input).

## Verification

- Ruff lint and formatting checks pass for all changed Python files
- focused theme/browser/config suite: **208 passed**
- rebased onto current `dev/tui`, including the merged corrupted-file repair from PR #257
