### PR TITLE
fix(paths): resolve project directories from the working directory 🤖🤖🤖

### DIFF
--- a/src/nooa/paths.py
+++ b/src/nooa/paths.py
@@ -29,16 +29,16 @@ DIR_NAME = ".nooa"
 
 
 def find_project_root() -> Path:
-    """Walk up from this file to find the project root (where pyproject.toml lives).
+    """Find the nearest project root by walking up from the working directory.
 
-    Falls back to ``Path.cwd()`` if no ``pyproject.toml`` is found (e.g. when
-    the package is installed into site-packages rather than run from source).
+    Include the working directory itself and fall back to it when no
+    ``pyproject.toml`` is found, independently of the library's installation path.
     """
-    current = Path(__file__).resolve()
-    for parent in current.parents:
+    current = Path.cwd().resolve()
+    for parent in (current, *current.parents):
         if (parent / "pyproject.toml").exists():
             return parent
-    return Path.cwd()
+    return current
 
 
 def get_user_dir(*parts: str) -> Path:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from nooa.paths import get_user_dir
+import pytest
+
+from nooa.paths import find_project_root, get_project_dir, get_user_dir
 
 
 def test_xdg_user_dir_uses_nooa_name(tmp_path, monkeypatch):
@@ -9,3 +11,37 @@ def test_xdg_user_dir_uses_nooa_name(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     assert get_user_dir() == tmp_path / "nooa"
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_project_root_starts_at_working_directory(tmp_path, monkeypatch, nested):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").touch()
+    cwd = project / "src" if nested else project
+    cwd.mkdir(exist_ok=True)
+    monkeypatch.chdir(cwd)
+    monkeypatch.delenv("NEMO_OO_PROJECT_DIR", raising=False)
+
+    assert find_project_root() == project
+    assert get_project_dir("sessions") == project / ".nooa" / "sessions"
+
+
+def test_project_root_uses_nearest_project(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").touch()
+    child = tmp_path / "child"
+    child.mkdir()
+    (child / "pyproject.toml").touch()
+    monkeypatch.chdir(child)
+    assert find_project_root() == child
+
+
+def test_project_root_without_marker_falls_back_to_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    assert find_project_root() == tmp_path
+
+
+def test_project_dir_honors_override(tmp_path, monkeypatch):
+    override = tmp_path / "custom-nooa"
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(override))
+    assert get_project_dir("settings.yaml") == override / "settings.yaml"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -7,6 +7,7 @@ from nooa.paths import find_project_root, get_project_dir, get_user_dir
 
 
 def test_xdg_user_dir_uses_nooa_name(tmp_path, monkeypatch):
+    """User-level settings retain their XDG-based nooa directory."""
     monkeypatch.delenv("NEMO_OO_USER_DIR", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
@@ -15,6 +16,7 @@ def test_xdg_user_dir_uses_nooa_name(tmp_path, monkeypatch):
 
 @pytest.mark.parametrize("nested", [False, True])
 def test_project_root_starts_at_working_directory(tmp_path, monkeypatch, nested):
+    """Project-local paths belong to the caller's project, including from subdirectories."""
     project = tmp_path / "project"
     project.mkdir()
     (project / "pyproject.toml").touch()
@@ -28,6 +30,7 @@ def test_project_root_starts_at_working_directory(tmp_path, monkeypatch, nested)
 
 
 def test_project_root_uses_nearest_project(tmp_path, monkeypatch):
+    """A nested project's marker takes precedence over an ancestor project's marker."""
     (tmp_path / "pyproject.toml").touch()
     child = tmp_path / "child"
     child.mkdir()
@@ -37,11 +40,13 @@ def test_project_root_uses_nearest_project(tmp_path, monkeypatch):
 
 
 def test_project_root_without_marker_falls_back_to_cwd(tmp_path, monkeypatch):
+    """Without a project marker, local state stays beneath the working directory."""
     monkeypatch.chdir(tmp_path)
     assert find_project_root() == tmp_path
 
 
 def test_project_dir_honors_override(tmp_path, monkeypatch):
+    """An explicit project-directory override still wins over automatic discovery."""
     override = tmp_path / "custom-nooa"
     monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(override))
     assert get_project_dir("settings.yaml") == override / "settings.yaml"


### PR DESCRIPTION
## What does this PR do?

In an editable install, `get_project_dir()` resolves `.nooa` under the framework checkout even when called from another project. Project configuration, sessions, and generated libraries can therefore use the wrong project's directory.

Search upward from the working directory, including that directory, for the nearest `pyproject.toml`. This matches the existing implementation and rationale in `nooa_cli._common.find_project_root()`. Preserve the working-directory fallback and `NEMO_OO_PROJECT_DIR` override; no import dependency on the optional CLI is added.

## Validation

Four regression cases fail before the fix. Afterward all 6 path tests pass. The related config-chain suite has 15 passing tests and one existing Windows failure because this host cannot create the symlink required by `test_symlink_dedup`.

Command: `uv run pytest -q tests/test_paths.py tests/test_llm_config_chain.py` — 21 passed, 1 platform-dependent failure as above.

Windows/Python 3.12 with external import-only helpers for #84/#85 (`fcntl`/`SIGUSR2`). Helpers are not included and do not validate POSIX locks/signals.

## Related issues

No matching open issue found.

## Checklist

- [x] Ruff lint and formatting pass.
- [x] Path regressions pass; related Windows test limitation disclosed.
- [x] Root-discovery docstring updated.
- [x] Existing SPDX headers retained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Project root detection now starts from the current working directory and correctly selects the nearest project marker.
  - When no project marker is found, the current directory is used as the fallback.
  - Project-directory overrides and user-directory behavior now work as expected, including from nested working directories.

- **Tests**
  - Expanded coverage for nested directories, project root discovery, fallback behavior, nearest-marker selection, directory overrides, and user-directory handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->