### PR TITLE
fix(storage): close the connection when close()'s commit fails 🤖🤖🤖

### DIFF
--- a/src/nooa/storage/sqlite.py
+++ b/src/nooa/storage/sqlite.py
@@ -866,11 +866,15 @@ class SQLiteStorageManager:
             if conn is not None:
                 if lock is not None:
                     with lock:
-                        conn.commit()
-                        conn.close()
+                        try:
+                            conn.commit()
+                        finally:
+                            conn.close()
                 else:
-                    conn.commit()
-                    conn.close()
+                    try:
+                        conn.commit()
+                    finally:
+                        conn.close()
         finally:
             if self._lock_fd is not None:
                 fcntl.flock(self._lock_fd, fcntl.LOCK_UN)

--- a/tests/unit/test_util_and_sqlite.py
+++ b/tests/unit/test_util_and_sqlite.py
@@ -654,6 +654,28 @@ class TestSQLiteStorageManager:
         assert backend._insertion_counter == initial + 2
         sm.close()
 
+    def test_close_closes_the_connection_when_commit_fails(self):
+        """A raising commit() must not leak the connection.
+
+        close() sets _closed before committing, so a connection missed here can
+        never be closed by a later close() call -- it early-returns.
+        """
+        import sqlite3
+
+        from nooa.storage.sqlite import SQLiteStorageManager
+
+        sm = SQLiteStorageManager(":memory:")
+        real_conn = sm._conn
+        try:
+            fake_conn = MagicMock(spec=sqlite3.Connection)
+            fake_conn.commit.side_effect = sqlite3.OperationalError("disk I/O error")
+            sm._conn = fake_conn
+            with pytest.raises(sqlite3.OperationalError):
+                sm.close()
+            assert fake_conn.close.called
+        finally:
+            real_conn.close()
+
     def test_restore_snapshot_not_found_raises(self):
         from nooa.errors.storage import SnapshotNotFoundError
         from nooa.storage.sqlite import SQLiteStorageManager


### PR DESCRIPTION
## What this fixes

`SQLiteStorageManager.close()` marks itself closed *before* it does the closing
(`src/nooa/storage/sqlite.py:859-878`):

```python
def close(self) -> None:
    if self._closed:
        return
    self._closed = True
    try:
        ...
        if conn is not None:
            if lock is not None:
                with lock:
                    conn.commit()      # if this raises...
                    conn.close()       # ...this never runs
            else:
                conn.commit()
                conn.close()
    finally:
        ...
```

`sqlite3.Connection.commit()` raises on a full disk, an I/O error, or a database another
process holds. When it does, `conn.close()` is skipped and the connection is left open --
and because `self._closed` is already `True`, the guard on the first line turns every
later `close()` into a no-op. Nothing can ever close it.

## Why it matters

`__exit__` is just `self.close()` (`src/nooa/storage/sqlite.py:884`), so this is reached by
the ordinary `with SQLiteStorageManager(...) as sm:` form. A block that fails to commit on
the way out leaks the connection and the file handle beneath it, and the caller's own
recovery path cannot reclaim them -- `sm.close()` in an `except`/`finally` returns
immediately, reporting success.

The `finally:` block does release the advisory session lock, so this is not a deadlock. It
is a connection and file-descriptor leak with no recovery, in exactly the situation where a
caller is most likely to be retrying.

## Reproduction

```python
sm = SQLiteStorageManager(":memory:")
fake = MagicMock(spec=sqlite3.Connection)
fake.commit.side_effect = sqlite3.OperationalError("disk I/O error")
sm._conn = fake

try:
    sm.close()
except sqlite3.OperationalError as e:
    print("close() raised     :", e)
print("manager._closed    :", sm._closed)
print("conn.close() called:", fake.close.called)
sm.close()   # a caller's error-recovery retry
print("after retry close():", fake.close.called)
```

On `main`:

```
close() raised     : disk I/O error
manager._closed    : True
conn.close() called: False
after retry close(): False
```

On this branch:

```
close() raised     : disk I/O error
manager._closed    : True
conn.close() called: True
after retry close(): True
```

## The fix

Commit in a `try` / `finally` so the close always runs, on both the locked and unlocked
paths:

```python
if lock is not None:
    with lock:
        try:
            conn.commit()
        finally:
            conn.close()
else:
    try:
        conn.commit()
    finally:
        conn.close()
```

The commit error still propagates unchanged -- the caller learns the commit failed, and now
the connection is closed either way. No signature change, no change on the success path.

## Test

One test, `test_close_closes_the_connection_when_commit_fails`, in the existing
`TestSQLiteStorageManager` class. Verified to fail on the unfixed tree before being kept:

```
FAILED tests/unit/test_util_and_sqlite.py::TestSQLiteStorageManager::
       test_close_closes_the_connection_when_commit_fails
E   AssertionError: assert False
E    +  where False = <MagicMock name='mock.close'>.called
```

## Scope

Only the commit/close ordering. The `finally:` block below it, which unlocks and closes
`_lock_fd`, is untouched -- that is the part #132 and #135 change for Windows, and this
branch deliberately stays out of their way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database shutdown reliability by ensuring SQLite connections close even when saving changes encounters an error.

* **Tests**
  * Added coverage for connection cleanup when a database operation fails during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->