### PR TITLE
fix(storage): skip non-string keys in SnapshotVars 🤖🤖🤖

### DIFF
--- a/src/nooa/storage/snapshot_vars.py
+++ b/src/nooa/storage/snapshot_vars.py
@@ -55,6 +55,15 @@ class SnapshotVars(MutableMapping):
         return self._data[key]
 
     def __setitem__(self, key: str, value: Any) -> None:
+        if not isinstance(key, str):
+            logger.warning(
+                "SnapshotVars: key %r (%s) is not a string and will NOT be persisted "
+                "(it won't survive /exit + resume): snapshots are JSON, which requires "
+                "string keys",
+                key,
+                type(key).__name__,
+            )
+            return
         try:
             serialize(value)
         except (SerializationError, TypeError, ValueError, RecursionError) as exc:

--- a/tests/storage/test_snapshot_vars.py
+++ b/tests/storage/test_snapshot_vars.py
@@ -71,6 +71,13 @@ class TestSnapshotVarsRoundTrips:
         assert blob["__type__"] == "dict_class"
         assert blob["data"]["_data"] == {"keep": {"token": "abc"}}
 
+    def test_snapshot_serialize_succeeds_even_after_non_string_key_write(self):
+        v = SnapshotVars()
+        v["keep"] = {"token": "abc"}
+        v[123] = "bad key"  # skipped on write
+        blob, _allow = serialize(v)
+        assert blob["data"]["_data"] == {"keep": {"token": "abc"}}
+
     def test_round_trip_preserves_kept_values(self):
         from nooa.storage.serialization import deserialize
 


### PR DESCRIPTION
## What this fixes

`SnapshotVars` exists for one reason, stated in its own module docstring
(`src/nooa/storage/snapshot_vars.py:6-10`):

> A single non-serializable value used to abort the *whole* snapshot, silently losing all
> durable state on the next resume. `SnapshotVars` moves that check to *write* time.

It checks the value on write and skips it. It never checks the **key**
(`src/nooa/storage/snapshot_vars.py:57-69`):

```python
def __setitem__(self, key: str, value: Any) -> None:
    try:
        serialize(value)                     # value is validated
    except (SerializationError, TypeError, ValueError, RecursionError) as exc:
        logger.warning(...)
        return
    self._data[key] = value                  # key is not
```

Snapshots are JSON, and `serialize()` rejects non-string dict keys outright
(`src/nooa/storage/serialization.py:124-128`). So a single non-string key does the exact
thing this class was built to prevent: it survives the write, then blows up at snapshot
time, where `AgentSnapshot.from_agent()` catches `SerializationError` and **drops the whole
attribute** (`src/nooa/storage/snapshot.py:109-121`) -- taking every other var with it.
The comment right there names the consequence exactly (`snapshot.py:112-114`):

> A single non-serializable attribute must not abort the whole snapshot -- that silently
> loses ALL durable state (vars, todos, ...).

That guard is doing its job. `SnapshotVars` is the layer meant to stop anything reaching it,
and for keys it does not.

## Why it matters

`self.vars` is agent-writable surface. It is `InteractiveAgent`'s persistent variable store
(`src/nooa/interactive.py:346`, `:351`), documented as "survives across turns AND across
sessions", and it is the type of `Todo.vars` (`src/nooa/tools/todo.py:77`), which coerces
any dict handed to it (`:90`). An agent writing `self.vars[step] = state` with an integer
step, or `Todo(vars={1: "..."})`, gets a container that looks like it stored the value.

The loss is silent from the agent's side: the write succeeds, the read succeeds, and the
warning that fires is at snapshot time, about `vars` as a whole, not about the key that
caused it. On the next `/exit` + resume every durable variable is gone.

## Reproduction

```python
from nooa.interactive import InteractiveAgent
from nooa.storage.snapshot import AgentSnapshot

a = InteractiveAgent()
a.vars["safe_var"] = "valuable state"
a.vars[123] = "bad key"
snap = AgentSnapshot.from_agent(a)
print("'vars' in snapshot attributes:", "vars" in snap.attributes)
```

On `main`:

```
WARNING nooa.storage.snapshot: Snapshot: skipping non-serializable attribute 'vars'
        (SnapshotVars): Dict key 123 (type: int) is not a string. JSON requires string keys.
vars container holds: {'safe_var': 'valuable state', 123: 'bad key'}
'vars' in snapshot attributes: False
snapshot attribute names: []
```

`safe_var` was never at fault and is lost anyway. On this branch:

```
WARNING nooa.storage.snapshot_vars: SnapshotVars: key 123 (int) is not a string and will
        NOT be persisted (it won't survive /exit + resume): snapshots are JSON, which
        requires string keys
vars container holds: {'safe_var': 'valuable state'}
'vars' in snapshot attributes: True
snapshot attribute names: ['vars']
```

## The fix

Validate the key the way the value is already validated -- warn, name the offending key,
skip the store:

```python
def __setitem__(self, key: str, value: Any) -> None:
    if not isinstance(key, str):
        logger.warning(
            "SnapshotVars: key %r (%s) is not a string and will NOT be persisted "
            "(it won't survive /exit + resume): snapshots are JSON, which requires "
            "string keys",
            key,
            type(key).__name__,
        )
        return
    ...
```

Nine lines, no signature change. It matches the existing `key: str` annotation and the
class's documented "skips the store, logs a warning" contract, so the behaviour is the one
already described in the docstring. It also moves the warning to the write that caused it,
which is where a user can act on it.

## Test

One test, `test_snapshot_serialize_succeeds_even_after_non_string_key_write`, placed beside
the existing `test_snapshot_serialize_succeeds_even_after_bad_write` it mirrors. Verified to
fail on the unfixed tree before being kept:

```
FAILED tests/storage/test_snapshot_vars.py::TestSnapshotVarsRoundTrips::
       test_snapshot_serialize_succeeds_even_after_non_string_key_write
E   nooa.errors.storage.SerializationError: Dict key 123 (type: int) is not a string.
    JSON requires string keys.
```

`tests/storage/test_snapshot_vars.py` is 15 passed on this branch against 14 on `main`.

## Scope

Only the missing key check. Nothing else in the container changes: reads, iteration,
deletion and the value path are untouched, and a non-string key was never retrievable from
a restored snapshot anyway -- it was only ever taking the rest of the snapshot down with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot storage now skips entries with non-string keys, preventing serialization issues while preserving valid entries.
  * A warning is logged when an unsupported key is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->