### PR TITLE
fix(memory): apply per_hop_decay once per hop in _spread 🤖🤖🤖

### DIFF
--- a/packages/nooa-memory/src/nooa_memory/retrieval.py
+++ b/packages/nooa-memory/src/nooa_memory/retrieval.py
@@ -265,8 +265,10 @@ class RetrievalEngine:
 
         spread: dict[str, float] = {}
         frontier = dict(seed_activation)
-        for h in range(1, hops + 1):
-            decay = cfg.per_hop_decay**h
+        # ``act`` already carries the decay of every earlier hop, so applying a
+        # single factor per step is what yields ``per_hop_decay ** h`` at hop h.
+        decay = cfg.per_hop_decay
+        for _ in range(hops):
             nxt: dict[str, float] = {}
             for node, act in frontier.items():
                 edges = self.store.neighbors(node)

--- a/packages/nooa-memory/tests/memory/test_memory_retrieval.py
+++ b/packages/nooa-memory/tests/memory/test_memory_retrieval.py
@@ -85,6 +85,27 @@ def test_spread_decays_per_hop(store, emb):
     assert b.id in spread1 and c.id not in spread1
 
 
+def test_spread_decay_is_one_factor_per_hop(store, emb):
+    # The docstring and ``per_hop_decay``'s own comment both say the decay is
+    # per hop, so at hop h the activation is delta**h along unit-weight causal
+    # edges -- not a compounded power that dies under ``activation_floor``.
+    a = _add(store, emb, "seed node alpha")
+    b = _add(store, emb, "node beta")
+    c = _add(store, emb, "node gamma")
+    d = _add(store, emb, "node delta")
+    for src, dst in ((a, b), (b, c), (c, d)):
+        store.add_edge(src.id, dst.id, EdgeType.CAUSES, 1.0)
+    eng = RetrievalEngine(
+        store,
+        emb,
+        RetrievalConfig(per_hop_decay=0.6, per_hop_fanout=5, activation_floor=0.05),
+    )
+    spread = eng._spread({a.id: 1.0}, hops=3)
+    assert spread[b.id] == pytest.approx(0.6)
+    assert spread[c.id] == pytest.approx(0.6**2)
+    assert spread[d.id] == pytest.approx(0.6**3)
+
+
 def test_multi_hop_surfaces_linked_dissimilar_memory(store, emb):
     # A is relevant to the query; B is dissimilar but linked from A. Several
     # unlinked, equally-dissimilar distractors compete for the second slot.


### PR DESCRIPTION
## What this fixes

`RetrievalEngine._spread` is documented as decaying once per hop, in the docstring
(`packages/nooa-memory/src/nooa_memory/retrieval.py:249`):

> Propagate activation outward over edges, decaying `per_hop_decay` per hop.

and again on the knob itself (`packages/nooa-memory/src/nooa_memory/config.py:35`):

```python
per_hop_decay: float = 0.6  # delta — activation decay per hop
```

The loop applies `per_hop_decay ** h` at hop `h`
(`packages/nooa-memory/src/nooa_memory/retrieval.py:265-283`):

```python
frontier = dict(seed_activation)
for h in range(1, hops + 1):
    decay = cfg.per_hop_decay**h
    ...
    for node, act in frontier.items():
        ...
            contrib = decay * act * e.weight * type_w
            if contrib < cfg.activation_floor:
                continue
            nxt[e.target_id] = nxt.get(e.target_id, 0.0) + contrib
    frontier = nxt
```

But `act` comes from `frontier`, which is last hop's `nxt` -- it already carries the decay
of every earlier hop. Multiplying by `delta ** h` again compounds them: the total applied
at hop `h` is `delta ** (1+2+...+h)`, i.e. `delta ** (h(h+1)/2)`, not `delta ** h`.

## Why it matters

The compounding collapses fast enough to cross `activation_floor` and silently discard
whole hops. On a chain of unit-weight `CAUSES` edges with the shipped defaults
(`per_hop_decay=0.6`, `activation_floor=0.05`):

| hop | measured on `main` | documented `delta ** h` |
|---|---|---|
| 1 | 0.600000 | 0.600000 |
| 2 | 0.216000 | 0.360000 |
| 3 | **dropped** (0.046656 < floor) | 0.216000 |

A memory three causal edges from the seed is never recalled, however strong the links --
`hops=3` behaves as `hops=2` at the defaults. At hop 2 it is not dropped, just scored 40%
low, which quietly moves it down the ranking against unlinked candidates.

`RetrievalConfig.hops` is documented as `0 = vector-only; 1 = +1 graph hop; 2+ = multi-hop`
(`config.py:34`), so `2+` is a supported configuration, not an edge case.

## Reproduction

Four memories in a chain `a -> b -> c -> d`, all `EdgeType.CAUSES`, all weight 1.0:

```python
cfg = RetrievalConfig(hops=3, per_hop_decay=0.6, activation_floor=0.05, per_hop_fanout=5)
eng = RetrievalEngine(store, emb, cfg)
spread = eng._spread({a.id: 1.0}, hops=3)
```

`main`:

```
hop  node        measured    documented d^h   compounded d^(h(h+1)/2)
1    b           0.600000          0.600000                  0.600000
2    c           0.216000          0.360000                  0.216000
3    d            DROPPED          0.216000                  0.046656
```

this branch:

```
1    b           0.600000          0.600000                  0.600000
2    c           0.360000          0.360000                  0.216000
3    d           0.216000          0.216000                  0.046656
```

## The fix

The frontier already carries the earlier hops, so apply one factor per step:

```diff
         spread: dict[str, float] = {}
         frontier = dict(seed_activation)
-        for h in range(1, hops + 1):
-            decay = cfg.per_hop_decay**h
+        # ``act`` already carries the decay of every earlier hop, so applying a
+        # single factor per step is what yields ``per_hop_decay ** h`` at hop h.
+        decay = cfg.per_hop_decay
+        for _ in range(hops):
             nxt: dict[str, float] = {}
```

**The behaviour change, stated plainly:** multi-hop spread values go up, so recall results
can reorder for anyone running `hops >= 2`. At the default `hops=1` nothing changes at all
-- `delta ** 1` is `delta` under either form. No existing test in
`packages/nooa-memory/tests/memory/` changes result; the one that covers this
(`test_spread_decays_per_hop`) asserts only `spread[b] > spread[c] > 0`, which is why the
rate was never pinned down. If you would rather keep today's numbers and correct the two
comments instead, say so and I will send that diff -- but at the defaults that means
documenting `hops=3` as having no third hop.

## Test

One test, `test_spread_decay_is_one_factor_per_hop`, placed beside the existing
`test_spread_decays_per_hop` it strengthens. Verified to fail on the unfixed tree before
being kept:

```
FAILED packages/nooa-memory/tests/memory/test_memory_retrieval.py::
       test_spread_decay_is_one_factor_per_hop
E   assert 0.216 == 0.36 ± 3.6e-07
E     Obtained: 0.216
E     Expected: 0.36 ± 3.6e-07
```

`packages/nooa-memory/tests/memory/` is 3 failed / 267 passed / 13 skipped on this branch
against 3 failed / 266 passed / 13 skipped on `main` -- the same three pre-existing
Windows-only failures (two `read_text()` calls with no `encoding=` inside the test files,
one expecting `/etc/passwd` to be absolute), plus the new test passing.

Worth noting: that directory is not in `testpaths`, so CI does not currently collect this
test. #292 is the one-line change that turns it on.

## Scope

Only the decay factor. `_visible` and the owner-scoping logic are untouched, so this does
not overlap #275.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected associative activation spreading so decay is applied consistently at each propagation step.
  - Improved activation values across multi-step causal chains, including values below the activation floor.

- **Tests**
  - Added regression coverage for cumulative per-hop decay across three-edge causal chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->