### PR TITLE
fix(ci): collect the nooa-memory test suite 🤖🤖🤖

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,7 @@ testpaths = [
     "packages/nooa-cli/tests",
     "packages/nooa-acp/tests",
     "packages/nooa-bench/tests",
+    "packages/nooa-memory/tests",
     "tests/trace_explorer",
 ]
 pythonpath = [


### PR DESCRIPTION
## What is wrong

`testpaths` in `pyproject.toml` lists three of the four packages under `packages/` —
`nooa-cli`, `nooa-acp`, `nooa-bench` — but not `nooa-memory`. The CI unit-test step
(`.github/workflows/ci.yml:46`) runs

```
uv run pytest -q -m "not integration and not stress and not sandbox"
```

with no path arguments, so pytest applies `testpaths` and never reaches
`packages/nooa-memory/tests`. The suite is installed and importable in CI —
`uv sync --all-extras --no-extra sandbox` pulls it in via the `memory` extra
(`pyproject.toml:88`) and it is a declared workspace member (`:72`) — it is simply
never collected.

Net effect: a shipped optional package has **no regression protection in CI**. Nothing
in `nooa-memory` can fail the build.

## Evidence

```
# CI's exact invocation, collect-only, on main
$ uv run pytest --collect-only -q -m "not integration and not stress and not sandbox"
7018/7262 tests collected
$ ... | grep -c nooa-memory
0

# the same tests, addressed directly
$ uv run pytest packages/nooa-memory/tests -q
282 collected
```

With this one-line change, the same CI-shaped collection goes **7018 → 7300**, exactly
the 282 that were dark.

## Why this is worth doing now

There are four open PRs against `nooa-memory` right now — #277, #278, #279 and #284 —
and each one **adds or edits a file under `packages/nooa-memory/tests/`**. Those
regression tests cannot currently fail, on those PRs or on any later change that breaks
them.

This is also a failure mode the project already treats as a bug. `ci.yml:40-44` installs
ripgrep specifically because otherwise "those tests silently skip and the job passes
vacuously. See #65", and the release and gitleaks steps (`ci.yml:190`, `:234`) both
hard-fail rather than pass vacuously. This is the same policy applied to a directory the
config never points at.

## What I could and could not verify

I ran the suite on Windows, so my numbers are not a substitute for your runner:

```
uv run pytest packages/nooa-memory/tests -q
  -> 266 passed, 3 failed, 13 skipped

PYTHONUTF8=1 uv run pytest packages/nooa-memory/tests -q
  -> 268 passed, 1 failed, 13 skipped
```

All three failures look platform-specific rather than product defects:

- two are in `tests/memory/test_memory_readme.py`, which calls `Path.read_text()` with no
  `encoding=` and so fails on a cp1252 console — they pass under `PYTHONUTF8=1`, and would
  pass on a UTF-8 runner;
- `test_file_capture_rejects_escaping_paths` expects `file:/etc/passwd` to take the
  "must be relative" branch, but `pathlib.Path("/etc/passwd").is_absolute()` is `False` on
  Windows, so it takes the "escapes the working dir" branch instead. The path is still
  rejected; only the message differs.

The full suite on this branch adds exactly those tests and moves nothing else. Both runs
behind the same harness, both under `PYTHONUTF8=1` so they are comparable to each other:

| Tree | failed | passed | skipped | errors |
|---|---|---|---|---|
| `main` @ `e137e1b` | 46 | 6,691 | 159 | 61 |
| this branch | 47 | 6,959 | 172 | 61 |

The delta — **+1 failed, +268 passed, +13 skipped, errors unchanged** — is exactly the
`nooa-memory` suite's standalone result above, so the one-line change adds that suite and
touches nothing else. The absolute failure count is high only because this is Windows,
where a lot of the suite is known-broken (#84, #95, #110); the delta is the point, not the
level.

**So I expect all 282 to be green on `ubuntu-latest`, but I have not been able to prove
that.** If turning them on does surface something, say so and I will fix the fallout in
this PR rather than leave you with a red build.

## Scope

One line. No source changes, no behaviour changes, no agent-facing contract touched.

Deliberately **not** included: `util/eval_pipeline/tests` is the other test directory
outside `testpaths`. It is dev tooling under `util/` rather than a shipped package, and I
have not audited its state, so it seemed wrong to bundle it into a one-line fix. Happy to
look at it separately if you want it collected too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test discovery configuration to include the memory package’s test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->