### PR TITLE
feat(tui): show live thinking duration

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1298,6 +1298,7 @@ class TUIApplication:
         self._pulse_frame: str = "·"
         self._pulse_frames = "·•"
         self._spinner_task: asyncio.Task | None = None
+        self._spinner_sleep: Callable[[float], Awaitable[None]] = asyncio.sleep
         self._thinking_started_at: float | None = None
         self._command_status_text: str = ""
         self._command_queue_texts: list[str] = []
@@ -3097,7 +3098,7 @@ class TUIApplication:
                     if self._app.is_running:
                         self._app.invalidate()
                     i += 1
-                    await asyncio.sleep(0.08)
+                    await self._spinner_sleep(0.08)
             finally:
                 # Paint once after the agent stops so the live status clears.
                 if self._app.is_running:
@@ -3496,12 +3497,13 @@ class TUIApplication:
         self._ensure_spinner_task()
 
     def runtime_notification_received(self) -> None:
-        """Refresh native chrome after the host dequeues runtime work."""
+        """Refresh native chrome after the host dequeues one turn's work."""
+        thinking_started_at = time.monotonic()
         if self._interrupt_completion_pending:
             # A replacement turn is beginning. Retire the completed turn's
             # optimistic label before rendering any chrome for the new work.
             self._clear_agent_interrupt_status()
-        self._on_dispatcher_dequeued()
+        self._on_dispatcher_dequeued(thinking_started_at)
 
     def runtime_state_changed(self) -> None:
         """Marshal a host-runtime state change onto the UI owner loop."""
@@ -3657,8 +3659,8 @@ class TUIApplication:
         if changed and app is not None and app.is_running:
             app.invalidate()
 
-    def _on_dispatcher_dequeued(self) -> None:
-        """React to a just-dequeued item: redraw queue pane, restart spinner.
+    def _on_dispatcher_dequeued(self, thinking_started_at: float) -> None:
+        """React to a just-dequeued item: reset timing and restart the spinner.
 
         Without this, the queue pane can show stale contents until the
         next event happens to trigger a redraw (spinner tick, user key,
@@ -3672,8 +3674,11 @@ class TUIApplication:
         except RuntimeError:
             on_ui_loop = False
         if ui_loop is not None and not on_ui_loop:
-            ui_loop.call_soon_threadsafe(self._on_dispatcher_dequeued)
+            ui_loop.call_soon_threadsafe(self._on_dispatcher_dequeued, thinking_started_at)
             return
+        # Unlike observations, notifications are not coalesced. Reset here so
+        # back-to-back THINKING turns cannot inherit the previous turn's clock.
+        self._thinking_started_at = thinking_started_at
         if self._app.is_running:
             self._app.invalidate()
         self._ensure_spinner_task()

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -5018,7 +5018,14 @@ class TUIApplication:
             started_at = self._thinking_started_at
             elapsed = 0.0 if started_at is None else time.monotonic() - started_at
             duration = _format_elapsed_duration(elapsed)
-            rows.append([("class:status", f"• thinking ({duration} • esc to interrupt)")])
+            rows.append(
+                [
+                    (
+                        "class:status",
+                        f"{self._spinner_frame} • thinking ({duration} • esc to interrupt)",
+                    )
+                ]
+            )
         if self._llm_probe_status_text:
             rows.append([("class:status", f"{self._spinner_frame} {self._llm_probe_status_text}")])
         auxiliary_status = ""

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -97,6 +97,18 @@ from .terminal_safety import (
 logger = logging.getLogger(__name__)
 
 
+def _format_elapsed_duration(elapsed_seconds: float) -> str:
+    """Format a live elapsed duration using compact whole-second units."""
+    total_seconds = max(0, int(elapsed_seconds))
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes}m {seconds}s"
+    if minutes:
+        return f"{minutes}m {seconds}s"
+    return f"{seconds}s"
+
+
 class _ResizeAwareApplication(Application[Any]):
     """Let native replay fold SIGWINCH into its semantic resize transaction."""
 
@@ -1286,6 +1298,8 @@ class TUIApplication:
         self._pulse_frame: str = "·"
         self._pulse_frames = "·•"
         self._spinner_task: asyncio.Task | None = None
+        self._spinner_wakeup: asyncio.Event | None = None
+        self._thinking_started_at: float | None = None
         self._command_status_text: str = ""
         self._command_queue_texts: list[str] = []
         # Admitted text remains visible here until its accepted transcript
@@ -3062,14 +3076,21 @@ class TUIApplication:
         return task
 
     def _ensure_spinner_task(self) -> None:
-        """Start a background task cycling the spinner frame while live work
-        needs animation. Invalidates the app each tick so the status line
-        redraws; exits when the animated statuses clear."""
+        """Refresh live work status at the cheapest cadence it needs.
+
+        The elapsed thinking timer changes once per second. Animated interrupt
+        and probe statuses retain their smoother 80ms cadence; a wakeup makes
+        transitions into those states immediate even during a timer-only wait.
+        """
         if self._spinner_task is not None and not self._spinner_task.done():
+            if self._spinner_wakeup is not None:
+                self._spinner_wakeup.set()
             return
 
         async def _animate() -> None:
             i = 0
+            wakeup = asyncio.Event()
+            self._spinner_wakeup = wakeup
             try:
                 while (
                     self.is_thinking()
@@ -3078,21 +3099,33 @@ class TUIApplication:
                 ):
                     self._spinner_frame = self._spinner_frames[i % len(self._spinner_frames)]
                     # Match the command runner's calm half-second dot pulse
-                    # while retaining the thinking spinner's smoother cadence.
+                    # while retaining the interrupt/probe spinner's smoother cadence.
                     pulse_index = int((i * 0.08) / 0.5)
                     self._pulse_frame = self._pulse_frames[pulse_index % len(self._pulse_frames)]
                     if self._app.is_running:
                         self._app.invalidate()
                     i += 1
-                    await asyncio.sleep(0.08)
+
+                    if self._interrupting_agent_turn or self._llm_probe_status_text:
+                        delay = 0.08
+                    else:
+                        started_at = self._thinking_started_at
+                        elapsed = 0.0 if started_at is None else time.monotonic() - started_at
+                        delay = max(0.01, 1.0 - (elapsed % 1.0))
+                    wakeup.clear()
+                    try:
+                        await asyncio.wait_for(wakeup.wait(), timeout=delay)
+                    except TimeoutError:
+                        pass
             finally:
-                # Paint once after the agent stops so "thinking…" clears.
+                self._spinner_wakeup = None
+                # Paint once after the agent stops so the live status clears.
                 if self._app.is_running:
                     self._app.invalidate()
 
         # Agent snapshots may arrive synchronously during construction,
         # before run_async() establishes the application owner loop.  In that
-        # case the initial render will start the spinner after startup.
+        # case the initial render will start the refresher after startup.
         loop = self._loop
         if loop is None or not loop.is_running():
             return
@@ -3466,6 +3499,12 @@ class TUIApplication:
             if not on_ui_loop:
                 loop.call_soon_threadsafe(self._on_agent_change, state)
                 return
+
+        is_thinking = state is not None and state.lifecycle is AgentLifecycle.THINKING
+        if is_thinking and self._thinking_started_at is None:
+            self._thinking_started_at = time.monotonic()
+        elif not is_thinking:
+            self._thinking_started_at = None
 
         # Observation teardown is independent from runtime turn cancellation.
         # Only runtime_cancelled() may acknowledge interrupt feedback; otherwise
@@ -4209,6 +4248,7 @@ class TUIApplication:
                     pass
             self._consumer_task = None
             self._spinner_task = None
+            self._spinner_wakeup = None
             self._queued_resize_replay_generation = None
             self._replay_columns_override = None
             self._loop = None
@@ -4996,7 +5036,10 @@ class TUIApplication:
         ):
             rows.append([("class:status", f"{self._pulse_frame} Interrupting agent turn")])
         elif self.is_thinking():
-            rows.append([("class:status", f"{self._spinner_frame} thinking...")])
+            started_at = self._thinking_started_at
+            elapsed = 0.0 if started_at is None else time.monotonic() - started_at
+            duration = _format_elapsed_duration(elapsed)
+            rows.append([("class:status", f"• thinking ({duration} • esc to interrupt)")])
         if self._llm_probe_status_text:
             rows.append([("class:status", f"{self._spinner_frame} {self._llm_probe_status_text}")])
         auxiliary_status = ""

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -5022,7 +5022,7 @@ class TUIApplication:
                 [
                     (
                         "class:status",
-                        f"{self._spinner_frame} • thinking ({duration} • esc to interrupt)",
+                        f"{self._spinner_frame} thinking ({duration} • esc to interrupt)",
                     )
                 ]
             )

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -1298,7 +1298,6 @@ class TUIApplication:
         self._pulse_frame: str = "·"
         self._pulse_frames = "·•"
         self._spinner_task: asyncio.Task | None = None
-        self._spinner_wakeup: asyncio.Event | None = None
         self._thinking_started_at: float | None = None
         self._command_status_text: str = ""
         self._command_queue_texts: list[str] = []
@@ -3076,21 +3075,14 @@ class TUIApplication:
         return task
 
     def _ensure_spinner_task(self) -> None:
-        """Refresh live work status at the cheapest cadence it needs.
-
-        The elapsed thinking timer changes once per second. Animated interrupt
-        and probe statuses retain their smoother 80ms cadence; a wakeup makes
-        transitions into those states immediate even during a timer-only wait.
-        """
+        """Start a background task cycling the spinner frame while live work
+        needs animation. Invalidates the app every 80ms so the status line
+        remains responsive and elapsed thinking time redraws continuously."""
         if self._spinner_task is not None and not self._spinner_task.done():
-            if self._spinner_wakeup is not None:
-                self._spinner_wakeup.set()
             return
 
         async def _animate() -> None:
             i = 0
-            wakeup = asyncio.Event()
-            self._spinner_wakeup = wakeup
             try:
                 while (
                     self.is_thinking()
@@ -3099,33 +3091,21 @@ class TUIApplication:
                 ):
                     self._spinner_frame = self._spinner_frames[i % len(self._spinner_frames)]
                     # Match the command runner's calm half-second dot pulse
-                    # while retaining the interrupt/probe spinner's smoother cadence.
+                    # while retaining the thinking spinner's smoother cadence.
                     pulse_index = int((i * 0.08) / 0.5)
                     self._pulse_frame = self._pulse_frames[pulse_index % len(self._pulse_frames)]
                     if self._app.is_running:
                         self._app.invalidate()
                     i += 1
-
-                    if self._interrupting_agent_turn or self._llm_probe_status_text:
-                        delay = 0.08
-                    else:
-                        started_at = self._thinking_started_at
-                        elapsed = 0.0 if started_at is None else time.monotonic() - started_at
-                        delay = max(0.01, 1.0 - (elapsed % 1.0))
-                    wakeup.clear()
-                    try:
-                        await asyncio.wait_for(wakeup.wait(), timeout=delay)
-                    except TimeoutError:
-                        pass
+                    await asyncio.sleep(0.08)
             finally:
-                self._spinner_wakeup = None
                 # Paint once after the agent stops so the live status clears.
                 if self._app.is_running:
                     self._app.invalidate()
 
         # Agent snapshots may arrive synchronously during construction,
-        # before run_async() establishes the application owner loop.  In that
-        # case the initial render will start the refresher after startup.
+        # before run_async() establishes the application owner loop. In that
+        # case the initial render will start the spinner after startup.
         loop = self._loop
         if loop is None or not loop.is_running():
             return
@@ -4248,7 +4228,6 @@ class TUIApplication:
                     pass
             self._consumer_task = None
             self._spinner_task = None
-            self._spinner_wakeup = None
             self._queued_resize_replay_generation = None
             self._replay_columns_override = None
             self._loop = None

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -551,13 +551,13 @@ async def test_thinking_status_shows_live_human_readable_elapsed_time():
     async with TUIHarness(agent=agent) as h:
         h.app.submit_message("hold the turn")
         await h.wait_for(h.app.is_thinking)
-        assert "• thinking (0s • esc to interrupt)" in h.app.status_text()
+        assert "thinking (0s • esc to interrupt)" in h.app.status_text()
 
         h.app._thinking_started_at -= 4
-        assert "• thinking (4s • esc to interrupt)" in h.app.status_text()
+        assert "thinking (4s • esc to interrupt)" in h.app.status_text()
 
         h.app._thinking_started_at -= 61
-        assert "• thinking (1m 5s • esc to interrupt)" in h.app.status_text()
+        assert "thinking (1m 5s • esc to interrupt)" in h.app.status_text()
         agent.block.set()
 
 
@@ -575,8 +575,8 @@ async def test_thinking_status_keeps_animated_spinner():
         h.app._spinner_frame = "⠙"
         second = h.app.status_text()
 
-        assert "⠋ • thinking (" in first
-        assert "⠙ • thinking (" in second
+        assert "⠋ thinking (" in first
+        assert "⠙ thinking (" in second
         assert first != second
         agent.block.set()
 

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -561,6 +561,26 @@ async def test_thinking_status_shows_live_human_readable_elapsed_time():
         agent.block.set()
 
 
+async def test_thinking_status_keeps_animated_spinner():
+    """The live duration supplements rather than replaces the spinner glyph."""
+    agent = FakeAgent()
+    agent.block.clear()
+
+    async with TUIHarness(agent=agent) as h:
+        h.app.submit_message("hold the turn")
+        await h.wait_for(h.app.is_thinking)
+
+        h.app._spinner_frame = "⠋"
+        first = h.app.status_text()
+        h.app._spinner_frame = "⠙"
+        second = h.app.status_text()
+
+        assert "⠋ • thinking (" in first
+        assert "⠙ • thinking (" in second
+        assert first != second
+        agent.block.set()
+
+
 async def test_thinking_timer_repaints_across_minute_boundary():
     """The timer task invalidates and renders the next whole-second value."""
     agent = FakeAgent()

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import io
 import threading
+import time
 
 import pytest
 
@@ -542,6 +543,40 @@ async def test_oauth_modal_ctrl_y_copies_full_authorization_url(monkeypatch):
         assert await prompt == ""
 
 
+async def test_thinking_status_shows_live_human_readable_elapsed_time():
+    """Thinking chrome uses a stable bullet and advances through time units."""
+    agent = FakeAgent()
+    agent.block.clear()
+
+    async with TUIHarness(agent=agent) as h:
+        h.app.submit_message("hold the turn")
+        await h.wait_for(h.app.is_thinking)
+        assert "• thinking (0s • esc to interrupt)" in h.app.status_text()
+
+        h.app._thinking_started_at -= 4
+        assert "• thinking (4s • esc to interrupt)" in h.app.status_text()
+
+        h.app._thinking_started_at -= 61
+        assert "• thinking (1m 5s • esc to interrupt)" in h.app.status_text()
+        agent.block.set()
+
+
+async def test_thinking_timer_repaints_across_minute_boundary():
+    """The timer task invalidates and renders the next whole-second value."""
+    agent = FakeAgent()
+    agent.block.clear()
+
+    async with TUIHarness(agent=agent) as h:
+        h.app.submit_message("hold the turn")
+        await h.wait_for(h.app.is_thinking)
+        h.app._thinking_started_at = time.monotonic() - 59.8
+        h.app._ensure_spinner_task()
+
+        await h.wait_for(lambda: "thinking (59s" in _last_screen_text(h.app))
+        await h.wait_for(lambda: "thinking (1m 0s" in _last_screen_text(h.app))
+        agent.block.set()
+
+
 async def test_status_text_separates_thinking_and_command_status():
     """Thinking and command statuses render as separated status rows."""
     agent = FakeAgent()
@@ -551,9 +586,9 @@ async def test_status_text_separates_thinking_and_command_status():
         await h.wait_for(h.app.is_thinking)
         h.app.set_command_status("· !find ~/dev/* | grep unified")
         status = h.app.status_text()
-        assert "thinking...\n\n· !find" in status
-        assert "thinking...\n· !find" not in status
-        assert "thinking...   · !find" not in status
+        assert "esc to interrupt)\n\n· !find" in status
+        assert "esc to interrupt)\n· !find" not in status
+        assert "esc to interrupt)   · !find" not in status
         agent.block.set()
 
 

--- a/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
+++ b/packages/nooa-cli/tests/tui/test_tui_app_behavior.py
@@ -25,9 +25,9 @@ from __future__ import annotations
 import asyncio
 import io
 import threading
-import time
 
 import pytest
+from nooa_cli.tui.tui_application import _format_elapsed_duration
 
 from .tui_app_harness import (
     FakeAgent,
@@ -561,39 +561,78 @@ async def test_thinking_status_shows_live_human_readable_elapsed_time():
         agent.block.set()
 
 
-async def test_thinking_status_keeps_animated_spinner():
-    """The live duration supplements rather than replaces the spinner glyph."""
+async def test_thinking_status_animates_at_80ms_with_live_duration():
+    """The animation task drives integrated spinner/timer frames at 80 ms."""
+    agent = FakeAgent()
+    agent.block.clear()
+    sleep_delays: list[float] = []
+    advance = asyncio.Event()
+
+    async def controlled_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+        await advance.wait()
+        advance.clear()
+
+    async with TUIHarness(agent=agent) as h:
+        h.app._spinner_sleep = controlled_sleep
+        h.app.submit_message("hold the turn")
+        await h.wait_for(lambda: h.app.is_thinking() and sleep_delays == [0.08])
+        h.app._thinking_started_at -= 4
+        assert "⠋ thinking (4s • esc to interrupt)" in h.app.status_text()
+
+        advance.set()
+        await h.wait_for(lambda: h.app._spinner_frame == "⠙")
+        assert sleep_delays == [0.08, 0.08]
+        assert "⠙ thinking (4s • esc to interrupt)" in h.app.status_text()
+        agent.block.set()
+        advance.set()
+
+
+async def test_thinking_duration_boundaries():
+    assert _format_elapsed_duration(59.999) == "59s"
+    assert _format_elapsed_duration(60) == "1m 0s"
+    assert _format_elapsed_duration(3599.999) == "59m 59s"
+    assert _format_elapsed_duration(3600) == "1h 0m 0s"
+
+
+async def test_back_to_back_notification_resets_coalesced_thinking_timer():
+    """A new turn resets timing even when observations coalesce THINKING states."""
     agent = FakeAgent()
     agent.block.clear()
 
     async with TUIHarness(agent=agent) as h:
-        h.app.submit_message("hold the turn")
+        h.app.submit_message("first turn")
         await h.wait_for(h.app.is_thinking)
+        h.app._thinking_started_at -= 30
+        previous_started_at = h.app._thinking_started_at
 
-        h.app._spinner_frame = "⠋"
-        first = h.app.status_text()
-        h.app._spinner_frame = "⠙"
-        second = h.app.status_text()
+        h.app.runtime_notification_received()
 
-        assert "⠋ thinking (" in first
-        assert "⠙ thinking (" in second
-        assert first != second
+        assert h.app.is_thinking()
+        assert h.app._thinking_started_at > previous_started_at
+        assert "thinking (0s • esc to interrupt)" in h.app.status_text()
         agent.block.set()
 
 
-async def test_thinking_timer_repaints_across_minute_boundary():
-    """The timer task invalidates and renders the next whole-second value."""
+async def test_thinking_duration_resets_for_next_turn():
     agent = FakeAgent()
     agent.block.clear()
 
     async with TUIHarness(agent=agent) as h:
-        h.app.submit_message("hold the turn")
+        h.app.submit_message("first turn")
         await h.wait_for(h.app.is_thinking)
-        h.app._thinking_started_at = time.monotonic() - 59.8
-        h.app._ensure_spinner_task()
+        first_started_at = h.app._thinking_started_at
+        assert first_started_at is not None
 
-        await h.wait_for(lambda: "thinking (59s" in _last_screen_text(h.app))
-        await h.wait_for(lambda: "thinking (1m 0s" in _last_screen_text(h.app))
+        agent.block.set()
+        await h.wait_for(lambda: not h.app.is_thinking())
+        assert h.app._thinking_started_at is None
+
+        agent.block.clear()
+        h.app.submit_message("second turn")
+        await h.wait_for(h.app.is_thinking)
+        assert h.app._thinking_started_at is not None
+        assert h.app._thinking_started_at > first_started_at
         agent.block.set()
 
 


### PR DESCRIPTION
## Summary

- keep the 80 ms animated Braille thinking spinner
- show live elapsed thinking time as `⠙ thinking (4s • esc to interrupt)`
- format longer durations as minutes/seconds and hours/minutes/seconds
- reset timing at the non-coalesced per-turn notification boundary
- add deterministic cadence, duration-boundary, and lifecycle regressions

## Verification

- Full TUI suite: 1,495 passed
- Ruff format/check passed
- git diff --check passed

## Review

Independent correctness, test-quality, and UX/simplicity reviews completed; all actionable findings addressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thinking status now shows live elapsed time in a human-readable format.
  * An interrupt hint is displayed while the assistant is thinking.
  * Spinner updates continue smoothly while reflecting the current thinking duration.

* **Bug Fixes**
  * Thinking timers now reset correctly between consecutive turns.
  * Elapsed-time display remains accurate across seconds, minutes, and hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->