### PR TITLE
fix(viewer): roll back a payload that fails partway through ingest 🤖🤖🤖

### DIFF
--- a/src/nooa/viewer/otlp_store.py
+++ b/src/nooa/viewer/otlp_store.py
@@ -755,6 +755,26 @@ def _ingest_one(body: dict, db: sqlite3.Connection) -> dict[str, Any]:
     return {"session_id": session_id, "experiment": experiment, "span_count": span_count}
 
 
+def _ingest_one_atomic(body: dict, db: sqlite3.Connection) -> dict[str, Any]:
+    """Run ``_ingest_one`` in a SAVEPOINT so a failed payload writes nothing.
+
+    ``_ingest_one`` writes as it goes and leaves the commit to its caller, so a
+    payload that raises partway through leaves the rows it already wrote in the
+    open transaction — where the next commit on that connection picks them up.
+    Rolling back to the savepoint discards exactly that payload's writes and
+    nothing else, so the rest of a batch stays committable.
+    """
+    db.execute("SAVEPOINT ingest_one")
+    try:
+        result = _ingest_one(body, db)
+    except Exception:
+        db.execute("ROLLBACK TO ingest_one")
+        raise
+    finally:
+        db.execute("RELEASE ingest_one")
+    return result
+
+
 def ingest(body: dict) -> dict[str, Any]:
     """Ingest an OTLP ExportTraceServiceRequest using the read connection.
 
@@ -762,7 +782,7 @@ def ingest(body: dict) -> dict[str, Any]:
     Use ingest_batch_write() from the writer executor thread instead.
     """
     db = _get_db()
-    result = _ingest_one(body, db)
+    result = _ingest_one_atomic(body, db)
     db.commit()
     return result
 
@@ -813,7 +833,7 @@ def ingest_batch_write_bytes(payloads: list[bytes]) -> list[dict[str, Any]]:
             # /tmp path. _log_oversized_payload() provides the diagnostics needed.
             if len(raw) > 1 * 1024 * 1024:  # 1 MB
                 _log_oversized_payload(body, len(raw))
-            results.append(_ingest_one(body, db))
+            results.append(_ingest_one_atomic(body, db))
         except Exception:
             log.exception("[ingest_batch_write_bytes] Failed to process one payload, skipping")
     db.commit()
@@ -848,7 +868,7 @@ def ingest_batch_write(bodies: list[dict]) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     for body in bodies:
         try:
-            results.append(_ingest_one(body, db))
+            results.append(_ingest_one_atomic(body, db))
         except Exception:
             log.exception("[ingest_batch_write] Failed to process one payload, skipping")
     db.commit()

--- a/tests/viewer/test_otlp_store.py
+++ b/tests/viewer/test_otlp_store.py
@@ -469,6 +469,29 @@ class TestIngestNewSession:
         }
 
 
+class TestFailedPayloadIsNotPartiallyWritten:
+    """A payload that raises partway through must leave no rows behind."""
+
+    def test_failed_payload_does_not_inflate_span_count(self):
+        """_ingest_one writes the session row before the spans; if the span
+        insert then fails, the session row must not survive the next commit."""
+        store.ingest(_make_body(session_id="sess-1"))
+
+        bad = _make_body(session_id="sess-1")
+        # sqlite3 cannot bind a dict, so this raises at the span insert —
+        # after the sessions row has already been updated.
+        bad["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["kind"] = {"unbindable": True}
+        with pytest.raises(sqlite3.Error):
+            store.ingest(bad)
+
+        # An unrelated, valid payload: its commit is what would otherwise
+        # flush the failed payload's leftovers to disk.
+        store.ingest(_make_body(session_id="sess-2"))
+
+        counts = {s["id"]: s["span_count"] for s in store.list_sessions()}
+        assert counts["sess-1"] == len(store.get_session_spans("sess-1"))
+
+
 # ---------------------------------------------------------------------------
 # ingest — re-ingest (session merge)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
_ingest_one() writes as it goes and leaves the commit to its caller (otlp_store.py:571-755). Nothing rolls back when it raises, so the rows it already wrote stay in the connection's open transaction and are committed by the next commit on that connection. There is no rollback() anywhere in the module.

Both batch callers catch the exception and log "Failed to process one payload, skipping" (:837, :872), and ingest_batch_write()'s docstring promises that "one malformed payload cannot prevent the rest of the batch from being committed". The payload is not skipped: its partial write is committed with the rest.

_ingest_one() updates the sessions row before it inserts the spans, so the common shape is a session whose span_count counts spans that were never written. Reproduced against the public API -- one good payload, then one malformed payload for the same session:

    sessions.span_count = 2
    rows in spans       = 1
    list_sessions() reports span_count = 2
    get_session_spans() returns        = 1 spans

The viewer's own two endpoints disagree, and the row survives a fresh connection.

ingest() is worse, because it has no catch at all: it raises, leaves the partial write in the open transaction, and the next unrelated ingest() commits it. A rejected request for one session is persisted on the back of a later, successful request for a different one:

    request 1 (malformed, sess-A): raised, in_transaction=True
    request 2 (valid, sess-B):     succeeded
    -> sess-A: span_count=2, actual spans=1   (committed by request 2)

Wrap _ingest_one() in a SAVEPOINT and roll back to it on failure. A savepoint rather than rollback() because the batch path must keep the payloads that already succeeded -- rolling back the whole transaction would break the batching behaviour the docstring documents.

## What does this PR do?

<!-- A clear, concise description of the change. -->

## Related issues

<!-- e.g. Closes #123 -->

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [x] Docs updated if behavior or public APIs changed — nothing to update: `_ingest_one_atomic()` is a private helper, the three public entry points keep their signatures and their documented behaviour (the batch docstring's promise is what this PR makes true), and `docs/` does not document `otlp_store`'s API — `docs/concepts/tracing.md` describes the viewer only as a process to start.
- [x] New source files carry an SPDX license header — no new files: both paths are modifications (`git diff --name-status` reports `M`, `M`). `scripts/hooks/check_spdx.py` exits 0 on this branch and `scripts/check_license_headers.py` reports "all 929 source Python files carry an SPDX header".

Re-verified on `ec2eb12` (Windows 11 / CPython 3.13.6): `uv run ruff check .` → `All checks passed!`, `uv run ruff format --check .` → `926 files already formatted`, and `tests/viewer` → **154 passed, 2 deselected** against **153 passed, 2 deselected** on `main`. The added test is non-vacuous by fault injection: point `ingest()` back at `_ingest_one()` and it fails with `assert 2 == 1` — exactly the `span_count` 2 / 1 stored span mismatch described above. A full `uv run pytest` does not complete on this machine (`src/nooa/storage/sqlite.py:10` imports `fcntl`), so the run is scoped to `tests/viewer`.


Separate, single-claim fix from #270/#271 and independent of the connection-lifecycle fix on `fix/viewer-close-trace-db`, opened since as #273 — please review on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed telemetry payloads no longer leave behind partial session or span data.
  * Subsequent valid payloads can be ingested successfully after an ingestion error.

* **Tests**
  * Added regression coverage to verify failed payloads do not inflate span counts or commit incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->