### PR TITLE
fix(skills): decode skill bodies as UTF-8 🤖🤖🤖

### DIFF
--- a/src/nooa/skill.py
+++ b/src/nooa/skill.py
@@ -208,7 +208,7 @@ def _parse_skill_md(path: Path) -> tuple[str, str, str]:
 
     props = _read_skill_properties(path)
     description = props.description or path.name
-    _, body = _parse_frontmatter(skill_md.read_text())
+    _, body = _parse_frontmatter(skill_md.read_text(encoding="utf-8"))
     return skill_id, description, body.strip()
 
 

--- a/tests/unit/test_skill.py
+++ b/tests/unit/test_skill.py
@@ -34,6 +34,18 @@ def test_skill_path_creates_dynamic_subclass(skill_dir):
     assert "Best practices for Git" in (type(skill).__doc__ or "")
 
 
+def test_skill_body_preserves_utf8_with_legacy_default(skill_dir, monkeypatch):
+    body = "Budget: 50€ → café 中文 🚀"
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: git-workflow\ndescription: Unicode instructions\n---\n{body}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("io.text_encoding", lambda encoding, stacklevel=2: encoding or "cp1252")
+    skill = TextSkill(path=skill_dir)
+    assert skill.description == "Unicode instructions"
+    assert (type(skill).__doc__ or "").split("\n---\n", 1)[1] == body
+
+
 def test_skill_content_constructor():
     skill = Skill(content="A helpful skill.")
     assert "A helpful skill." in (type(skill).__doc__ or "")

--- a/tests/unit/test_skill.py
+++ b/tests/unit/test_skill.py
@@ -29,12 +29,14 @@ def test_skill_path_loads_id(skill_dir):
 
 
 def test_skill_path_creates_dynamic_subclass(skill_dir):
+    """A path-loaded skill exposes its description through a generated skill subclass."""
     skill = TextSkill(path=skill_dir)
     assert type(skill).__name__ != "Skill"
     assert "Best practices for Git" in (type(skill).__doc__ or "")
 
 
 def test_skill_body_preserves_utf8_with_legacy_default(skill_dir, monkeypatch):
+    """UTF-8 instructions reach the skill docstring unchanged under a legacy locale."""
     body = "Budget: 50€ → café 中文 🚀"
     (skill_dir / "SKILL.md").write_text(
         f"---\nname: git-workflow\ndescription: Unicode instructions\n---\n{body}\n",
@@ -47,6 +49,7 @@ def test_skill_body_preserves_utf8_with_legacy_default(skill_dir, monkeypatch):
 
 
 def test_skill_content_constructor():
+    """Direct text construction exposes the provided instructions in the skill docstring."""
     skill = Skill(content="A helpful skill.")
     assert "A helpful skill." in (type(skill).__doc__ or "")
 


### PR DESCRIPTION
## What does this PR do?

Skill metadata is read as UTF-8, but `_parse_skill_md()` reads the body using the locale encoding. A UTF-8 skill containing `50€ → café 中文 🚀` becomes corrupted instructions on a cp1252 host. Read the body as UTF-8 too.

Add a regression that forces a legacy default even on UTF-8 hosts and checks the loaded skill's full body. The test fails before the fix.

## Related issues

The parser remains in use in #161; this change is limited to its body decoding and does not alter that refactor's APIs or arbitrary-file encoding policy.

## Validation

`uv run pytest -q tests/unit/test_skill.py -k 'not run_script'` — 19 passed, 7 Bash-dependent tests deselected.

Windows/Python 3.12 with external import-only helpers for #84/#85 (`fcntl`/`SIGUSR2`). Helpers are not included; POSIX locks/signals and Bash execution are not validated by this run.

## Checklist

- [x] Ruff lint and formatting pass.
- [x] Regression and skill-loading tests pass.
- [x] Existing UTF-8 skill format retained.
- [x] Existing SPDX headers retained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Skill files are now consistently read as UTF-8, preserving Unicode characters regardless of the platform’s default text encoding.
  - Skill descriptions continue to be parsed correctly when files contain Unicode content.

- **Tests**
  - Added regression coverage for loading path-based skills with Unicode content under differing default encodings.
  - Added explanatory documentation to related test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->