### PR TITLE
fix(storage): expose active sessions across sandboxes

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/bootstrap.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/bootstrap.py
@@ -407,10 +407,9 @@ async def bootstrap(
             )
         )
     except SessionAlreadyActiveError as exc:
-        detail = f" (pid {exc.owner_pid})" if exc.owner_pid is not None else ""
         messages.append(
             TextOutput(
-                f"Session {str(resume_id)[:8]!r} is active in another process{detail}; starting new.",
+                f"Could not resume session {str(resume_id)[:8]!r}: {exc} Starting new.",
                 "warning",
             )
         )

--- a/packages/nooa-cli/tests/tui/test_session_manager.py
+++ b/packages/nooa-cli/tests/tui/test_session_manager.py
@@ -188,6 +188,20 @@ class TestSessionManagerClose:
             metas = SessionManager.list_sessions()
         assert any(m.id == sid for m in metas)
 
+    def test_live_sandbox_session_is_active_without_shared_flock(self, tmp_path, monkeypatch):
+        """The shared claim exposes activity across independent lock namespaces."""
+        import nooa.storage.sqlite as sqlite_storage
+
+        with patch("nooa_cli.tui.session_manager.SESSIONS_DIR", tmp_path):
+            sm = _make_sm(tmp_path, session_id="sandbox-live")
+            try:
+                # Model host and sandbox kernels that do not share flock state.
+                monkeypatch.setattr(sqlite_storage.fcntl, "flock", lambda *_args: None)
+                assert SessionManager.is_active(sm.session_id)
+            finally:
+                sm.close()
+            assert not SessionManager.is_active(sm.session_id)
+
     def test_close_session_still_accessible(self, tmp_path):
         """After close(), load_turns still works."""
         before = time.time()

--- a/packages/nooa-cli/tests/tui/test_session_resumed_event.py
+++ b/packages/nooa-cli/tests/tui/test_session_resumed_event.py
@@ -76,6 +76,33 @@ async def test_on_handler_receives_event():
 
 
 @pytest.mark.asyncio
+async def test_active_session_warning_preserves_recovery_instructions(tmp_path, monkeypatch):
+    """Startup tells users how to reclaim an orphaned cross-sandbox claim."""
+    from nooa_cli.tui import session_manager as session_manager_module
+
+    monkeypatch.setattr(session_manager_module, "SESSIONS_DIR", tmp_path)
+    original = await bootstrap(Config())
+    session_id = original.session_id
+    await original.agent.close()
+    original.session_manager.close()
+    claim_path = tmp_path / f"{session_id}.active"
+    claim_path.mkdir()
+    (claim_path / "owner-orphan.json").write_text('{"pid": 123}')
+
+    fallback = await bootstrap(Config(), resume_session_id=session_id)
+    try:
+        warnings = [output.content for output in fallback.messages]
+        assert any(str(claim_path) in warning for warning in warnings)
+        assert any("remove" in warning and "Starting new" in warning for warning in warnings)
+        assert not fallback.resumed
+    finally:
+        await fallback.agent.close()
+        fallback.session_manager.close()
+        (claim_path / "owner-orphan.json").unlink()
+        claim_path.rmdir()
+
+
+@pytest.mark.asyncio
 async def test_resume_without_snapshot_emits_restored_false(tmp_path, monkeypatch):
     """-c on a session with no snapshot must emit restored=False, not True.
 

--- a/src/nooa/storage/sqlite.py
+++ b/src/nooa/storage/sqlite.py
@@ -305,7 +305,12 @@ class SQLiteEventBackend:
     def _try_deserialize(self, data: str, *, context: str) -> EventBase | None:
         try:
             return self._deserialize(data)
-        except (json.JSONDecodeError, UnicodeDecodeError, TypeError, PydanticValidationError) as e:
+        except (
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+            TypeError,
+            PydanticValidationError,
+        ) as e:
             logger.warning("%s: skipping corrupt event data (%s)", context, type(e).__name__)
             return None
 
@@ -389,7 +394,9 @@ class SQLiteEventBackend:
                 if not _is_corruption_error(e):
                     raise
                 logger.warning(
-                    "get(%s): corrupt/unreadable row, skipping (%s)", tag, type(e).__name__
+                    "get(%s): corrupt/unreadable row, skipping (%s)",
+                    tag,
+                    type(e).__name__,
                 )
                 return None
             if row is None:
@@ -446,7 +453,9 @@ class SQLiteEventBackend:
                 if not _is_corruption_error(e):
                     raise
                 logger.warning(
-                    "remove(%s): corrupt/unreadable DB, skipping (%s)", tag, type(e).__name__
+                    "remove(%s): corrupt/unreadable DB, skipping (%s)",
+                    tag,
+                    type(e).__name__,
                 )
                 return False
             if row is None:
@@ -486,7 +495,10 @@ class SQLiteEventBackend:
             except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
                 if not _is_corruption_error(e):
                     raise
-                logger.error("active_tags(): table corrupt, returning empty (%s)", type(e).__name__)
+                logger.error(
+                    "active_tags(): table corrupt, returning empty (%s)",
+                    type(e).__name__,
+                )
                 return []
             return [r[0] for r in rows]
 
@@ -520,7 +532,10 @@ class SQLiteEventBackend:
             except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
                 if not _is_corruption_error(e):
                     raise
-                logger.error("all_events(): query failed due to corruption (%s)", type(e).__name__)
+                logger.error(
+                    "all_events(): query failed due to corruption (%s)",
+                    type(e).__name__,
+                )
                 return
         for (data,) in rows:
             if event := self._try_deserialize(data, context="all_events()"):
@@ -693,10 +708,13 @@ class _SessionClaim:
             raise
 
     def _remove_owned_claim(self) -> None:
-        """Remove only this owner's unguessable marker, then its empty directory."""
+        """Best-effort removal of only this owner's unguessable marker."""
         try:
             self._owner_path.unlink()
         except FileNotFoundError:
+            return
+        except OSError:
+            logger.warning("Could not remove session claim owner %s", self._owner_path)
             return
         try:
             self._claim_path.rmdir()
@@ -811,10 +829,12 @@ def delete_sqlite_database(db_path: str | Path) -> bool:
                 pass
         return existed
     finally:
-        if claim is not None:
-            claim.close()
-        fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        os.close(lock_fd)
+        try:
+            if claim is not None:
+                claim.close()
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
 
 
 class SQLiteStorageManager:
@@ -980,13 +1000,17 @@ class SQLiteStorageManager:
 
     def _release_session_ownership(self) -> None:
         """Release cross-namespace and local ownership guards once."""
-        if self._session_claim is not None:
-            self._session_claim.close()
-            self._session_claim = None
-        if self._lock_fd is not None:
-            fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
-            os.close(self._lock_fd)
-            self._lock_fd = None
+        claim, self._session_claim = self._session_claim, None
+        lock_fd, self._lock_fd = self._lock_fd, None
+        try:
+            if claim is not None:
+                claim.close()
+        finally:
+            if lock_fd is not None:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                finally:
+                    os.close(lock_fd)
 
     def close(self) -> None:
         if self._closed:

--- a/src/nooa/storage/sqlite.py
+++ b/src/nooa/storage/sqlite.py
@@ -595,8 +595,8 @@ class SessionAlreadyActiveError(Exception):
     """Raised when a session database is already open in another process.
 
     Attributes:
-        session_id: The session identifier (db filename stem), if known.
-        owner_pid: PID read from the lock file, or None if unavailable/unparseable.
+        session_id: The session identifier (database filename stem), if known.
+        owner_pid: Diagnostic PID recorded by the active owner, if available.
     """
 
     def __init__(
@@ -630,6 +630,90 @@ def _read_lock_pid(lock_path: str) -> int | None:
         return None
 
 
+def _claim_path(db_path: str | Path) -> Path:
+    return Path(db_path).with_suffix(".active")
+
+
+def _read_claim_owner(claim_path: Path) -> int | None:
+    """Return the diagnostic PID from an active-session claim, if readable."""
+    try:
+        owner_path = next(claim_path.glob("owner-*.json"))
+        payload = json.loads(owner_path.read_text(encoding="utf-8"))
+        pid = payload.get("pid")
+        return pid if isinstance(pid, int) else None
+    except (OSError, StopIteration, ValueError, TypeError):
+        return None
+
+
+class _SessionClaim:
+    """Atomic ownership marker visible across sandbox and host namespaces.
+
+    Unlike ``flock``, creating a directory on the shared filesystem remains
+    visible when the sandbox and host use independent lock namespaces. Claims
+    intentionally do not expire: reclaiming on a timeout could admit a second
+    writer while a paused owner is still alive. After an unclean exit, users
+    must remove the ``.active`` directory explicitly.
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._claim_path = _claim_path(db_path)
+        self._token = uuid.uuid4().hex
+        self._owner_path = self._claim_path / f"owner-{self._token}.json"
+        self._pid = os.getpid()
+        session_id = Path(db_path).stem
+        try:
+            self._claim_path.mkdir(mode=0o755)
+        except FileExistsError:
+            owner_pid = _read_claim_owner(self._claim_path)
+            detail = f" (pid {owner_pid})" if owner_pid is not None else ""
+            raise SessionAlreadyActiveError(
+                f"Session {session_id!r} is already active in another process{detail}. "
+                f"If that process is gone, remove {str(self._claim_path)!r} to reclaim it.",
+                session_id=session_id,
+                owner_pid=owner_pid,
+            ) from None
+
+        try:
+            payload = json.dumps({"token": self._token, "pid": self._pid}).encode()
+            fd = os.open(self._owner_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            try:
+                os.write(fd, payload)
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        except BaseException:
+            try:
+                self._owner_path.unlink()
+            except FileNotFoundError:
+                pass
+            try:
+                self._claim_path.rmdir()
+            except OSError:
+                pass
+            raise
+
+    def _remove_owned_claim(self) -> None:
+        """Remove only this owner's unguessable marker, then its empty directory."""
+        try:
+            self._owner_path.unlink()
+        except FileNotFoundError:
+            return
+        try:
+            self._claim_path.rmdir()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            # Another owner marker means recovery replaced the claim. Never
+            # remove an entry whose random token does not belong to us.
+            logger.warning("Could not remove session claim %s", self._claim_path)
+
+    def close(self) -> None:
+        # A forked child must not remove the parent's claim. The tokenized owner
+        # filename also makes cleanup harmless if recovery replaced the directory.
+        if os.getpid() == self._pid:
+            self._remove_owned_claim()
+
+
 def _acquire_session_lock(lock_path: str) -> int:
     """Acquire an exclusive flock on *lock_path*, returning the held fd.
 
@@ -651,11 +735,7 @@ def _acquire_session_lock(lock_path: str) -> int:
         owner_pid = _read_lock_pid(lock_path)
         session_id = Path(lock_path).stem
         if owner_pid is not None:
-            msg = (
-                f"Session {session_id!r} is already active in another process "
-                f"(pid {owner_pid}). If that process is gone, remove "
-                f"{lock_path!r} to reclaim the session."
-            )
+            msg = f"Session {session_id!r} is already active in another process (pid {owner_pid})."
         else:
             msg = (
                 f"Session {session_id!r} is already active in another process "
@@ -671,10 +751,19 @@ def _acquire_session_lock(lock_path: str) -> int:
 
 
 def is_sqlite_database_active(db_path: str | Path) -> bool:
-    """Return whether an open manager currently holds the database lock."""
+    """Return whether a local lock or shared-filesystem claim is active."""
     path = Path(db_path)
     if str(db_path) == ":memory:":
         return False
+    claim_path = _claim_path(path)
+    try:
+        claim_path.stat()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        return True
+    else:
+        return True
     try:
         fd = os.open(path.with_suffix(".lock"), os.O_RDWR)
     except FileNotFoundError:
@@ -693,12 +782,12 @@ def is_sqlite_database_active(db_path: str | Path) -> bool:
 def delete_sqlite_database(db_path: str | Path) -> bool:
     """Delete an inactive SQLite database and its WAL/SHM sidecars.
 
-    The same file lock used by :class:`SQLiteStorageManager` is held for the
-    whole deletion. Attempting to delete a live session therefore raises
-    :class:`SessionAlreadyActiveError` instead of unlinking an open database.
-    The lock file itself is intentionally retained: unlinking a flock target
-    creates a race where another process can lock a different inode at the
-    same path.
+    The same file lock and shared-filesystem claim used by
+    :class:`SQLiteStorageManager` are held for the whole deletion. Attempting
+    to delete a live session therefore raises :class:`SessionAlreadyActiveError`
+    instead of unlinking an open database. The lock file itself is intentionally
+    retained: unlinking a flock target creates a race where another process can
+    lock a different inode at the same path.
 
     Returns:
         True when the main database existed, otherwise false.
@@ -711,7 +800,9 @@ def delete_sqlite_database(db_path: str | Path) -> bool:
 
     lock_path = str(path.with_suffix(".lock"))
     lock_fd = _acquire_session_lock(lock_path)
+    claim: _SessionClaim | None = None
     try:
+        claim = _SessionClaim(path)
         existed = path.exists()
         for candidate in (path, Path(f"{path}-wal"), Path(f"{path}-shm")):
             try:
@@ -720,6 +811,8 @@ def delete_sqlite_database(db_path: str | Path) -> bool:
                 pass
         return existed
     finally:
+        if claim is not None:
+            claim.close()
         fcntl.flock(lock_fd, fcntl.LOCK_UN)
         os.close(lock_fd)
 
@@ -752,11 +845,19 @@ class SQLiteStorageManager:
         self._db_path = str(db_path)
         self._check_same_thread = check_same_thread
         self._lock_fd: int | None = None
+        self._session_claim: _SessionClaim | None = None
         self._closed = False
 
         if self._db_path != ":memory:":
             lock_path = str(Path(self._db_path).with_suffix(".lock"))
             self._lock_fd = _acquire_session_lock(lock_path)
+            try:
+                self._session_claim = _SessionClaim(self._db_path)
+            except BaseException:
+                fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
+                os.close(self._lock_fd)
+                self._lock_fd = None
+                raise
 
         self._db_lock = threading.RLock()
 
@@ -765,7 +866,7 @@ class SQLiteStorageManager:
             _ensure_schema(self._conn)
             self._backend = SQLiteEventBackend(self._conn, lock=self._db_lock)
             self._backend._on_io_error = self._reconnect
-        except Exception:
+        except BaseException:
             self.close()
             raise
 
@@ -810,10 +911,11 @@ class SQLiteStorageManager:
             pass
         try:
             new_conn = self._open_connection()
-        except Exception:
-            # Reconnect failed — mark as closed so callers get a clear error
-            # rather than "cannot operate on a closed database".
+        except BaseException:
+            # Reconnect failed after closing the old connection. Release session
+            # ownership immediately; close() remains idempotent afterward.
             self._closed = True
+            self._release_session_ownership()
             raise
         self._conn = new_conn
         self._backend._conn = self._conn
@@ -876,6 +978,16 @@ class SQLiteStorageManager:
         self.restore_snapshot(snapshot_id, agent)
         return True
 
+    def _release_session_ownership(self) -> None:
+        """Release cross-namespace and local ownership guards once."""
+        if self._session_claim is not None:
+            self._session_claim.close()
+            self._session_claim = None
+        if self._lock_fd is not None:
+            fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
+            os.close(self._lock_fd)
+            self._lock_fd = None
+
     def close(self) -> None:
         if self._closed:
             return
@@ -892,10 +1004,7 @@ class SQLiteStorageManager:
                     conn.commit()
                     conn.close()
         finally:
-            if self._lock_fd is not None:
-                fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
-                os.close(self._lock_fd)
-                self._lock_fd = None
+            self._release_session_ownership()
 
     def __enter__(self) -> Self:
         return self

--- a/tests/sessions/test_store.py
+++ b/tests/sessions/test_store.py
@@ -215,6 +215,37 @@ def test_orphaned_shared_claim_requires_explicit_recovery(tmp_path, monkeypatch)
     resumed.close()
 
 
+def test_claim_cleanup_failure_still_releases_local_lock(tmp_path, monkeypatch):
+    """A marker unlink error cannot leak the manager's flock descriptor."""
+    import nooa.storage.sqlite as sqlite_storage
+
+    path = tmp_path / "cleanup-failure.db"
+    manager = sqlite_storage.SQLiteStorageManager(path)
+    claim = manager._session_claim
+    assert claim is not None
+    owner_path = claim._owner_path
+    claim_path = sqlite_storage._claim_path(path)
+    original_unlink = sqlite_storage.Path.unlink
+
+    def fail_owner_unlink(target, *args, **kwargs):
+        if target == owner_path:
+            raise PermissionError("owner cleanup denied")
+        return original_unlink(target, *args, **kwargs)
+
+    monkeypatch.setattr(sqlite_storage.Path, "unlink", fail_owner_unlink)
+    manager.close()
+
+    assert manager._lock_fd is None
+    assert manager._session_claim is None
+    # The claim remains fail-closed, but after explicit recovery the released
+    # flock must permit a replacement manager in this same process.
+    monkeypatch.undo()
+    owner_path.unlink()
+    claim_path.rmdir()
+    replacement = sqlite_storage.SQLiteStorageManager(path)
+    replacement.close()
+
+
 def test_old_owner_does_not_remove_replacement_claim(tmp_path):
     """Token checking keeps stale cleanup from deleting a successor's claim."""
     import nooa.storage.sqlite as sqlite_storage
@@ -240,7 +271,9 @@ def test_old_owner_does_not_remove_replacement_claim(tmp_path):
     displaced.rmdir()
 
 
-def test_user_messages_are_thread_safe_when_host_opts_into_cross_thread_access(tmp_path):
+def test_user_messages_are_thread_safe_when_host_opts_into_cross_thread_access(
+    tmp_path,
+):
     store = SessionStore(tmp_path)
     session = store.create(session_id="threaded", check_same_thread=False)
     barrier = threading.Barrier(3)

--- a/tests/sessions/test_store.py
+++ b/tests/sessions/test_store.py
@@ -5,7 +5,10 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
+import subprocess
+import sys
 import threading
 from datetime import UTC, datetime
 
@@ -108,6 +111,133 @@ def test_same_live_session_cannot_be_opened_twice(tmp_path):
 
     resumed = store.open("live")
     resumed.close()
+
+
+def test_shared_claim_blocks_open_when_flock_namespace_cannot_see_owner(tmp_path, monkeypatch):
+    """The filesystem claim prevents a second writer even if flock appears free."""
+    import nooa.storage.sqlite as sqlite_storage
+
+    store = SessionStore(tmp_path)
+    session = store.create(session_id="sandbox-live")
+    try:
+        # Simulate a host/sandbox boundary whose flock namespaces do not contend.
+        monkeypatch.setattr(sqlite_storage.fcntl, "flock", lambda *_args: None)
+
+        assert sqlite_storage.is_sqlite_database_active(session.path)
+        with pytest.raises(SessionAlreadyActiveError) as exc_info:
+            store.open(session.id)
+        assert exc_info.value.owner_pid == os.getpid()
+        with pytest.raises(SessionAlreadyActiveError):
+            store.delete(session.id)
+    finally:
+        session.close()
+
+
+def test_shared_claim_is_visible_to_an_independent_process(tmp_path):
+    """A separate process observes the claim even when its flock is disabled."""
+    store = SessionStore(tmp_path)
+    session = store.create(session_id="process-live")
+    script = """
+import sys
+import nooa.storage.sqlite as sqlite_storage
+from nooa.sessions import SessionStore
+from nooa.storage import SessionAlreadyActiveError
+
+sqlite_storage.fcntl.flock = lambda *_args: None
+store = SessionStore(sys.argv[1])
+try:
+    store.open("process-live")
+except SessionAlreadyActiveError:
+    pass
+else:
+    raise SystemExit("independent process opened an active session")
+try:
+    store.delete("process-live")
+except SessionAlreadyActiveError:
+    pass
+else:
+    raise SystemExit("independent process deleted an active session")
+"""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", script, str(tmp_path)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, result.stderr or result.stdout
+    finally:
+        session.close()
+
+
+def test_forked_child_close_does_not_remove_parent_claim(tmp_path, monkeypatch):
+    """A forked copy cannot release the original process's ownership marker."""
+    import nooa.storage.sqlite as sqlite_storage
+
+    path = tmp_path / "fork-safe.db"
+    manager = sqlite_storage.SQLiteStorageManager(path)
+    claim = manager._session_claim
+    assert claim is not None
+    claim_path = sqlite_storage._claim_path(path)
+    parent_pid = os.getpid()
+
+    monkeypatch.setattr(sqlite_storage.os, "getpid", lambda: parent_pid + 1)
+    claim.close()
+    assert claim_path.is_dir()
+
+    monkeypatch.setattr(sqlite_storage.os, "getpid", lambda: parent_pid)
+    manager.close()
+    assert not claim_path.exists()
+
+
+def test_orphaned_shared_claim_requires_explicit_recovery(tmp_path, monkeypatch):
+    """An orphaned claim never silently admits a potentially live old writer."""
+    import nooa.storage.sqlite as sqlite_storage
+
+    store = SessionStore(tmp_path)
+    session = store.create(session_id="orphaned")
+    path = session.path
+    session.close()
+
+    claim_path = sqlite_storage._claim_path(path)
+    claim_path.mkdir()
+    owner_path = claim_path / "owner-unknown.json"
+    owner_path.write_text('{"token": "unknown", "pid": 123}')
+    monkeypatch.setattr(sqlite_storage.fcntl, "flock", lambda *_args: None)
+
+    assert sqlite_storage.is_sqlite_database_active(path)
+    with pytest.raises(SessionAlreadyActiveError, match="remove .*orphaned.active"):
+        store.open("orphaned")
+
+    owner_path.unlink()
+    claim_path.rmdir()
+    resumed = store.open("orphaned")
+    resumed.close()
+
+
+def test_old_owner_does_not_remove_replacement_claim(tmp_path):
+    """Token checking keeps stale cleanup from deleting a successor's claim."""
+    import nooa.storage.sqlite as sqlite_storage
+
+    path = tmp_path / "replaced.db"
+    manager = sqlite_storage.SQLiteStorageManager(path)
+    claim = manager._session_claim
+    assert claim is not None
+    claim_path = sqlite_storage._claim_path(path)
+    displaced = claim_path.with_name("replaced.displaced")
+    claim_path.rename(displaced)
+    claim_path.mkdir()
+    replacement_owner = claim_path / "owner-replacement.json"
+    replacement_owner.write_text('{"token": "replacement", "pid": 456}')
+
+    manager.close()
+
+    assert claim_path.is_dir()
+    assert json.loads(replacement_owner.read_text())["token"] == "replacement"
+    replacement_owner.unlink()
+    claim_path.rmdir()
+    next(displaced.iterdir()).unlink()
+    displaced.rmdir()
 
 
 def test_user_messages_are_thread_safe_when_host_opts_into_cross_thread_access(tmp_path):

--- a/tests/test_sqlite_reconnect.py
+++ b/tests/test_sqlite_reconnect.py
@@ -50,6 +50,23 @@ class TestReconnect:
         assert retrieved is not None
         assert retrieved.tag == "1"
 
+    def test_failed_reconnect_releases_session_ownership(self, storage, monkeypatch):
+        """A failed reconnect must not leave the database permanently claimed."""
+        db_path = storage.path
+        assert db_path is not None
+        monkeypatch.setattr(
+            storage,
+            "_open_connection",
+            lambda: (_ for _ in ()).throw(RuntimeError("connect failed")),
+        )
+
+        with pytest.raises(RuntimeError, match="connect failed"):
+            storage._reconnect()
+
+        assert not db_path.with_suffix(".active").exists()
+        replacement = SQLiteStorageManager(db_path)
+        replacement.close()
+
     def test_store_retries_on_disk_io_error(self, storage):
         """store() should reconnect and retry once on disk I/O error."""
         call_count = 0

--- a/tests/unit/test_remaining_full_coverage.py
+++ b/tests/unit/test_remaining_full_coverage.py
@@ -754,6 +754,38 @@ class TestSQLiteSessionLocking:
         ):
             with pytest.raises(RuntimeError, match="connect failed"):
                 SQLiteStorageManager(db_path=db_path)
+        assert not db_path.with_suffix(".active").exists()
+
+    def test_claim_owner_creation_failure_removes_active_directory(self, tmp_path):
+        """Failure before the owner marker exists must remove the empty claim."""
+        import nooa.storage.sqlite as sqlite_storage
+
+        db_path = tmp_path / "owner-failure.db"
+        original_open = sqlite_storage.os.open
+
+        def fail_owner(path, flags, mode=0o777):
+            if str(path).endswith(".json"):
+                raise PermissionError("owner denied")
+            return original_open(path, flags, mode)
+
+        with patch.object(sqlite_storage.os, "open", side_effect=fail_owner):
+            with pytest.raises(PermissionError, match="owner denied"):
+                sqlite_storage.SQLiteStorageManager(db_path=db_path)
+
+        assert not db_path.with_suffix(".active").exists()
+
+    def test_initialization_interrupt_releases_active_claim(self, tmp_path):
+        """Interrupted initialization must not strand a persistent active claim."""
+        from nooa.storage.sqlite import SQLiteStorageManager
+
+        db_path = tmp_path / "interrupted.db"
+        with patch(
+            "nooa.storage.sqlite.sqlite3.connect",
+            side_effect=KeyboardInterrupt,
+        ):
+            with pytest.raises(KeyboardInterrupt):
+                SQLiteStorageManager(db_path=db_path)
+        assert not db_path.with_suffix(".active").exists()
 
 
 class TestSQLiteModuleLevelAssertions:


### PR DESCRIPTION
## Summary

- add an atomic shared-filesystem active-session claim alongside the existing `flock`
- make `/resume`, session open, and session deletion recognize owners across host/sandbox lock namespaces
- keep claim cleanup owner-specific and release ownership on initialization and reconnect failures
- retain conservative explicit recovery after unclean exits rather than risking two writers through timeout-based takeover

## Root cause

Session ownership was represented only by `fcntl.flock`. An sbx sandbox and its host can see the same mounted session database while not sharing flock state. The host therefore classified a live sandbox session as detached/resumable and could attempt to open a second writer.

## Design

Each file-backed `SQLiteStorageManager` now atomically creates `<session>.active/` with an unguessable owner marker. Directory creation is observable through the shared filesystem even when kernel lock namespaces differ. The existing flock remains as the local crash-safe guard.

The claim intentionally does not expire. A timeout could create split brain if a paused or filesystem-stalled owner resumed later. Following an unclean exit, the error identifies the `.active` path that must be removed explicitly after confirming the owner is gone.

## Verification

- `pytest -q tests packages/nooa-cli/tests/tui -p no:rerunfailures`: **8,333 passed, 5 skipped**
- focused storage/session/TUI regression set: **104 passed**
- Ruff check and format check: passed
- `git diff --check`: passed
- independent correctness reviews completed; stale-takeover, token-cleanup, reconnect, interruption, and owner-marker failure paths addressed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite session activity detection across processes, including environments where shared file locks are unavailable.
  * Prevented stale or orphaned session claims from blocking recovery or replacement connections.
  * Improved cleanup after interrupted initialization, failed reconnection, and process forking.
  * Updated session-resume warnings with clearer error details and recovery guidance.

* **Tests**
  * Added regression coverage for session ownership, cleanup, reconnection failures, orphaned claims, and cross-process activity detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->