### PR TITLE
feat(tui): support graceful fleet restarts

### DIFF
--- a/packages/nooa-cli/README.md
+++ b/packages/nooa-cli/README.md
@@ -268,3 +268,13 @@ conversation replay shared by CLI hosts such as the native TUI and ACP. The
 process running an agent owns the writable session handle; other hosts attach
 through their transport or use read-only discovery. Generic event and SQLite
 storage primitives remain in the core `nooa` package.
+
+## Development fleet restarts
+
+A running TUI publishes a private runtime record under
+`${NOOA_TUI_RUNTIME_DIR:-~/.nooa/run/tui}`. On POSIX systems, `SIGUSR1` requests a
+graceful restart: the TUI stops through its normal teardown path, saves its agent
+snapshot, releases the session database, and re-execs the same command with the
+current session ID. The optional `nooa-dev-fleet` package in `nemo-oo-skills` uses
+this contract for branch notifications and coordinated multi-TUI restarts. Do not
+use `SIGKILL`; it bypasses snapshot and session cleanup.

--- a/packages/nooa-cli/src/nooa_cli/tui/main.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/main.py
@@ -116,4 +116,65 @@ async def main(
     frontend.init_input(registry)  # terminal-specific: prompt_toolkit completions
     session = build_session(result, frontend, registry, initial_outputs=_initial_outputs)
 
-    await session.run()
+    runtime_registration = None
+    restart_requested = False
+    restart_task = None
+    if result.session_id is not None:
+        import asyncio
+
+        from .runtime_registration import TUIRuntimeRegistration
+
+        candidate = TUIRuntimeRegistration(
+            session_id=result.session_id,
+            working_dir=config.agent.working_dir,
+        )
+        restart_event = asyncio.Event()
+
+        def _request_restart() -> None:
+            nonlocal restart_requested
+            restart_requested = True
+            restart_event.set()
+
+        if candidate.install_restart_signal(asyncio.get_running_loop(), _request_restart):
+            try:
+                candidate.publish()
+            except OSError:
+                candidate.close()
+            else:
+                runtime_registration = candidate
+
+                def _update_runtime_session(session_id: str) -> None:
+                    try:
+                        candidate.update_session(session_id)
+                    except OSError:
+                        candidate.close()
+                        session._on_session_change = None
+
+                session._on_session_change = _update_runtime_session
+
+                async def _exit_when_restart_requested() -> None:
+                    await restart_event.wait()
+                    while session._app is None or not session._app.is_running:
+                        await asyncio.sleep(0.01)
+                    session._app.exit()
+
+                restart_task = asyncio.create_task(
+                    _exit_when_restart_requested(), name="tui-graceful-restart"
+                )
+
+    try:
+        await session.run()
+    finally:
+        if restart_task is not None and not restart_task.done():
+            restart_task.cancel()
+            try:
+                await restart_task
+            except asyncio.CancelledError:
+                pass
+        if runtime_registration is not None:
+            runtime_registration.close()
+
+    if restart_requested and runtime_registration is not None:
+        from .runtime_registration import reexec_tui
+
+        reexec_tui(runtime_registration.restart_argv)

--- a/packages/nooa-cli/src/nooa_cli/tui/main.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/main.py
@@ -134,6 +134,7 @@ async def main(
         restart_event = asyncio.Event()
 
         def _request_restart() -> None:
+            """Latch a signal request onto the running TUI lifecycle."""
             nonlocal restart_requested
             restart_requested = True
             restart_event.set()
@@ -149,6 +150,7 @@ async def main(
                 runtime_registration = candidate
 
                 def _update_runtime_session(session_id: str) -> None:
+                    """Keep restart metadata aligned with in-process session changes."""
                     try:
                         candidate.update_session(session_id)
                     except OSError:
@@ -158,6 +160,7 @@ async def main(
                 session._on_session_change = _update_runtime_session
 
                 async def _exit_when_restart_requested() -> None:
+                    """Exit the running app after a graceful restart is requested."""
                     await restart_event.wait()
                     while session._app is None or not session._app.is_running:
                         await asyncio.sleep(0.01)

--- a/packages/nooa-cli/src/nooa_cli/tui/main.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/main.py
@@ -124,10 +124,13 @@ async def main(
 
         from .runtime_registration import TUIRuntimeRegistration
 
-        candidate = TUIRuntimeRegistration(
-            session_id=result.session_id,
-            working_dir=config.agent.working_dir,
-        )
+        try:
+            candidate = TUIRuntimeRegistration(
+                session_id=result.session_id,
+                working_dir=config.agent.working_dir,
+            )
+        except (OSError, ValueError):
+            candidate = None
         restart_event = asyncio.Event()
 
         def _request_restart() -> None:
@@ -135,7 +138,9 @@ async def main(
             restart_requested = True
             restart_event.set()
 
-        if candidate.install_restart_signal(asyncio.get_running_loop(), _request_restart):
+        if candidate is not None and candidate.install_restart_signal(
+            asyncio.get_running_loop(), _request_restart
+        ):
             try:
                 candidate.publish()
             except OSError:

--- a/packages/nooa-cli/src/nooa_cli/tui/runtime_registration.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/runtime_registration.py
@@ -49,6 +49,7 @@ def _source_root() -> Path:
 
 
 def _source_revision(root: Path) -> str | None:
+    """Return the Git revision for *root* when it can be resolved."""
     try:
         result = subprocess.run(
             ["git", "-C", str(root), "rev-parse", "HEAD"],
@@ -108,6 +109,8 @@ def explicit_resume_argv(argv: list[str], session_id: str) -> list[str]:
         if argument in {"-c", "--continue"}:
             index += 2
             continue
+        if argument == "--":
+            return [*result, "--continue", session_id, *argv[index:]]
         result.append(argument)
         index += 1
     return [*result, "--continue", session_id]
@@ -119,6 +122,7 @@ class TUIRuntimeRegistration:
     def __init__(
         self, *, session_id: str, working_dir: str, original_argv: list[str] | None = None
     ) -> None:
+        """Capture process, session, source, and restart invocation identity."""
         self.session_id = session_id
         self.working_dir = str(Path(working_dir).expanduser().resolve())
         self.pid = os.getpid()
@@ -134,6 +138,7 @@ class TUIRuntimeRegistration:
         self._previous_handler: Any = None
 
     def _payload(self) -> dict[str, Any]:
+        """Build the minimal public runtime-registration payload."""
         identity = process_identity(self.pid)
         if identity is None:
             raise OSError("cannot determine a stable process identity")

--- a/packages/nooa-cli/src/nooa_cli/tui/runtime_registration.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/runtime_registration.py
@@ -10,11 +10,16 @@ SQLite ownership, agent resources, and terminal state have been released.
 
 from __future__ import annotations
 
-import fcntl
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - exercised by platform import tests
+    fcntl = None  # type: ignore[assignment]
+
 import json
 import os
 import secrets
 import signal
+import stat
 import subprocess
 import sys
 import time
@@ -83,18 +88,25 @@ def process_identity(pid: int) -> str | None:
 
 
 def explicit_resume_argv(argv: list[str], session_id: str) -> list[str]:
-    """Return *argv* with exactly one explicit ``--continue SESSION`` option."""
-    result: list[str] = []
-    index = 0
+    """Add one resume option after the actual ``tui`` command boundary.
+
+    Interpreter and wrapper arguments before ``tui`` are opaque.  In particular,
+    Python's ``-c PROGRAM`` must never be mistaken for Click's short continue
+    option.
+    """
+    try:
+        command_index = argv.index("tui")
+    except ValueError as exc:
+        raise ValueError("cannot identify the tui command in the restart argv") from exc
+    result = argv[: command_index + 1]
+    index = command_index + 1
     while index < len(argv):
         argument = argv[index]
         if argument.startswith("--continue="):
             index += 1
             continue
         if argument in {"-c", "--continue"}:
-            index += 1
-            if index < len(argv) and not argv[index].startswith("-"):
-                index += 1
+            index += 2
             continue
         result.append(argument)
         index += 1
@@ -104,15 +116,17 @@ def explicit_resume_argv(argv: list[str], session_id: str) -> list[str]:
 class TUIRuntimeRegistration:
     """Own one atomic live-process record for an active TUI session."""
 
-    def __init__(self, *, session_id: str, working_dir: str) -> None:
+    def __init__(
+        self, *, session_id: str, working_dir: str, original_argv: list[str] | None = None
+    ) -> None:
         self.session_id = session_id
         self.working_dir = str(Path(working_dir).expanduser().resolve())
         self.pid = os.getpid()
         self.token = secrets.token_hex(16)
         self.source_root = _source_root()
         self.started_at = time.time()
-        original_argv = list(getattr(sys, "orig_argv", [sys.executable, *sys.argv]))
-        self.restart_argv = explicit_resume_argv(original_argv, session_id)
+        invocation = original_argv or list(getattr(sys, "orig_argv", [sys.executable, *sys.argv]))
+        self.restart_argv = explicit_resume_argv(invocation, session_id)
         self.path = runtime_directory() / f"{self.pid}.json"
         self.lock_path = self.path.with_suffix(".lock")
         self._lock_fd: int | None = None
@@ -133,34 +147,61 @@ class TUIRuntimeRegistration:
             "working_dir": self.working_dir,
             "source_root": str(self.source_root),
             "source_revision": _source_revision(self.source_root),
-            "argv": self.restart_argv,
             "started_at": self.started_at,
         }
 
     def publish(self) -> None:
         """Atomically publish this process as restart-capable."""
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        os.chmod(self.path.parent, 0o700)
-        if self._lock_fd is None:
-            self._lock_fd = os.open(self.lock_path, os.O_RDWR | os.O_CREAT, 0o600)
-            try:
-                fcntl.flock(self._lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                os.ftruncate(self._lock_fd, 0)
-                os.write(self._lock_fd, self.token.encode())
-            except BaseException:
-                os.close(self._lock_fd)
-                self._lock_fd = None
-                raise
-        temporary = self.path.with_suffix(f".json.{self.token}.tmp")
-        payload = (json.dumps(self._payload(), sort_keys=True) + "\n").encode()
-        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        if fcntl is None:
+            raise OSError("runtime registration requires POSIX file locking")
+        directory = self.path.parent
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        directory_flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+        directory_fd = os.open(directory, directory_flags)
         try:
-            with os.fdopen(descriptor, "wb") as stream:
-                stream.write(payload)
-            temporary.replace(self.path)
-        except BaseException:
-            temporary.unlink(missing_ok=True)
-            raise
+            directory_stat = os.fstat(directory_fd)
+            if directory_stat.st_uid != os.geteuid():
+                raise OSError("runtime directory is not owned by the current user")
+            os.fchmod(directory_fd, 0o700)
+            if self._lock_fd is None:
+                flags = os.O_RDWR | os.O_CREAT
+                flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+                self._lock_fd = os.open(self.lock_path.name, flags, 0o600, dir_fd=directory_fd)
+                try:
+                    lock_stat = os.fstat(self._lock_fd)
+                    if (
+                        not stat.S_ISREG(lock_stat.st_mode)
+                        or lock_stat.st_uid != os.geteuid()
+                        or lock_stat.st_nlink != 1
+                    ):
+                        raise OSError("unsafe runtime lock file")
+                    fcntl.flock(self._lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    os.ftruncate(self._lock_fd, 0)
+                    os.write(self._lock_fd, self.token.encode())
+                except BaseException:
+                    os.close(self._lock_fd)
+                    self._lock_fd = None
+                    raise
+            temporary_name = f"{self.path.name}.{self.token}.tmp"
+            payload = (json.dumps(self._payload(), sort_keys=True) + "\n").encode()
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+            descriptor = os.open(temporary_name, flags, 0o600, dir_fd=directory_fd)
+            try:
+                with os.fdopen(descriptor, "wb") as stream:
+                    stream.write(payload)
+                os.replace(
+                    temporary_name, self.path.name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd
+                )
+            except BaseException:
+                try:
+                    os.unlink(temporary_name, dir_fd=directory_fd)
+                except FileNotFoundError:
+                    pass
+                raise
+        finally:
+            os.close(directory_fd)
 
     def update_session(self, session_id: str) -> None:
         """Republish this process with a new active session and resume target."""
@@ -170,7 +211,11 @@ class TUIRuntimeRegistration:
 
     def install_restart_signal(self, loop: Any, request_restart: Any) -> bool:
         """Route SIGUSR1 onto *loop*; return false on unsupported platforms."""
-        if not hasattr(signal, "SIGUSR1") or not hasattr(loop, "add_signal_handler"):
+        if (
+            fcntl is None
+            or not hasattr(signal, "SIGUSR1")
+            or not hasattr(loop, "add_signal_handler")
+        ):
             return False
         try:
             self._previous_handler = signal.getsignal(signal.SIGUSR1)
@@ -204,6 +249,7 @@ class TUIRuntimeRegistration:
             except FileNotFoundError:
                 pass
         if self._lock_fd is not None:
+            assert fcntl is not None
             try:
                 fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
             finally:

--- a/packages/nooa-cli/src/nooa_cli/tui/runtime_registration.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/runtime_registration.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime registration and graceful self-restart support for the TUI.
+
+A small JSON record lets an external, developer-owned supervisor discover TUI
+processes without guessing from ``ps`` output.  SIGUSR1 asks the TUI to leave
+through its normal shutdown path; the caller re-execs only after snapshots,
+SQLite ownership, agent resources, and terminal state have been released.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import secrets
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_RUNTIME_DIR_ENV = "NOOA_TUI_RUNTIME_DIR"
+
+
+def runtime_directory() -> Path:
+    """Return the shared directory containing live-TUI records."""
+    configured = os.environ.get(_RUNTIME_DIR_ENV)
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".nooa" / "run" / "tui"
+
+
+def _source_root() -> Path:
+    """Find the source/install root that supplied ``nooa_cli``."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / ".git").exists() or (
+            (parent / "pyproject.toml").exists() and (parent / "packages" / "nooa-cli").exists()
+        ):
+            return parent
+    return here.parent
+
+
+def _source_revision(root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    revision = result.stdout.strip()
+    return revision or None
+
+
+def process_identity(pid: int) -> str | None:
+    """Return a stable identity for this incarnation of *pid*, when available."""
+    stat_path = Path(f"/proc/{pid}/stat")
+    try:
+        # Field 22 is the process start time in clock ticks since boot.  Split
+        # after the final ')' because process names may contain spaces.
+        fields = stat_path.read_text().rsplit(")", 1)[1].split()
+        return f"proc:{fields[19]}"
+    except (OSError, IndexError):
+        pass
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "lstart="],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    started = " ".join(result.stdout.split())
+    return f"ps:{started}" if started else None
+
+
+def explicit_resume_argv(argv: list[str], session_id: str) -> list[str]:
+    """Return *argv* with exactly one explicit ``--continue SESSION`` option."""
+    result: list[str] = []
+    index = 0
+    while index < len(argv):
+        argument = argv[index]
+        if argument.startswith("--continue="):
+            index += 1
+            continue
+        if argument in {"-c", "--continue"}:
+            index += 1
+            if index < len(argv) and not argv[index].startswith("-"):
+                index += 1
+            continue
+        result.append(argument)
+        index += 1
+    return [*result, "--continue", session_id]
+
+
+class TUIRuntimeRegistration:
+    """Own one atomic live-process record for an active TUI session."""
+
+    def __init__(self, *, session_id: str, working_dir: str) -> None:
+        self.session_id = session_id
+        self.working_dir = str(Path(working_dir).expanduser().resolve())
+        self.pid = os.getpid()
+        self.token = secrets.token_hex(16)
+        self.source_root = _source_root()
+        self.started_at = time.time()
+        original_argv = list(getattr(sys, "orig_argv", [sys.executable, *sys.argv]))
+        self.restart_argv = explicit_resume_argv(original_argv, session_id)
+        self.path = runtime_directory() / f"{self.pid}.json"
+        self.lock_path = self.path.with_suffix(".lock")
+        self._lock_fd: int | None = None
+        self._installed_loop: Any | None = None
+        self._previous_handler: Any = None
+
+    def _payload(self) -> dict[str, Any]:
+        identity = process_identity(self.pid)
+        if identity is None:
+            raise OSError("cannot determine a stable process identity")
+        return {
+            "schema_version": 1,
+            "pid": self.pid,
+            "token": self.token,
+            "process_identity": identity,
+            "restart_signal": "SIGUSR1",
+            "session_id": self.session_id,
+            "working_dir": self.working_dir,
+            "source_root": str(self.source_root),
+            "source_revision": _source_revision(self.source_root),
+            "argv": self.restart_argv,
+            "started_at": self.started_at,
+        }
+
+    def publish(self) -> None:
+        """Atomically publish this process as restart-capable."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        os.chmod(self.path.parent, 0o700)
+        if self._lock_fd is None:
+            self._lock_fd = os.open(self.lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+            try:
+                fcntl.flock(self._lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                os.ftruncate(self._lock_fd, 0)
+                os.write(self._lock_fd, self.token.encode())
+            except BaseException:
+                os.close(self._lock_fd)
+                self._lock_fd = None
+                raise
+        temporary = self.path.with_suffix(f".json.{self.token}.tmp")
+        payload = (json.dumps(self._payload(), sort_keys=True) + "\n").encode()
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(payload)
+            temporary.replace(self.path)
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            raise
+
+    def update_session(self, session_id: str) -> None:
+        """Republish this process with a new active session and resume target."""
+        self.session_id = session_id
+        self.restart_argv = explicit_resume_argv(self.restart_argv, session_id)
+        self.publish()
+
+    def install_restart_signal(self, loop: Any, request_restart: Any) -> bool:
+        """Route SIGUSR1 onto *loop*; return false on unsupported platforms."""
+        if not hasattr(signal, "SIGUSR1") or not hasattr(loop, "add_signal_handler"):
+            return False
+        try:
+            self._previous_handler = signal.getsignal(signal.SIGUSR1)
+            loop.add_signal_handler(signal.SIGUSR1, request_restart)
+        except (NotImplementedError, RuntimeError, ValueError):
+            return False
+        self._installed_loop = loop
+        return True
+
+    def close(self) -> None:
+        """Remove signal routing and records without deleting a successor's."""
+        if self._installed_loop is not None:
+            try:
+                self._installed_loop.remove_signal_handler(signal.SIGUSR1)
+                if self._previous_handler is not None:
+                    signal.signal(signal.SIGUSR1, self._previous_handler)
+            except (OSError, RuntimeError, ValueError):
+                pass
+            self._installed_loop = None
+        try:
+            payload = json.loads(self.path.read_text())
+        except (OSError, ValueError, TypeError):
+            payload = None
+        if (
+            isinstance(payload, dict)
+            and payload.get("pid") == self.pid
+            and payload.get("token") == self.token
+        ):
+            try:
+                self.path.unlink()
+            except FileNotFoundError:
+                pass
+        if self._lock_fd is not None:
+            try:
+                fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
+            finally:
+                os.close(self._lock_fd)
+                self._lock_fd = None
+            try:
+                self.lock_path.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def reexec_tui(argv: list[str]) -> None:
+    """Replace the current process with its recorded Python invocation."""
+    if not argv:
+        raise ValueError("restart argv must not be empty")
+    os.execvp(argv[0], argv)

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -352,6 +352,7 @@ class Session:
         self._pending_code: dict[str, str] = {}
         self._background_tasks: set[asyncio.Task] = set()  # fire-and-forget tasks
         self._command_runner = None
+        self._on_session_change: Callable[[str], None] | None = None
 
         # Populated at the start of ``run()``; referenced by the handler
         # methods (``_on_command``, ``_on_user_message_ui``, ``_loud_handler``,
@@ -1655,6 +1656,9 @@ class Session:
         self.registry.session_manager = new_sm
         for cmd in self.registry.commands():
             cmd.session_manager = new_sm
+        on_session_change = getattr(self, "_on_session_change", None)
+        if on_session_change is not None:
+            on_session_change(new_sm.session_id)
         # Start a fresh trace for the new session so it gets its own .jsonl file.
         # Use the first 8 chars of the SQLite session UUID to correlate trace↔storage.
         try:

--- a/packages/nooa-cli/tests/tui/test_runtime_registration.py
+++ b/packages/nooa-cli/tests/tui/test_runtime_registration.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import signal
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from nooa_cli.tui.runtime_registration import (
+    TUIRuntimeRegistration,
+    explicit_resume_argv,
+    reexec_tui,
+)
+
+
+def test_explicit_resume_argv_replaces_short_and_long_forms():
+    assert explicit_resume_argv(
+        ["/venv/bin/python", "/venv/bin/nooa", "tui", "-w", "/work", "-c", "old"], "new"
+    ) == ["/venv/bin/python", "/venv/bin/nooa", "tui", "-w", "/work", "--continue", "new"]
+    assert explicit_resume_argv(
+        ["/venv/bin/python", "-m", "nooa_cli", "tui", "--continue=old", "--python"], "new"
+    ) == ["/venv/bin/python", "-m", "nooa_cli", "tui", "--python", "--continue", "new"]
+
+
+def test_registration_publishes_private_record_and_removes_only_its_own(tmp_path: Path):
+    with (
+        patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
+        patch("nooa_cli.tui.runtime_registration._source_root", return_value=Path("/source")),
+        patch("nooa_cli.tui.runtime_registration._source_revision", return_value="abc123"),
+        patch("sys.orig_argv", ["/venv/bin/python", "/venv/bin/nooa", "tui", "-w", "/work"]),
+    ):
+        registration = TUIRuntimeRegistration(session_id="session-1", working_dir="/work")
+        registration.publish()
+
+    payload = json.loads(registration.path.read_text())
+    assert registration.path.parent == tmp_path
+    assert payload["pid"] == registration.pid
+    assert payload["process_identity"]
+    assert payload["restart_signal"] == "SIGUSR1"
+    assert payload["session_id"] == "session-1"
+    assert payload["source_root"] == "/source"
+    assert payload["source_revision"] == "abc123"
+    assert payload["argv"][-2:] == ["--continue", "session-1"]
+    assert registration.path.stat().st_mode & 0o777 == 0o600
+    assert registration.path.parent.stat().st_mode & 0o777 == 0o700
+
+    payload["token"] = "successor"
+    registration.path.write_text(json.dumps(payload))
+    registration.close()
+    assert registration.path.exists()
+
+    payload["token"] = registration.token
+    registration.path.write_text(json.dumps(payload))
+    registration.close()
+    assert not registration.path.exists()
+
+
+def test_install_restart_signal_routes_callback_and_restores_handler(tmp_path: Path):
+    if not hasattr(signal, "SIGUSR1"):
+        return
+    loop = MagicMock()
+    callback = MagicMock()
+    with (
+        patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
+        patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),
+        patch("nooa_cli.tui.runtime_registration.signal.getsignal", return_value=signal.SIG_DFL),
+        patch("nooa_cli.tui.runtime_registration.signal.signal") as set_signal,
+    ):
+        registration = TUIRuntimeRegistration(session_id="session-1", working_dir=str(tmp_path))
+        assert registration.install_restart_signal(loop, callback)
+        registration.close()
+
+    loop.add_signal_handler.assert_called_once_with(signal.SIGUSR1, callback)
+    loop.remove_signal_handler.assert_called_once_with(signal.SIGUSR1)
+    set_signal.assert_called_once_with(signal.SIGUSR1, signal.SIG_DFL)
+
+
+def test_update_session_republishes_resume_target(tmp_path: Path):
+    with (
+        patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
+        patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),
+        patch("nooa_cli.tui.runtime_registration._source_revision", return_value="abc123"),
+        patch("sys.orig_argv", ["python", "-m", "nooa_cli", "tui", "-c", "old"]),
+    ):
+        registration = TUIRuntimeRegistration(session_id="old", working_dir=str(tmp_path))
+        registration.publish()
+        registration.update_session("new")
+
+    payload = json.loads(registration.path.read_text())
+    assert payload["session_id"] == "new"
+    assert payload["argv"][-2:] == ["--continue", "new"]
+    registration.close()
+
+
+def test_reexec_uses_path_search():
+    with patch("nooa_cli.tui.runtime_registration.os.execvp") as execvp:
+        reexec_tui(["python", "-m", "nooa_cli", "tui"])
+    execvp.assert_called_once_with("python", ["python", "-m", "nooa_cli", "tui"])
+
+
+def test_publish_fails_closed_without_process_identity(tmp_path: Path):
+    with (
+        patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
+        patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),
+        patch("nooa_cli.tui.runtime_registration.process_identity", return_value=None),
+    ):
+        registration = TUIRuntimeRegistration(session_id="session-1", working_dir=str(tmp_path))
+        with pytest.raises(OSError, match="stable process identity"):
+            registration.publish()
+    assert not registration.path.exists()
+
+
+def test_close_releases_lock_when_record_disappeared(tmp_path: Path):
+    with (
+        patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
+        patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),
+    ):
+        registration = TUIRuntimeRegistration(session_id="session-1", working_dir=str(tmp_path))
+        registration.publish()
+        registration.path.unlink()
+        registration.close()
+    assert registration._lock_fd is None
+    assert not registration.lock_path.exists()
+
+
+def test_registration_holds_runtime_ownership_lock(tmp_path: Path):
+    with (
+        patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
+        patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),
+    ):
+        registration = TUIRuntimeRegistration(session_id="session-1", working_dir=str(tmp_path))
+        registration.publish()
+        contender = os.open(registration.lock_path, os.O_RDWR)
+        try:
+            with pytest.raises(BlockingIOError):
+                fcntl.flock(contender, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        finally:
+            os.close(contender)
+        registration.close()
+    assert not registration.lock_path.exists()

--- a/packages/nooa-cli/tests/tui/test_runtime_registration.py
+++ b/packages/nooa-cli/tests/tui/test_runtime_registration.py
@@ -3,7 +3,11 @@
 
 from __future__ import annotations
 
-import fcntl
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - platform dependent
+    fcntl = None
+
 import json
 import os
 import signal
@@ -27,6 +31,61 @@ def test_explicit_resume_argv_replaces_short_and_long_forms():
     ) == ["/venv/bin/python", "-m", "nooa_cli", "tui", "--python", "--continue", "new"]
 
 
+def test_explicit_resume_argv_preserves_interpreter_c_before_tui():
+    argv = ["python", "-c", "launch_tui()", "tui", "--continue", "old"]
+    assert explicit_resume_argv(argv, "new") == [
+        "python",
+        "-c",
+        "launch_tui()",
+        "tui",
+        "--continue",
+        "new",
+    ]
+
+
+def test_explicit_resume_argv_requires_tui_command():
+    with pytest.raises(ValueError, match="tui command"):
+        explicit_resume_argv(["python", "-c", "launch_tui()"], "new")
+
+
+def test_publish_rejects_symlinked_lock_without_touching_target(tmp_path: Path):
+    target = tmp_path / "target"
+    target.write_text("keep me")
+    with (
+        patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
+        patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),
+        patch("sys.orig_argv", ["python", "-m", "nooa_cli", "tui"]),
+    ):
+        registration = TUIRuntimeRegistration(
+            session_id="session-1",
+            working_dir=str(tmp_path),
+            original_argv=["python", "-m", "nooa_cli", "tui"],
+        )
+        registration.lock_path.symlink_to(target)
+        with pytest.raises(OSError):
+            registration.publish()
+        registration.close()
+    assert target.read_text() == "keep me"
+
+
+def test_registration_disables_restart_without_fcntl(tmp_path: Path):
+    loop = MagicMock()
+    with (
+        patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
+        patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),
+        patch("sys.orig_argv", ["python", "-m", "nooa_cli", "tui"]),
+        patch("nooa_cli.tui.runtime_registration.fcntl", None),
+    ):
+        registration = TUIRuntimeRegistration(
+            session_id="session-1",
+            working_dir=str(tmp_path),
+            original_argv=["python", "-m", "nooa_cli", "tui"],
+        )
+        assert registration.install_restart_signal(loop, MagicMock()) is False
+        with pytest.raises(OSError, match="POSIX file locking"):
+            registration.publish()
+
+
 def test_registration_publishes_private_record_and_removes_only_its_own(tmp_path: Path):
     with (
         patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
@@ -45,7 +104,7 @@ def test_registration_publishes_private_record_and_removes_only_its_own(tmp_path
     assert payload["session_id"] == "session-1"
     assert payload["source_root"] == "/source"
     assert payload["source_revision"] == "abc123"
-    assert payload["argv"][-2:] == ["--continue", "session-1"]
+    assert "argv" not in payload
     assert registration.path.stat().st_mode & 0o777 == 0o600
     assert registration.path.parent.stat().st_mode & 0o777 == 0o700
 
@@ -71,7 +130,11 @@ def test_install_restart_signal_routes_callback_and_restores_handler(tmp_path: P
         patch("nooa_cli.tui.runtime_registration.signal.getsignal", return_value=signal.SIG_DFL),
         patch("nooa_cli.tui.runtime_registration.signal.signal") as set_signal,
     ):
-        registration = TUIRuntimeRegistration(session_id="session-1", working_dir=str(tmp_path))
+        registration = TUIRuntimeRegistration(
+            session_id="session-1",
+            working_dir=str(tmp_path),
+            original_argv=["python", "-m", "nooa_cli", "tui"],
+        )
         assert registration.install_restart_signal(loop, callback)
         registration.close()
 
@@ -93,7 +156,8 @@ def test_update_session_republishes_resume_target(tmp_path: Path):
 
     payload = json.loads(registration.path.read_text())
     assert payload["session_id"] == "new"
-    assert payload["argv"][-2:] == ["--continue", "new"]
+    assert "argv" not in payload
+    assert registration.restart_argv[-2:] == ["--continue", "new"]
     registration.close()
 
 
@@ -109,7 +173,11 @@ def test_publish_fails_closed_without_process_identity(tmp_path: Path):
         patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),
         patch("nooa_cli.tui.runtime_registration.process_identity", return_value=None),
     ):
-        registration = TUIRuntimeRegistration(session_id="session-1", working_dir=str(tmp_path))
+        registration = TUIRuntimeRegistration(
+            session_id="session-1",
+            working_dir=str(tmp_path),
+            original_argv=["python", "-m", "nooa_cli", "tui"],
+        )
         with pytest.raises(OSError, match="stable process identity"):
             registration.publish()
     assert not registration.path.exists()
@@ -120,7 +188,11 @@ def test_close_releases_lock_when_record_disappeared(tmp_path: Path):
         patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
         patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),
     ):
-        registration = TUIRuntimeRegistration(session_id="session-1", working_dir=str(tmp_path))
+        registration = TUIRuntimeRegistration(
+            session_id="session-1",
+            working_dir=str(tmp_path),
+            original_argv=["python", "-m", "nooa_cli", "tui"],
+        )
         registration.publish()
         registration.path.unlink()
         registration.close()
@@ -128,12 +200,17 @@ def test_close_releases_lock_when_record_disappeared(tmp_path: Path):
     assert not registration.lock_path.exists()
 
 
+@pytest.mark.skipif(fcntl is None, reason="requires POSIX file locking")
 def test_registration_holds_runtime_ownership_lock(tmp_path: Path):
     with (
         patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
         patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),
     ):
-        registration = TUIRuntimeRegistration(session_id="session-1", working_dir=str(tmp_path))
+        registration = TUIRuntimeRegistration(
+            session_id="session-1",
+            working_dir=str(tmp_path),
+            original_argv=["python", "-m", "nooa_cli", "tui"],
+        )
         registration.publish()
         contender = os.open(registration.lock_path, os.O_RDWR)
         try:

--- a/packages/nooa-cli/tests/tui/test_runtime_registration.py
+++ b/packages/nooa-cli/tests/tui/test_runtime_registration.py
@@ -21,8 +21,11 @@ from nooa_cli.tui.runtime_registration import (
     reexec_tui,
 )
 
+requires_fcntl = pytest.mark.skipif(fcntl is None, reason="requires POSIX file locking")
+
 
 def test_explicit_resume_argv_replaces_short_and_long_forms():
+    """Canonicalize existing short and long continue options."""
     assert explicit_resume_argv(
         ["/venv/bin/python", "/venv/bin/nooa", "tui", "-w", "/work", "-c", "old"], "new"
     ) == ["/venv/bin/python", "/venv/bin/nooa", "tui", "-w", "/work", "--continue", "new"]
@@ -31,7 +34,25 @@ def test_explicit_resume_argv_replaces_short_and_long_forms():
     ) == ["/venv/bin/python", "-m", "nooa_cli", "tui", "--python", "--continue", "new"]
 
 
+def test_explicit_resume_argv_inserts_continue_before_option_terminator():
+    """Keep the resume option parseable when argv contains an option terminator."""
+    argv = ["python", "-m", "nooa_cli", "tui", "--python", "--", "payload", "-c"]
+    assert explicit_resume_argv(argv, "new") == [
+        "python",
+        "-m",
+        "nooa_cli",
+        "tui",
+        "--python",
+        "--continue",
+        "new",
+        "--",
+        "payload",
+        "-c",
+    ]
+
+
 def test_explicit_resume_argv_preserves_interpreter_c_before_tui():
+    """Do not confuse Python interpreter flags with TUI options."""
     argv = ["python", "-c", "launch_tui()", "tui", "--continue", "old"]
     assert explicit_resume_argv(argv, "new") == [
         "python",
@@ -44,11 +65,14 @@ def test_explicit_resume_argv_preserves_interpreter_c_before_tui():
 
 
 def test_explicit_resume_argv_requires_tui_command():
+    """Reject invocations whose TUI command boundary cannot be identified."""
     with pytest.raises(ValueError, match="tui command"):
         explicit_resume_argv(["python", "-c", "launch_tui()"], "new")
 
 
+@requires_fcntl
 def test_publish_rejects_symlinked_lock_without_touching_target(tmp_path: Path):
+    """Reject a planted lock symlink without modifying its target."""
     target = tmp_path / "target"
     target.write_text("keep me")
     with (
@@ -69,6 +93,7 @@ def test_publish_rejects_symlinked_lock_without_touching_target(tmp_path: Path):
 
 
 def test_registration_disables_restart_without_fcntl(tmp_path: Path):
+    """Disable registration cleanly when POSIX file locking is unavailable."""
     loop = MagicMock()
     with (
         patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
@@ -86,7 +111,9 @@ def test_registration_disables_restart_without_fcntl(tmp_path: Path):
             registration.publish()
 
 
+@requires_fcntl
 def test_registration_publishes_private_record_and_removes_only_its_own(tmp_path: Path):
+    """Publish private metadata and avoid deleting a successor record."""
     with (
         patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
         patch("nooa_cli.tui.runtime_registration._source_root", return_value=Path("/source")),
@@ -119,7 +146,9 @@ def test_registration_publishes_private_record_and_removes_only_its_own(tmp_path
     assert not registration.path.exists()
 
 
+@requires_fcntl
 def test_install_restart_signal_routes_callback_and_restores_handler(tmp_path: Path):
+    """Install and restore the graceful-restart signal handler."""
     if not hasattr(signal, "SIGUSR1"):
         return
     loop = MagicMock()
@@ -143,7 +172,9 @@ def test_install_restart_signal_routes_callback_and_restores_handler(tmp_path: P
     set_signal.assert_called_once_with(signal.SIGUSR1, signal.SIG_DFL)
 
 
+@requires_fcntl
 def test_update_session_republishes_resume_target(tmp_path: Path):
+    """Track an in-process session change in metadata and restart argv."""
     with (
         patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
         patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),
@@ -162,12 +193,15 @@ def test_update_session_republishes_resume_target(tmp_path: Path):
 
 
 def test_reexec_uses_path_search():
+    """Re-execute through PATH so console-script launches remain valid."""
     with patch("nooa_cli.tui.runtime_registration.os.execvp") as execvp:
         reexec_tui(["python", "-m", "nooa_cli", "tui"])
     execvp.assert_called_once_with("python", ["python", "-m", "nooa_cli", "tui"])
 
 
+@requires_fcntl
 def test_publish_fails_closed_without_process_identity(tmp_path: Path):
+    """Do not advertise restart without a stable process identity."""
     with (
         patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
         patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),
@@ -183,7 +217,9 @@ def test_publish_fails_closed_without_process_identity(tmp_path: Path):
     assert not registration.path.exists()
 
 
+@requires_fcntl
 def test_close_releases_lock_when_record_disappeared(tmp_path: Path):
+    """Release ownership even when the runtime record was removed."""
     with (
         patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
         patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),
@@ -200,8 +236,9 @@ def test_close_releases_lock_when_record_disappeared(tmp_path: Path):
     assert not registration.lock_path.exists()
 
 
-@pytest.mark.skipif(fcntl is None, reason="requires POSIX file locking")
+@requires_fcntl
 def test_registration_holds_runtime_ownership_lock(tmp_path: Path):
+    """Hold the ownership lock until registration closes."""
     with (
         patch.dict("os.environ", {"NOOA_TUI_RUNTIME_DIR": str(tmp_path)}),
         patch("nooa_cli.tui.runtime_registration._source_root", return_value=tmp_path),

--- a/packages/nooa-cli/tests/tui/test_session_plumbing.py
+++ b/packages/nooa-cli/tests/tui/test_session_plumbing.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from pathlib import Path
 
 import pytest
 from nooa_cli.tui.console import TUIConsole
@@ -752,6 +753,37 @@ async def test_run_command_marks_session_transition_while_cancelling() -> None:
     session._swap_session_manager.assert_awaited_once_with(new_sm)
 
 
+async def test_session_swap_notifies_runtime_registration() -> None:
+    """An external restart must resume the session active after an in-process swap."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nooa_cli.tui.session import Session
+
+    session = Session.__new__(Session)
+    session.agent = MagicMock()
+    session.agent._storage = MagicMock()
+    session.agent.event_manager = MagicMock()
+    session.registry = MagicMock()
+    session.registry.commands.return_value = []
+    session.config = MagicMock()
+    session._session_manager = MagicMock()
+    session._local_agent_runner = MagicMock()
+    session._local_agent_runner.shutdown_queue_manager = AsyncMock()
+    session._local_agent_runner.run_async = AsyncMock(side_effect=lambda function: function())
+    session._app = None
+    session._on_session_change = MagicMock()
+    new_manager = SimpleNamespace(
+        session_id="new-session",
+        agent_db_path=Path("/tmp/new-session.db"),
+        _storage=MagicMock(),
+    )
+
+    await session._swap_session_manager(new_manager)
+
+    session._on_session_change.assert_called_once_with("new-session")
+
+
 async def test_on_command_slash_result_posts_to_queue_without_double_submit() -> None:
     """A slash command returning a result must be delivered to the agent
     exactly once. ``_on_command`` posts the ``SlashCommandResult`` to the
@@ -1191,6 +1223,7 @@ async def test_session_run_startup_failure_teardown_order(
         "terminal restore",
         "exit message",
     ]
+
 
 @pytest.mark.asyncio
 async def test_exit_diagnostics_omit_current_task(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- publish private runtime registrations for live NOOA TUI processes
- handle `SIGUSR1` as a graceful restart request through the normal session teardown path
- re-exec the original invocation with an explicit `--continue <session_id>` after state and terminal cleanup
- keep runtime metadata synchronized across in-process session changes

## Safety
- runtime files and lock records are private and atomically published
- restart capability is advertised only when a stable process identity and signal handler are available
- startup signals are latched until the prompt-toolkit application is running

## Validation
- full `packages/nooa-cli/tests`: 1,729 passed, 2 skipped
- focused final suite: 56 passed
- Ruff check/format and `git diff --check` passed
- cross-package live restart smoke test passed

The companion fleet watcher/controller is in the internal `nemo-oo-skills` MR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added graceful TUI restart support for coordinated development-fleet workflows.
  * TUI sessions now preserve their active session when restarted.
  * Restart requests are handled safely through `SIGUSR1`, with session state restored automatically.
  * Restart handling includes secure runtime tracking, argument preservation, and automatic cleanup.
  * Added documentation covering restart behavior and safe signal usage.

* **Tests**
  * Added coverage for restart handling, session updates, secure runtime records, cleanup, re-execution, and option handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->