### PR TITLE
feat(tui): add on-demand theme gallery

### DIFF
--- a/packages/nooa-cli/README.md
+++ b/packages/nooa-cli/README.md
@@ -198,8 +198,9 @@ session database. Both choices are persisted per agent in `settings.yaml`.
 
 ### Themes
 
-Use `/theme` for a full-screen browser with live previews, or `/theme <id>` to
-switch directly. Custom Base16/Base24 YAML themes
+Use `/theme` for installed themes, `/theme gallery` for the on-demand Tinted
+catalog, `/theme update` to refresh it, or `/theme <id>` to switch directly.
+Custom Base16/Base24 YAML themes
 can be installed in `~/.config/nooa/themes/` or `<project>/.nooa/themes/`. See
 [`docs/themes.md`](docs/themes.md) for the schema, semantic color roles, and
 validation rules.

--- a/packages/nooa-cli/docs/themes.md
+++ b/packages/nooa-cli/docs/themes.md
@@ -2,7 +2,16 @@
 
 NOOA ships four themes: `mocha`, `latte`, `vsdark`, and `vslight`.
 
-Use `/theme` with no arguments to open the full-screen theme browser. Moving through the list previews the complete theme immediately, including syntax-highlighted code and a unified diff. **Enter** applies and saves it, while **Esc** or **q** closes the browser and restores the theme that was active when it opened. `/theme <id>` remains the scriptable shortcut.
+Use `/theme` or `/theme picker` to open the installed-theme browser. Moving through the list previews the complete theme immediately, including syntax-highlighted code and a unified diff. **Enter** applies and saves it, while **Esc** or **q** closes the browser and restores the theme that was active when it opened. `/theme <id>` remains the scriptable shortcut.
+
+The remote gallery is opt-in and performs no network access during startup, completion, or normal picker use:
+
+```text
+/theme update    # download and validate the canonical Tinted scheme catalog
+/theme gallery   # use the cached catalog, or download it once if no cache exists
+```
+
+In the gallery, **Enter** atomically installs the selected source YAML in the user theme directory, then applies and saves it. The catalog comes from the pinned `spec-0.11` branch of [`tinted-theming/schemes`](https://github.com/tinted-theming/schemes), which is also the source behind the [Tinted Gallery](https://tinted-theming.github.io/tinted-gallery/). The downloaded archive is cached under `~/.config/nooa/theme-gallery/`.
 
 ## Semantic color roles
 

--- a/packages/nooa-cli/src/nooa_cli/tui/commands.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/commands.py
@@ -1115,33 +1115,59 @@ class ThemeCommand(Command):
 
         current = theme_module.get_theme() if hasattr(self, "config") else "?"
         return {
-            "/theme [name]": f"Browse or switch themes (currently {current})",
+            "/theme [picker|gallery|update|name]": f"Browse or switch themes (currently {current})",
         }
 
     def validate_args(self, args: list[str]) -> tuple[bool, str | None]:
         from .theme import reload_themes
 
         names = reload_themes()
+        actions = ("picker", "gallery", "update")
         if len(args) > 1:
-            return False, f"Usage: /theme [{'|'.join(names)}]"
-        if len(args) == 1 and args[0].lower() not in names:
-            return False, f"Theme must be one of: {', '.join(names)}"
+            return False, "Usage: /theme [picker|gallery|update|theme-id]"
+        if len(args) == 1 and args[0].lower() not in {*actions, *names}:
+            return False, f"Theme must be an action or one of: {', '.join(names)}"
         return True, None
 
     async def execute(self, args: list[str]) -> "CommandResult":
         from . import theme as theme_module
 
-        if not args:
-            open_browser = getattr(self.frontend, "open_theme_explorer", None)
+        action = args[0].lower() if args else "picker"
+        if action == "update":
+            from .theme_gallery import update_gallery_catalog
+
+            try:
+                catalog = await asyncio.to_thread(update_gallery_catalog)
+            except Exception as exc:
+                return CommandResult.err(f"Theme catalog update failed: {exc}")
+            return CommandResult.ok(
+                TextOutput(
+                    f"Updated theme gallery: {len(catalog.themes)} schemes"
+                    f" ({len(catalog.diagnostics)} skipped).",
+                    "success",
+                )
+            )
+        if action in {"picker", "gallery"}:
+            open_browser = getattr(
+                self.frontend,
+                "open_theme_gallery" if action == "gallery" else "open_theme_explorer",
+                None,
+            )
             if not callable(open_browser):
                 return CommandResult.err("The theme browser requires the terminal TUI.")
             try:
-                await open_browser()
-            except Exception as exc:
-                return CommandResult.err(f"Theme browser failed: {exc}")
-            return CommandResult.ok(TextOutput("Theme browser closed.", "status"))
+                if action == "gallery":
+                    from .theme_gallery import ensure_gallery_catalog
 
-        name = args[0].lower()
+                    catalog = await asyncio.to_thread(ensure_gallery_catalog)
+                    await open_browser(catalog)
+                else:
+                    await open_browser()
+            except Exception as exc:
+                return CommandResult.err(f"Theme {action} failed: {exc}")
+            return CommandResult.ok(TextOutput(f"Theme {action} closed.", "status"))
+
+        name = action
         theme_module.set_theme(name)
         self.config.theme = name
 

--- a/packages/nooa-cli/src/nooa_cli/tui/completer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/completer.py
@@ -308,13 +308,19 @@ class Completer:
         prefix = "/theme "
         partial = text[len(prefix) :]
         items = []
-        for name in theme_names():
+        choices = (
+            ("picker", "Browse installed themes"),
+            ("gallery", "Browse and install remote themes"),
+            ("update", "Download or refresh the remote catalog"),
+            *((name, f"Switch to {name} theme") for name in theme_names()),
+        )
+        for name, description in choices:
             if name.startswith(partial.lower()):
                 items.append(
                     CompletionItem(
                         text=prefix + name,
                         display=prefix + name,
-                        description=f"Switch to {name} theme",
+                        description=description,
                     )
                 )
         return items

--- a/packages/nooa-cli/src/nooa_cli/tui/frontend.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/frontend.py
@@ -179,7 +179,11 @@ class Frontend(Protocol):
         ...
 
     async def open_theme_explorer(self) -> None:
-        """Open the full-screen theme browser."""
+        """Open the full-screen installed-theme browser."""
+        ...
+
+    async def open_theme_gallery(self, catalog: object) -> None:
+        """Open the full-screen remote-theme gallery."""
         ...
 
     async def prompt_sensitive(
@@ -296,6 +300,11 @@ class TerminalFrontend:
         if self._app is None:
             raise RuntimeError("TUI application is not ready.")
         await self._app.open_theme_explorer(refresh=self.refresh_theme)
+
+    async def open_theme_gallery(self, catalog: object) -> None:
+        if self._app is None:
+            raise RuntimeError("TUI application is not ready.")
+        await self._app.open_theme_gallery(catalog, refresh=self.refresh_theme)
 
     async def open_activity_overlay(self, outputs: list[Output]) -> None:
         if self._app is None:

--- a/packages/nooa-cli/src/nooa_cli/tui/highlight_preview.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/highlight_preview.py
@@ -28,24 +28,24 @@ class InlineCodePalette:
 
 CANDIDATES: dict[str, tuple[InlineCodePalette, ...]] = {
     "mocha": (
-        InlineCodePalette("Balanced", "blue chip", "#11111b", "#89b4fa"),
-        InlineCodePalette("Cool", "teal chip", "#11111b", "#94e2d5"),
-        InlineCodePalette("Warm", "peach chip", "#11111b", "#fab387"),
+        InlineCodePalette("Balanced", "blue text", "#89b4fa", "#1e1e2e"),
+        InlineCodePalette("Cool", "teal text", "#94e2d5", "#1e1e2e"),
+        InlineCodePalette("Warm", "peach text", "#fab387", "#1e1e2e"),
     ),
     "latte": (
-        InlineCodePalette("Balanced", "blue chip", "#ffffff", "#1e66f5"),
-        InlineCodePalette("Cool", "teal chip", "#ffffff", "#007b83"),
-        InlineCodePalette("Warm", "rose chip", "#ffffff", "#a83f55"),
+        InlineCodePalette("Balanced", "blue text", "#1858c7", "#eff1f5"),
+        InlineCodePalette("Cool", "teal text", "#006f76", "#eff1f5"),
+        InlineCodePalette("Warm", "rose text", "#a83f55", "#eff1f5"),
     ),
     "vsdark": (
-        InlineCodePalette("Balanced", "blue chip", "#1e1e1e", "#9cdcfe"),
-        InlineCodePalette("Cool", "teal chip", "#1e1e1e", "#4ec9b0"),
-        InlineCodePalette("Warm", "peach chip", "#1e1e1e", "#ce9178"),
+        InlineCodePalette("Balanced", "blue text", "#569cd6", "#1e1e1e"),
+        InlineCodePalette("Cool", "teal text", "#4ec9b0", "#1e1e1e"),
+        InlineCodePalette("Warm", "peach text", "#ce9178", "#1e1e1e"),
     ),
     "vslight": (
-        InlineCodePalette("Balanced", "blue chip", "#ffffff", "#005fb8"),
-        InlineCodePalette("Cool", "green chip", "#ffffff", "#107c10"),
-        InlineCodePalette("Warm", "red chip", "#ffffff", "#a31515"),
+        InlineCodePalette("Balanced", "blue text", "#005fb8", "#ffffff"),
+        InlineCodePalette("Cool", "green text", "#107c10", "#ffffff"),
+        InlineCodePalette("Warm", "red text", "#a31515", "#ffffff"),
     ),
 }
 
@@ -69,15 +69,14 @@ def _paint(text: str, candidate: InlineCodePalette, *, enabled: bool) -> str:
     if not enabled:
         return text
     fg = tuple(int(candidate.foreground[index : index + 2], 16) for index in (1, 3, 5))
-    bg = tuple(int(candidate.background[index : index + 2], 16) for index in (1, 3, 5))
-    return f"\x1b[38;2;{fg[0]};{fg[1]};{fg[2]};48;2;{bg[0]};{bg[1]};{bg[2]}m{text}{RESET}"
+    return f"\x1b[1;38;2;{fg[0]};{fg[1]};{fg[2]}m{text}{RESET}"
 
 
 def render(theme: str, selected: int = 0, *, color: bool = True) -> str:
     """Render three inline-code choices for one theme."""
     lines = [
         f"NOOA INLINE-CODE LAB  ·  theme: {theme}",
-        "The actual `inline code` chip is previewed below for every option.",
+        "The actual bold `inline code` text is previewed below for every option.",
         "",
     ]
     for index, candidate in enumerate(CANDIDATES[theme]):

--- a/packages/nooa-cli/src/nooa_cli/tui/theme.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme.py
@@ -56,8 +56,8 @@ _MOCHA: dict[str, str] = {
     "base": "#1e1e2e",
     "mantle": "#181825",
     "crust": "#11111b",
-    "inline_code_fg": "#11111b",
-    "inline_code_bg": "#89b4fa",
+    "inline_code_fg": "#89b4fa",
+    "inline_code_bg": "#1e1e2e",
 }
 
 _LATTE: dict[str, str] = {
@@ -87,8 +87,8 @@ _LATTE: dict[str, str] = {
     "base": "#eff1f5",
     "mantle": "#e6e9ef",
     "crust": "#dce0e8",
-    "inline_code_fg": "#ffffff",
-    "inline_code_bg": "#1e66f5",
+    "inline_code_fg": "#1858c7",
+    "inline_code_bg": "#eff1f5",
 }
 
 # VS Code Dark+ — keys mapped to Catppuccin semantic roles
@@ -119,8 +119,8 @@ _VS_DARK: dict[str, str] = {
     "base": "#1e1e1e",
     "mantle": "#181818",
     "crust": "#111111",
-    "inline_code_fg": "#1e1e1e",
-    "inline_code_bg": "#9cdcfe",
+    "inline_code_fg": "#569cd6",
+    "inline_code_bg": "#1e1e1e",
 }
 
 # VS Code Light — keys mapped to Catppuccin semantic roles
@@ -151,8 +151,8 @@ _VS_LIGHT: dict[str, str] = {
     "base": "#ffffff",
     "mantle": "#f8f8f8",
     "crust": "#ececec",
-    "inline_code_fg": "#ffffff",
-    "inline_code_bg": "#005fb8",
+    "inline_code_fg": "#005fb8",
+    "inline_code_bg": "#ffffff",
 }
 
 _BUILTIN_SEMANTICS = {
@@ -418,9 +418,8 @@ def create_theme() -> Theme:
             "spinner.text": c["subtext1"],
             # Code/technical
             "code": c["peach"],
-            # Inline-code chips have dedicated colors: their compact filled
-            # shape needs different contrast than syntax tokens or panels.
-            "markdown.code": f"{c['inline_code_fg']} on {c['inline_code_bg']}",
+            # Inline code stays subtle: bold semantic text, no filled chip.
+            "markdown.code": f"bold {c['inline_code_fg']}",
             "path": c["code_path"],
             "number": c["code_number"],
             # History tags

--- a/packages/nooa-cli/src/nooa_cli/tui/theme_catalog.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme_catalog.py
@@ -89,8 +89,8 @@ def semanticize(palette: dict[str, str]) -> dict[str, str]:
         "focus_accent": result["lavender"],
         "user_message_fg": result["text"],
         "user_message_bg": result["surface2"],
-        "inline_code_fg": result["text"],
-        "inline_code_bg": result["surface0"],
+        "inline_code_fg": result["blue"],
+        "inline_code_bg": result["base"],
         "code_path": result["teal"],
         "code_number": result["peach"],
     }
@@ -166,6 +166,11 @@ def _base16_palette(data: dict[str, Any]) -> dict[str, str]:
         palette[f"{role}_bg"] = background
     palette["user_message_fg"] = palette["selection_fg"]
     palette["user_message_bg"] = palette["selection_bg"]
+    # Inline code is bold accent text on the terminal background, not a chip.
+    palette["inline_code_fg"] = bases["base0D"]
+    if contrast_ratio(palette["inline_code_fg"], palette["base"]) < 4.5:
+        palette["inline_code_fg"] = palette["text_primary"]
+    palette["inline_code_bg"] = palette["base"]
     base24_keys = {f"base{index:02x}" for index in range(16, 24)}
     focus_candidates = [bases["base0D"], bases["base0B"], bases["base0A"]]
     if base24_keys <= folded.keys():
@@ -198,7 +203,11 @@ def parse_theme(data: dict[str, Any], *, fallback_id: str, source: str) -> Theme
     variant = str(variant_value) if variant_value is not None else ""
     if variant and variant not in {"dark", "light"}:
         raise ValueError("variant must be dark or light")
-    folded_keys = {str(key).lower() for key in data}
+    palette_data = data.get("palette")
+    if palette_data is not None and not isinstance(palette_data, dict):
+        raise ValueError("palette must be a mapping")
+    colors = {**data, **(palette_data or {})}
+    folded_keys = {str(key).lower() for key in colors}
     base24 = {f"base{index:02x}" for index in range(16, 24)}
     present_base24 = base24 & folded_keys
     if present_base24 and present_base24 != base24:
@@ -207,7 +216,7 @@ def parse_theme(data: dict[str, Any], *, fallback_id: str, source: str) -> Theme
     missing = [f"base{index:02X}" for index in range(16) if f"base{index:02x}" not in folded_keys]
     if missing:
         raise ValueError("theme must contain all Base16 base00..base0F colors")
-    palette = _base16_palette(data)
+    palette = _base16_palette(colors)
     for key in SEMANTIC_KEYS:
         if key in data:
             palette[key] = normalize_color(data[key])
@@ -253,7 +262,7 @@ def validate_palette(palette: dict[str, str]) -> None:
         "user message": (palette["user_message_fg"], palette["user_message_bg"]),
         "search match": (palette["search_match_fg"], palette["search_match_bg"]),
         "current search match": (palette["search_current_fg"], palette["search_current_bg"]),
-        "inline code": (palette["inline_code_fg"], palette["inline_code_bg"]),
+        "inline code": (palette["inline_code_fg"], palette["base"]),
         "success": (palette["feedback_success"], palette["base"]),
         "error": (palette["feedback_error"], palette["base"]),
         "warning": (palette["feedback_warning"], palette["base"]),
@@ -268,7 +277,6 @@ def validate_palette(palette: dict[str, str]) -> None:
     ]
     accents = {
         "focus accent": palette["focus_accent"],
-        "inline-code surface": palette["inline_code_bg"],
     }
     failures.extend(
         f"{role} ({contrast_ratio(color, palette['base']):.2f}:1)"

--- a/packages/nooa-cli/src/nooa_cli/tui/theme_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme_explorer.py
@@ -7,14 +7,18 @@ from __future__ import annotations
 import io
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from rich.console import Console
 from rich.syntax import Syntax
 
 from . import theme
 from .explorer_base import ExplorerConfig, ExplorerModel, ExplorerView
-from .theme import create_syntax_theme, get_theme, set_theme
+from .theme import SemanticSyntaxTheme, get_theme, set_theme
 from .theme_catalog import ThemeRecord
+
+if TYPE_CHECKING:
+    from .theme_gallery import GalleryTheme
 
 
 def _rgb(color: str) -> str:
@@ -22,14 +26,14 @@ def _rgb(color: str) -> str:
     return ";".join(str(int(value[index : index + 2], 16)) for index in (0, 2, 4))
 
 
-def _style(text: str, foreground: str, background: str | None = None) -> str:
-    code = f"38;2;{_rgb(foreground)}"
+def _style(text: str, foreground: str, background: str | None = None, *, bold: bool = False) -> str:
+    code = f"{'1;' if bold else ''}38;2;{_rgb(foreground)}"
     if background is not None:
         code += f";48;2;{_rgb(background)}"
     return f"\x1b[{code}m{text}\x1b[0m"
 
 
-def _syntax_lines(code: str, lexer: str, *, theme_id: str, width: int) -> list[str]:
+def _syntax_lines(code: str, lexer: str, *, record: ThemeRecord, width: int) -> list[str]:
     """Render a compact syntax sample with the same Pygments theme as the TUI."""
     output = io.StringIO()
     console = Console(
@@ -42,7 +46,7 @@ def _syntax_lines(code: str, lexer: str, *, theme_id: str, width: int) -> list[s
         Syntax(
             code,
             lexer,
-            theme=create_syntax_theme(theme_id),
+            theme=SemanticSyntaxTheme(record.syntax_theme, record.palette),
             background_color="default",
             word_wrap=True,
             padding=0,
@@ -130,12 +134,12 @@ class ThemeExplorerView(ExplorerView):
     def detail_lines(self, row: ThemeExplorerRow, width: int) -> list[str]:
         p = row.record.palette
         swatches = "  ".join(
-            _style(f" {label} ", fg, bg)
-            for label, fg, bg in (
-                ("inline code", p["inline_code_fg"], p["inline_code_bg"]),
-                ("selected", p["selection_fg"], p["selection_bg"]),
-                ("match", p["search_match_fg"], p["search_match_bg"]),
-                ("current", p["search_current_fg"], p["search_current_bg"]),
+            _style(f" {label} ", fg, bg, bold=bold)
+            for label, fg, bg, bold in (
+                ("inline code", p["inline_code_fg"], None, True),
+                ("selected", p["selection_fg"], p["selection_bg"], False),
+                ("match", p["search_match_fg"], p["search_match_bg"], False),
+                ("current", p["search_current_fg"], p["search_current_bg"], False),
             )
         )
         feedback = "  ".join(
@@ -166,7 +170,7 @@ class ThemeExplorerView(ExplorerView):
             *_syntax_lines(
                 'def greet(name: str) -> str:\n    return f"Hello, {name}!"',
                 "python",
-                theme_id=row.id,
+                record=row.record,
                 width=width,
             ),
             "",
@@ -174,7 +178,7 @@ class ThemeExplorerView(ExplorerView):
             *_syntax_lines(
                 "@@ -1,2 +1,2 @@\n-old_value = 1\n+new_value = 2",
                 "diff",
-                theme_id=row.id,
+                record=row.record,
                 width=width,
             ),
             "",
@@ -209,3 +213,51 @@ class ThemeExplorerView(ExplorerView):
         if not self._committed and get_theme() != self._opening_theme:
             set_theme(self._opening_theme)
             self._refresh()
+
+
+class ThemeGalleryView(ThemeExplorerView):
+    """Browse remote schemes without mutating the active theme until installation."""
+
+    item_name = "scheme"
+
+    def __init__(
+        self,
+        entries: dict[str, GalleryTheme],
+        *,
+        install: Callable[[GalleryTheme], None],
+    ) -> None:
+        self._entries = entries
+        self._install = install
+        self._install_error = ""
+        super().__init__(build_theme_rows({key: value.record for key, value in entries.items()}))
+        self.title = "Theme Gallery"
+        self.config.title = self.title
+
+    def _preview_current(self) -> None:
+        """The detail pane previews remote colors without registering them globally."""
+
+    def detail_lines(self, row: ThemeExplorerRow, width: int) -> list[str]:
+        lines = super().detail_lines(row, width)
+        lines[-1] = "Enter installs, applies, and saves this theme. Esc or q closes."
+        if self._install_error:
+            lines.extend(
+                (
+                    "",
+                    _style(
+                        f"Install failed: {self._install_error}",
+                        row.record.palette["feedback_error"],
+                    ),
+                )
+            )
+        return lines
+
+    def handle_action(self, action: str, row: ThemeExplorerRow | None) -> str:
+        if action != "enter" or row is None:
+            return "ignored"
+        try:
+            self._install(self._entries[row.id])
+        except Exception as exc:
+            self._install_error = str(exc)
+            return "handled"
+        self._committed = True
+        return "close"

--- a/packages/nooa-cli/src/nooa_cli/tui/theme_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme_explorer.py
@@ -236,6 +236,9 @@ class ThemeGalleryView(ThemeExplorerView):
     def _preview_current(self) -> None:
         """The detail pane previews remote colors without registering them globally."""
 
+    def on_selection_changed(self) -> None:
+        self._install_error = ""
+
     def detail_lines(self, row: ThemeExplorerRow, width: int) -> list[str]:
         lines = super().detail_lines(row, width)
         lines[-1] = "Enter installs, applies, and saves this theme. Esc or q closes."

--- a/packages/nooa-cli/src/nooa_cli/tui/theme_gallery.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme_gallery.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""On-demand, cached access to the canonical Tinted Theming scheme catalog."""
+
+from __future__ import annotations
+
+import io
+import os
+import tarfile
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from .theme_catalog import ThemeRecord, parse_theme
+
+CATALOG_URL = "https://github.com/tinted-theming/schemes/archive/refs/heads/spec-0.11.tar.gz"
+_ALLOWED_HOSTS = {"github.com", "codeload.github.com"}
+_MAX_ARCHIVE_BYTES = 4 * 1024 * 1024
+_MAX_MEMBER_BYTES = 64 * 1024
+_MAX_TOTAL_BYTES = 16 * 1024 * 1024
+_MAX_SCHEMES = 1024
+_MAX_ARCHIVE_MEMBERS = 2048
+
+
+@dataclass(frozen=True, slots=True)
+class GalleryTheme:
+    """One validated remote scheme plus its original YAML document."""
+
+    id: str
+    system: str
+    record: ThemeRecord
+    document: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class GalleryInstall:
+    """Filesystem receipt used to roll back an interrupted install."""
+
+    path: Path
+    previous: bytes | None
+
+
+@dataclass(frozen=True, slots=True)
+class GalleryCatalog:
+    """Validated schemes and isolated diagnostics from one archive."""
+
+    themes: dict[str, GalleryTheme]
+    diagnostics: tuple[str, ...] = ()
+
+
+_loaded_catalog: GalleryCatalog | None = None
+
+
+def gallery_loaded() -> bool:
+    """Return whether this process has loaded the remote catalog on demand."""
+    return _loaded_catalog is not None
+
+
+def _cache_path() -> Path:
+    from nooa.paths import get_user_dir
+
+    return get_user_dir("theme-gallery", "schemes-spec-0.11.tar.gz")
+
+
+def _validate_catalog_url(url: str) -> None:
+    parsed = urllib.parse.urlsplit(url)
+    if parsed.scheme != "https" or (parsed.hostname or "").lower() not in _ALLOWED_HOSTS:
+        raise ValueError(f"Unexpected theme catalog URL: {url}")
+
+
+class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Reject redirects away from the pinned catalog hosts before following them."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        _validate_catalog_url(newurl)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _fetch_archive(url: str = CATALOG_URL) -> bytes:
+    """Download one bounded archive from the pinned canonical origin."""
+    _validate_catalog_url(url)
+    request = urllib.request.Request(url, headers={"User-Agent": "NOOA theme gallery"})
+    opener = urllib.request.build_opener(_SafeRedirectHandler())
+    with opener.open(request, timeout=30) as response:
+        _validate_catalog_url(response.geturl())
+        declared = response.headers.get("Content-Length")
+        if declared and int(declared) > _MAX_ARCHIVE_BYTES:
+            raise ValueError("Theme catalog archive exceeds 4 MiB")
+        data = response.read(_MAX_ARCHIVE_BYTES + 1)
+    if len(data) > _MAX_ARCHIVE_BYTES:
+        raise ValueError("Theme catalog archive exceeds 4 MiB")
+    return data
+
+
+def _flatten_document(document: dict[str, object]) -> dict[str, object]:
+    """Flatten the current Tinted schema's nested palette for NOOA parsing."""
+    palette = document.get("palette")
+    if not isinstance(palette, dict):
+        raise ValueError("scheme palette must be a mapping")
+    return {**document, **palette}
+
+
+def parse_gallery_archive(data: bytes) -> GalleryCatalog:
+    """Validate all Base16/Base24 YAML schemes from a bounded tar archive."""
+    if len(data) > _MAX_ARCHIVE_BYTES:
+        raise ValueError("Theme catalog archive exceeds 4 MiB")
+    themes: dict[str, GalleryTheme] = {}
+    diagnostics: list[str] = []
+    total_bytes = 0
+    seen = 0
+    member_count = 0
+    try:
+        archive = tarfile.open(fileobj=io.BytesIO(data), mode="r|gz")
+    except (tarfile.TarError, OSError) as exc:
+        raise ValueError(f"Invalid theme catalog archive: {exc}") from exc
+    with archive:
+        for member in archive:
+            member_count += 1
+            if member_count > _MAX_ARCHIVE_MEMBERS:
+                raise ValueError("Theme catalog contains too many archive members")
+            if member.size < 0 or member.size > _MAX_TOTAL_BYTES - total_bytes:
+                raise ValueError("Theme catalog expands beyond 16 MiB")
+            total_bytes += member.size
+            parts = Path(member.name).parts
+            if (
+                not member.isfile()
+                or len(parts) != 3
+                or parts[1] not in {"base16", "base24"}
+                or Path(parts[2]).suffix.lower() not in {".yaml", ".yml"}
+            ):
+                continue
+            seen += 1
+            if seen > _MAX_SCHEMES:
+                raise ValueError("Theme catalog contains too many schemes")
+            if member.size > _MAX_MEMBER_BYTES:
+                diagnostics.append(f"Skipped {member.name}: file exceeds 64 KiB")
+                continue
+            try:
+                extracted = archive.extractfile(member)
+                if extracted is None:
+                    raise ValueError("scheme file is unreadable")
+                raw = extracted.read(_MAX_MEMBER_BYTES + 1)
+                if len(raw) > _MAX_MEMBER_BYTES:
+                    raise ValueError("scheme file exceeds 64 KiB")
+                document = yaml.safe_load(raw.decode("utf-8"))
+                if not isinstance(document, dict):
+                    raise ValueError("scheme document must be a mapping")
+                system = parts[1]
+                slug = Path(parts[2]).stem.lower()
+                theme_id = f"{system}-{slug}"
+                normalized = _flatten_document(document)
+                normalized["id"] = theme_id
+                record = parse_theme(
+                    normalized,
+                    fallback_id=theme_id,
+                    source=f"gallery:{system}",
+                )
+                themes[theme_id] = GalleryTheme(theme_id, system, record, document)
+            except Exception as exc:
+                diagnostics.append(f"Skipped {member.name}: {exc}")
+    return GalleryCatalog(dict(sorted(themes.items())), tuple(diagnostics))
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        with temporary.open("wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def update_gallery_catalog(
+    fetch: Callable[[], bytes] | None = None,
+) -> GalleryCatalog:
+    """Fetch, validate, cache, and activate the canonical catalog."""
+    global _loaded_catalog
+    data = (fetch or _fetch_archive)()
+    catalog = parse_gallery_archive(data)
+    if not catalog.themes:
+        raise ValueError("Theme catalog contains no valid schemes")
+    _atomic_write(_cache_path(), data)
+    _loaded_catalog = catalog
+    return catalog
+
+
+def ensure_gallery_catalog(
+    fetch: Callable[[], bytes] | None = None,
+) -> GalleryCatalog:
+    """Load the catalog lazily from memory/cache, fetching only when absent."""
+    global _loaded_catalog
+    if _loaded_catalog is not None:
+        return _loaded_catalog
+    cache = _cache_path()
+    if cache.is_file():
+        try:
+            if cache.stat().st_size > _MAX_ARCHIVE_BYTES:
+                raise ValueError("Cached theme catalog archive exceeds 4 MiB")
+            with cache.open("rb") as stream:
+                data = stream.read(_MAX_ARCHIVE_BYTES + 1)
+            if len(data) > _MAX_ARCHIVE_BYTES:
+                raise ValueError("Cached theme catalog archive exceeds 4 MiB")
+            _loaded_catalog = parse_gallery_archive(data)
+            return _loaded_catalog
+        except Exception:
+            pass
+    return update_gallery_catalog(fetch)
+
+
+def install_gallery_theme(entry: GalleryTheme) -> GalleryInstall:
+    """Atomically install one validated gallery scheme in the user theme directory."""
+    from nooa.paths import get_user_dir
+
+    target = get_user_dir("themes", f"{entry.id}.yaml")
+    previous = target.read_bytes() if target.is_file() else None
+    document = dict(entry.document)
+    document["id"] = entry.id
+    payload = yaml.safe_dump(document, sort_keys=False, allow_unicode=True).encode("utf-8")
+    if len(payload) > _MAX_MEMBER_BYTES:
+        raise ValueError("Installed theme exceeds 64 KiB")
+    _atomic_write(target, payload)
+    return GalleryInstall(target, previous)
+
+
+def rollback_gallery_install(install: GalleryInstall) -> None:
+    """Restore the file state captured before an unsuccessful install."""
+    if install.previous is None:
+        install.path.unlink(missing_ok=True)
+    else:
+        _atomic_write(install.path, install.previous)

--- a/packages/nooa-cli/src/nooa_cli/tui/theme_gallery.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme_gallery.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import gzip
 import io
 import os
 import tarfile
@@ -24,6 +25,7 @@ _MAX_MEMBER_BYTES = 64 * 1024
 _MAX_TOTAL_BYTES = 16 * 1024 * 1024
 _MAX_SCHEMES = 1024
 _MAX_ARCHIVE_MEMBERS = 2048
+_MAX_EXPANDED_ARCHIVE_BYTES = 20 * 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
@@ -96,6 +98,26 @@ def _fetch_archive(url: str = CATALOG_URL) -> bytes:
     return data
 
 
+class _BoundedReader:
+    """Limit bytes returned from a decompression stream, including tar metadata."""
+
+    def __init__(self, stream, limit: int) -> None:
+        self._stream = stream
+        self._limit = limit
+        self._read = 0
+
+    def read(self, size: int = -1) -> bytes:
+        remaining = self._limit - self._read
+        if remaining < 0:
+            raise ValueError("Theme catalog expands beyond 20 MiB")
+        requested = remaining + 1 if size < 0 else min(size, remaining + 1)
+        data = self._stream.read(requested)
+        self._read += len(data)
+        if self._read > self._limit:
+            raise ValueError("Theme catalog expands beyond 20 MiB")
+        return data
+
+
 def _flatten_document(document: dict[str, object]) -> dict[str, object]:
     """Flatten the current Tinted schema's nested palette for NOOA parsing."""
     palette = document.get("palette")
@@ -114,7 +136,9 @@ def parse_gallery_archive(data: bytes) -> GalleryCatalog:
     seen = 0
     member_count = 0
     try:
-        archive = tarfile.open(fileobj=io.BytesIO(data), mode="r|gz")
+        compressed = io.BytesIO(data)
+        expanded = _BoundedReader(gzip.GzipFile(fileobj=compressed), _MAX_EXPANDED_ARCHIVE_BYTES)
+        archive = tarfile.open(fileobj=expanded, mode="r|")
     except (tarfile.TarError, OSError) as exc:
         raise ValueError(f"Invalid theme catalog archive: {exc}") from exc
     with archive:

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2086,15 +2086,17 @@ class TUIApplication:
                 raise ValueError(
                     f"Theme {entry.id!r} is shadowed by a project theme; remove it first"
                 )
-            install = install_gallery_theme(entry)
+            installation = install_gallery_theme(entry)
             try:
                 theme.reload_themes()
                 installed = theme.get_theme_record(entry.id)
                 if not installed.source.startswith("user:"):
-                    raise ValueError(f"Theme {entry.id!r} was not installed from {install.path}")
+                    raise ValueError(
+                        f"Theme {entry.id!r} was not installed from {installation.path}"
+                    )
                 write_settings_updates({("tui", "theme"): entry.id})
             except Exception:
-                rollback_gallery_install(install)
+                rollback_gallery_install(installation)
                 theme.reload_themes()
                 raise
             theme.set_theme(entry.id)

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -2066,6 +2066,49 @@ class TUIApplication:
             ThemeExplorerView(refresh=refresh or self.refresh_style, persist=persist)
         )
 
+    async def open_theme_gallery(
+        self, catalog: object, *, refresh: Callable[[], None] | None = None
+    ) -> None:
+        """Open the cached remote-theme gallery; Enter installs and applies."""
+        from . import theme
+        from .settings import write_settings_updates
+        from .theme_explorer import ThemeGalleryView
+        from .theme_gallery import GalleryCatalog, install_gallery_theme, rollback_gallery_install
+
+        if not isinstance(catalog, GalleryCatalog):
+            raise TypeError("Invalid theme gallery catalog")
+        tui_config = getattr(self._config, "tui", self._config)
+        refresh_ui = refresh or self.refresh_style
+
+        def install(entry) -> None:
+            existing = theme.THEME_RECORDS.get(entry.id)
+            if existing is not None and existing.source.startswith("project:"):
+                raise ValueError(
+                    f"Theme {entry.id!r} is shadowed by a project theme; remove it first"
+                )
+            install = install_gallery_theme(entry)
+            try:
+                theme.reload_themes()
+                installed = theme.get_theme_record(entry.id)
+                if not installed.source.startswith("user:"):
+                    raise ValueError(f"Theme {entry.id!r} was not installed from {install.path}")
+                write_settings_updates({("tui", "theme"): entry.id})
+            except Exception:
+                rollback_gallery_install(install)
+                theme.reload_themes()
+                raise
+            theme.set_theme(entry.id)
+            if tui_config is not None:
+                tui_config.theme = entry.id
+            try:
+                refresh_ui()
+            except Exception:
+                # Installation and persistence have committed; a repaint failure
+                # must not misreport the transaction as rolled back.
+                pass
+
+        await self.open_subview(ThemeGalleryView(catalog.themes, install=install))
+
     async def open_memory_explorer(self) -> None:
         """Open the host-provided memory explorer view."""
         if self._host_services.open_memory_view is None:

--- a/packages/nooa-cli/tests/tui/test_completer.py
+++ b/packages/nooa-cli/tests/tui/test_completer.py
@@ -115,6 +115,12 @@ def test_theme_completion_uses_discovered_theme_ids(completer, monkeypatch) -> N
 
     monkeypatch.setattr(theme, "theme_names", lambda: ("mocha", "custom-night"))
 
+    assert [item.text for item in completer.complete("/theme ")][:3] == [
+        "/theme picker",
+        "/theme gallery",
+        "/theme update",
+    ]
+    assert [item.text for item in completer.complete("/theme g")] == ["/theme gallery"]
     assert [item.text for item in completer.complete("/theme custom")] == ["/theme custom-night"]
 
 

--- a/packages/nooa-cli/tests/tui/test_highlight_preview.py
+++ b/packages/nooa-cli/tests/tui/test_highlight_preview.py
@@ -13,7 +13,7 @@ def test_preview_offers_three_accessible_candidates_per_theme() -> None:
         assert candidates[0].name == "Balanced"
         for candidate in candidates:
             assert contrast_ratio(candidate.foreground, candidate.background) >= 4.5
-            assert contrast_ratio(candidate.background, theme.THEMES[theme_name]["base"]) >= 3
+            assert candidate.background == theme.THEMES[theme_name]["base"]
 
 
 def test_balanced_candidate_matches_live_inline_code_palette() -> None:

--- a/packages/nooa-cli/tests/tui/test_input_style.py
+++ b/packages/nooa-cli/tests/tui/test_input_style.py
@@ -96,11 +96,7 @@ def test_agent_message_bodies_use_terminal_default_foreground() -> None:
 
 
 def test_inline_code_spans_follow_the_active_theme() -> None:
-    """Inline ``code`` spans must not keep Rich's fixed cyan-on-black style.
-
-    The default markdown.code style ignores the palette, so light themes
-    rendered unreadable blue-on-black chips.
-    """
+    """Inline ``code`` uses bold theme accent text without a filled chip."""
     from nooa_cli.tui.config import Config
     from nooa_cli.tui.frontend import TerminalFrontend
     from nooa_cli.tui.output import AgentMessage
@@ -117,12 +113,10 @@ def test_inline_code_spans_follow_the_active_theme() -> None:
             bodies[name] = body
             style = frontend._console.console.get_style("markdown.code")
             assert style.color is not None
-            assert style.bgcolor is not None
+            assert style.bold is True
+            assert style.bgcolor is None
             assert style.color.triplet == tuple(
                 int(theme.COLORS["inline_code_fg"][index : index + 2], 16) for index in (1, 3, 5)
-            )
-            assert style.bgcolor.triplet == tuple(
-                int(theme.COLORS["inline_code_bg"][index : index + 2], 16) for index in (1, 3, 5)
             )
             assert "\x1b[40m" not in body, (name, body)
             assert "chip" in body
@@ -151,8 +145,8 @@ def _contrast_ratio(foreground: str, background: str) -> float:
 @pytest.mark.parametrize("name", theme.THEMES)
 def test_each_theme_has_accessible_inline_code_colors(name: str) -> None:
     palette = theme.THEMES[name]
-    assert _contrast_ratio(palette["inline_code_fg"], palette["inline_code_bg"]) >= 4.5
-    assert _contrast_ratio(palette["inline_code_bg"], palette["base"]) >= 3
+    assert _contrast_ratio(palette["inline_code_fg"], palette["base"]) >= 4.5
+    assert palette["inline_code_bg"] == palette["base"]
 
 
 @pytest.mark.parametrize("name", theme.THEMES)

--- a/packages/nooa-cli/tests/tui/test_theme_catalog.py
+++ b/packages/nooa-cli/tests/tui/test_theme_catalog.py
@@ -85,7 +85,7 @@ def test_standard_solarized_theme_gets_accessible_derived_highlights() -> None:
 
     for role in ("search_current", "inline_code"):
         assert contrast_ratio(record.palette[f"{role}_fg"], record.palette[f"{role}_bg"]) >= 4.5
-    assert contrast_ratio(record.palette["inline_code_bg"], record.palette["base"]) >= 3
+    assert record.palette["inline_code_bg"] == record.palette["base"]
 
 
 def test_base16_theme_accepts_semantic_overrides() -> None:
@@ -93,8 +93,8 @@ def test_base16_theme_accepts_semantic_overrides() -> None:
         _base16(
             id="custom",
             variant="dark",
-            inline_code_fg="#11111b",
-            inline_code_bg="#89b4fa",
+            inline_code_fg="#89b4fa",
+            inline_code_bg="#181818",
             search_match_fg="#11111b",
             search_current_fg="#11111b",
             diff_added="#a6e3a1",
@@ -105,7 +105,7 @@ def test_base16_theme_accepts_semantic_overrides() -> None:
     )
 
     assert record.id == "custom"
-    assert record.palette["inline_code_bg"] == "#89b4fa"
+    assert record.palette["inline_code_bg"] == "#181818"
     assert record.palette["diff_added"] == "#a6e3a1"
     assert record.source == "test"
 

--- a/packages/nooa-cli/tests/tui/test_theme_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_theme_explorer.py
@@ -29,6 +29,11 @@ def test_theme_rows_expose_metadata_and_semantic_preview() -> None:
     plain = strip_safe_ansi(rendered)
     assert "Semantic highlights" in rendered
     assert "inline code" in rendered
+    inline_rgb = ";".join(
+        str(int(rows[0].record.palette["inline_code_fg"].lstrip("#")[index : index + 2], 16))
+        for index in (0, 2, 4)
+    )
+    assert f"\x1b[1;38;2;{inline_rgb}m inline code " in rendered
     assert "success" in rendered and "error" in rendered
     assert "Syntax-highlighted code" in rendered
     assert "def greet" in plain and "return" in plain
@@ -145,6 +150,324 @@ async def test_theme_command_without_args_opens_browser() -> None:
     assert result.success is True
     assert isinstance(result.outputs[0], TextOutput)
     frontend.open_theme_explorer.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_theme_picker_action_opens_installed_browser() -> None:
+    frontend = MagicMock()
+    frontend.open_theme_explorer = AsyncMock()
+    command = ThemeCommand(frontend, MagicMock(), MagicMock())
+
+    result = await command.execute(["picker"])
+
+    assert result.success is True
+    frontend.open_theme_explorer.assert_awaited_once_with()
+
+
+def test_theme_action_validation_is_local_and_does_not_load_gallery(monkeypatch) -> None:
+    from nooa_cli.tui import theme_gallery
+
+    monkeypatch.setattr(
+        theme_gallery,
+        "ensure_gallery_catalog",
+        lambda: (_ for _ in ()).throw(AssertionError("gallery must remain lazy")),
+    )
+    command = ThemeCommand(MagicMock(), MagicMock(), MagicMock())
+
+    assert command.validate_args(["picker"]) == (True, None)
+    assert command.validate_args(["gallery"]) == (True, None)
+    assert command.validate_args(["update"]) == (True, None)
+
+
+@pytest.mark.asyncio
+async def test_theme_update_downloads_catalog_without_opening_browser(monkeypatch) -> None:
+    from nooa_cli.tui import theme_gallery
+
+    catalog = theme_gallery.GalleryCatalog({"base16-ocean": MagicMock()}, ("bad",))
+    update = MagicMock(return_value=catalog)
+    monkeypatch.setattr(theme_gallery, "update_gallery_catalog", update)
+    frontend = MagicMock()
+    command = ThemeCommand(frontend, MagicMock(), MagicMock())
+
+    result = await command.execute(["update"])
+
+    assert result.success is True
+    assert "1 schemes (1 skipped)" in result.outputs[0].content
+    update.assert_called_once_with()
+    frontend.open_theme_explorer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_theme_gallery_loads_on_demand_and_opens_browser(monkeypatch) -> None:
+    from nooa_cli.tui import theme_gallery
+
+    catalog = theme_gallery.GalleryCatalog({"base16-ocean": MagicMock()})
+    ensure = MagicMock(return_value=catalog)
+    monkeypatch.setattr(theme_gallery, "ensure_gallery_catalog", ensure)
+    frontend = MagicMock()
+    frontend.open_theme_gallery = AsyncMock()
+    command = ThemeCommand(frontend, MagicMock(), MagicMock())
+
+    result = await command.execute(["gallery"])
+
+    assert result.success is True
+    ensure.assert_called_once_with()
+    frontend.open_theme_gallery.assert_awaited_once_with(catalog)
+
+
+def test_gallery_view_previews_without_changing_active_theme() -> None:
+    from nooa_cli.tui.theme_explorer import ThemeGalleryView
+    from nooa_cli.tui.theme_gallery import GalleryTheme
+
+    original = theme.get_theme()
+    remote = theme.ThemeRecord(
+        "base16-remote",
+        "Remote",
+        dict(theme.THEMES["latte"]),
+        "vs",
+        "light",
+        "gallery:base16",
+    )
+    entry = GalleryTheme(remote.id, "base16", remote, {"name": "Remote"})
+    try:
+        theme.set_theme("mocha")
+        view = ThemeGalleryView({entry.id: entry}, install=MagicMock())
+        view.on_open()
+        assert theme.get_theme() == "mocha"
+        assert "Remote" in "\n".join(view.detail_lines(view.model.current, 80))
+    finally:
+        theme.set_theme(original)
+
+
+def test_gallery_view_keeps_open_and_reports_install_failure() -> None:
+    from nooa_cli.tui.theme_explorer import ThemeGalleryView
+    from nooa_cli.tui.theme_gallery import GalleryTheme
+
+    remote = theme.ThemeRecord(
+        "base16-remote",
+        "Remote",
+        dict(theme.THEMES["latte"]),
+        "vs",
+        "light",
+        "gallery:base16",
+    )
+    entry = GalleryTheme(remote.id, "base16", remote, {"name": "Remote"})
+    view = ThemeGalleryView(
+        {entry.id: entry},
+        install=MagicMock(side_effect=OSError("disk full")),
+    )
+
+    assert view.handle_action("enter", view.model.current) == "handled"
+    assert "Install failed: disk full" in "\n".join(view.detail_lines(view.model.current, 80))
+
+
+@pytest.mark.asyncio
+async def test_tui_application_installs_and_applies_gallery_theme(tmp_path, monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    import yaml
+    from nooa_cli.tui.config import TUIConfig
+    from nooa_cli.tui.theme_gallery import GalleryCatalog, GalleryTheme
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(tmp_path / "user"))
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(tmp_path / "project"))
+    remote = theme.ThemeRecord(
+        "base16-remote",
+        "Remote",
+        dict(theme.THEMES["latte"]),
+        "vs",
+        "light",
+        "gallery:base16",
+    )
+    document = {
+        "system": "base16",
+        "name": "Remote",
+        "variant": "light",
+        "palette": {
+            f"base{index:02X}": value
+            for index, value in enumerate(
+                [
+                    "eff1f5",
+                    "e6e9ef",
+                    "dce0e8",
+                    "acb0be",
+                    "6c6f85",
+                    "4c4f69",
+                    "3c3f59",
+                    "24273a",
+                    "d20f39",
+                    "fe640b",
+                    "df8e1d",
+                    "40a02b",
+                    "179299",
+                    "1e66f5",
+                    "8839ef",
+                    "dc8a78",
+                ]
+            )
+        },
+    }
+    entry = GalleryTheme(remote.id, "base16", remote, document)
+    app = object.__new__(TUIApplication)
+    app._config = SimpleNamespace(tui=TUIConfig())
+    app.open_subview = AsyncMock()
+    original = theme.get_theme()
+    try:
+        await app.open_theme_gallery(GalleryCatalog({entry.id: entry}), refresh=MagicMock())
+        view = app.open_subview.await_args.args[0]
+        target = view.model.current
+        assert view.handle_action("enter", target) == "close"
+
+        installed = tmp_path / "user" / "themes" / "base16-remote.yaml"
+        assert installed.exists()
+        assert yaml.safe_load(installed.read_text(encoding="utf-8"))["name"] == "Remote"
+        assert app._config.tui.theme == "base16-remote"
+        assert theme.get_theme() == "base16-remote"
+    finally:
+        theme.set_theme(original)
+        theme.reload_themes()
+
+
+@pytest.mark.asyncio
+async def test_gallery_install_rolls_back_when_settings_write_fails(tmp_path, monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    import yaml
+    from nooa_cli.tui.config import TUIConfig
+    from nooa_cli.tui.theme_gallery import GalleryCatalog, GalleryTheme
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    user_dir = tmp_path / "user"
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(user_dir))
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(tmp_path / "project"))
+    target = user_dir / "themes" / "base16-remote.yaml"
+    target.parent.mkdir(parents=True)
+    original_document = {
+        "system": "base16",
+        "name": "Original",
+        "variant": "light",
+        "palette": {
+            f"base{index:02X}": value
+            for index, value in enumerate(
+                [
+                    "eff1f5",
+                    "e6e9ef",
+                    "dce0e8",
+                    "acb0be",
+                    "6c6f85",
+                    "4c4f69",
+                    "3c3f59",
+                    "24273a",
+                    "d20f39",
+                    "fe640b",
+                    "df8e1d",
+                    "40a02b",
+                    "179299",
+                    "1e66f5",
+                    "8839ef",
+                    "dc8a78",
+                ]
+            )
+        },
+    }
+    target.write_text(yaml.safe_dump(original_document), encoding="utf-8")
+    theme.reload_themes()
+    remote = theme.ThemeRecord(
+        "base16-remote",
+        "Replacement",
+        dict(theme.THEMES["latte"]),
+        "vs",
+        "light",
+        "gallery:base16",
+    )
+    replacement_document = {**original_document, "name": "Replacement"}
+    entry = GalleryTheme(remote.id, "base16", remote, replacement_document)
+    app = object.__new__(TUIApplication)
+    app._config = SimpleNamespace(tui=TUIConfig())
+    app.open_subview = AsyncMock()
+    monkeypatch.setattr(
+        "nooa_cli.tui.settings.write_settings_updates",
+        MagicMock(side_effect=OSError("settings unavailable")),
+    )
+
+    await app.open_theme_gallery(GalleryCatalog({entry.id: entry}), refresh=MagicMock())
+    view = app.open_subview.await_args.args[0]
+
+    assert view.handle_action("enter", view.model.current) == "handled"
+    assert yaml.safe_load(target.read_text(encoding="utf-8"))["name"] == "Original"
+    assert "settings unavailable" in "\n".join(view.detail_lines(view.model.current, 80))
+    theme.reload_themes()
+
+
+@pytest.mark.asyncio
+async def test_gallery_refresh_failure_does_not_misreport_committed_install(
+    tmp_path, monkeypatch
+) -> None:
+    from types import SimpleNamespace
+
+    import yaml
+    from nooa_cli.tui.config import TUIConfig
+    from nooa_cli.tui.theme_gallery import GalleryCatalog, GalleryTheme
+    from nooa_cli.tui.tui_application import TUIApplication
+
+    user_dir = tmp_path / "user"
+    project_dir = tmp_path / "project"
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(user_dir))
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(project_dir))
+    remote = theme.ThemeRecord(
+        "base16-remote", "Remote", dict(theme.THEMES["latte"]), "vs", "light", "gallery:base16"
+    )
+    document = {
+        "system": "base16",
+        "name": "Remote",
+        "variant": "light",
+        "palette": {
+            f"base{index:02X}": value
+            for index, value in enumerate(
+                [
+                    "eff1f5",
+                    "e6e9ef",
+                    "dce0e8",
+                    "acb0be",
+                    "6c6f85",
+                    "4c4f69",
+                    "3c3f59",
+                    "24273a",
+                    "d20f39",
+                    "fe640b",
+                    "df8e1d",
+                    "40a02b",
+                    "179299",
+                    "1e66f5",
+                    "8839ef",
+                    "dc8a78",
+                ]
+            )
+        },
+    }
+    entry = GalleryTheme(remote.id, "base16", remote, document)
+    app = object.__new__(TUIApplication)
+    app._config = SimpleNamespace(tui=TUIConfig())
+    app.open_subview = AsyncMock()
+    original = theme.get_theme()
+    try:
+        await app.open_theme_gallery(
+            GalleryCatalog({entry.id: entry}),
+            refresh=MagicMock(side_effect=RuntimeError("paint failed")),
+        )
+        view = app.open_subview.await_args.args[0]
+
+        assert view.handle_action("enter", view.model.current) == "close"
+        assert (user_dir / "themes" / "base16-remote.yaml").exists()
+        assert (
+            yaml.safe_load((project_dir / "settings.yaml").read_text())["tui"]["theme"] == entry.id
+        )
+        assert app._config.tui.theme == entry.id
+        assert theme.get_theme() == entry.id
+    finally:
+        theme.set_theme(original)
+        theme.reload_themes()
 
 
 @pytest.mark.asyncio

--- a/packages/nooa-cli/tests/tui/test_theme_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_theme_explorer.py
@@ -259,6 +259,8 @@ def test_gallery_view_keeps_open_and_reports_install_failure() -> None:
 
     assert view.handle_action("enter", view.model.current) == "handled"
     assert "Install failed: disk full" in "\n".join(view.detail_lines(view.model.current, 80))
+    view.on_selection_changed()
+    assert "Install failed" not in "\n".join(view.detail_lines(view.model.current, 80))
 
 
 @pytest.mark.asyncio
@@ -391,13 +393,15 @@ async def test_gallery_install_rolls_back_when_settings_write_fails(tmp_path, mo
         MagicMock(side_effect=OSError("settings unavailable")),
     )
 
-    await app.open_theme_gallery(GalleryCatalog({entry.id: entry}), refresh=MagicMock())
-    view = app.open_subview.await_args.args[0]
+    try:
+        await app.open_theme_gallery(GalleryCatalog({entry.id: entry}), refresh=MagicMock())
+        view = app.open_subview.await_args.args[0]
 
-    assert view.handle_action("enter", view.model.current) == "handled"
-    assert yaml.safe_load(target.read_text(encoding="utf-8"))["name"] == "Original"
-    assert "settings unavailable" in "\n".join(view.detail_lines(view.model.current, 80))
-    theme.reload_themes()
+        assert view.handle_action("enter", view.model.current) == "handled"
+        assert yaml.safe_load(target.read_text(encoding="utf-8"))["name"] == "Original"
+        assert "settings unavailable" in "\n".join(view.detail_lines(view.model.current, 80))
+    finally:
+        theme.reload_themes()
 
 
 @pytest.mark.asyncio

--- a/packages/nooa-cli/tests/tui/test_theme_gallery.py
+++ b/packages/nooa-cli/tests/tui/test_theme_gallery.py
@@ -117,6 +117,24 @@ def test_parse_gallery_archive_bounds_ignored_expanded_data(monkeypatch) -> None
         parse_gallery_archive(data)
 
 
+def test_parse_gallery_archive_bounds_hidden_pax_metadata(monkeypatch) -> None:
+    output = io.BytesIO()
+    with tarfile.open(
+        fileobj=output,
+        mode="w:gz",
+        format=tarfile.PAX_FORMAT,
+        pax_headers={"comment": "x" * 10_000},
+    ) as archive:
+        payload = b"ignored"
+        info = tarfile.TarInfo("schemes-spec-0.11/notes/readme.txt")
+        info.size = len(payload)
+        archive.addfile(info, io.BytesIO(payload))
+    monkeypatch.setattr(theme_gallery, "_MAX_EXPANDED_ARCHIVE_BYTES", 1024)
+
+    with pytest.raises(ValueError, match="expands beyond"):
+        parse_gallery_archive(output.getvalue())
+
+
 def test_oversized_disk_cache_is_replaced_without_parsing(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("NEMO_OO_USER_DIR", str(tmp_path))
     monkeypatch.setattr(theme_gallery, "_loaded_catalog", None)

--- a/packages/nooa-cli/tests/tui/test_theme_gallery.py
+++ b/packages/nooa-cli/tests/tui/test_theme_gallery.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the on-demand Tinted theme gallery catalog."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import pytest
+import yaml
+from nooa_cli.tui import theme_gallery
+from nooa_cli.tui.theme_gallery import (
+    install_gallery_theme,
+    parse_gallery_archive,
+)
+
+
+def _scheme(system: str = "base16", name: str = "Ocean") -> dict[str, object]:
+    palette = {
+        "base00": "181818",
+        "base01": "282828",
+        "base02": "383838",
+        "base03": "585858",
+        "base04": "b8b8b8",
+        "base05": "d8d8d8",
+        "base06": "e8e8e8",
+        "base07": "f8f8f8",
+        "base08": "ab4642",
+        "base09": "dc9656",
+        "base0A": "f7ca88",
+        "base0B": "a1b56c",
+        "base0C": "86c1b9",
+        "base0D": "7cafc2",
+        "base0E": "ba8baf",
+        "base0F": "a16946",
+    }
+    if system == "base24":
+        palette.update({f"base{index:02X}": "ffffff" for index in range(16, 24)})
+    return {"system": system, "name": name, "variant": "dark", "palette": palette}
+
+
+def _archive(files: dict[str, object]) -> bytes:
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as archive:
+        for relative, document in files.items():
+            payload = yaml.safe_dump(document).encode("utf-8")
+            info = tarfile.TarInfo(f"schemes-spec-0.11/{relative}")
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return output.getvalue()
+
+
+def _raw_archive(files: dict[str, bytes]) -> bytes:
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as archive:
+        for relative, payload in files.items():
+            info = tarfile.TarInfo(f"schemes-spec-0.11/{relative}")
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return output.getvalue()
+
+
+def test_gallery_catalog_is_lazy_on_import(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(tmp_path))
+    monkeypatch.setattr(theme_gallery, "_loaded_catalog", None)
+
+    assert theme_gallery.gallery_loaded() is False
+    assert not theme_gallery._cache_path().exists()
+
+
+def test_parse_gallery_archive_accepts_nested_base16_and_base24() -> None:
+    catalog = parse_gallery_archive(
+        _archive(
+            {
+                "base16/ocean.yaml": _scheme(),
+                "base24/ayu.yaml": _scheme("base24", "Ayu"),
+            }
+        )
+    )
+
+    assert list(catalog.themes) == ["base16-ocean", "base24-ayu"]
+    assert catalog.themes["base16-ocean"].record.name == "Ocean"
+    assert catalog.themes["base24-ayu"].system == "base24"
+    assert catalog.diagnostics == ()
+
+
+def test_parse_gallery_archive_skips_malformed_and_unsafe_members() -> None:
+    data = _archive(
+        {
+            "base16/good.yaml": _scheme(),
+            "base16/bad.yaml": {"name": "Bad", "palette": {"base00": "000000"}},
+            "../base16/escape.yaml": _scheme(name="Escape"),
+        }
+    )
+
+    catalog = parse_gallery_archive(data)
+
+    assert list(catalog.themes) == ["base16-good"]
+    assert len(catalog.diagnostics) == 1
+    assert "bad.yaml" in catalog.diagnostics[0]
+
+
+def test_parse_gallery_archive_bounds_all_members(monkeypatch) -> None:
+    monkeypatch.setattr(theme_gallery, "_MAX_ARCHIVE_MEMBERS", 1)
+    data = _raw_archive({"notes/one.txt": b"one", "notes/two.txt": b"two"})
+
+    with pytest.raises(ValueError, match="too many archive members"):
+        parse_gallery_archive(data)
+
+
+def test_parse_gallery_archive_bounds_ignored_expanded_data(monkeypatch) -> None:
+    monkeypatch.setattr(theme_gallery, "_MAX_TOTAL_BYTES", 10)
+    data = _raw_archive({"notes/readme.txt": b"x" * 11})
+
+    with pytest.raises(ValueError, match="expands beyond"):
+        parse_gallery_archive(data)
+
+
+def test_oversized_disk_cache_is_replaced_without_parsing(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(tmp_path))
+    monkeypatch.setattr(theme_gallery, "_loaded_catalog", None)
+    cache = theme_gallery._cache_path()
+    cache.parent.mkdir(parents=True)
+    cache.write_bytes(b"x" * (theme_gallery._MAX_ARCHIVE_BYTES + 1))
+    payload = _archive({"base16/ocean.yaml": _scheme()})
+
+    catalog = theme_gallery.ensure_gallery_catalog(lambda: payload)
+
+    assert list(catalog.themes) == ["base16-ocean"]
+    assert cache.read_bytes() == payload
+
+
+def test_update_fetches_once_and_gallery_reuses_cache(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(tmp_path))
+    monkeypatch.setattr(theme_gallery, "_loaded_catalog", None)
+    payload = _archive({"base16/ocean.yaml": _scheme()})
+    calls = 0
+
+    def fetch() -> bytes:
+        nonlocal calls
+        calls += 1
+        return payload
+
+    updated = theme_gallery.update_gallery_catalog(fetch)
+    cached = theme_gallery.ensure_gallery_catalog(lambda: (_ for _ in ()).throw(AssertionError()))
+
+    assert calls == 1
+    assert cached is updated
+    assert theme_gallery._cache_path().read_bytes() == payload
+
+
+def test_gallery_uses_disk_cache_after_process_restart(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(tmp_path))
+    payload = _archive({"base16/ocean.yaml": _scheme()})
+    path = theme_gallery._cache_path()
+    path.parent.mkdir(parents=True)
+    path.write_bytes(payload)
+    monkeypatch.setattr(theme_gallery, "_loaded_catalog", None)
+
+    catalog = theme_gallery.ensure_gallery_catalog(
+        lambda: (_ for _ in ()).throw(AssertionError("network should not be used"))
+    )
+
+    assert list(catalog.themes) == ["base16-ocean"]
+
+
+def test_install_gallery_theme_writes_source_document(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(tmp_path))
+    catalog = parse_gallery_archive(_archive({"base16/ocean.yaml": _scheme()}))
+
+    install = install_gallery_theme(catalog.themes["base16-ocean"])
+
+    assert install.path == tmp_path / "themes" / "base16-ocean.yaml"
+    assert install.previous is None
+    document = yaml.safe_load(install.path.read_text(encoding="utf-8"))
+    assert document["name"] == "Ocean"
+    assert document["id"] == "base16-ocean"
+
+
+def test_install_gallery_theme_can_replace_and_roll_back(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("NEMO_OO_USER_DIR", str(tmp_path))
+    catalog = parse_gallery_archive(_archive({"base16/ocean.yaml": _scheme()}))
+    target = tmp_path / "themes" / "base16-ocean.yaml"
+    target.parent.mkdir(parents=True)
+    target.write_text("existing", encoding="utf-8")
+
+    install = install_gallery_theme(catalog.themes["base16-ocean"])
+    theme_gallery.rollback_gallery_install(install)
+
+    assert install.previous == b"existing"
+    assert target.read_text(encoding="utf-8") == "existing"

--- a/packages/nooa-cli/tests/tui/test_theme_gallery.py
+++ b/packages/nooa-cli/tests/tui/test_theme_gallery.py
@@ -61,6 +61,35 @@ def _raw_archive(files: dict[str, bytes]) -> bytes:
     return output.getvalue()
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://github.com/tinted-theming/schemes/archive/x.tar.gz",
+        "https://evil.example.com/schemes.tar.gz",
+        "https://github.com.evil.example.com/schemes.tar.gz",
+        "ftp://github.com/schemes.tar.gz",
+    ],
+)
+def test_catalog_url_validation_rejects_unpinned_origins(url: str) -> None:
+    with pytest.raises(ValueError, match="Unexpected theme catalog URL"):
+        theme_gallery._validate_catalog_url(url)
+
+
+def test_catalog_url_validation_accepts_pinned_origins() -> None:
+    theme_gallery._validate_catalog_url(theme_gallery.CATALOG_URL)
+    theme_gallery._validate_catalog_url(
+        "https://codeload.github.com/tinted-theming/schemes/tar.gz/x"
+    )
+
+
+def test_redirect_handler_rejects_offsite_redirect() -> None:
+    handler = theme_gallery._SafeRedirectHandler()
+    with pytest.raises(ValueError, match="Unexpected theme catalog URL"):
+        handler.redirect_request(
+            None, None, 302, "Found", {}, "https://evil.example.com/schemes.tar.gz"
+        )
+
+
 def test_gallery_catalog_is_lazy_on_import(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("NEMO_OO_USER_DIR", str(tmp_path))
     monkeypatch.setattr(theme_gallery, "_loaded_catalog", None)


### PR DESCRIPTION
## Summary
- add an on-demand Tinted Theming gallery under `/theme gallery` and explicit refresh via `/theme update`
- securely download, validate, cache, preview, and atomically install Base16/Base24 schemes without startup network access
- keep installed-theme browsing at `/theme` and `/theme picker`, with nested completion and direct installed-theme selection
- render inline Markdown code as subtle bold accent text without a filled background
- document the new workflow and cover gallery, picker, completion, rollback, and styling behavior

## Testing
- `git diff --check`
- `uv run --project packages/nooa-cli ruff check ...` (touched files)
- `uv run --project packages/nooa-cli ruff format --check ...` (touched files)
- focused TUI suite: 228 passed
- full CLI suite collected 1,711 tests and reached ~69% before the execution timeout; the two PTY fullscreen tests also time out in isolation and are being checked against the unchanged base


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/theme picker` for previewing, applying, and restoring installed themes.
  * Added opt-in `/theme gallery` and `/theme update` commands for browsing and refreshing the Tinted theme catalog.
  * Gallery themes can be previewed and installed directly, with cached catalog access and safe recovery if installation fails.
  * Added command completion for the new theme actions.

* **Style**
  * Improved inline-code previews with bold colored text on the theme background.

* **Documentation**
  * Updated theme command documentation and usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->