### PR TITLE
fix(storage): restore the last saved snapshot when timestamps tie 🤖🤖🤖

### DIFF
--- a/src/nooa/storage/sqlite.py
+++ b/src/nooa/storage/sqlite.py
@@ -837,7 +837,7 @@ class SQLiteStorageManager:
         """Return the snapshot_id of the most recently saved snapshot, or None."""
         with self._db_lock:
             row = self._conn.execute(
-                "SELECT snapshot_id FROM snapshots ORDER BY created_at DESC LIMIT 1"
+                "SELECT snapshot_id FROM snapshots ORDER BY created_at DESC, rowid DESC LIMIT 1"
             ).fetchone()
             return row[0] if row is not None else None
 

--- a/tests/test_sqlite_storage_latest.py
+++ b/tests/test_sqlite_storage_latest.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from unittest.mock import patch
+
 from nooa import Agent
 from nooa.storage import SQLiteStorageManager
 from nooa.unifiedllm import CompletionClient
@@ -57,3 +60,28 @@ def test_restore_latest_returns_most_recent():
     agent2 = _SimpleAgent(storage=storage)
     storage.restore_latest_snapshot(agent2)
     assert agent2.value == 99
+
+
+def test_latest_snapshot_breaks_timestamp_ties_after_reopen(tmp_path):
+    path = tmp_path / "snapshots.sqlite"
+    storage = SQLiteStorageManager(path)
+    try:
+        agent = _SimpleAgent(storage=storage)
+        with patch("nooa.storage.sqlite.datetime") as clock:
+            clock.now.return_value = datetime(2026, 1, 1, tzinfo=UTC)
+            agent.value = 1
+            storage.save_snapshot(agent)
+            agent.value = 99
+            latest = storage.save_snapshot(agent)
+        assert storage.get_latest_snapshot_id() == latest
+    finally:
+        storage.close()
+
+    reopened = SQLiteStorageManager(path)
+    try:
+        restored = _SimpleAgent(storage=reopened)
+        assert reopened.get_latest_snapshot_id() == latest
+        assert reopened.restore_latest_snapshot(restored)
+        assert restored.value == 99
+    finally:
+        reopened.close()

--- a/tests/test_sqlite_storage_latest.py
+++ b/tests/test_sqlite_storage_latest.py
@@ -48,6 +48,7 @@ def test_restore_latest_snapshot_returns_true_after_save():
 
 
 def test_restore_latest_returns_most_recent():
+    """Restoring without a snapshot ID loads the most recently saved agent state."""
     storage = _make_storage()
     agent = _SimpleAgent(storage=storage)
 
@@ -63,6 +64,7 @@ def test_restore_latest_returns_most_recent():
 
 
 def test_latest_snapshot_breaks_timestamp_ties_after_reopen(tmp_path):
+    """Save order breaks identical timestamps, including after reopening the database."""
     path = tmp_path / "snapshots.sqlite"
     storage = SQLiteStorageManager(path)
     try:


### PR DESCRIPTION
## What does this PR do?

Two snapshots can receive identical `created_at` timestamps. `restore_latest_snapshot()` then selects the earlier save, restoring stale agent state. Break timestamp ties by descending SQLite row insertion order while retaining timestamp ordering for distinct saves; no schema migration is required.

Add a fixed-clock regression that saves values 1 and 99 and checks that 99 is restored, including after reopening the database. It fails before the fix.

## Related issues

No matching open issue found. This does not change the context serialization or durable operation work in #235/#174.

## Validation

`uv run pytest -q tests/test_sqlite_storage_latest.py tests/storage` — 102 passed.

Windows/Python 3.12; external import-only helpers bypass the existing `fcntl`/`SIGUSR2` blockers (#84/#85). This verifies snapshot ordering and persistence, not POSIX locking or signal behavior. Helpers are not included.

## Checklist

- [x] Ruff lint and formatting pass.
- [x] Regression and storage tests pass.
- [x] No public API or documentation change required.
- [x] Existing SPDX headers retained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed snapshot retrieval so the most recently saved snapshot is consistently selected when multiple snapshots share the same creation time, including after reopening storage.
  * Snapshot ordering is now deterministic in these tie cases.

* **Tests**
  * Added regression coverage for snapshot ordering when timestamps are identical and storage is reopened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->