### PR TITLE
fix(runtime): let a caller's cancellation escape cancel() and race() 🤖🤖🤖

### DIFF
--- a/src/nooa/runtime/channels.py
+++ b/src/nooa/runtime/channels.py
@@ -122,7 +122,15 @@ class JobHandle:
         self._task.cancel()
         try:
             await self._task
-        except (asyncio.CancelledError, Exception):
+        except asyncio.CancelledError:
+            # Task.cancel() delegates to the future being awaited, so the
+            # job's unwinding and our caller's own cancellation both surface
+            # here. cancelling() distinguishes them; the caller's is not ours
+            # to swallow.
+            current = asyncio.current_task()
+            if current is not None and current.cancelling() > 0:
+                raise
+        except Exception:
             pass
         if self.state == "running":
             self.state = "cancelled"
@@ -906,6 +914,13 @@ class QueueManager:
             for t in pending:
                 try:
                     await t
+                except asyncio.CancelledError:
+                    # Same delegation as JobHandle.cancel(): reaping a loser we
+                    # just cancelled and being cancelled ourselves both surface
+                    # here. Only the loser's unwinding is ours to absorb.
+                    current = asyncio.current_task()
+                    if current is not None and current.cancelling() > 0:
+                        raise
                 except BaseException:
                     pass
 

--- a/tests/runtime/test_channels_queue_ergonomics.py
+++ b/tests/runtime/test_channels_queue_ergonomics.py
@@ -425,3 +425,84 @@ class TestIntegrationSpawnFlushReplaceRespawn:
         assert h.state == "cancelled"
 
         await qm.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Cancellation propagation
+# ---------------------------------------------------------------------------
+
+
+async def test_shutdown_does_not_swallow_the_callers_own_cancellation():
+    """A caller cancelled inside shutdown() must stay cancelled.
+
+    ``Task.cancel()`` delegates to the future the task is awaiting, so the
+    caller's own CancelledError arrives at the same ``await self._task`` that
+    JobHandle.cancel() uses to reap the job it just cancelled.
+    """
+    qm = QueueManager()
+    qm.queue("slow")
+
+    async def slow_job():
+        try:
+            await asyncio.sleep(100)
+        except asyncio.CancelledError:
+            await asyncio.sleep(0.2)  # cleanup holds the caller inside cancel()
+            raise
+
+    qm.spawn(slow_job(), channel="slow")
+    await asyncio.sleep(0)  # let the job task start
+
+    reached_end = False
+
+    async def caller():
+        nonlocal reached_end
+        await qm.shutdown()
+        reached_end = True
+
+    task = asyncio.create_task(caller())
+    await asyncio.sleep(0.05)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert not reached_end
+
+
+async def test_race_does_not_swallow_the_callers_own_cancellation():
+    """A caller cancelled inside race() must stay cancelled.
+
+    race() cancels the losing drain tasks and awaits each one to reap it. That
+    ``await`` is where a cancellation aimed at the *caller* is delivered too, so
+    a blanket handler there cannot tell the two apart and drops the caller's.
+    """
+    qm = QueueManager()
+    fast = qm.queue("fast")
+    slow = qm.queue("slow")
+
+    async def slow_to_cancel():
+        try:
+            await asyncio.sleep(100)
+        except asyncio.CancelledError:
+            await asyncio.sleep(0.2)  # unwinding holds the caller inside `await t`
+            raise
+
+    # race() drains losers through the internal _drain_one; make the loser's
+    # cancellation slow so the caller is provably inside that await.
+    slow._drain_one = slow_to_cancel  # type: ignore[method-assign]
+
+    reached_end = False
+
+    async def caller():
+        nonlocal reached_end
+        await qm.race()
+        reached_end = True
+
+    task = asyncio.create_task(caller())
+    await asyncio.sleep(0)  # let race() reach asyncio.wait
+    fast.put("winner")  # fast wins; slow becomes a pending loser
+    await asyncio.sleep(0.05)  # race() is now reaping the loser
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert not reached_end


### PR DESCRIPTION
## What this fixes

Two places in `src/nooa/runtime/channels.py` reap a task they have just cancelled by
awaiting it under a blanket handler:

```python
    async def cancel(self) -> None:                       # JobHandle.cancel(), :118-129
        self._task.cancel()
        try:
            await self._task
        except (asyncio.CancelledError, Exception):
            pass
```

```python
            for t in pending:                             # QueueManager.race(), :906-910
                try:
                    await t
                except BaseException:
                    pass
```

Swallowing the *reaped task's* `CancelledError` is the intent, and it is correct. But
`Task.cancel()` delegates to the future the target task is currently awaiting. So when the
**caller** is itself cancelled, its `CancelledError` is delivered at that exact `await` —
into the same handler — and is discarded. The caller then runs on as if it had never been
cancelled.

- `QueueManager.shutdown()` is a loop of `cancel()` calls (`channels.py:1055-1057`), so it
  inherits the behaviour: a task cancelled while shutting the queue manager down does not
  stop.
- `race()` goes further and **returns a winning item** to a caller that was supposed to be
  cancelled, so the statement after `race()` runs too.

Both lines read as safe — each is awaiting a task it cancelled itself, so catching
`CancelledError` looks obviously right, and that is why they survive review. The delegation
is the part that does not show up locally: nothing in either function is awaiting anything
else, yet a second, unrelated `CancelledError` can arrive at that same `await`.

## Reproduction

**`shutdown()`** — a job with a short cleanup, caller cancelled while inside `shutdown()`:

```python
async def stubborn():
    try:
        await asyncio.sleep(3600)
    except asyncio.CancelledError:
        await asyncio.sleep(0.5)      # cleanup holds the caller inside cancel()
        raise
```

```
main        : BUG : cancellation swallowed -> shutdown() returned normally | ['code after shutdown() RAN']
this branch : OK  : CancelledError propagated to the caller | []
```

**`race()`** — two queue channels; the loser's unwinding holds the caller inside the reap
loop:

```
main        : caller outcome: returned normally         | code after race() ran: True
              race() returned: [('fast', 'winner')]
this branch : caller outcome: CancelledError propagated | code after race() ran: False
              race() returned: None
```

## The fix

The two cases are distinguishable through the uncancel protocol (`Task.cancelling()`,
3.11+; this project requires 3.12+). A non-zero count means *this* task has an outstanding
cancellation request of its own, which is not ours to absorb:

```python
        except asyncio.CancelledError:
            current = asyncio.current_task()
            if current is not None and current.cancelling() > 0:
                raise
        except Exception:
            pass
```

The same guard in both places. The reaped task's expected unwinding is still swallowed, and
a job that failed with a real exception is still absorbed exactly as before — `spawn()`'s
`_run` wrapper has already recorded that as `state="failed"` and emitted `JobError`, so
re-raising it here would be a second report of the same failure.

In `race()` the re-raise lands in that function's existing outer `except BaseException:`
handler (`channels.py:938`), which already cancels in-flight tasks and restores their items
to the head of their channels before propagating — so no item is dropped on the way out.

An earlier attempt keyed on `self._task.cancelled()` instead; it does not work, because the
delegation means the reaped task has usually already completed as cancelled by the time
either error surfaces. Noting it in case it looks like the more obvious fix.

## Tests

One regression test per site, both in the "Cancellation propagation" block of
`tests/runtime/test_channels_queue_ergonomics.py`:

- `test_shutdown_does_not_swallow_the_callers_own_cancellation`
- `test_race_does_not_swallow_the_callers_own_cancellation`

Pure `asyncio` — no subprocess, no platform assumptions. Each was verified to fail on the
unfixed tree before being kept:

```
FAILED tests/runtime/test_channels_queue_ergonomics.py::test_race_does_not_swallow_the_callers_own_cancellation
E   Failed: DID NOT RAISE CancelledError
```

`tests/runtime` + `src/nooa/runtime/tests` (excluding `tests/runtime/sandbox`, which cannot
be collected on this machine) measured on both trees:

```
main        : 9 failed, 1222 passed, 10 skipped
this branch : 9 failed, 1224 passed, 10 skipped
```

Same nine failures either way — they are pre-existing Windows-only failures on this machine
(`os.killpg` in `producers.py`) and unrelated to this change. The `+2` is these two tests.
`ruff check .` and `ruff format --check .` are clean, and `pyright src/nooa/runtime/channels.py`
is 0 errors on both `--pythonplatform Linux` and the host.

## Scope

Two handlers, one claim: a caller's cancellation is not ours to swallow.

One adjacent observation left deliberately alone, since fixing it would be a second claim:
`shutdown()` clears `self._handles` *before* awaiting the cancels, so a `shutdown()` that
now correctly propagates a cancellation leaves the not-yet-cancelled handles untracked.
That was true before this change too — it was simply unreachable while the cancellation was
being swallowed. Happy to raise it separately if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved caller-initiated cancellation during job shutdown and task racing.
  * Prevented cancelled operations from swallowing cancellation signals or continuing with post-operation work.
  * Improved handling while waiting for cancelled jobs to finish cleanup.

* **Tests**
  * Added regression coverage confirming cancellation reaches callers during shutdown and task racing, including slow cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->