### PR TITLE
fix(memory): exclude archived nodes from associative recall 🤖🤖🤖

### DIFF
--- a/packages/nooa-memory/src/nooa_memory/retrieval.py
+++ b/packages/nooa-memory/src/nooa_memory/retrieval.py
@@ -250,17 +250,20 @@ class RetrievalEngine:
 
         With ``owner``, spread is confined to visible memories (that owner +
         unowned): an edge must not leak — or amplify through — another agent's
-        memory in an owner-scoped recall.
+        memory in an owner-scoped recall. Archived memories never receive or
+        relay activation, regardless of owner scope.
         """
         cfg = self.config
         visible_cache: dict[str, bool] = {}
 
         def _visible(mid: str) -> bool:
-            if owner is None:
-                return True
             if mid not in visible_cache:
-                mem_owner = self.store.owner_of(mid)
-                visible_cache[mid] = mem_owner is not None and owner_matches(mem_owner, owner)
+                memory = self.store.get(mid)
+                visible_cache[mid] = (
+                    memory is not None
+                    and not memory.archived
+                    and (owner is None or owner_matches(memory.owner, owner))
+                )
             return visible_cache[mid]
 
         spread: dict[str, float] = {}

--- a/packages/nooa-memory/src/nooa_memory/retrieval.py
+++ b/packages/nooa-memory/src/nooa_memory/retrieval.py
@@ -257,6 +257,7 @@ class RetrievalEngine:
         visible_cache: dict[str, bool] = {}
 
         def _visible(mid: str) -> bool:
+            """Cache whether a non-archived record is visible to this recall's owner."""
             if mid not in visible_cache:
                 memory = self.store.get(mid)
                 visible_cache[mid] = (

--- a/packages/nooa-memory/tests/memory/test_memory_retrieval.py
+++ b/packages/nooa-memory/tests/memory/test_memory_retrieval.py
@@ -3,7 +3,7 @@
 """Tests for retrieval: scoring, recency/importance, multi-hop spread."""
 
 import pytest
-from nooa_memory.config import RetrievalConfig
+from nooa_memory.config import RetrievalConfig, ScoringWeights
 from nooa_memory.embeddings import HashingEmbedder
 from nooa_memory.retrieval import RetrievalEngine, base_level_activation
 from nooa_memory.schema import AccessRecord, EdgeType, Memory
@@ -99,3 +99,34 @@ def test_multi_hop_surfaces_linked_dissimilar_memory(store, emb):
     # A wins on relevance; B is pulled into the top-2 by associative spread
     # over the causal edge, beating the unlinked distractors.
     assert a.id in ids and b.id in ids
+
+
+@pytest.mark.parametrize("owner", [None, "alice"])
+def test_recall_does_not_resurface_archived_neighbor(store, emb, owner):
+    a = _add(store, emb, "deploy ship release production rollout", owner="alice", importance=10)
+    b = _add(store, emb, "obsolete instructions", owner="alice")
+    _add(store, emb, "deploy weather forecast", owner="alice", importance=0)
+    store.add_edge(a.id, b.id, EdgeType.CAUSES)
+    eng = RetrievalEngine(store, emb, RetrievalConfig(weights=ScoringWeights(recency=0)))
+    assert b.id in {m.id for m in eng.recall("deploy ship release", owner=owner, touch=False)}
+
+    store.archive(b.id)
+    res = eng.recall("deploy ship release", owner=owner)
+    assert a.id in {m.id for m in res}
+    assert b.id not in {m.id for m in res}
+    assert store.get(b.id).access_count == 0
+    assert b.id not in {row["id"] for row in eng.explain("deploy ship release", owner=owner)}
+
+
+@pytest.mark.parametrize("owner", [None, "alice"])
+def test_spread_does_not_relay_through_archived_memory(store, emb, owner):
+    a = _add(store, emb, "seed node", owner="alice")
+    b = _add(store, emb, "bridge node", owner="alice")
+    c = _add(store, emb, "downstream node", owner="alice")
+    store.add_edge(a.id, b.id, EdgeType.CAUSES)
+    store.add_edge(b.id, c.id, EdgeType.CAUSES)
+    eng = RetrievalEngine(store, emb, RetrievalConfig())
+    assert c.id in eng._spread({a.id: 1.0}, hops=2, owner=owner)
+
+    store.archive(b.id)
+    assert eng._spread({a.id: 1.0}, hops=2, owner=owner) == {}

--- a/packages/nooa-memory/tests/memory/test_memory_retrieval.py
+++ b/packages/nooa-memory/tests/memory/test_memory_retrieval.py
@@ -103,6 +103,7 @@ def test_multi_hop_surfaces_linked_dissimilar_memory(store, emb):
 
 @pytest.mark.parametrize("owner", [None, "alice"])
 def test_recall_does_not_resurface_archived_neighbor(store, emb, owner):
+    """Archiving a linked memory removes it from recall, explanations, and touches."""
     a = _add(store, emb, "deploy ship release production rollout", owner="alice", importance=10)
     b = _add(store, emb, "obsolete instructions", owner="alice")
     _add(store, emb, "deploy weather forecast", owner="alice", importance=0)
@@ -120,6 +121,7 @@ def test_recall_does_not_resurface_archived_neighbor(store, emb, owner):
 
 @pytest.mark.parametrize("owner", [None, "alice"])
 def test_spread_does_not_relay_through_archived_memory(store, emb, owner):
+    """An archived bridge cannot relay activation to otherwise reachable memories."""
     a = _add(store, emb, "seed node", owner="alice")
     b = _add(store, emb, "bridge node", owner="alice")
     c = _add(store, emb, "downstream node", owner="alice")


### PR DESCRIPTION
## What does this PR do?

An archived memory can reappear in associative recall and receive another access entry. It can also relay activation to other memories through a multi-hop path. Check that each graph target exists, is active, and matches the requested owner scope before adding it to the next frontier.

Add regressions for archived results and archived bridges, both with and without an owner filter. The four regression cases fail before the fix.

## Related issues

No matching open issue found.

## Validation

`uv run pytest -q packages/nooa-memory/tests/memory/test_memory_retrieval.py packages/nooa-memory/tests/memory/test_memory_owner.py packages/nooa-memory/tests/memory/test_memory_owner_roles.py` — 33 passed.

Validated on Windows/Python 3.12 with external import-only compatibility helpers for the existing `fcntl` and `SIGUSR2` blockers (#84/#85). The helpers are not included in this PR and do not validate POSIX locking or signals. No live model calls were used.

## Checklist

- [x] Ruff lint and formatting pass.
- [x] Regression and owner-isolation tests pass.
- [x] Traversal docstring updated.
- [x] Existing SPDX headers retained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archived memories are excluded from retrieval results and explanations.
  * Archived memories no longer receive activation or relay it to other memories.
  * Retrieval continues to include relevant active memories while respecting owner visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->