### PR TITLE
docs(cli): name the core package nooa, not nemo-oo-agents 🤖🤖🤖

### DIFF
--- a/packages/nooa-cli/README.md
+++ b/packages/nooa-cli/README.md
@@ -1,6 +1,6 @@
 # nooa-cli
 
-CLI for [nemo-oo-agents](https://github.com/NVIDIA-NeMo/labs-OO-Agents). Ships the `nooa` command with subcommands for running evaluations, browsing traces, and managing config.
+CLI for [nooa](https://github.com/NVIDIA-NeMo/labs-OO-Agents). Ships the `nooa` command with subcommands for running evaluations, browsing traces, and managing config.
 
 ## Install
 
@@ -11,7 +11,7 @@ uv add nooa-cli
 uv add "nooa-cli[datascience]"
 ```
 
-`nooa-cli` automatically pulls in matching `nemo-oo-agents` (the core framework). The `[datascience]` extra adds libraries the LLM can use in REPL-generated code.
+`nooa-cli` automatically pulls in matching `nooa` (the core framework). The `[datascience]` extra adds libraries the LLM can use in REPL-generated code.
 
 ## Usage
 

--- a/packages/nooa-cli/pyproject.toml
+++ b/packages/nooa-cli/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nooa-cli"
 # Version is derived from git tags at build time by uv-dynamic-versioning.
 dynamic = ["version"]
-description = "CLI for nemo-oo-agents (`nooa` command: eval runner, trace viewer, config)"
+description = "CLI for nooa (`nooa` command: eval runner, trace viewer, config)"
 license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.12,<3.14"


### PR DESCRIPTION
## What this fixes

`nooa-cli` tells users, in its PyPI strapline and its README, that it is the CLI for a
package called `nemo-oo-agents`. Its actual dependency is `nooa`, and `nemo-oo-agents` is
not a distribution this project publishes.

Three lines:

| Line | Says | Should say |
|---|---|---|
| `packages/nooa-cli/pyproject.toml:5` | ``description = "CLI for nemo-oo-agents (…)"`` | `nooa` |
| `packages/nooa-cli/README.md:3` | ``CLI for [nemo-oo-agents](…)`` | `nooa` |
| `packages/nooa-cli/README.md:14` | ``automatically pulls in matching `nemo-oo-agents` `` | `nooa` |

The `description` field is the strapline shown on the PyPI project page, so this is
user-facing on the package's front door.

## Why these three were missed

They are leftovers from the distribution rename in `68ebfca`
(*"rename: distribution names nemo-labs-oo-agents-\* -> nooa-\*"*), whose stated goal was
to *"make the pip distribution names match the Python modules"*. That commit edited both
of these files — and edited the README sentence in question:

```diff
-`nemo-labs-oo-agents-cli` automatically pulls in matching `nemo-oo-agents` (the core framework).
+`nooa-cli` automatically pulls in matching `nemo-oo-agents` (the core framework).
```

The sweep matched `nemo-labs-oo-agents`, so the first name on that line was renamed and
the second — spelled `nemo-oo-agents`, without `labs` — was not. The same commit changed
the dependency itself (`"nemo-labs-oo-agents>=0.2.0"` → `"nooa>=0.2.0"`) while leaving
the `description` directly above it untouched.

That commit was also explicit about what it left deliberately (*"Left as-is: the
'NeMo Labs' branding badge in README (org branding, not a package name)"*), which is the
distinction applied below.

## What this deliberately does NOT touch

Every other `nemo-oo-agents` occurrence in the tree is either a genuinely different
package or a non-package reference, and is left alone:

- `src/nooa/mcp/oauth.py:747` — `"clientInfo": {"name": "nemo-oo-agents"}`. This is the
  identity sent to MCP servers on the wire; changing it would be a protocol-visible
  behaviour change, not a docs fix.
- `THIRD_PARTY_NOTICES.md` — `nemo-oo-agents-benchmarks`, a separate distribution.
- `tests/test_mcp/__init__.py`, `tests/tracing/__init__.py` — `mcp-nemo-oo-agents` and
  `openinference-instrumentation-nemo-oo-agents`, both separate packages.
- `pyproject.toml:31` — a comment about `mcp-nemo-oo-agents` (now internal).
- `packages/nooa-cli/src/nooa_cli/commands/eval.py:59` — *"ships with the nemo-oo-agents
  monorepo workspace"*, a reference to the repo, not to a pip name.

`nemo-oo-agents-nvidia`, which is a real and unrelated NVIDIA package, does not appear in
this diff.

## Scope

Docs and packaging metadata only — three lines, no code, no test changes. `ruff check .`
and `ruff format --check .` are clean and the suite is unchanged.
