### PR TITLE
feat(bench): port the experimental single-tool context to bench agents

### DIFF
--- a/packages/nooa-bench/src/nooa_bench/bench_agent.py
+++ b/packages/nooa-bench/src/nooa_bench/bench_agent.py
@@ -226,7 +226,15 @@ class BenchAgent(
             self.todo.merge_todo(updated, base=todo_base)
         return result
 
-    @strategy(CodeActExperimental(config=CodeActConfig(max_retries=10)))
+    @_hidden
+    @strategy(
+        CodeActExperimental(config=CodeActConfig(max_retries=10, cell_timeout=1800.0)),
+        context={
+            "state": None,
+            "execution_context": None,
+            "self": Context(expr="doc(type(self), concise=True)", prefix=True),
+        },
+    )
     async def _solve_task(self, description: str) -> TaskResult:
         """Solve the supplied task completely.
 
@@ -255,7 +263,15 @@ class RLMBenchAgent(BenchAgent):
 
     _worker_init_command = _OPTIONAL_TESTBED_ACTIVATE
 
-    @strategy(CodeActExperimental(config=CodeActConfig(max_retries=10)))
+    @_hidden
+    @strategy(
+        CodeActExperimental(config=CodeActConfig(max_retries=10, cell_timeout=1800.0)),
+        context={
+            "state": None,
+            "execution_context": None,
+            "self": Context(expr="doc(type(self), concise=True)", prefix=True),
+        },
+    )
     async def _solve_task(self, description: str) -> TaskResult:
         """Solve the supplied task completely.
 

--- a/packages/nooa-bench/tests/test_bench_agent.py
+++ b/packages/nooa-bench/tests/test_bench_agent.py
@@ -4,12 +4,14 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from nooa_bench import bench_agent as bench_agent_module
 from nooa_bench.bench_agent import BenchAgent, RLMBenchAgent, TaskResult
 
 from nooa.agentdoc import doc
-from nooa.unifiedllm import FakeLLMClient
+from nooa.unifiedllm import FakeLLMClient, LLMResponse, ToolCall
 
 
 class _FakeShell:
@@ -484,3 +486,58 @@ def test_problem_statement_skips_blank_primary_field():
         )
         == "use this"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("agent_type", [BenchAgent, RLMBenchAgent])
+async def test_solve_task_uses_experimental_single_tool_contract(agent_type, tmp_path):
+    """Bench agents share the experimental TUI agent's context contract.
+
+    The single python_cell tool stays; duplicated framework blocks (state,
+    execution_context, context_usage, strategy prompt) are suppressed; the
+    class docs render once, concisely, as the self block; live cell context and
+    state blocks replace the generic ones.
+    """
+    code = (
+        "return_result(TaskResult(solution_description='done', evidence='ran true', "
+        "command_to_verify='true'))"
+    )
+    llm = FakeLLMClient(
+        scripted_responses=[
+            LLMResponse(
+                raw_response=None,
+                content="",
+                tool_calls=[
+                    ToolCall(id="call_1", name="python_cell", arguments=json.dumps({"code": code}))
+                ],
+                finish_reason="tool_calls",
+                assistant_message={"role": "assistant", "content": ""},
+            )
+        ]
+    )
+    agent = agent_type(llm=llm, working_dir=str(tmp_path))
+    try:
+        result = await agent._solve_task("solve the supplied task")
+        assert result.solution_description == "done"
+
+        assert [tool.name for tool in llm.last_tools or []] == ["python_cell"]
+        system_prompt = "\n".join(
+            str(message.get("content", ""))
+            for message in llm.last_messages
+            if message.get("role") == "system"
+        )
+        rendered = "\n".join(str(m.get("content", "")) for m in llm.last_messages)
+
+        assert "<state" not in system_prompt
+        assert "<execution_context" not in rendered
+        assert "<context_usage" not in rendered
+        assert "<strategy_prompt" not in rendered
+        assert "<python_cell_tools" in system_prompt
+        assert "<python_cell_context" in system_prompt
+        assert "<python_cell_state" in rendered
+        assert "<self" in system_prompt
+        assert "You are an autonomous software engineering agent." in system_prompt
+        assert "Solve the supplied task completely." in rendered
+        assert len(system_prompt) < 20_000
+    finally:
+        await agent.close()


### PR DESCRIPTION
## What

Ports the experimental TUI agent's single-tool context contract to `BenchAgent` and `RLMBenchAgent`.

## Why

The bench agents already ran `CodeActExperimental` and the single `python_cell` tool, but kept the generic framework context on top: the `<state>` and `<execution_context>` blocks duplicated what `python_cell_context`/`python_cell_state` render, and the full class docs were sent twice. The TUI agent (the default interactive agent) already established the leaner contract; benchmark agents should run the same interface so prompt changes are comparable across host types.

## Changes (both agents)

- `@strategy(..., context={"state": None, "execution_context": None, "self": Context(expr="doc(type(self), concise=True)", prefix=True)})` - suppress the duplicated generic blocks and render concise class docs once
- `cell_timeout=1800.0` - long benchmark cells need the same headroom the TUI agent uses
- `_solve_task` stays hidden from model-facing docs (no new model API)

Measured: system prompt ~19.3k -> ~17.5k chars; block markers now match the TUI agent exactly (`<python_cell_context>` in system, `<python_cell_state>` live, no `<state>`/`<execution_context>`/`<context_usage>`/`<strategy_prompt>`).

## Validation

- New parametrized regression `test_solve_task_uses_experimental_single_tool_contract` (both agents)
- Bench suite: **31 passed**
- Full suite on the combined tree (current dev/tui + this change): **8,645 passed**, 7 skipped, 3 xfailed
- Ruff: all checks passed
- Commit tree blob-SHA-verified against the validated local build (tree `19b9af9f`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark task execution with a longer cell timeout and clearer execution context.
  * Ensured task results are processed consistently through the experimental Python tool workflow.
  * Reduced duplicate framework instructions and kept system prompts concise.

* **Tests**
  * Added coverage validating tool usage, context rendering, task completion, prompt size, and agent cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->