### PR TITLE
fix(viewer): close the trace store connection 🤖🤖🤖

### DIFF
--- a/src/nooa/viewer/main.py
+++ b/src/nooa/viewer/main.py
@@ -181,6 +181,8 @@ async def lifespan(app: FastAPI):
         worker.cancel()
         memory_routes.close_stores()
         _write_executor.shutdown(wait=True)
+        # After the writer thread is joined, so nothing is mid-write.
+        otlp_store.close_db()
         log.info("Shutdown complete")
 
 

--- a/src/nooa/viewer/otlp_store.py
+++ b/src/nooa/viewer/otlp_store.py
@@ -238,6 +238,17 @@ def _check_writable(path: Path) -> None:
         probe.close()
 
 
+def close_db() -> None:
+    """Close the schema connection opened by init_db(). Idempotent."""
+    global _db
+    if _db is not None:
+        try:
+            _db.close()
+        except Exception:
+            log.debug("Failed to close schema connection", exc_info=True)
+        _db = None
+
+
 def init_db() -> int:
     """Create tables and return the number of existing sessions.
 
@@ -270,6 +281,10 @@ def init_db() -> int:
                 "Failed to close thread-local write connection during init_db()", exc_info=True
             )
         del _write_tls.conn
+
+    # Same reason as the two resets above: without this the previous schema
+    # connection (and its handle on the old DB file) leaks on every re-init.
+    close_db()
 
     _db = sqlite3.connect(str(DB_PATH), check_same_thread=False)
     _db.execute("PRAGMA journal_mode=WAL")

--- a/tests/viewer/test_otlp_store.py
+++ b/tests/viewer/test_otlp_store.py
@@ -1021,6 +1021,21 @@ class TestStartupLockCheck:
             blocker.close()
 
 
+class TestSchemaConnectionLifecycle:
+    """``init_db`` must not leak the schema connection it replaces."""
+
+    def test_reinit_closes_the_previous_schema_connection(self, tmp_path, monkeypatch):
+        """A second init_db() at a new path closes the first connection."""
+        first = store._db
+        monkeypatch.setattr(store, "DB_PATH", tmp_path / "second.db")
+
+        store.init_db()
+
+        assert store._db is not first
+        with pytest.raises(sqlite3.ProgrammingError):
+            first.execute("SELECT 1")
+
+
 class TestExistingSessionEvalEnrichment:
     def test_existing_default_session_can_be_grouped_into_eval_experiment(self):
         store.ingest(_make_body(session_id="trial-1", experiment="default"))


### PR DESCRIPTION
otlp_store.init_db() opens a module-global SQLite connection (otlp_store.py:274) that nothing ever closes: the module has no close_db(), no shutdown() and no atexit. init_db() carefully closes both thread-local connections before reopening them (:253-272), then reassigns _db without closing it. So every init_db() call leaks its predecessor, and even a single call holds the database file for the life of the process.

The same asymmetry shows up three ways:

- viewer/main.py:176-184 -- the lifespan opens two stores at startup and closes one at shutdown. memory_routes.close_stores() is called; the trace store is not.
- memory_routes.py:60/:68 already has both close_stores() and an atexit.register(close_stores), landed in #121 and #131. The trace store never got the same treatment.
- tests/viewer/test_otlp_store.py's isolated_db fixture hand-rolls the close the module does not provide -- it nulls _db before init_db() and closes _db afterwards. The suite already had to work around the missing API.

Add close_db(), call it in init_db() before reopening (alongside the two thread-local resets already there), and call it in the viewer lifespan's finally after the write executor is joined, so no write is in flight. Purely additive: no existing signature or behaviour changes.

On Linux the leak degrades quietly -- fds and WAL/SHM mappings accumulate while the file still unlinks. On Windows the database file becomes undeletable. Four init_db() calls against four temp databases leave 4/4 connections open and 4/4 directories undeletable before this change; after it, 3/4 close and their directories delete, the last staying open only because nothing has called close_db() on it.

Follow-up, deliberately not bundled: eval_pipeline's HeadlessOtlpBackend needs a settle delay (or TemporaryDirectory(ignore_cleanup_errors=True)) before cleanup, because Windows releases the file handle asynchronously after close(). That is a different claim in a different package.

## What does this PR do?

<!-- A clear, concise description of the change. -->

## Related issues

<!-- e.g. Closes #123 -->

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass) — re-run on `9a9b5d6`: `All checks passed!` and `926 files already formatted`.
- [x] Tests added/updated and passing — `tests/viewer` is **154 passed, 2 deselected** on this branch against **153 passed, 2 deselected** on `main`; the extra test is the added `TestSchemaConnectionLifecycle::test_reinit_closes_the_previous_schema_connection`. It was proved non-vacuous by fault injection rather than by assertion: with the new `close_db()` call removed from `init_db()` and the test kept, it fails with `Failed: DID NOT RAISE ProgrammingError`; the call was restored afterwards. A full `uv run pytest` does not complete on this machine because `src/nooa/storage/sqlite.py:10` imports `fcntl` (POSIX-only), so the run is scoped to `tests/viewer`. Measured on Windows 11 / CPython 3.13.6.
- [x] Docs updated if behavior or public APIs changed — nothing to update: `close_db()` is purely additive, no existing signature or behaviour changes, and `docs/` describes the viewer only as a process to start (`docs/concepts/tracing.md`) — it does not document `otlp_store`'s API, which has no `__all__` and is not re-exported from `src/nooa/viewer/__init__.py`.
- [x] New source files carry an SPDX license header — no new files: all three paths are modifications (`git diff --name-status` reports `M`, `M`, `M`). Both header checkers pass on this branch anyway — `scripts/hooks/check_spdx.py` (the pre-commit hook) exits 0 and `scripts/check_license_headers.py` reports "all 929 source Python files carry an SPDX header".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application shutdown reliability by ensuring local storage is closed cleanly after background processing finishes.
  - Improved database reinitialization so previous storage connections are closed before a new connection is opened.
  - Storage close operations now handle repeated calls and close failures more safely without interrupting shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->