### PR TITLE
docs(skills): correct two stale quickstart example paths 🤖🤖🤖

### DIFF
--- a/skills/nooa-middleware-hooks/SKILL.md
+++ b/skills/nooa-middleware-hooks/SKILL.md
@@ -52,7 +52,7 @@ Verified semantics:
 - On a context-window error the runtime archives events, rebuilds messages, and retries — so `llm_call` middleware can run more than once per logical turn; keep it idempotent.
 - The tracing `on_messages_built` hook fires inside the innermost core, so traces show the **post-middleware** messages.
 
-Worked production example: `src/nooa/nemo_relay_middleware.py` installs all three kinds to route calls through NeMo Relay (guardrails/ATIF); `nemo_relay_scope(agent, name)` wraps install/uninstall. Runnable: `examples/quickstart/13_nemo_relay.py`. Test patterns (mutate/short-circuit/ordering): `tests/test_event_middleware.py`.
+Worked production example: `src/nooa/nemo_relay_middleware.py` installs all three kinds to route calls through NeMo Relay (guardrails/ATIF); `nemo_relay_scope(agent, name)` wraps install/uninstall. Runnable: `examples/quickstart/15_nemo_relay.py`. Test patterns (mutate/short-circuit/ordering): `tests/test_event_middleware.py`.
 
 ## Observers (`on`)
 

--- a/skills/nooa-tools-and-skills/SKILL.md
+++ b/skills/nooa-tools-and-skills/SKILL.md
@@ -133,7 +133,7 @@ img = Image.from_file("photo.png")     # also .from_bytes(media_type=...), .from
 await MediaAgent().describe(img)
 ```
 
-Only works with multimodal-capable models — text-only models error when handed media. See `examples/quickstart/12_multimodal.py`.
+Only works with multimodal-capable models — text-only models error when handed media. See `examples/quickstart/13_multimodal.py`.
 
 ## Pitfalls
 


### PR DESCRIPTION
Two SKILL.md files cite quickstart examples by a filename that belongs to a different example. Because both cited paths exist, nothing errors — the reader is quietly sent to the wrong file.

- nooa-middleware-hooks/SKILL.md:55 cites 13_nemo_relay.py; the NeMo Relay example is 15_nemo_relay.py (13 is the multimodal example).
- nooa-tools-and-skills/SKILL.md:136 cites 12_multimodal.py; the multimodal example is 13_multimodal.py (12 is the memory example).

Swept every other examples/quickstart/ citation in the repo; all resolve to the example they describe.

## What does this PR do?

<!-- A clear, concise description of the change. -->

## Related issues

<!-- e.g. Closes #123 -->

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass) — re-run on `2f4b68d`: `All checks passed!` and `926 files already formatted`.
- [x] Tests added/updated and passing — no test applies: the change edits two `SKILL.md` files and touches no code, and nothing under `tests/` asserts on the content of `skills/*/SKILL.md`. Instead the claim itself was re-verified: every `examples/quickstart/NN_*.py` citation in the repo (`AGENTS.md`, `README.md`, `pyproject.toml`, `docs/`, `examples/README.md`, `skills/`, `packages/nooa-memory/`) was re-swept on this branch and each one now resolves to the example it describes. The skill-adjacent suites were run as a guard — `tests/test_skill_frontmatter.py`, `tests/test_skill_registry_extended.py`, `tests/unit/test_skill.py` and `packages/nooa-memory/tests/memory/test_memory_readme.py`: **79 passed, 6 failed**, and the same 6 fail identically on `main`: 4 × `AssertionError: pass_fds not supported on Windows.` in `tests/unit/test_skill.py` (upstream #110), and 2 × `read_text()` with no `encoding=` inside `test_memory_readme.py` itself, which are green under `PYTHONUTF8=1`. A full `uv run pytest` does not complete on this machine because `src/nooa/storage/sqlite.py:10` imports `fcntl`, as noted on #271, so the run is scoped.
- [x] Docs updated if behavior or public APIs changed — this PR *is* the docs change; no behaviour and no public API is touched.
- [x] New source files carry an SPDX license header — no new files: both paths are modifications (`git diff --name-status` reports `M`, `M`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the NeMo Relay quickstart reference to the current example location.
  - Updated the multimodal quickstart reference to the current example location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->