### PR TITLE
fix(atif): write trajectory JSON as UTF-8🤖🤖🤖

### DIFF
--- a/src/nooa/atif/exporter.py
+++ b/src/nooa/atif/exporter.py
@@ -1310,7 +1310,13 @@ class AtifExporter:
         try:
             self.path.parent.mkdir(parents=True, exist_ok=True)
             tmp = self.path.with_suffix(self.path.suffix + ".tmp")
-            tmp.write_text(self._trajectory.model_dump_json(indent=2, exclude_none=True))
+            # JSON is UTF-8 by definition (RFC 8259 section 8.1). Without an
+            # explicit encoding this uses the locale default, and non-ASCII
+            # model output raises into the swallow below, losing the file.
+            tmp.write_text(
+                self._trajectory.model_dump_json(indent=2, exclude_none=True),
+                encoding="utf-8",
+            )
             os.replace(tmp, self.path)
         except Exception:  # noqa: BLE001
             # Tracing must never break the run; log and move on.

--- a/tests/atif/test_exporter_state_machine.py
+++ b/tests/atif/test_exporter_state_machine.py
@@ -207,12 +207,19 @@ class TestBasicTurn:
         reaches disk.
         """
         prompt = "Explain: throughput ⇒ latency — “cached” 🚀"
+        stdout = "α ⇒ β\n"
         exporter.on_task(Task(prompt=prompt))
-        _drive_basic_codeact_turn(exporter, stdout="α ⇒ β\n")
+        _drive_basic_codeact_turn(exporter, stdout=stdout)
 
         assert exporter.path.exists(), "trajectory was dropped instead of written"
         loaded = Trajectory.model_validate_json(exporter.path.read_bytes().decode("utf-8"))
         assert loaded.steps[1].message == prompt
+        # Tool output reaches the file by a different route than the prompt,
+        # so assert it separately — otherwise the test still passes when the
+        # observation is dropped or mangled on the way through.
+        observation = loaded.steps[2].observation
+        assert observation is not None
+        assert stdout.rstrip("\n") in (observation.results[0].content or "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/atif/test_exporter_state_machine.py
+++ b/tests/atif/test_exporter_state_machine.py
@@ -186,6 +186,22 @@ class TestBasicTurn:
         # No leftover .tmp file.
         assert not (tmp_path / "trajectory.json.tmp").exists()
 
+    def test_writes_non_ascii_content_as_utf8(self, exporter: AtifExporter) -> None:
+        """Trajectory text is model output, so non-ASCII is the common case.
+
+        Written without an explicit encoding the file picks up the locale
+        default (cp1252 on Windows), and ``_write`` swallows the resulting
+        UnicodeEncodeError — the run succeeds while the trajectory never
+        reaches disk.
+        """
+        prompt = "Explain: throughput ⇒ latency — “cached” 🚀"
+        exporter.on_task(Task(prompt=prompt))
+        _drive_basic_codeact_turn(exporter, stdout="α ⇒ β\n")
+
+        assert exporter.path.exists(), "trajectory was dropped instead of written"
+        loaded = Trajectory.model_validate_json(exporter.path.read_bytes().decode("utf-8"))
+        assert loaded.steps[1].message == prompt
+
 
 # ---------------------------------------------------------------------------
 # Joinability — the original observation-dropping regression must pass by

--- a/tests/atif/test_exporter_state_machine.py
+++ b/tests/atif/test_exporter_state_machine.py
@@ -179,6 +179,12 @@ class TestBasicTurn:
         assert traj.final_metrics.total_cost_usd == pytest.approx(0.001)
 
     def test_writes_file_atomically(self, exporter: AtifExporter, tmp_path: Path) -> None:
+        """The trajectory reaches its final path through a rename, not a partial write.
+
+        ``_write`` serialises to ``trajectory.json.tmp`` and ``os.replace``s
+        it, so a concurrent reader never sees a half-written document and no
+        ``.tmp`` file is left behind.
+        """
         exporter.on_task(Task(prompt="hi"))
         _drive_basic_codeact_turn(exporter)
         loaded = Trajectory.model_validate_json(exporter.path.read_text())

--- a/tests/atif/test_exporter_state_machine.py
+++ b/tests/atif/test_exporter_state_machine.py
@@ -155,6 +155,12 @@ def _drive_basic_codeact_turn(
 
 class TestBasicTurn:
     def test_single_codeact_turn_round_trip(self, exporter: AtifExporter) -> None:
+        """One CodeAct turn produces a schema-valid, normative trajectory.
+
+        Covers the whole happy path in one pass: the system/user/agent step
+        shape, tool calls joined to their observation by ``tool_call_id``,
+        and token and cost totals rolled up into ``final_metrics``.
+        """
         exporter.on_task(Task(prompt="Say hello in Python."))
         _drive_basic_codeact_turn(exporter)
 


### PR DESCRIPTION
## What does this PR do?

`AtifExporter._write()` serialises the trajectory and calls `Path.write_text()`
with no `encoding`, so the file is written with the platform's locale codec
instead of UTF-8. This adds `encoding="utf-8"`.

### Why it matters

The write sits inside a deliberate catch-all:

```python
except Exception:  # noqa: BLE001
    # Tracing must never break the run; log and move on.
    logger.exception("atif: failed to write trajectory to %s", self.path)
```

That guard is right for its purpose, but it turns an encoding failure into
**silent data loss** rather than a crash. On a non-UTF-8 locale (cp1252 on
Windows) any non-ASCII character in the trajectory raises `UnicodeEncodeError`,
the exception is swallowed, the agent run reports success, and the trajectory
file is never created. The only trace is one log line.

Trajectory content is model output, which routinely carries arrows, dashes,
curly quotes and emoji, so this is the common case rather than an edge case.

JSON is defined as UTF-8 by [RFC 8259 §8.1](https://www.rfc-editor.org/rfc/rfc8259#section-8.1),
so writing it as UTF-8 is a conformance fix, not a platform preference.

CI is green today because every job runs `ubuntu-latest`, where the locale
default already is UTF-8.

### The change

```diff
-            tmp.write_text(self._trajectory.model_dump_json(indent=2, exclude_none=True))
+            tmp.write_text(
+                self._trajectory.model_dump_json(indent=2, exclude_none=True),
+                encoding="utf-8",
+            )
```

One argument, a short comment recording why the encoding is explicit here, and
one regression test.

### Evidence

Windows 11 / CPython 3.13.6 (`locale.getpreferredencoding(False) == 'cp1252'`),
at `e137e1b`.

**Before — `uv run pytest tests/atif -q`**

```
collected 126 items
...
FAILED tests/atif/test_phase4_nesting.py::test_case_b_same_agent_nested_flattens
FAILED tests/atif/test_phase4_nesting.py::test_case_c_standalone_embeds_subagent
FAILED tests/atif/test_phase4_nesting.py::test_case_d2_gather_over_standalones_yields_n_subagents
================== 3 failed, 122 passed, 1 skipped in 19.28s ==================
```

Note how the failure presents. The test does not fail with an encoding error —
it fails because the file is not there:

```
tests/atif/test_phase4_nesting.py:110: in test_case_b_same_agent_nested_flattens
    loaded = Trajectory.model_validate_json(out.read_text())
E   FileNotFoundError: [Errno 2] No such file or directory: '...\traj.json'
```

The cause is visible only in the captured log:

```
ERROR    nooa.atif.exporter:exporter.py:1317 atif: failed to write trajectory to ...\traj.json
  File "src\nooa\atif\exporter.py", line 1313, in _write
    tmp.write_text(self._trajectory.model_dump_json(indent=2, exclude_none=True))
  File "...\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input, self.errors, encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '⇒' in position 6875: character maps to <undefined>
```

**After — `uv run pytest tests/atif -q`**

```
======================= 126 passed, 1 skipped in 12.75s =======================
```

(126 = the 125 existing tests plus the one added here.)

**The new test fails without the production change** — one-line fix reverted,
test kept:

```
FAILED tests/atif/test_exporter_state_machine.py::TestBasicTurn::test_writes_non_ascii_content_as_utf8
UnicodeEncodeError: 'charmap' codec can't encode character '⇒' in position 507
============================== 1 failed in 1.86s ==============================
```

**Lint, whole repo**

```
$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
926 files already formatted
```

### Reproducing without Windows

The failure is locale-dependent, not OS-dependent — `Path.write_text()` with no
`encoding` uses `locale.getpreferredencoding(False)`. On any machine:

```python
import locale, pathlib, tempfile
print(locale.getpreferredencoding(False))          # 'utf-8' on CI, 'cp1252' here
pathlib.Path(tempfile.mktemp()).write_text("⇒")    # raises wherever that is not UTF-8
```

### Test added

One test, in the file that already covers `AtifExporter`'s write path, directly
after `test_writes_file_atomically`. It drives a normal CodeAct turn whose task
prompt and tool output contain non-ASCII text, then asserts the file exists and
the text round-trips. It fails on current `main` and passes with this change.

### Scope

One claim, one behaviour change. The wider question — this repo has other call
sites that read and write text with the locale default, some of them handling
formats that also mandate UTF-8 — is deliberately **not** in this PR; changing
how existing files are *read* is a compatibility decision that belongs to the
maintainers. Happy to open a separate issue with an inventory if useful.

No TUI or `packages/nooa-cli` code is touched.

## Related issues

None open that I could find — this does not appear to have been reported.

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing — `tests/atif` (126 passed, 1 skipped) plus the adjacent
  ATIF-touching suites. A full `uv run pytest` does not complete on this machine for reasons
  unrelated to this change: `src/nooa/storage/sqlite.py:10` imports `fcntl` and
  `src/nooa/runtime/debug_handler.py:429` uses `signal.SIGUSR2`, both POSIX-only, so `nooa` will
  not import on Windows without stubs. Happy to file that separately.
- [x] Docs updated if behavior or public APIs changed — no public API or documented behaviour changes
- [x] New source files carry an SPDX license header — no new files added

---

Drafted with AI assistance; the commit carries
`Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Trajectory files now consistently preserve non-ASCII content, including accented characters, symbols, and emoji, regardless of system locale.
  - Exported JSON is written using UTF-8, preventing corruption or loss of international text in prompts and tool output.
  - Reloaded trajectories retain Unicode content correctly, improving reliability when working with multilingual model responses.

- **Tests**
  - Added coverage confirming Unicode prompts and tool output are correctly saved and restored through trajectory persistence workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->