### PR TITLE
fix(memory): defer resources for disabled managers 🤖🤖🤖

### DIFF
--- a/packages/nooa-memory/src/nooa_memory/README.md
+++ b/packages/nooa-memory/src/nooa_memory/README.md
@@ -35,6 +35,11 @@ accreted over time**, modeled on how the brain uses memory.
 When `enabled=False` (or not installed), the agent is byte-for-byte unchanged — the
 *additive guarantee* (regression-tested).
 
+A disabled installation does not construct an embedder or open its database.
+Explicitly accessing the manager's store or calling its operations initializes
+the resources on demand; agent-facing memory tools remain disabled. Uninstalling
+an unused disabled manager does not create resources either.
+
 ---
 
 ## Quick start

--- a/packages/nooa-memory/src/nooa_memory/manager.py
+++ b/packages/nooa-memory/src/nooa_memory/manager.py
@@ -23,6 +23,7 @@ import logging
 import threading
 import time
 from collections.abc import Callable
+from functools import cached_property
 from typing import Any
 
 from nooa.agent import Agent
@@ -141,24 +142,7 @@ class MemoryManager:
         # the TUI pass their stable per-agent key; "" writes to the shared
         # namespace); the honest library default is the agent's class name.
         self.owner = self.config.owner if self.config.owner is not None else type(agent).__name__
-        self.embedder = embedder or get_embedder(self.config.embedding)
-        self.store = self._make_store(agent)
-        self.retrieval = RetrievalEngine(
-            self.store,
-            self.embedder,
-            self.config.retrieval,
-            access_log_cap=self.config.observability.access_log_cap,
-        )
-        # Engines consolidate at ROLE scope: instance scope would fragment
-        # knowledge per session (and reflection must fold across instances).
-        self.reflection_engine = ReflectionEngine(
-            self.store,
-            self.embedder,
-            self.config.reflection,
-            self.config.forget,
-            owner=self.role,
-        )
-        self.forgetting = ForgettingEngine(self.store, self.config.forget, owner=self.role)
+        self._provided_embedder = embedder
         self._reasoner = reasoner
         self._reconciler = reconciler
         self.stats = MemoryStats()
@@ -174,7 +158,42 @@ class MemoryManager:
         self._last_query_hash: int | None = None
         self._primed = False
 
+        if self.config.enabled:
+            # Keep enabled installs eager, including backend validation.
+            _ = self.retrieval, self.reflection_engine, self.forgetting
         self._install_hooks()
+
+    @cached_property
+    def embedder(self) -> Embedder:
+        return self._provided_embedder or get_embedder(self.config.embedding)
+
+    @cached_property
+    def store(self) -> MemoryStore:
+        return self._make_store(self.agent)
+
+    @cached_property
+    def retrieval(self) -> RetrievalEngine:
+        return RetrievalEngine(
+            self.store,
+            self.embedder,
+            self.config.retrieval,
+            access_log_cap=self.config.observability.access_log_cap,
+        )
+
+    @cached_property
+    def reflection_engine(self) -> ReflectionEngine:
+        # Engines consolidate at ROLE scope, folding knowledge across instances.
+        return ReflectionEngine(
+            self.store,
+            self.embedder,
+            self.config.reflection,
+            self.config.forget,
+            owner=self.role,
+        )
+
+    @cached_property
+    def forgetting(self) -> ForgettingEngine:
+        return ForgettingEngine(self.store, self.config.forget, owner=self.role)
 
     def _make_store(self, agent: Agent) -> MemoryStore:
         path = self.config.path or self._default_path(agent)
@@ -244,7 +263,10 @@ class MemoryManager:
             if not task.done():
                 task.cancel()
         self._pending.clear()
-        self.store.close()
+        # Uninstalling an unused disabled manager must not initialize its store.
+        store = self.__dict__.get("store")
+        if store is not None:
+            store.close()
         if getattr(self.agent, "_memory", None) is self:
             del self.agent._memory  # type: ignore[attr-defined]
 

--- a/packages/nooa-memory/src/nooa_memory/manager.py
+++ b/packages/nooa-memory/src/nooa_memory/manager.py
@@ -165,14 +165,17 @@ class MemoryManager:
 
     @cached_property
     def embedder(self) -> Embedder:
+        """Reuse the supplied embedder or construct the configured backend on first use."""
         return self._provided_embedder or get_embedder(self.config.embedding)
 
     @cached_property
     def store(self) -> MemoryStore:
+        """Open the configured memory database once, only when storage is needed."""
         return self._make_store(self.agent)
 
     @cached_property
     def retrieval(self) -> RetrievalEngine:
+        """Build the recall engine against this manager's shared store and embedder."""
         return RetrievalEngine(
             self.store,
             self.embedder,
@@ -182,6 +185,7 @@ class MemoryManager:
 
     @cached_property
     def reflection_engine(self) -> ReflectionEngine:
+        """Initialize role-scoped reflection lazily, sharing the manager's resources."""
         # Engines consolidate at ROLE scope, folding knowledge across instances.
         return ReflectionEngine(
             self.store,
@@ -193,9 +197,11 @@ class MemoryManager:
 
     @cached_property
     def forgetting(self) -> ForgettingEngine:
+        """Initialize role-scoped forgetting against the cached memory store."""
         return ForgettingEngine(self.store, self.config.forget, owner=self.role)
 
     def _make_store(self, agent: Agent) -> MemoryStore:
+        """Open explicit or agent-default storage using the configured embedding dimension."""
         path = self.config.path or self._default_path(agent)
         return MemoryStore(path, vector_config=self.config.vector, embedding_dim=self.embedder.dim)
 

--- a/packages/nooa-memory/tests/memory/test_memory_manager.py
+++ b/packages/nooa-memory/tests/memory/test_memory_manager.py
@@ -69,6 +69,39 @@ def test_disabled_install_is_inert(agent):
     assert len(agent.event_manager._middleware["agent_call"]) == 0
 
 
+def test_disabled_install_does_not_create_database(agent, tmp_path):
+    path = tmp_path / "unused" / "memory.sqlite"
+    mgr = MemoryManager.install(agent, config=MemoryConfig(enabled=False, path=str(path)))
+    try:
+        assert not path.parent.exists()
+    finally:
+        mgr.uninstall()
+    assert not path.parent.exists()
+
+
+def test_disabled_install_does_not_construct_embedder(agent, monkeypatch):
+    def unexpected_embedder(config):
+        pytest.fail("disabled installation constructed an embedder")
+
+    monkeypatch.setattr("nooa_memory.manager.get_embedder", unexpected_embedder)
+    mgr = MemoryManager.install(agent, config=MemoryConfig(enabled=False, path=":memory:"))
+    mgr.uninstall()
+
+
+def test_disabled_manager_explicit_use_initializes_resources_once(agent, tmp_path):
+    path = tmp_path / "memory.sqlite"
+    mgr = MemoryManager.install(agent, config=MemoryConfig(enabled=False, path=str(path)))
+    try:
+        mid = mgr.remember("explicit manager operation")
+        assert path.exists()
+        store = mgr.store
+        assert mgr.store is store
+        assert store.get(mid).content == "explicit manager operation"
+        assert mgr._unsubs == []
+    finally:
+        mgr.uninstall()
+
+
 def test_install_replaces_existing_manager_without_leaking_hooks(agent):
     first = _install(agent)
     second = _install(agent)

--- a/packages/nooa-memory/tests/memory/test_memory_manager.py
+++ b/packages/nooa-memory/tests/memory/test_memory_manager.py
@@ -64,12 +64,14 @@ def test_uninstall_removes_all_hooks(agent):
 
 
 def test_disabled_install_is_inert(agent):
+    """Disabled installation does not register hooks or enable agent-facing memory tools."""
     mgr = MemoryManager.install(agent, config=MemoryConfig(enabled=False, path=":memory:"))
     assert mgr._unsubs == []
     assert len(agent.event_manager._middleware["agent_call"]) == 0
 
 
 def test_disabled_install_does_not_create_database(agent, tmp_path):
+    """Installing and uninstalling an unused disabled manager leaves the filesystem alone."""
     path = tmp_path / "unused" / "memory.sqlite"
     mgr = MemoryManager.install(agent, config=MemoryConfig(enabled=False, path=str(path)))
     try:
@@ -80,7 +82,10 @@ def test_disabled_install_does_not_create_database(agent, tmp_path):
 
 
 def test_disabled_install_does_not_construct_embedder(agent, monkeypatch):
+    """An unused disabled manager never needs to construct an embedding backend."""
+
     def unexpected_embedder(config):
+        """Fail immediately if disabled installation tries to initialize embedding resources."""
         pytest.fail("disabled installation constructed an embedder")
 
     monkeypatch.setattr("nooa_memory.manager.get_embedder", unexpected_embedder)
@@ -89,6 +94,7 @@ def test_disabled_install_does_not_construct_embedder(agent, monkeypatch):
 
 
 def test_disabled_manager_explicit_use_initializes_resources_once(agent, tmp_path):
+    """Direct manager operations lazily reuse resources without enabling agent-facing hooks."""
     path = tmp_path / "memory.sqlite"
     mgr = MemoryManager.install(agent, config=MemoryConfig(enabled=False, path=str(path)))
     try:
@@ -103,6 +109,7 @@ def test_disabled_manager_explicit_use_initializes_resources_once(agent, tmp_pat
 
 
 def test_install_replaces_existing_manager_without_leaking_hooks(agent):
+    """Replacing a manager unregisters the previous hooks before installing new ones."""
     first = _install(agent)
     second = _install(agent)
 


### PR DESCRIPTION
## What does this PR do?

Installing `MemoryManager` with `enabled=False` still constructs an embedder and creates the configured SQLite database/directories before the disabled check. Defer these resources for disabled managers using cached properties, and avoid initializing the store during uninstall.

Enabled installation remains eager, preserving backend validation and hook setup. Explicit direct manager operations still work and initialize resources on demand; agent-facing tools stay disabled. Document that distinction.

## Validation

New regressions reproduce directory creation and unnecessary embedder construction before the fix. Additional coverage checks explicit manager access, cached resource reuse, and uninstall.

`uv run pytest -q packages/nooa-memory/tests/memory/test_memory_manager.py packages/nooa-memory/tests/memory/test_memory_owner.py packages/nooa-memory/tests/memory/test_memory_skill.py packages/nooa-memory/tests/memory/test_memory_reflection_interrupt.py` — 54 passed. Targeted Pyright: 0 errors/warnings.

Windows/Python 3.12 with external import-only helpers for #84/#85 (`fcntl`/`SIGUSR2`); helpers are not included and do not validate POSIX locking/signals. No live model calls.

## Related issues

No matching open issue found. Independent of the record-update fix in #277.

## Checklist

- [x] Ruff lint and formatting pass.
- [x] Regression and manager/owner/skill/interrupt tests pass.
- [x] Memory README describes lazy disabled resources.
- [x] Existing SPDX headers retained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled memory managers no longer create databases or initialize embedding resources during installation.
  * Uninstalling an unused disabled manager no longer creates or opens storage.
  * Explicit memory manager operations initialize required resources on demand.
  * Agent-facing memory tools remain disabled when memory is disabled.

* **Documentation**
  * Added documentation describing disabled-memory lifecycle behavior.

* **Tests**
  * Added explanatory documentation to tests covering disabled installation and manager behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->