### PR TITLE
fix(memory): refresh derived state after memory updates 🤖🤖🤖

### DIFF
--- a/packages/nooa-memory/src/nooa_memory/manager.py
+++ b/packages/nooa-memory/src/nooa_memory/manager.py
@@ -403,14 +403,16 @@ class MemoryManager:
         status: str | None = None,
         references: list[str] | None = None,
     ) -> bool:
-        """Refine an existing memory in place (re-embeds if content changed)."""
+        """Refine a memory, refreshing derived metadata and changed embedding input."""
         m = self._find(memory_id)
         if m is None:
             return False
         self._assert_writable(m)
-        content_changed = content is not None and content != m.content
-        if content is not None:
-            m.content = content
+        embedding_before = m.embedding_text()
+        if content is not None and content != m.content:
+            # Reuse the schema's derivation rules without losing record history.
+            data = m.model_dump(exclude={"size_chars", "token_len", "sentence_count"})
+            m = Memory.model_validate({**data, "content": content})
         if importance is not None:
             m.importance = max(0.0, min(10.0, importance))
         if type is not None:
@@ -434,7 +436,7 @@ class MemoryManager:
             reinforce=False,
             cap=self.config.observability.access_log_cap,
         )
-        if content_changed:
+        if m.embedding_text() != embedding_before:
             self.store.add(m, self.embedder.embed(m.embedding_text()))  # re-embed + replace
         else:
             self.store.save(m)

--- a/packages/nooa-memory/tests/memory/test_memory_manager.py
+++ b/packages/nooa-memory/tests/memory/test_memory_manager.py
@@ -7,9 +7,12 @@ consolidation are exercised directly.
 """
 
 from pathlib import Path
+from unittest.mock import patch
 
+import numpy as np
 import pytest
 from nooa_memory import (
+    Memory,
     MemoryConfig,
     MemoryManager,
     MemoryToolsMixin,
@@ -152,6 +155,44 @@ def test_remember_dedups_on_write(agent):
     assert id1 == id2  # NOOP: reinforced the existing memory
     assert mgr.store.count() == 1
     assert mgr.store.get(id1).reinforcement_count >= 1
+
+
+@pytest.mark.parametrize("content", ["A longer sentence. Another sentence! A third?", "Hi.", ""])
+def test_update_refreshes_content_metadata(agent, content):
+    mgr = _install(agent)
+    try:
+        mid = mgr.remember("Original content to be revised.", tags=["original"])
+        before = mgr.store.get(mid)
+        assert mgr.update(mid, content=content)
+        after = mgr.store.get(mid)
+        expected = Memory(content=content)
+        assert after.content == content
+        for field in ("size_chars", "token_len", "sentence_count"):
+            assert getattr(after, field) == getattr(expected, field)
+        for field in ("id", "owner", "created_at", "tags"):
+            assert getattr(after, field) == getattr(before, field)
+        assert after.access_log[:-1] == before.access_log
+        assert after.reinforcement_count == before.reinforcement_count + 1
+    finally:
+        mgr.uninstall()
+
+
+@pytest.mark.parametrize("tags", [["aardvark", "zebra"], []])
+def test_update_reembeds_changed_tags_only_when_needed(agent, tags):
+    mgr = _install(agent)
+    try:
+        mid = mgr.remember("A stored fact.", tags=["original"])
+        original = mgr.store.get_embedding(mid)
+        assert mgr.update(mid, tags=tags)
+        current = mgr.store.get(mid)
+        expected = mgr.embedder.embed(current.embedding_text())
+        assert not np.allclose(original, expected)
+        np.testing.assert_allclose(mgr.store.get_embedding(mid), expected)
+        with patch.object(mgr.embedder, "embed", wraps=mgr.embedder.embed) as embed:
+            assert mgr.update(mid, tags=tags, importance=9)
+            embed.assert_not_called()
+    finally:
+        mgr.uninstall()
 
 
 # --------------------------------------------------------------------------

--- a/packages/nooa-memory/tests/memory/test_memory_manager.py
+++ b/packages/nooa-memory/tests/memory/test_memory_manager.py
@@ -149,6 +149,7 @@ def test_remember_and_recall_via_tools(agent):
 
 
 def test_remember_dedups_on_write(agent):
+    """Remembering an existing fact reinforces its record instead of adding a duplicate."""
     mgr = _install(agent)
     id1 = agent.remember("identical fact about shipping releases", type="info")
     id2 = agent.remember("identical fact about shipping releases", type="info")
@@ -159,6 +160,7 @@ def test_remember_dedups_on_write(agent):
 
 @pytest.mark.parametrize("content", ["A longer sentence. Another sentence! A third?", "Hi.", ""])
 def test_update_refreshes_content_metadata(agent, content):
+    """Content edits recalculate size metadata while preserving identity and history."""
     mgr = _install(agent)
     try:
         mid = mgr.remember("Original content to be revised.", tags=["original"])
@@ -179,6 +181,7 @@ def test_update_refreshes_content_metadata(agent, content):
 
 @pytest.mark.parametrize("tags", [["aardvark", "zebra"], []])
 def test_update_reembeds_changed_tags_only_when_needed(agent, tags):
+    """Changed tags refresh the embedding, but unchanged embedding input is reused."""
     mgr = _install(agent)
     try:
         mid = mgr.remember("A stored fact.", tags=["original"])


### PR DESCRIPTION
## What does this PR do?

Updating a memory's content leaves its size, token estimate, and sentence count describing the previous text. Updating only tags leaves the embedding describing the previous tags, even though tags are part of `embedding_text()`.

Re-derive content metadata through the Memory schema on content changes and re-embed when the embedding input changes. Preserve record identity and history; unrelated edits and unchanged tags do not call the embedder.

## Validation

Five new cases fail before the fix: longer, shorter, and empty content updates, plus tag replacement and removal. `uv run pytest -q packages/nooa-memory/tests/memory/test_memory_manager.py packages/nooa-memory/tests/memory/test_memory_todo.py packages/nooa-memory/tests/memory/test_memory_owner.py packages/nooa-memory/tests/memory/test_memory_schema.py` — 67 passed.

Windows/Python 3.12, deterministic offline hashing embedder. External import-only helpers bypass #84/#85 (`fcntl`/`SIGUSR2`); they are not part of this PR and do not validate locking or signals.

## Related issues

No matching open issue found.

## Checklist

- [x] Ruff lint and formatting pass.
- [x] Regression and related tests pass.
- [x] Update docstring describes the behavior.
- [x] Existing SPDX headers retained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated memories now refresh derived metadata when their content changes while preserving existing history and identity.
  - Embeddings are refreshed whenever the text used to generate them changes, including tag updates.
  - Avoided unnecessary embedding updates when relevant text remains unchanged.

- **Tests**
  - Added coverage for metadata preservation, reinforcement counts, embedding refreshes, and redundant update prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->