### PR TITLE
feat(tui): preview input window and scrollback themes

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/theme_catalog.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme_catalog.py
@@ -165,16 +165,26 @@ def _base16_palette(data: dict[str, Any]) -> dict[str, str]:
         palette[f"{role}_fg"] = foreground
         palette[f"{role}_bg"] = background
     # The scrollback user bar must always read as highlighted, but stays
-    # neutral: prefer a visible step on the scheme's grayscale ramp (base02,
-    # then base03) with whichever of base00/base07 reads best on it, and fall
-    # back to the already-validated selection pair when no gray step reaches
-    # the required 4.5:1 contrast.
-    user_bg = bases["base02"]
-    if contrast_ratio(user_bg, palette["base"]) < 1.2:
-        user_bg = bases["base03"]
-    user_fg = _contrast_foreground(user_bg, dark, light)
-    if contrast_ratio(user_fg, user_bg) < 4.5:
-        user_fg, user_bg = palette["selection_fg"], palette["selection_bg"]
+    # neutral: use the first grayscale step (base02, then base03) that stays
+    # visibly distinct from the background, pair it with whichever of
+    # base00/base07 reads best, and fall back to the already-validated
+    # selection pair when no step qualifies — either because it blends into
+    # the base or because its best foreground misses the 4.5:1 contrast.
+    user_bg = next(
+        (
+            candidate
+            for candidate in (bases["base02"], bases["base03"])
+            if contrast_ratio(candidate, palette["base"]) >= 1.2
+        ),
+        None,
+    )
+    if user_bg is None:
+        user_fg = palette["selection_fg"]
+        user_bg = palette["selection_bg"]
+    else:
+        user_fg = _contrast_foreground(user_bg, dark, light)
+        if contrast_ratio(user_fg, user_bg) < 4.5:
+            user_fg, user_bg = palette["selection_fg"], palette["selection_bg"]
     palette["user_message_fg"] = user_fg
     palette["user_message_bg"] = user_bg
     # Inline code is bold accent text on the terminal background, not a chip.

--- a/packages/nooa-cli/src/nooa_cli/tui/theme_catalog.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme_catalog.py
@@ -164,8 +164,19 @@ def _base16_palette(data: dict[str, Any]) -> dict[str, str]:
                     break
         palette[f"{role}_fg"] = foreground
         palette[f"{role}_bg"] = background
-    palette["user_message_fg"] = palette["selection_fg"]
-    palette["user_message_bg"] = palette["selection_bg"]
+    # The scrollback user bar must always read as highlighted, but stays
+    # neutral: prefer a visible step on the scheme's grayscale ramp (base02,
+    # then base03) with whichever of base00/base07 reads best on it, and fall
+    # back to the already-validated selection pair when no gray step reaches
+    # the required 4.5:1 contrast.
+    user_bg = bases["base02"]
+    if contrast_ratio(user_bg, palette["base"]) < 1.2:
+        user_bg = bases["base03"]
+    user_fg = _contrast_foreground(user_bg, dark, light)
+    if contrast_ratio(user_fg, user_bg) < 4.5:
+        user_fg, user_bg = palette["selection_fg"], palette["selection_bg"]
+    palette["user_message_fg"] = user_fg
+    palette["user_message_bg"] = user_bg
     # Inline code is bold accent text on the terminal background, not a chip.
     palette["inline_code_fg"] = bases["base0D"]
     if contrast_ratio(palette["inline_code_fg"], palette["base"]) < 4.5:

--- a/packages/nooa-cli/src/nooa_cli/tui/theme_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme_explorer.py
@@ -151,6 +151,28 @@ class ThemeExplorerView(ExplorerView):
                 ("info", "feedback_info"),
             )
         )
+        input_window = (
+            _style("› ", p["focus_accent"])
+            + _style("run the tests ", p["text_primary"], p["base"])
+            + _style("selected", p["selection_fg"], p["selection_bg"])
+        )
+        completions = "  ".join(
+            (
+                _style(" completion ", p["text_primary"], p["surface_raised"]),
+                _style(" current ", p["selection_fg"], p["selection_bg"]),
+            )
+        )
+        scrollback = "  ".join(
+            (
+                _style(
+                    " You: how does my message look? ",
+                    p["user_message_fg"],
+                    p["user_message_bg"],
+                ),
+                _style("Agent: this is how a reply reads.", p["text_primary"], p["base"]),
+                _style("status", p["text_subtle"]),
+            )
+        )
         return [
             f"{row.title} ({row.id})",
             f"Variant: {row.variant}    Source: {row.source}",
@@ -162,6 +184,13 @@ class ThemeExplorerView(ExplorerView):
             "",
             "Feedback and accents",
             feedback,
+            "",
+            "Input window",
+            input_window,
+            completions,
+            "",
+            "Scrollback",
+            scrollback,
             "",
             _style(" Primary text ", p["text_primary"], p["base"]),
             _style(" Muted text ", p["text_muted"], p["surface_raised"]),

--- a/packages/nooa-cli/src/nooa_cli/tui/theme_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme_explorer.py
@@ -16,6 +16,7 @@ from . import theme
 from .explorer_base import ExplorerConfig, ExplorerModel, ExplorerView
 from .theme import SemanticSyntaxTheme, get_theme, set_theme
 from .theme_catalog import ThemeRecord
+from .user_message import render_user_bar
 
 if TYPE_CHECKING:
     from .theme_gallery import GalleryTheme
@@ -151,31 +152,28 @@ class ThemeExplorerView(ExplorerView):
                 ("info", "feedback_info"),
             )
         )
+        # The real input window: '❯ ' prompt in the theme's green, transparent
+        # input text (the terminal program's own background shows through),
+        # selection styling, and the actual completion-menu pair.
         input_window = (
-            _style("› ", p["focus_accent"])
-            # Input text has no background: the real window is transparent and
-            # shows the terminal program's own background color.
-            + _style("run the tests ", p["text_primary"])
+            _style("❯ ", p["green"])
+            + _style("run the tests ", p["text"])
             + _style("selected", p["selection_fg"], p["selection_bg"])
         )
         completions = "  ".join(
             (
-                _style(" completion ", p["text_primary"], p["surface_raised"]),
-                _style(" current ", p["selection_fg"], p["selection_bg"]),
+                _style(" completion ", p["text"], p["surface0"]),
+                _style(" current ", p["mauve"], p["surface2"]),
             )
         )
-        scrollback = "  ".join(
-            (
-                _style(
-                    " You: how does my message look? ",
-                    p["user_message_fg"],
-                    p["user_message_bg"],
-                ),
-                # Agent replies render as plain text over the terminal background.
-                _style("Agent: this is how a reply reads.", p["text_primary"]),
-                _style("status", p["text_subtle"]),
-            )
-        )
+        # The real scrollback: render the exact user-bar artifact the transcript
+        # shows (256-color quantization, '❯ ' prefix, ▔/▁ breathing-room edges),
+        # then a plain agent reply and subtle status text.
+        scrollback = [
+            *render_user_bar("how does my message look?", width, p).rstrip("\n").split("\n"),
+            _style("Agent: this is how a reply reads.", p["text"]),
+            _style("status", p["text_subtle"]),
+        ]
         return [
             f"{row.title} ({row.id})",
             f"Variant: {row.variant}    Source: {row.source}",
@@ -193,7 +191,7 @@ class ThemeExplorerView(ExplorerView):
             completions,
             "",
             "Scrollback",
-            scrollback,
+            *scrollback,
             "",
             _style(" Primary text ", p["text_primary"], p["base"]),
             _style(" Muted text ", p["text_muted"], p["surface_raised"]),

--- a/packages/nooa-cli/src/nooa_cli/tui/theme_explorer.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/theme_explorer.py
@@ -153,7 +153,9 @@ class ThemeExplorerView(ExplorerView):
         )
         input_window = (
             _style("› ", p["focus_accent"])
-            + _style("run the tests ", p["text_primary"], p["base"])
+            # Input text has no background: the real window is transparent and
+            # shows the terminal program's own background color.
+            + _style("run the tests ", p["text_primary"])
             + _style("selected", p["selection_fg"], p["selection_bg"])
         )
         completions = "  ".join(
@@ -169,7 +171,8 @@ class ThemeExplorerView(ExplorerView):
                     p["user_message_fg"],
                     p["user_message_bg"],
                 ),
-                _style("Agent: this is how a reply reads.", p["text_primary"], p["base"]),
+                # Agent replies render as plain text over the terminal background.
+                _style("Agent: this is how a reply reads.", p["text_primary"]),
                 _style("status", p["text_subtle"]),
             )
         )

--- a/packages/nooa-cli/tests/tui/test_theme_catalog.py
+++ b/packages/nooa-cli/tests/tui/test_theme_catalog.py
@@ -210,6 +210,19 @@ def test_base16_user_bar_is_neutral_and_readable() -> None:
     assert validate_palette(palette) is None
 
 
+def test_base16_user_bar_rejects_indistinct_base03() -> None:
+    # Both grayscale steps blend into the background: neither is a visible
+    # highlight, so the user bar falls back to the validated selection pair
+    # instead of rendering an invisible bar.
+    data = _base16(**{"base02": "181818", "base03": "191919"})
+    record = parse_theme(data, fallback_id="base16", source="test")
+    palette = record.palette
+
+    assert palette["user_message_fg"] == palette["selection_fg"]
+    assert palette["user_message_bg"] == palette["selection_bg"]
+    assert contrast_ratio(palette["user_message_fg"], palette["user_message_bg"]) >= 4.5
+
+
 def test_base16_user_bar_falls_back_when_gray_is_unreadable() -> None:
     # #767676 is the WCAG boundary gray: neither base00 (dark) nor base07
     # (light) reaches 4.5:1 on it, so the already-validated selection pair is

--- a/packages/nooa-cli/tests/tui/test_theme_catalog.py
+++ b/packages/nooa-cli/tests/tui/test_theme_catalog.py
@@ -198,6 +198,38 @@ def test_builtins_define_valid_semantic_roles() -> None:
         validate_palette(record.palette)
 
 
+def test_base16_user_bar_is_neutral_and_readable() -> None:
+    data = _base16()
+    record = parse_theme(data, fallback_id="base16", source="test")
+    palette = record.palette
+
+    # The scrollback user bar is a highlighted but neutral gray step, never an
+    # accent, and always satisfies the same 4.5:1 contrast as every other pair.
+    assert contrast_ratio(palette["user_message_fg"], palette["user_message_bg"]) >= 4.5
+    assert palette["user_message_bg"] in {palette["surface1"], palette["surface2"]}
+    assert validate_palette(palette) is None
+
+
+def test_base16_user_bar_falls_back_when_gray_is_unreadable() -> None:
+    # #767676 is the WCAG boundary gray: neither base00 (dark) nor base07
+    # (light) reaches 4.5:1 on it, so the already-validated selection pair is
+    # used instead — the user bar is never unreadable.
+    data = _base16(**{"base02": "767676", "base03": "767676"})
+    record = parse_theme(data, fallback_id="base16", source="test")
+    palette = record.palette
+
+    assert palette["user_message_fg"] == palette["selection_fg"]
+    assert palette["user_message_bg"] == palette["selection_bg"]
+
+
+def test_builtins_keep_readable_user_bar() -> None:
+    from nooa_cli.tui.theme import THEME_RECORDS
+
+    for record in THEME_RECORDS.values():
+        palette = record.palette
+        assert contrast_ratio(palette["user_message_fg"], palette["user_message_bg"]) >= 4.5
+
+
 def test_builtins_expose_every_semantic_role() -> None:
     from nooa_cli.tui.theme import THEME_RECORDS
     from nooa_cli.tui.theme_catalog import SEMANTIC_KEYS

--- a/packages/nooa-cli/tests/tui/test_theme_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_theme_explorer.py
@@ -20,6 +20,37 @@ from prompt_toolkit.data_structures import Size
 from prompt_toolkit.output import DummyOutput
 
 
+@pytest.fixture(autouse=True)
+def _restore_global_theme_catalog():
+    """Snapshot the process-global theme catalog and restore it after each test.
+
+    Opening the default theme browser reloads user/project themes from the
+    test-isolated config directories, which drops previously discovered user
+    themes from the shared catalog for the rest of the session. Restoring the
+    snapshot keeps later modules (e.g. input-style parametrization, which is
+    collected against the startup catalog) stable.
+    """
+    snapshot = (
+        dict(theme.THEME_RECORDS),
+        dict(theme.THEMES),
+        dict(theme.SYNTAX_THEMES),
+        theme.THEME_DIAGNOSTICS,
+        theme._active_name,
+    )
+    yield
+    records, palettes, syntax, diagnostics, active = snapshot
+    theme.THEME_RECORDS.clear()
+    theme.THEME_RECORDS.update(records)
+    theme.THEMES.clear()
+    theme.THEMES.update(palettes)
+    theme.SYNTAX_THEMES.clear()
+    theme.SYNTAX_THEMES.update(syntax)
+    theme.THEME_DIAGNOSTICS = diagnostics
+    theme._active_name = active
+    if active in theme.THEMES:
+        theme.set_theme(active)
+
+
 def test_theme_rows_expose_metadata_and_semantic_preview() -> None:
     rows = build_theme_rows()
 
@@ -65,9 +96,20 @@ def test_input_window_and_scrollback_preview_use_theme_palette() -> None:
     assert f"38;2;{_ansi_rgb(p['green'])}m\u276f " in rendered
     assert f"38;2;{_ansi_rgb(p['text'])}mrun the tests " in rendered
     assert f";48;2;{_ansi_rgb(p['base'])}mrun the tests " not in rendered
-    assert f"38;2;{_ansi_rgb(p['selection_fg'])};48;2;{_ansi_rgb(p['selection_bg'])}" in rendered
-    assert f"38;2;{_ansi_rgb(p['text'])};48;2;{_ansi_rgb(p['surface0'])}m completion " in rendered
-    assert f"38;2;{_ansi_rgb(p['mauve'])};48;2;{_ansi_rgb(p['surface2'])}m current " in rendered
+    # Complete fragments (label + reset) bind each assertion to the exact
+    # element it describes, so it cannot match the earlier " selected "
+    # swatch or the later " Muted text " sample.
+    selection = (
+        f"\x1b[38;2;{_ansi_rgb(p['selection_fg'])};48;2;{_ansi_rgb(p['selection_bg'])}"
+        "mselected\x1b[0m"
+    )
+    completion = (
+        f"\x1b[38;2;{_ansi_rgb(p['text'])};48;2;{_ansi_rgb(p['surface0'])}m completion \x1b[0m"
+    )
+    current = f"\x1b[38;2;{_ansi_rgb(p['mauve'])};48;2;{_ansi_rgb(p['surface2'])}m current \x1b[0m"
+    assert selection in rendered
+    assert completion in rendered
+    assert current in rendered
 
     # The scrollback preview embeds the exact artifact the transcript renders:
     # the 256-color quantized user bar with its '❯ ' prefix and breathing-room
@@ -364,8 +406,12 @@ async def test_tui_application_installs_and_applies_gallery_theme(tmp_path, monk
         assert app._config.tui.theme == "base16-remote"
         assert theme.get_theme() == "base16-remote"
     finally:
-        theme.set_theme(original)
+        # Reload under the real directories: the monkeypatched environment is
+        # undone first, so the process-global catalog (including any themes
+        # the user has installed) is fully restored for later test modules.
+        monkeypatch.undo()
         theme.reload_themes()
+        theme.set_theme(original)
 
 
 @pytest.mark.asyncio
@@ -438,6 +484,7 @@ async def test_gallery_install_rolls_back_when_settings_write_fails(tmp_path, mo
         assert yaml.safe_load(target.read_text(encoding="utf-8"))["name"] == "Original"
         assert "settings unavailable" in "\n".join(view.detail_lines(view.model.current, 80))
     finally:
+        monkeypatch.undo()
         theme.reload_themes()
 
 
@@ -507,8 +554,9 @@ async def test_gallery_refresh_failure_does_not_misreport_committed_install(
         assert app._config.tui.theme == entry.id
         assert theme.get_theme() == entry.id
     finally:
-        theme.set_theme(original)
+        monkeypatch.undo()
         theme.reload_themes()
+        theme.set_theme(original)
 
 
 @pytest.mark.asyncio

--- a/packages/nooa-cli/tests/tui/test_theme_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_theme_explorer.py
@@ -14,6 +14,7 @@ from nooa_cli.tui.fullscreen_browser import ExplorerBrowser
 from nooa_cli.tui.output import TextOutput
 from nooa_cli.tui.terminal_safety import strip_safe_ansi
 from nooa_cli.tui.theme_explorer import ThemeExplorerView, build_theme_rows
+from nooa_cli.tui.user_message import render_user_bar
 from prompt_toolkit.application import Application
 from prompt_toolkit.data_structures import Size
 from prompt_toolkit.output import DummyOutput
@@ -42,7 +43,7 @@ def test_theme_rows_expose_metadata_and_semantic_preview() -> None:
     assert "Input window" in rendered
     assert "run the tests" in plain and "completion" in plain and "current" in plain
     assert "Scrollback" in rendered
-    assert "You: how does my message look?" in plain
+    assert "how does my message look?" in plain
     assert "Agent: this is how a reply reads." in plain and "status" in plain
 
 
@@ -57,21 +58,24 @@ def test_input_window_and_scrollback_preview_use_theme_palette() -> None:
     rendered = "\n".join(ThemeExplorerView([row]).detail_lines(row, 100))
     p = row.record.palette
 
-    # The input window previews the accent prompt, transparent input text
-    # (foreground only — the real window shows the terminal program's own
-    # background color), selection styling, and both completion-menu states.
-    assert f"38;2;{_ansi_rgb(p['focus_accent'])}" in rendered
-    assert f"38;2;{_ansi_rgb(p['text_primary'])}mrun the tests " in rendered
+    # The input window matches the real renderers: the '❯ ' prompt uses the
+    # theme's green (class:prompt), input text is foreground-only over the
+    # terminal's own background, selection keeps its filled pair, and the
+    # completion menu uses text-on-surface0 with mauve-on-surface2 current.
+    assert f"38;2;{_ansi_rgb(p['green'])}m\u276f " in rendered
+    assert f"38;2;{_ansi_rgb(p['text'])}mrun the tests " in rendered
     assert f";48;2;{_ansi_rgb(p['base'])}mrun the tests " not in rendered
     assert f"38;2;{_ansi_rgb(p['selection_fg'])};48;2;{_ansi_rgb(p['selection_bg'])}" in rendered
-    assert f"48;2;{_ansi_rgb(p['surface_raised'])}" in rendered
+    assert f"38;2;{_ansi_rgb(p['text'])};48;2;{_ansi_rgb(p['surface0'])}m completion " in rendered
+    assert f"38;2;{_ansi_rgb(p['mauve'])};48;2;{_ansi_rgb(p['surface2'])}m current " in rendered
 
-    # The scrollback preview shows the highlighted user bar, a plain agent
-    # reply over the terminal background, and subtle status text.
-    assert (
-        f"38;2;{_ansi_rgb(p['user_message_fg'])};48;2;{_ansi_rgb(p['user_message_bg'])}" in rendered
-    )
-    assert f"38;2;{_ansi_rgb(p['text_primary'])}mAgent: this is how a reply reads." in rendered
+    # The scrollback preview embeds the exact artifact the transcript renders:
+    # the 256-color quantized user bar with its '❯ ' prefix and breathing-room
+    # edges, followed by a plain agent reply and subtle status text.
+    bar = render_user_bar("how does my message look?", 100, p).rstrip("\n")
+    assert bar in rendered
+    assert "\x1b[38;5;" in rendered
+    assert f"38;2;{_ansi_rgb(p['text'])}mAgent: this is how a reply reads." in rendered
     assert f"38;2;{_ansi_rgb(p['text_subtle'])}m" in rendered
 
 

--- a/packages/nooa-cli/tests/tui/test_theme_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_theme_explorer.py
@@ -39,7 +39,37 @@ def test_theme_rows_expose_metadata_and_semantic_preview() -> None:
     assert "def greet" in plain and "return" in plain
     assert "Unified diff" in rendered
     assert "-old_value = 1" in plain and "+new_value = 2" in plain
-    assert "\x1b[38;2;" in rendered
+    assert "Input window" in rendered
+    assert "run the tests" in plain and "completion" in plain and "current" in plain
+    assert "Scrollback" in rendered
+    assert "You: how does my message look?" in plain
+    assert "Agent: this is how a reply reads." in plain and "status" in plain
+
+
+def _ansi_rgb(color: str) -> str:
+    value = color.lstrip("#")
+    return ";".join(str(int(value[index : index + 2], 16)) for index in (0, 2, 4))
+
+
+def test_input_window_and_scrollback_preview_use_theme_palette() -> None:
+    rows = build_theme_rows()
+    row = next(r for r in rows if r.id == "latte")
+    rendered = "\n".join(ThemeExplorerView([row]).detail_lines(row, 100))
+    p = row.record.palette
+
+    # The input window previews the accent prompt, primary text on the base
+    # surface, selection styling, and both completion-menu states.
+    assert f"38;2;{_ansi_rgb(p['focus_accent'])}" in rendered
+    assert f"38;2;{_ansi_rgb(p['text_primary'])};48;2;{_ansi_rgb(p['base'])}" in rendered
+    assert f"38;2;{_ansi_rgb(p['selection_fg'])};48;2;{_ansi_rgb(p['selection_bg'])}" in rendered
+    assert f"48;2;{_ansi_rgb(p['surface_raised'])}" in rendered
+
+    # The scrollback preview shows the highlighted user bar, plain agent reply
+    # text, and subtle status text with the exact palette the TUI would use.
+    assert (
+        f"38;2;{_ansi_rgb(p['user_message_fg'])};48;2;{_ansi_rgb(p['user_message_bg'])}" in rendered
+    )
+    assert f"38;2;{_ansi_rgb(p['text_subtle'])}m" in rendered
 
 
 @pytest.mark.parametrize("name", ["latte", "vslight"])

--- a/packages/nooa-cli/tests/tui/test_theme_explorer.py
+++ b/packages/nooa-cli/tests/tui/test_theme_explorer.py
@@ -57,18 +57,21 @@ def test_input_window_and_scrollback_preview_use_theme_palette() -> None:
     rendered = "\n".join(ThemeExplorerView([row]).detail_lines(row, 100))
     p = row.record.palette
 
-    # The input window previews the accent prompt, primary text on the base
-    # surface, selection styling, and both completion-menu states.
+    # The input window previews the accent prompt, transparent input text
+    # (foreground only — the real window shows the terminal program's own
+    # background color), selection styling, and both completion-menu states.
     assert f"38;2;{_ansi_rgb(p['focus_accent'])}" in rendered
-    assert f"38;2;{_ansi_rgb(p['text_primary'])};48;2;{_ansi_rgb(p['base'])}" in rendered
+    assert f"38;2;{_ansi_rgb(p['text_primary'])}mrun the tests " in rendered
+    assert f";48;2;{_ansi_rgb(p['base'])}mrun the tests " not in rendered
     assert f"38;2;{_ansi_rgb(p['selection_fg'])};48;2;{_ansi_rgb(p['selection_bg'])}" in rendered
     assert f"48;2;{_ansi_rgb(p['surface_raised'])}" in rendered
 
-    # The scrollback preview shows the highlighted user bar, plain agent reply
-    # text, and subtle status text with the exact palette the TUI would use.
+    # The scrollback preview shows the highlighted user bar, a plain agent
+    # reply over the terminal background, and subtle status text.
     assert (
         f"38;2;{_ansi_rgb(p['user_message_fg'])};48;2;{_ansi_rgb(p['user_message_bg'])}" in rendered
     )
+    assert f"38;2;{_ansi_rgb(p['text_primary'])}mAgent: this is how a reply reads." in rendered
     assert f"38;2;{_ansi_rgb(p['text_subtle'])}m" in rendered
 
 


### PR DESCRIPTION
## Summary
- preview the input window in the theme picker and gallery: accent prompt, primary text on the base surface, selection styling, and both completion-menu states
- preview the scrollback: the highlighted user bar (" You: how does my message look? "), a plain agent reply, and subtle status text, using the exact palette colors the TUI would render
- derive a dedicated, always-highlighted but neutral scrollback user bar for Base16/24 schemes: a visible grayscale step (base02, falling back to base03) paired with the more readable of base00/base07, falling back to the already-validated selection pair when no gray reaches 4.5:1

## Testing
- `git diff --check`
- Ruff check and format check on touched files
- touched-area suite: 208 passed
- live Tinted archive validation: 447 schemes parse (unchanged); 35 use the neutral gray bar, the rest the selection fallback; none below 4.5:1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved readability and contrast for user-message highlights across themes, including Base16 themes.
  * Added safer fallback colors when background shades lack sufficient contrast.
  * Enhanced theme previews with more accurate user-message rendering, scrollback, input prompts, completion states, selections, messages, and status text.
  * Updated previews to better reflect transparent input areas, terminal backgrounds, and palette-specific colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->