### PR TITLE
fix(runtime): decode monitor() output with replacement 🤖🤖🤖

### DIFF
--- a/src/nooa/runtime/producers.py
+++ b/src/nooa/runtime/producers.py
@@ -69,6 +69,8 @@ async def monitor(cmd: str):
     """Stream stdout lines from a shell command as they appear.
 
     Yields each line (stripped) as it's written to stdout.
+    Output is decoded as UTF-8 with undecodable bytes replaced, so a
+    command that emits non-UTF-8 output does not terminate the stream.
     stderr is merged into stdout.  Uses ``start_new_session=True``
     for process-group isolation so multiple concurrent monitors
     (and the agent itself) don't contend for ptys or interfere
@@ -84,7 +86,7 @@ async def monitor(cmd: str):
     assert proc.stdout is not None
     try:
         async for line in proc.stdout:
-            yield line.decode().rstrip("\n")
+            yield line.decode("utf-8", errors="replace").rstrip("\n")
         await proc.wait()
     finally:
         if proc.returncode is None:

--- a/tests/runtime/test_producers.py
+++ b/tests/runtime/test_producers.py
@@ -5,6 +5,7 @@
 import asyncio
 import os
 import platform
+import sys
 
 import pytest
 
@@ -130,3 +131,26 @@ class TestMonitorProcessIsolation:
 
         await asyncio.wait_for(survivor_task, timeout=5)
         assert "survived" in survivor_lines
+
+
+class TestMonitorOutputDecoding:
+    """Verify monitor() tolerates command output that is not valid UTF-8."""
+
+    async def test_undecodable_byte_does_not_end_the_stream(self, tmp_path):
+        """A non-UTF-8 byte must not kill the producer or drop later lines."""
+        emitter = tmp_path / "emit.py"
+        emitter.write_text(
+            "import sys\n"
+            "out = sys.stdout.buffer\n"
+            "out.write(b'first\\n')\n"
+            "out.write(b'caf\\xe9\\n')\n"  # latin-1 'e-acute': invalid UTF-8
+            "out.write(b'last\\n')\n"
+            "out.flush()\n",
+            encoding="utf-8",
+        )
+
+        lines = [line async for line in monitor(f'"{sys.executable}" "{emitter}"')]
+
+        # The undecodable byte becomes U+FFFD rather than being dropped, and
+        # "last" proves the stream continued past it.
+        assert lines == ["first", "caf\ufffd", "last"]


### PR DESCRIPTION
## What this fixes

`producers.monitor()` decodes subprocess output with a bare `bytes.decode()`, which is
strict UTF-8:

```python
async for line in proc.stdout:
    yield line.decode().rstrip("\n")      # src/nooa/runtime/producers.py:87
```

`monitor()` streams **arbitrary command output** — it is exposed to every agent as
`self.producers.monitor` via the `nemo.producers` entry point. Any tool that emits a
byte sequence which is not valid UTF-8 (a legacy OEM/ANSI code page, a stray byte in a
build log, binary noise on stderr — which is merged into stdout here) raises
`UnicodeDecodeError` **out of the async generator**. The producer dies mid-stream and
every subsequent line is lost.

## Reproduction

A command emitting one clean line, one latin-1 line, then one more clean line:

```
monitor() RAISED UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 3: invalid continuation byte
lines delivered: ['clean line']
-> 'after' delivered: False
```

`after` and everything after it are gone. The failure is not confined to the bad line —
it terminates the stream.

## The fix

One argument, matching what this codebase already does for the *other* subprocess line
reader. `src/nooa/tools/_bash_session.py:549` reads:

```python
line = raw.decode("utf-8", errors="replace").rstrip("\n")
```

`monitor()` is the one place that reads subprocess output without it. This change makes
the two consistent:

```python
yield line.decode("utf-8", errors="replace").rstrip("\n")
```

`errors="replace"` is the established convention here — it is used at
`_bash_session.py:387, 423, 530, 531, 549, 586`, `unifiedllm/http_logging.py:282, 370`,
`runtime/sandbox/guards.py:198` and throughout `nooa-cli`'s file tools.

**No behaviour change for output that is already valid UTF-8** — same bytes in, same
strings out. The only difference is that undecodable bytes now become U+FFFD instead of
killing the producer. The docstring is updated to state this.

## Test

One regression test, `TestMonitorOutputDecoding::test_undecodable_byte_does_not_end_the_stream`.
It spawns a Python emitter that writes `first` / an invalid UTF-8 byte / `last` and
asserts the stream survives to `last`. It is platform-independent (raw
`sys.stdout.buffer` writes, no shell builtins, no newline translation), so it is not
vacuous on the Linux CI that runs it.

Verified to fail on the unfixed tree before being kept:

```
E   UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 3: invalid continuation byte
FAILED tests/runtime/test_producers.py::TestMonitorOutputDecoding::test_undecodable_byte_does_not_end_the_stream
```

## Scope

Deliberately limited to the decode. `producers.py` has a separate, unrelated defect in
`monitor()`'s cleanup path (`os.killpg` is POSIX-only and `AttributeError` escapes the
`finally`); that is a platform question that overlaps #98/#137, and is raised separately as
#288 rather than folded in here -- the obvious one-line guard turns the crash into an
unbounded hang on cancel, so it needs a maintainer decision, not a drive-by patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Command output containing invalid UTF-8 bytes is now handled safely, replacing undecodable characters instead of terminating the output stream.
  - Subsequent valid output remains available after encountering malformed text.

- **Documentation**
  - Added documentation describing how invalid UTF-8 output is handled.

- **Tests**
  - Added regression coverage to verify stream continuity and replacement-character behavior for undecodable command output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->