### PR TITLE
fix(tools): keep files newline-terminated after replace() at EOF

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/coding/activity.py
+++ b/packages/nooa-cli/src/nooa_cli/coding/activity.py
@@ -69,8 +69,15 @@ def _edit_diff(
     old_text: str,
     new_text: str,
     start_line: int | None,
+    *,
+    whole_file: bool = False,
 ) -> tuple[str, bool]:
-    """Return a bounded, line-oriented unified diff and its completeness."""
+    """Return a bounded, line-oriented unified diff and its completeness.
+
+    ``whole_file`` marks both texts as complete file contents, where a missing
+    final newline is a real file state worth reporting. Fragment diffs stop
+    mid-file, so the EOF marker there was noise.
+    """
     if _diff_input_is_too_large(old_text) or _diff_input_is_too_large(new_text):
         return _omitted_diff(path, "file content exceeds the safe diff preview limit")
 
@@ -91,7 +98,13 @@ def _edit_diff(
         if not line.endswith("\n"):
             # difflib emits the source line verbatim, so unterminated content
             # would run the next marker onto the same line ("-a+b").
-            line = f"{line}\n\\ No newline at end of file\n"
+            if whole_file:
+                line = f"{line}\n\\ No newline at end of file\n"
+            else:
+                # A fragment routinely stops before the file's final
+                # newline; marking that as "no newline at end of file"
+                # reported a file state that does not exist.
+                line = f"{line}\n"
         output.write(line)
     return output.getvalue(), not output.was_truncated
 
@@ -504,6 +517,7 @@ class ActivityShellTools(Skill):
                 old_diff_text or "",
                 content,
                 None,
+                whole_file=True,
             )
         self._emit(
             FileEdit(

--- a/packages/nooa-cli/tests/test_coding_activity.py
+++ b/packages/nooa-cli/tests/test_coding_activity.py
@@ -80,7 +80,7 @@ async def test_match_replace_emits_actual_before_and_after_text(tmp_path):
     assert "@@ -2 +2 @@" in edit.diff
 
 
-async def test_match_replace_at_end_of_file_reports_the_unterminated_text(tmp_path):
+async def test_match_replace_at_end_of_file_keeps_the_file_terminated(tmp_path):
     shell, events = _observed_shell(tmp_path)
     (tmp_path / "example.txt").write_text("one\ntwo\nthree\n")
     try:
@@ -90,9 +90,10 @@ async def test_match_replace_at_end_of_file_reports_the_unterminated_text(tmp_pa
         await shell.close()
 
     edit = next(event for event in events if isinstance(event, FileEdit))
-    # Nothing follows the region, so no newline is added and none is reported.
-    assert edit.new_text == "changed"
-    assert (tmp_path / "example.txt").read_text() == "one\ntwo\nchanged"
+    # The region reaches EOF in a file that ended with a newline, so the
+    # replacement is re-terminated — and reported as what was actually written.
+    assert edit.new_text == "changed\n"
+    assert (tmp_path / "example.txt").read_text() == "one\ntwo\nchanged\n"
 
 
 async def test_match_replace_after_cwd_change_emits_original_path(tmp_path):
@@ -111,7 +112,8 @@ async def test_match_replace_after_cwd_change_emits_original_path(tmp_path):
 
     edit = next(event for event in events if isinstance(event, FileEdit))
     assert edit.path == str(original)
-    assert original.read_text() == "after"
+    # Whole-file region at EOF keeps the file newline-terminated.
+    assert original.read_text() == "after\n"
     assert (other / "example.txt").read_text() == "wrong file\n"
 
 
@@ -315,12 +317,28 @@ def test_every_hunk_is_offset_not_just_the_first():
     assert complete is True
 
 
-def test_a_missing_final_newline_is_marked():
-    """Unterminated content needs the marker, or the diff is not applicable."""
-    diff, _ = activity._edit_diff("f.py", "a", "b", start_line=None)
+def test_a_missing_final_newline_is_marked_for_whole_file_diffs():
+    """Unterminated file content needs the marker, or the diff is not applicable."""
+    diff, _ = activity._edit_diff("f.py", "a", "b", start_line=None, whole_file=True)
 
     assert "-a" in diff and "+b" in diff
     assert "\\ No newline at end of file" in diff, diff
+
+
+def test_fragment_diffs_do_not_claim_a_missing_final_newline():
+    """replace() diffs fragments, not files — an unterminated fragment is
+    not a file state, so the EOF marker there was noise.
+
+    A snippet that simply stops before the file's last newline used to make
+    every edit report "\\ No newline at end of file" even though the file
+    on disk was newline-terminated.
+    """
+    diff, _ = activity._edit_diff("f.py", "a", "b", start_line=None)
+
+    assert "-a" in diff and "+b" in diff
+    assert "\\ No newline at end of file" not in diff, diff
+    # The line still ends newline-terminated so it cannot glue to a marker.
+    assert diff.endswith("+b\n"), diff
 
 
 async def test_overwriting_an_empty_file_reports_no_original_lines(tmp_path):

--- a/src/nooa/tools/shell_tools.py
+++ b/src/nooa/tools/shell_tools.py
@@ -758,7 +758,16 @@ class ShellTools(Skill):
 
             before = all_lines[: target.start - 1]
             after = all_lines[target.end :]
-            if new_text and not new_text.endswith("\n") and after:
+            # Keep the file newline-terminated when the replaced region
+            # reaches end-of-file and the original content ended with a
+            # newline — otherwise the edit silently strips the final byte.
+            reaches_end = target.end >= len(all_lines)
+            ended_with_newline = content.endswith("\n")
+            if (
+                new_text
+                and not new_text.endswith("\n")
+                and (after or (reaches_end and ended_with_newline))
+            ):
                 new_text += "\n"
             new_content = "".join(before) + new_text + "".join(after)
             resolved.write_text(new_content)

--- a/tests/tools/test_shell_tools_modern_behavior.py
+++ b/tests/tools/test_shell_tools_modern_behavior.py
@@ -99,7 +99,9 @@ async def test_file_operations_allow_paths_outside_cwd(sh, tmp_path):
     await sh.replace(
         Match(relative, 2, 2, "two\n", resolved_path=sibling / "relative.txt"), "replaced"
     )
-    assert (sibling / "relative.txt").read_text() == "changed\nreplaced"
+    # The region reaches EOF in a file that ended with a newline, so the
+    # replacement is re-terminated rather than stripping the final byte.
+    assert (sibling / "relative.txt").read_text() == "changed\nreplaced\n"
 
     await sh.write_file(str(absolute), "absolute")
     assert (await sh.read(str(absolute))).text == "absolute"
@@ -118,7 +120,9 @@ async def test_match_from_read_stays_bound_after_cwd_change(sh, tmp_path):
     await sh.run("cd other")
     await sh.replace(sliced, "after")
 
-    assert original.read_text() == "after"
+    # Whole-file region at EOF in a newline-terminated file keeps its final
+    # newline instead of silently stripping it.
+    assert original.read_text() == "after\n"
     assert (other / "original.txt").read_text() == "wrong file\n"
 
 
@@ -160,3 +164,21 @@ def test_match_keeps_an_absolute_resolved_path(tmp_path):
     target.write_text("hello\n")
     match = Match("f.txt", 1, 1, "hello\n", resolved_path=target)
     assert match.resolved_path == str(target.resolve())
+
+
+@pytest.mark.asyncio
+async def test_replace_match_at_eof_keeps_trailing_newline(sh, tmp_path):
+    """A replacement reaching end-of-file must not strip the file's final newline."""
+    await sh.write_file("f.py", "a = 1\nb = 2\n")
+    match = await sh.read("f.py", (2, 2))
+    await sh.replace(match, "b = 20")  # no trailing newline in the replacement
+    assert (tmp_path / "f.py").read_text() == "a = 1\nb = 20\n"
+
+
+@pytest.mark.asyncio
+async def test_replace_match_at_eof_preserves_missing_newline(sh, tmp_path):
+    """A file that genuinely lacks a final newline must not gain one."""
+    await sh.write_file("f.py", "a = 1\nb = 2")  # no trailing newline
+    match = await sh.read("f.py", (2, 2))
+    await sh.replace(match, "b = 20")
+    assert (tmp_path / "f.py").read_text() == "a = 1\nb = 20"


### PR DESCRIPTION
## Problem

Two related defects in the file-edit path:

1. **Real data bug:** `replace(match, new_text)` whose region reaches end-of-file silently stripped the file's final newline. Re-termination was gated on after-lines existing, so an unterminated replacement at EOF left the file without its trailing newline (git then flags every such file as 'no newline at end of file').
2. **Noisy/incorrect output:** fragment diffs (the `replace()` previews shown as `oo update` activity) emitted git's `\ No newline at end of file` marker whenever the edit snippet stopped before the file's last newline — i.e. almost every edit — even though the file on disk was newline-terminated.

## Fix

- `ShellTools.replace` (Match form) now re-terminates the replacement when the region reaches EOF **and** the original content ended with a newline. A file that genuinely lacks a final newline keeps lacking one — no spurious additions.
- `_edit_diff` gained a `whole_file` flag (default off). The EOF marker is now emitted only for whole-file overwrites (`write_file`), where it is accurate; fragment diffs keep the line newline-terminated (so it can't glue to the next marker) but no longer claim a file state that does not exist.

## Testing

- 2 new regression tests for the EOF cases (keeps newline; preserves genuine lack of one)
- New test that fragment diffs do not emit the marker; marker test updated to the `whole_file=True` path
- 4 existing tests updated where they had pinned the old stripping/marker behavior as intentional
- `tests/tools/test_shell_tools_modern_behavior.py` + `packages/nooa-cli/tests/test_coding_activity.py`: 34 passed; ruff check + format clean

Note: two of the updated tests previously documented the stripping as deliberate ('Nothing follows the region, so no newline is added'). Per discussion this was a bug, not a feature — the intent of the re-termination logic was to preserve the file's termination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved trailing newlines when replacing file content at the end of a file.
  - Maintained files without a final newline without adding one.
  - Improved diff output to distinguish complete-file changes from partial content changes, including accurate end-of-file markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->