### PR TITLE
fix(agentdoc): preserve Unicode in file-backed output 🤖🤖🤖

### DIFF
--- a/src/nooa/agentdoc/_truncating_stream.py
+++ b/src/nooa/agentdoc/_truncating_stream.py
@@ -154,7 +154,7 @@ class FileBackedTruncatingStringIO(TruncatingStringIO):
 
     Behaves identically to :class:`TruncatingStringIO` for in-memory
     head/tail truncation, but additionally streams all written content to a
-    temporary file on disk.  When truncated, ``getvalue()`` includes the
+    temporary UTF-8 file on disk.  When truncated, ``getvalue()`` includes the
     file path in the notice so the user can inspect the full output.
 
     File I/O errors are handled gracefully — if the temp file cannot be
@@ -181,7 +181,7 @@ class FileBackedTruncatingStringIO(TruncatingStringIO):
         self._file: io.TextIOWrapper | None = None
         try:
             fd, path = tempfile.mkstemp(dir=dir, prefix=prefix, suffix=suffix)
-            self._file = os.fdopen(fd, "w")
+            self._file = os.fdopen(fd, "w", encoding="utf-8")
             self._file_path = path
         except OSError:
             _log.warning(
@@ -196,7 +196,7 @@ class FileBackedTruncatingStringIO(TruncatingStringIO):
             try:
                 self._file.write(s)
                 self._file.flush()
-            except OSError:
+            except (OSError, UnicodeEncodeError):
                 _log.warning("Failed to write to temp file; disabling file backing", exc_info=True)
                 self._file_failed = True
         return super().write(s)

--- a/tests/agentdoc/test_file_backed_truncating_stream.py
+++ b/tests/agentdoc/test_file_backed_truncating_stream.py
@@ -75,13 +75,19 @@ class TestFileBackedBasicBehavior:
         finally:
             buf.cleanup()
 
-    def test_unicode_round_trip(self, buf):
+    def test_unicode_round_trip(self, monkeypatch):
         """Unicode characters survive the write-read round trip in both memory and file."""
-        text = "Hello 世界! 🚀 café"
-        buf.write(text)
-        assert buf.getvalue() == text
-        with open(buf.file_path) as f:
-            assert f.read() == text
+        # Exercise a non-UTF-8 default even on UTF-8 CI hosts.
+        monkeypatch.setattr("io.text_encoding", lambda encoding, stacklevel=2: encoding or "cp1252")
+        buf = FileBackedTruncatingStringIO(limit=100)
+        try:
+            text = "Hello 世界! 🚀 café"
+            buf.write(text)
+            assert buf.getvalue() == text
+            with open(buf.file_path, encoding="utf-8") as f:
+                assert f.read() == text
+        finally:
+            buf.cleanup()
 
 
 class TestFileBackedFileOutput:
@@ -197,6 +203,17 @@ class TestFileBackedTruncationNotice:
 
 class TestFileBackedErrorHandling:
     """Verify graceful fallback when file I/O fails."""
+
+    def test_fallback_on_unencodable_text(self, buf):
+        """Lone surrogates cannot be encoded as UTF-8 but remain usable in memory."""
+        text = "before\ud800after"
+        assert buf.write(text) == len(text)
+        assert buf.getvalue() == text
+        assert buf.write("x" * 200) == 200
+        assert buf.chars_written == len(text) + 200
+        value = buf.getvalue()
+        assert "not recoverable" in value
+        assert "full untruncated output" not in value
 
     def test_fallback_on_invalid_dir(self):
         """Invalid dir falls back to in-memory-only; no file path in notice."""


### PR DESCRIPTION
_Use_ UTF-8 for captured output and preserve the in-memory fallback when text cannot be encoded. Add regression coverage.

## What does this PR do?

`FileBackedTruncatingStringIO` opens its output file with the locale encoding. On a cp1252 host, writing `Hello 世界! 🚀 café` raises `UnicodeEncodeError` before the in-memory buffer receives the text. The existing Unicode round-trip test fails for this reason.

Write captured output as UTF-8. If a string still cannot be encoded (for example, it contains a lone surrogate), use the class's documented in-memory fallback. Encoding errors are not subclasses of `OSError`, so the existing handler misses them.

The updated round-trip test forces a cp1252 default on UTF-8 hosts too, reads the saved file as UTF-8, and checks both copies of the output. One additional test checks that an encoding failure preserves text and subsequent writes in memory without advertising an incomplete file as the full output.

## Related issues

No matching open issue or PR found in the September 5, 2026 search. This is separate from the ATIF exporter change in #271.

## Validation

- Before the production fix: stream suite **2 failed, 28 passed**, including the new fallback regression.
- After: `uv run pytest -q tests/agentdoc` — **707 passed**.
- `uv run ruff check .` and `uv run ruff format --check .` — pass.
- `uv run pyright src/nooa/agentdoc/_truncating_stream.py` — no errors or warnings.
- `uv run python scripts/check_license_headers.py` and `git diff --check` — pass.

Test host: Windows, CPython 3.12.14, pytest 9.1.1, Ruff 0.15.20. To collect unrelated tests past the existing Windows import blockers (#84 and #85), this run used external audit-only shims for `fcntl` and `SIGUSR2`. They do not modify stream or encoding behavior and are not part of this patch. The full repository suite is not green on this host; unrelated failures are recorded separately. Linux CI has not been executed locally.

## Checklist

- [x] Code follows the project style.
- [x] Relevant tests updated and passing.
- [x] Class documentation states the output encoding.
- [x] Existing SPDX headers retained; no new source files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode handling when temporary-file storage is used, including environments with non-UTF-8 defaults.
  * Prevented unsupported characters from interrupting text processing by falling back to in-memory storage.
  * Preserved usable character counting and truncation behavior for unencodable text.

* **Documentation**
  * Clarified that temporary files use UTF-8 encoding.

* **Tests**
  * Added coverage for Unicode round trips, file-backed reads, and fallback truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->