### PR TITLE
fix(memory): validate merged configuration 🤖🤖🤖

### DIFF
--- a/packages/nooa-memory/src/nooa_memory/config.py
+++ b/packages/nooa-memory/src/nooa_memory/config.py
@@ -198,5 +198,5 @@ class MemoryConfig(BaseModel, frozen=True):
     observability: ObservabilityConfig = ObservabilityConfig()
 
     def merge_with(self, **overrides: object) -> MemoryConfig:
-        """Return a copy with top-level fields overridden."""
-        return self.model_copy(update=overrides)
+        """Return a validated copy with top-level fields overridden."""
+        return type(self).model_validate({**self.model_dump(), **overrides})

--- a/packages/nooa-memory/tests/memory/test_memory_config.py
+++ b/packages/nooa-memory/tests/memory/test_memory_config.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration merging obeys the same validation rules as construction."""
+
+import pytest
+from nooa_memory.config import EmbeddingConfig, MemoryConfig
+from pydantic import ValidationError
+
+
+def test_merge_coerces_boolean_without_mutating_original():
+    original = MemoryConfig(enabled=True, path=":memory:")
+    merged = original.merge_with(enabled="false")
+    assert merged.enabled is False
+    assert merged.path == original.path
+    assert original.enabled is True
+
+
+def test_merge_validates_nested_config_as_top_level_replacement():
+    original = MemoryConfig(embedding=EmbeddingConfig(dim=64, batch_size=3))
+    merged = original.merge_with(embedding={"backend": "hashing", "dim": 16})
+    assert isinstance(merged.embedding, EmbeddingConfig)
+    assert merged.embedding.dim == 16
+    assert merged.embedding.batch_size == EmbeddingConfig().batch_size
+    assert original.embedding.dim == 64
+    assert original.embedding.batch_size == 3
+
+
+@pytest.mark.parametrize(
+    "overrides", [{"owner": "invalid_owner"}, {"embedding": {"backend": "unknown"}}]
+)
+def test_merge_rejects_invalid_configuration(overrides):
+    with pytest.raises(ValidationError):
+        MemoryConfig().merge_with(**overrides)

--- a/packages/nooa-memory/tests/memory/test_memory_config.py
+++ b/packages/nooa-memory/tests/memory/test_memory_config.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 
 
 def test_merge_coerces_boolean_without_mutating_original():
+    """Overrides use Pydantic coercion without changing the original configuration."""
     original = MemoryConfig(enabled=True, path=":memory:")
     merged = original.merge_with(enabled="false")
     assert merged.enabled is False
@@ -16,6 +17,7 @@ def test_merge_coerces_boolean_without_mutating_original():
 
 
 def test_merge_validates_nested_config_as_top_level_replacement():
+    """Nested dictionaries become validated models using top-level replacement semantics."""
     original = MemoryConfig(embedding=EmbeddingConfig(dim=64, batch_size=3))
     merged = original.merge_with(embedding={"backend": "hashing", "dim": 16})
     assert isinstance(merged.embedding, EmbeddingConfig)
@@ -29,5 +31,6 @@ def test_merge_validates_nested_config_as_top_level_replacement():
     "overrides", [{"owner": "invalid_owner"}, {"embedding": {"backend": "unknown"}}]
 )
 def test_merge_rejects_invalid_configuration(overrides):
+    """Invalid owner and embedding settings fail during the merge, not at later use."""
     with pytest.raises(ValidationError):
         MemoryConfig().merge_with(**overrides)


### PR DESCRIPTION
## What does this PR do?

`MemoryConfig.merge_with()` bypasses Pydantic validation: `enabled="false"` remains truthy, invalid owners are accepted, and nested embedding dictionaries remain plain dictionaries that fail when used by the manager.

Validate the merged data through the configuration class. Preserve the documented top-level replacement behavior and the original frozen configuration.

## Validation

All four new cases fail before the fix. `uv run pytest -q packages/nooa-memory/tests/memory/test_memory_config.py packages/nooa-memory/tests/memory/test_memory_skill.py packages/nooa-memory/tests/memory/test_memory_owner_roles.py` — 19 passed, including the MemorySkill call site of `merge_with()`.

Windows/Python 3.12 with external import-only helpers for the existing `fcntl`/`SIGUSR2` blockers (#84/#85). No live model calls; helpers are not included and do not validate locking or signals.

## Related issues

No matching open issue found.

## Checklist

- [x] Ruff lint and formatting pass.
- [x] Regression and related tests pass.
- [x] Docstring states validation behavior.
- [x] SPDX header check passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration overrides are now validated before being applied, improving handling of type conversions and invalid values.
  * Nested embedding settings correctly replace prior values while restoring applicable defaults.
  * Original configuration remains unchanged when overrides are applied.

* **Tests**
  * Added coverage for configuration validation, boolean coercion, nested settings, invalid owner values, and unsupported embedding backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->