### PR TITLE
fix(memory): match memory ID prefixes literally 🤖🤖🤖

### DIFF
--- a/packages/nooa-memory/src/nooa_memory/store.py
+++ b/packages/nooa-memory/src/nooa_memory/store.py
@@ -341,8 +341,9 @@ class MemoryStore:
                 return str(row["id"])
             if len(id_or_prefix) < 6:
                 return None
+            prefix = id_or_prefix.replace("!", "!!").replace("%", "!%").replace("_", "!_")
             rows = self._conn.execute(
-                "SELECT id FROM memories WHERE id LIKE ? LIMIT 2", (id_or_prefix + "%",)
+                "SELECT id FROM memories WHERE id LIKE ? ESCAPE '!' LIMIT 2", (prefix + "%",)
             ).fetchall()
             if len(rows) > 1:
                 raise ValueError(f"memory id prefix {id_or_prefix!r} is ambiguous")

--- a/packages/nooa-memory/tests/memory/test_memory_contract.py
+++ b/packages/nooa-memory/tests/memory/test_memory_contract.py
@@ -141,6 +141,20 @@ def test_too_short_prefix_is_not_found(agent):
     assert agent.forget("abc") is False  # <6 chars never prefix-matches
 
 
+@pytest.mark.parametrize("prefix", ["%%%%%%", "______"])
+def test_wildcard_prefix_cannot_update_or_forget_memory(agent, prefix):
+    mgr = _install(agent)
+    try:
+        mid = agent.remember("original fact", type="info")
+        assert agent.update_memory(prefix, content="wrong replacement") is False
+        assert agent.forget(prefix) is False
+        stored = mgr.store.get(mid)
+        assert stored.content == "original fact"
+        assert stored.archived is False
+    finally:
+        mgr.uninstall()
+
+
 # --------------------------------------------------------------------------
 # raise-don't-recover at the tool boundary
 # --------------------------------------------------------------------------

--- a/packages/nooa-memory/tests/memory/test_memory_contract.py
+++ b/packages/nooa-memory/tests/memory/test_memory_contract.py
@@ -136,6 +136,7 @@ def test_ambiguous_prefix_raises(agent):
 
 
 def test_too_short_prefix_is_not_found(agent):
+    """A prefix shorter than the public minimum cannot select a stored memory."""
     _install(agent)
     agent.remember("something", type="info")
     assert agent.forget("abc") is False  # <6 chars never prefix-matches
@@ -143,6 +144,7 @@ def test_too_short_prefix_is_not_found(agent):
 
 @pytest.mark.parametrize("prefix", ["%%%%%%", "______"])
 def test_wildcard_prefix_cannot_update_or_forget_memory(agent, prefix):
+    """Wildcard-looking input leaves unrelated memory content and archive state intact."""
     mgr = _install(agent)
     try:
         mid = agent.remember("original fact", type="info")

--- a/packages/nooa-memory/tests/memory/test_memory_store.py
+++ b/packages/nooa-memory/tests/memory/test_memory_store.py
@@ -42,6 +42,21 @@ def test_add_get_roundtrip(store, emb):
     assert got.importance == 7.0
 
 
+@pytest.mark.parametrize("prefix", ["%%%%%%", "______", "abcde%", "abcde_"])
+def test_resolve_id_does_not_expand_sql_wildcards(store, prefix):
+    store.add(Memory(id="abcdef123456", content="original"))
+    assert store.resolve_id(prefix) is None
+
+
+@pytest.mark.parametrize("character", ["%", "_", "!"])
+def test_resolve_id_matches_literal_special_characters(store, character):
+    mid = f"abcde{character}123456"
+    store.add(Memory(id=mid, content="literal id"))
+    store.add(Memory(id="abcdef123456", content="different id"))
+    assert store.resolve_id(mid) == mid
+    assert store.resolve_id(mid[:6]) == mid
+
+
 def test_save_persists_mutation(store, emb):
     m = _add(store, emb, "fact")
     m.touch()

--- a/packages/nooa-memory/tests/memory/test_memory_store.py
+++ b/packages/nooa-memory/tests/memory/test_memory_store.py
@@ -34,6 +34,7 @@ def _add(store, emb, content, **kw):
 
 
 def test_add_get_roundtrip(store, emb):
+    """Reading a newly stored memory preserves its content and importance."""
     m = _add(store, emb, "deploy uses make ship", type=MemoryType.SKILL, importance=7.0)
     got = store.get(m.id)
     assert got is not None
@@ -44,12 +45,14 @@ def test_add_get_roundtrip(store, emb):
 
 @pytest.mark.parametrize("prefix", ["%%%%%%", "______", "abcde%", "abcde_"])
 def test_resolve_id_does_not_expand_sql_wildcards(store, prefix):
+    """SQL wildcard characters cannot broaden an otherwise nonmatching ID prefix."""
     store.add(Memory(id="abcdef123456", content="original"))
     assert store.resolve_id(prefix) is None
 
 
 @pytest.mark.parametrize("character", ["%", "_", "!"])
 def test_resolve_id_matches_literal_special_characters(store, character):
+    """Literal percent, underscore, and escape characters remain valid ID text."""
     mid = f"abcde{character}123456"
     store.add(Memory(id=mid, content="literal id"))
     store.add(Memory(id="abcdef123456", content="different id"))
@@ -58,6 +61,7 @@ def test_resolve_id_matches_literal_special_characters(store, character):
 
 
 def test_save_persists_mutation(store, emb):
+    """Saving an existing memory persists its updated access metadata."""
     m = _add(store, emb, "fact")
     m.touch()
     m.importance = 9.0


### PR DESCRIPTION
## What does this PR do?

`resolve_id()` treats `%` and `_` in an ID prefix as SQL LIKE wildcards. With one stored memory, `update_memory("%%%%%%", ...)` updates that record, and `forget("______")` can archive it even though neither is a prefix of its ID.

Escape LIKE metacharacters and the escape character so prefixes are matched literally. Keep exact matches, abbreviated IDs, and ambiguous-prefix errors. This is incorrect wildcard interpretation in a parameterized query, not SQL injection.

## Validation

Eight new regression cases fail before the fix; a ninth verifies literal escape-character handling. Store and public-tool tests cover literal special characters and preservation of records after invalid update/forget requests.

`uv run pytest -q packages/nooa-memory/tests/memory/test_memory_store.py packages/nooa-memory/tests/memory/test_memory_contract.py` — 35 passed.

Windows/Python 3.12 with external import-only helpers for #84/#85. A broader run also passed 19 reference tests; the existing POSIX absolute-path error-message assertion fails on Windows. Helpers are not included and do not validate POSIX locks/signals.

## Related issues

No matching open issue found.

## Checklist

- [x] Ruff lint and formatting pass.
- [x] Regression and related store/tool tests pass.
- [x] Existing literal-prefix API contract retained.
- [x] Existing SPDX headers retained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed memory ID resolution so `%`, `_`, and `!` are treated as literal characters rather than wildcard patterns.
  - Prevented wildcard-like prefixes from incorrectly updating, forgetting, or archiving stored memories.
  - Improved reliability when searching for memories using IDs or prefixes containing special characters.

- **Tests**
  - Added regression coverage for literal-character handling, unmatched prefixes, exact and prefix resolution, and safe memory operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->