### PR TITLE
fix(tui): harden restart re-exec and make update/restart notices legible

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/main.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/main.py
@@ -13,6 +13,7 @@ The ``main()`` coroutine keeps its original signature so that callers like
 
 import asyncio
 import logging
+import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -262,4 +263,10 @@ async def main(
     if restart_requested and restart_ready and runtime_registration is not None:
         from .runtime_registration import reexec_tui
 
+        # Say so before the exec: the ordinary session teardown prints its
+        # goodbye + resume hint above, which alone reads like a plain quit.
+        sys.stderr.write(
+            "\x1b[2mRestarting: reloading this session on the current code "
+            "(pid stays with the process)...\x1b[0m\n"
+        )
         reexec_tui(runtime_registration.restart_argv)

--- a/packages/nooa-cli/src/nooa_cli/tui/runtime_registration.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/runtime_registration.py
@@ -271,7 +271,21 @@ class TUIRuntimeRegistration:
 
 
 def reexec_tui(argv: list[str]) -> None:
-    """Replace the current process with its recorded Python invocation."""
+    """Replace the current process with its recorded Python invocation.
+
+    The restart signal is set to SIG_IGN before exec: an *ignored*
+    disposition survives ``exec``, so a racing or duplicate SIGUSR1 can
+    neither kill the process in the window after the handler is removed
+    (the default action for SIGUSR1 is terminate) nor hit the freshly
+    exec'd boot before it installs its real handler — that second signal
+    is exactly what produced restart chains that drained twice and then
+    died. The new boot re-arms the real handler during startup.
+    """
     if not argv:
         raise ValueError("restart argv must not be empty")
+    try:
+        if hasattr(signal, "SIGUSR1"):
+            signal.signal(signal.SIGUSR1, signal.SIG_IGN)
+    except (OSError, ValueError):
+        pass  # best-effort; the fresh boot re-arms its own handler anyway
     os.execvp(argv[0], argv)

--- a/packages/nooa-cli/src/nooa_cli/tui/session.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/session.py
@@ -456,6 +456,17 @@ class Session:
                 # status surface must not silently swallow the notice.
                 logger.warning("update notice could not be displayed", exc_info=True)
                 return
+        # The status-bar notice is easy to miss mid-scroll; also put one
+        # durable block into the transcript so the update is unmissable.
+        emit_block = getattr(self._app, "emit_block", None)
+        if callable(emit_block):
+            try:
+                emit_block(
+                    "\x1b[33mUpdate available — call /restart to reload "
+                    "(the running code no longer matches this checkout).\x1b[0m\n"
+                )
+            except Exception:
+                logger.debug("update notice transcript block failed", exc_info=True)
         # Latch only after the notice is actually displayed.
         self._update_notice_shown = True
         logger.info(

--- a/packages/nooa-cli/tests/tui/test_runtime_registration.py
+++ b/packages/nooa-cli/tests/tui/test_runtime_registration.py
@@ -199,6 +199,27 @@ def test_reexec_uses_path_search():
     execvp.assert_called_once_with("python", ["python", "-m", "nooa_cli", "tui"])
 
 
+def test_reexec_ignores_restart_signal_before_execvp():
+    """A racing/duplicate SIGUSR1 must not kill or re-drain across the exec.
+
+    SIGUSR1's default action is terminate: a signal landing in the window
+    between handler removal and exec kills the process, and one reaching the
+    freshly exec'd boot (before it installs its handler) makes that boot drain
+    and re-exec again — the observed restart chain. An *ignored* disposition
+    survives exec, so the new boot starts with the signal inert until it
+    arms its real handler.
+    """
+    if not hasattr(signal, "SIGUSR1"):  # pragma: no cover - platform dependent
+        pytest.skip("SIGUSR1 not available")
+    with (
+        patch("nooa_cli.tui.runtime_registration.signal.signal") as sig,
+        patch("nooa_cli.tui.runtime_registration.os.execvp") as execvp,
+    ):
+        reexec_tui(["python", "-m", "nooa_cli", "tui"])
+    sig.assert_called_once_with(signal.SIGUSR1, signal.SIG_IGN)
+    execvp.assert_called_once()
+
+
 @requires_fcntl
 def test_publish_fails_closed_without_process_identity(tmp_path: Path):
     """Do not advertise restart without a stable process identity."""

--- a/packages/nooa-cli/tests/tui/test_update_notice_restart.py
+++ b/packages/nooa-cli/tests/tui/test_update_notice_restart.py
@@ -67,7 +67,8 @@ async def test_update_watch_shows_notice_once_and_never_restarts() -> None:
     session._startup_source_revision = "aaa"
     session._update_notice_shown = False
     set_notice = Mock()
-    session._app = SimpleNamespace(set_status_notice=set_notice)
+    emit_block = Mock()
+    session._app = SimpleNamespace(set_status_notice=set_notice, emit_block=emit_block)
     calls = {"n": 0}
 
     def fake_current():
@@ -83,6 +84,9 @@ async def test_update_watch_shows_notice_once_and_never_restarts() -> None:
 
     assert calls["n"] == 1  # one comparison was enough
     set_notice.assert_called_once_with("Update available — call /restart to reload")
+    # The notice is also written into the transcript so it cannot be missed.
+    emit_block.assert_called_once()
+    assert "/restart" in emit_block.call_args.args[0]
     assert session._update_notice_shown
 
 


### PR DESCRIPTION
Live-testing the merged restart feature (#269) surfaced two issues; this fixes the code defects and makes the UX legible.

**What happened in testing**

1. *No update notice after `git pull` under a running TUI.* The instance running at pull time predated #269 (no update-watch existed in it), and the relaunched instance snapshotted the *post-pull* HEAD as its baseline — correctly silent. But the notice was also status-bar-only, easy to miss mid-scroll.
2. *A restart chain that drained twice then died with `No such command 'tui'`.* The first drain+re-exec worked; the fresh boot received a second SIGUSR1 (double-tap or fleet resend) before installing its handler, drained instantly, re-exec'd again, and the third boot hit a transient failure. SIGUSR1's *default* action is terminate, so any signal landing in the handler-removal→exec window kills the process outright.

**Fixes**

- `reexec_tui` now sets `SIG_IGN` before `execvp`: an *ignored* disposition survives `exec`, so a racing or duplicate SIGUSR1 can neither kill the pre-exec process nor re-drain the fresh boot before it arms its real handler. Regression test pins the `SIG_IGN` call.
- The update notice now also writes one durable transcript block (not just the status bar), so an available update cannot scroll past unnoticed.
- A real restart exit now prints `Restarting: reloading this session on the current code…` before the exec — previously only the ordinary goodbye + resume hint printed, reading exactly like a plain quit.

**Validation**: full suite 8,824 passed, 7 skipped; ruff clean; `git diff --check` clean; the exact recorded restart argv verified working (`nooa tui --continue … --help` rc=0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible message when the terminal interface restarts, confirming it is relaunching with the current code while retaining the existing process.
  * Update notifications now appear as a persistent, highlighted transcript message in addition to the status bar, including instructions to restart.

* **Bug Fixes**
  * Improved restart handling to prevent duplicate or overlapping restart requests from interrupting the new session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->