### PR TITLE
fix(mcp): ignore a token cache that is not a JSON object 🤖🤖🤖

### DIFF
--- a/src/nooa/mcp/oauth.py
+++ b/src/nooa/mcp/oauth.py
@@ -796,6 +796,8 @@ def _load_cached_token(server_url: str) -> OAuthToken | None:
         data = json.loads(path.read_text())
     except (OSError, ValueError):
         return None
+    if not isinstance(data, dict):
+        return None
     entry = data.get(server_url)
     if not isinstance(entry, dict) or "access_token" not in entry:
         return None

--- a/tests/test_mcp/test_oauth_discovery.py
+++ b/tests/test_mcp/test_oauth_discovery.py
@@ -205,6 +205,20 @@ def test_token_is_expired_logic():
     assert not no_exp.is_expired()
 
 
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [("array", "[]"), ("string", '"nope"'), ("null", "null")],
+)
+def test_load_cached_token_ignores_non_object_cache(tmp_path, monkeypatch, label, payload):
+    """A valid-but-non-object cache file must fall back to None, not raise."""
+    monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(tmp_path))
+    cache_file = tmp_path / ".nooa" / "mcp_tokens.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(payload, encoding="utf-8")
+
+    assert oauth._load_cached_token("https://maas.example/mcp") is None
+
+
 def test_token_cache_roundtrip(tmp_path, monkeypatch):
     monkeypatch.setenv("NEMO_OO_PROJECT_DIR", str(tmp_path))
     url = "https://maas.example/mcp"


### PR DESCRIPTION
## What this fixes

`_load_cached_token()` promises in its own docstring to load a cached token *"if present
and well-formed"*, but it only validates the **entry**, never the top-level document:

```python
def _load_cached_token(server_url: str) -> OAuthToken | None:
    """Load a cached OAuth token for ``server_url`` if present and well-formed."""
    path = _token_cache_path()
    try:
        data = json.loads(path.read_text())
    except (OSError, ValueError):
        return None
    entry = data.get(server_url)          # src/nooa/mcp/oauth.py:799
```

`json.loads` returns a `list`, `str`, `int` or `None` for any valid-but-non-object file.
`data.get` then raises `AttributeError`, which the `(OSError, ValueError)` guard does not
cover — so instead of falling back to a fresh OAuth flow, the exception escapes into the
MCP connection path and the server simply fails to connect. Recovering requires the user
to find and delete `.nooa/mcp_tokens.json` by hand.

## The inconsistency

Its sibling `_save_cached_token()` guards the identical read, twenty lines below at
`oauth.py:818-820`:

```python
try:
    data = json.loads(path.read_text())
    if not isinstance(data, dict):
        data = {}
except (OSError, ValueError):
    data = {}
```

So the write path already treats a non-object cache as recoverable. Only the read path
does not. This change brings the two into line.

## Reproduction

```
  JSON array   -> RAISED AttributeError: 'list' object has no attribute 'get'
  JSON string  -> RAISED AttributeError: 'str' object has no attribute 'get'
  JSON null    -> RAISED AttributeError: 'NoneType' object has no attribute 'get'

the sibling save path handles the same input:
  _save_cached_token -> OK (isinstance guard at oauth.py:819-820)
```

## The fix

Two lines, mirroring the sibling:

```python
if not isinstance(data, dict):
    return None
```

A cache file that is not a JSON object is now treated exactly like a missing or corrupt
one — return `None` and let the caller start a fresh OAuth flow. No signature change, and
no behaviour change for a well-formed cache.

## Test

`test_load_cached_token_ignores_non_object_cache`, parametrized over the three shapes
(`[]`, `"nope"`, `null`), placed beside the existing `test_token_cache_roundtrip`.
Verified to fail on the unfixed tree before being kept:

```
FAILED tests/test_mcp/test_oauth_discovery.py::test_load_cached_token_ignores_non_object_cache[array-[]]
FAILED tests/test_mcp/test_oauth_discovery.py::test_load_cached_token_ignores_non_object_cache[string-"nope"]
FAILED tests/test_mcp/test_oauth_discovery.py::test_load_cached_token_ignores_non_object_cache[null-null]
E   AttributeError: 'NoneType' object has no attribute 'get'
src/nooa/mcp/oauth.py:799: AttributeError
```

## Scope

Only the guard. Two adjacent observations in this file are deliberately left alone as
separate concerns: `_save_cached_token` writes the cache with a plain `write_text()`
rather than the tmp+`replace()` pattern used elsewhere, and the `read_text()` calls here
carry no explicit `encoding`. Happy to raise either separately if useful.
