### PR TITLE
fix(tui): bound resume preview workers

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -632,6 +632,17 @@ class ResumePicker(ExplorerBrowser):
         # reuses their transcript instead of growing without limit.
         self._preview_models: OrderedDict[tuple[str, int], Any] = OrderedDict()
         self._preview_tasks: dict[tuple[str, int], Any] = {}
+        # Cancellation of an asyncio.to_thread awaiter does not stop its worker.
+        # Serialize actual render calls so superseded chunks cannot accumulate
+        # and contend for the GIL while the user keeps navigating.
+        import asyncio
+
+        self._preview_worker_lock = asyncio.Lock()
+        # Keep superseded tasks until their non-cancellable executor chunk has
+        # actually drained; the key map alone intentionally forgets them so a
+        # replacement selection can be scheduled immediately.
+        self._all_preview_tasks: set[Any] = set()
+        self._preview_worker_tasks: set[Any] = set()
         # Event for the in-flight preview build thread; superseding or
         # closing sets it so a stale build stops between chunks.
         self._preview_build_cancel: threading.Event | None = None
@@ -822,6 +833,38 @@ class ResumePicker(ExplorerBrowser):
             width,
         )
 
+    async def _render_preview_chunk_bounded(
+        self, turns: list[Any], start: int, row_id: str, width: int
+    ) -> str:
+        """Run at most one preview renderer and drain it before cancellation returns.
+
+        ``asyncio.to_thread`` cancellation normally abandons the executor future.
+        Holding the lock until that future actually finishes prevents later
+        selections from starting concurrent stale renderers.
+        """
+        import asyncio
+
+        async with self._preview_worker_lock:
+            worker = asyncio.create_task(
+                asyncio.to_thread(self._render_preview_chunk, turns, start, row_id, width)
+            )
+            self._preview_worker_tasks.add(worker)
+            worker.add_done_callback(self._preview_worker_tasks.discard)
+            cancelled = False
+            while True:
+                try:
+                    result = await asyncio.shield(worker)
+                    break
+                except asyncio.CancelledError:
+                    # Repeated navigation/close cancellation must not release the
+                    # lock while this non-cancellable callable still owns a worker.
+                    cancelled = True
+                    if worker.done():
+                        break
+            if cancelled:
+                raise asyncio.CancelledError
+            return result
+
     async def _build_preview_progressively(
         self,
         row: ResumePickerRow,
@@ -839,8 +882,6 @@ class ResumePicker(ExplorerBrowser):
         receives the partial transcript after each chunk; returns None when
         superseded.
         """
-        import asyncio
-
         from .fullscreen_transcript import FullscreenTranscriptModel
         from .output import HistoryTurn
 
@@ -851,9 +892,7 @@ class ResumePicker(ExplorerBrowser):
         for chunk_index, start in enumerate(reversed(starts)):
             if cancel is not None and cancel.is_set():
                 return None
-            ansi = await asyncio.to_thread(
-                self._render_preview_chunk, turns, start, row.id, width
-            )
+            ansi = await self._render_preview_chunk_bounded(turns, start, row.id, width)
             if cancel is not None and cancel.is_set():
                 return None
             # Disclose bottom-up: publish the newest turns first, then prepend
@@ -978,7 +1017,10 @@ class ResumePicker(ExplorerBrowser):
             loop = asyncio.get_running_loop()
         except RuntimeError:
             return
-        self._preview_tasks[key] = loop.create_task(prepare())
+        task = loop.create_task(prepare())
+        self._preview_tasks[key] = task
+        self._all_preview_tasks.add(task)
+        task.add_done_callback(self._all_preview_tasks.discard)
 
     def _preview_transcript(self, width: int, height: int):
         """Provide the asynchronously prepared replay to ExplorerBrowser."""
@@ -1059,7 +1101,8 @@ class ResumePicker(ExplorerBrowser):
     def close(self) -> None:
         """Cancel preview preparation when the picker is dismissed."""
         self.preview_control.cancel_drag()
-        for task in self._preview_tasks.values():
+        tasks = tuple(self._all_preview_tasks)
+        for task in tasks:
             task.cancel()
         self._preview_tasks.clear()
         # Escape/Enter can arrive while a build thread is mid-history; the
@@ -1067,6 +1110,14 @@ class ResumePicker(ExplorerBrowser):
         # (and the resume that follows) is not starved by GIL-bound work.
         if self._preview_build_cancel is not None:
             self._preview_build_cancel.set()
+
+    async def wait_closed(self) -> None:
+        """Wait until cancelled preview tasks have drained their active chunk."""
+        import asyncio
+
+        while self._all_preview_tasks or self._preview_worker_tasks:
+            tasks = tuple(self._all_preview_tasks | self._preview_worker_tasks)
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     def selected_id(self) -> str | None:
         return self.model.current.id if self.model.can_select and self.model.current else None

--- a/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/resume_picker.py
@@ -622,6 +622,7 @@ class ResumePicker(ExplorerBrowser):
         selection_copy_callback: Callable[[str], None] | None = None,
         selection_status: Callable[[], str] | None = None,
     ):
+        """Create a session picker with bounded, asynchronously prepared previews."""
         self.app = app
         self.model = ResumePickerModel(rows)
         # Real option rows drive the shared option controls and the inherited
@@ -936,6 +937,7 @@ class ResumePicker(ExplorerBrowser):
             self._preview_models.popitem(last=False)
 
     def _prepare_current_preview(self) -> None:
+        """Schedule one dwell-gated preview build for the currently selected row."""
         import asyncio
 
         row = self.model.current

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -425,7 +425,8 @@ class Session:
 
         # Pending asyncio tasks
         try:
-            pending = [t for t in asyncio.all_tasks() if not t.done()]
+            current = asyncio.current_task()
+            pending = [t for t in asyncio.all_tasks() if not t.done() and t is not current]
             if pending:
                 lines.append(f"Pending asyncio tasks ({len(pending)}):")
                 for t in pending:

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1854,8 +1854,9 @@ class TUIApplication:
             return await done
         finally:
             if self._resume_picker_done is done:
-                if self._resume_picker is not None:
-                    self._resume_picker.close()
+                closing_picker = self._resume_picker
+                if closing_picker is not None:
+                    closing_picker.close()
                 self._resume_picker = None
                 self._resume_picker_done = None
                 try:
@@ -1863,6 +1864,8 @@ class TUIApplication:
                 except ValueError:
                     self._app.layout.focus(self._input_window)
                 self._app.invalidate()
+                if closing_picker is not None:
+                    await closing_picker.wait_closed()
 
     def _finish_resume_picker(self, value: str | None) -> None:
         done = self._resume_picker_done

--- a/packages/nooa-cli/tests/tui/test_session_plumbing.py
+++ b/packages/nooa-cli/tests/tui/test_session_plumbing.py
@@ -1191,3 +1191,39 @@ async def test_session_run_startup_failure_teardown_order(
         "terminal restore",
         "exit message",
     ]
+
+@pytest.mark.asyncio
+async def test_exit_diagnostics_omit_current_task(monkeypatch) -> None:
+    """Exit diagnostics omit their own task while retaining worker visibility."""
+    from types import SimpleNamespace
+
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session._background_tasks = set()
+    output: list[str] = []
+    session._write_terminal_fallback = output.append
+
+    release = asyncio.Event()
+    pending = asyncio.create_task(release.wait(), name="actual-background-work")
+    idle_executor = SimpleNamespace(is_alive=lambda: True, daemon=False, name="asyncio_0", ident=1)
+    real_worker = SimpleNamespace(is_alive=lambda: True, daemon=False, name="other-worker", ident=2)
+    monkeypatch.setattr(
+        threading,
+        "enumerate",
+        lambda: [threading.main_thread(), idle_executor, real_worker],
+    )
+
+    try:
+        session._dump_exit_diagnostics()
+    finally:
+        release.set()
+        await pending
+
+    diagnostic = "".join(output)
+    assert "Pending asyncio tasks (1):" in diagnostic
+    assert "actual-background-work" in diagnostic
+    assert "other-worker" in diagnostic
+    # Executor threads can be idle, but hiding all of them by name would also
+    # hide a genuinely blocked callable that can delay asyncio.run() shutdown.
+    assert "asyncio_0" in diagnostic

--- a/packages/nooa-cli/tests/tui/test_session_resume_picker.py
+++ b/packages/nooa-cli/tests/tui/test_session_resume_picker.py
@@ -1619,3 +1619,126 @@ def test_rapid_a_b_a_keeps_new_preview_task_tracked(monkeypatch) -> None:
         await asyncio.gather(old_a, new_a, return_exceptions=True)
 
     asyncio.run(run())
+
+@pytest.mark.asyncio
+async def test_preview_workers_are_serialized_and_close_drains_them(monkeypatch) -> None:
+    """Superseded to_thread chunks never overlap or survive picker teardown."""
+    import threading
+
+    import nooa_cli.tui.resume_picker as rp
+
+    monkeypatch.setattr(rp, "_PREVIEW_DEBOUNCE_SECONDS", 0)
+    app = MagicMock()
+    app.output.get_size.return_value = SimpleNamespace(columns=80, rows=24)
+    turns = (ResumePickerTurn("agent", "preview"),)
+    picker = ResumePicker([row("a", "A", turns=turns), row("b", "B", turns=turns)], app)
+    picker.preview_control.viewport = (40, 5)
+
+    first_started = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    release_second = threading.Event()
+    state_lock = threading.Lock()
+    active = 0
+    max_active = 0
+    started: list[str] = []
+
+    def blocking_render(turns_list, start, row_id, width):
+        nonlocal active, max_active
+        with state_lock:
+            active += 1
+            max_active = max(max_active, active)
+            started.append(row_id)
+        try:
+            if row_id == "a":
+                first_started.set()
+                assert release_first.wait(2)
+            else:
+                second_started.set()
+                assert release_second.wait(2)
+            return f"{row_id}\n"
+        finally:
+            with state_lock:
+                active -= 1
+
+    monkeypatch.setattr(ResumePicker, "_render_preview_chunk", staticmethod(blocking_render))
+
+    picker._prepare_current_preview()
+    for _ in range(100):
+        if first_started.is_set():
+            break
+        await asyncio.sleep(0.005)
+    assert first_started.is_set()
+
+    picker.move(1)
+    await asyncio.sleep(0.05)
+    assert not second_started.is_set(), "replacement render overlapped the stale worker"
+    assert max_active == 1
+
+    release_first.set()
+    for _ in range(100):
+        if second_started.is_set():
+            break
+        await asyncio.sleep(0.005)
+    assert second_started.is_set()
+
+    picker.close()
+    closing = asyncio.create_task(picker.wait_closed())
+    await asyncio.sleep(0)
+    assert not closing.done(), "close forgot the active executor-backed task"
+    release_second.set()
+    await asyncio.wait_for(closing, 1)
+
+    assert max_active == 1
+    assert started == ["a", "b"]
+    assert not picker._all_preview_tasks
+
+
+@pytest.mark.asyncio
+async def test_close_drains_worker_after_preview_task_was_already_cancelled(monkeypatch) -> None:
+    """A second cancellation cannot orphan a superseded executor chunk."""
+    import threading
+
+    import nooa_cli.tui.resume_picker as rp
+
+    monkeypatch.setattr(rp, "_PREVIEW_DEBOUNCE_SECONDS", 0)
+    app = MagicMock()
+    app.output.get_size.return_value = SimpleNamespace(columns=80, rows=24)
+    turns = (ResumePickerTurn("agent", "preview"),)
+    picker = ResumePicker([row("a", "A", turns=turns), row("b", "B", turns=turns)], app)
+    picker.preview_control.viewport = (40, 5)
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    worker_finished = threading.Event()
+
+    def blocking_render(turns_list, start, row_id, width):
+        worker_started.set()
+        try:
+            assert release_worker.wait(2)
+            return f"{row_id}\n"
+        finally:
+            worker_finished.set()
+
+    monkeypatch.setattr(ResumePicker, "_render_preview_chunk", staticmethod(blocking_render))
+
+    picker._prepare_current_preview()
+    for _ in range(100):
+        if worker_started.is_set():
+            break
+        await asyncio.sleep(0.005)
+    assert worker_started.is_set()
+
+    picker.move(1)  # First cancellation: supersede A with B.
+    await asyncio.sleep(0)
+    picker.close()  # Second cancellation while A drains its worker.
+    closing = asyncio.create_task(picker.wait_closed())
+    await asyncio.sleep(0.05)
+    assert not closing.done()
+    assert not worker_finished.is_set()
+
+    release_worker.set()
+    await asyncio.wait_for(closing, 1)
+    assert worker_finished.is_set()
+    assert not picker._all_preview_tasks
+    assert not picker._preview_worker_tasks

--- a/packages/nooa-cli/tests/tui/test_session_resume_picker.py
+++ b/packages/nooa-cli/tests/tui/test_session_resume_picker.py
@@ -1644,6 +1644,7 @@ async def test_preview_workers_are_serialized_and_close_drains_them(monkeypatch)
     started: list[str] = []
 
     def blocking_render(turns_list, start, row_id, width):
+        """Block each fake render so the test can observe worker overlap."""
         nonlocal active, max_active
         with state_lock:
             active += 1
@@ -1713,6 +1714,7 @@ async def test_close_drains_worker_after_preview_task_was_already_cancelled(monk
     worker_finished = threading.Event()
 
     def blocking_render(turns_list, start, row_id, width):
+        """Keep the fake worker alive across both outer-task cancellations."""
         worker_started.set()
         try:
             assert release_worker.wait(2)


### PR DESCRIPTION
## Summary

- serialize actual `/resume` preview renderer work so cancelled `asyncio.to_thread` awaiters cannot leave multiple GIL-heavy chunks running concurrently
- retain and drain both superseded preview tasks and their executor wrappers, including repeated-cancellation during picker close
- restore the main UI/focus immediately when the picker closes, then finish bounded worker cleanup before the dialog coroutine returns
- omit the currently executing TUI coroutine from exit diagnostics while preserving visibility of executor threads that may still be blocked

## Why

Rapid session paging could outpace the 120 ms preview dwell gate. Cancelling the asyncio task did not stop a chunk already executing in the default thread pool, so stale chunks accumulated, starved the UI, and were later joined by `asyncio.run()` after the goodbye message. The reported `Task-1: main` was the diagnostics function observing its own caller rather than leaked work.

## Verification

- `uv run pytest packages/nooa-cli/tests/tui -q` — 1,443 passed
- focused resume-picker/session-plumbing tests — 100 passed
- Ruff check — passed
- `git diff --check` — passed

New regressions cover worker serialization, close-time draining, repeated cancellation during drain, and actionable exit diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume preview stability by preventing overlapping renders and ensuring cancelled preview work finishes before the picker closes.
  * Improved session shutdown diagnostics by excluding the active diagnostic task from pending-task reports.
  * Ensured focus and picker cleanup complete reliably when closing the resume dialog.

* **Tests**
  * Added coverage for preview rendering, cancellation, worker cleanup, and shutdown diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->