### PR TITLE
perf(tui): replay grapheme paint plans instead of re-deriving cells

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -24,6 +24,7 @@ import re
 import shutil
 import subprocess
 import time
+from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
@@ -202,6 +203,53 @@ class DispatcherExit(Exception):
     """
 
 
+class _GraphemePaintPlan:
+    """Derived cell writes for one (content, geometry), replayed across frames.
+
+    The renderer builds a fresh ``Screen`` every frame on purpose — its
+    old-vs-new diff is what emits minimal terminal output — so "reuse one
+    buffer" is only possible above it: derive each row's writes once and
+    rewrite the fresh screen rows in place. Holds a reference to the
+    ``UIContent`` it was derived from so the identity-based cache key stays
+    valid for as long as the plan is cached.
+    """
+
+    __slots__ = (
+        "ui_content",
+        "visible_lines",
+        "grapheme_coordinates",
+        "blank_map",
+        "row_writes",
+        "escape_clear_range",
+    )
+
+    def __init__(
+        self,
+        ui_content: UIContent,
+        visible_lines: dict[int, tuple[int, int]],
+        grapheme_coordinates: dict[tuple[int, int], tuple[int, int]],
+        blank_map: dict[int, Char],
+        row_writes: list[tuple[int, dict[int, Char], dict[int, str]]],
+        escape_clear_range: range,
+    ) -> None:
+        self.ui_content = ui_content
+        self.visible_lines = visible_lines
+        self.grapheme_coordinates = grapheme_coordinates
+        self.blank_map = blank_map
+        self.row_writes = row_writes
+        self.escape_clear_range = escape_clear_range
+
+
+# Shared blank/continuation cells: the renderer compares painted cells with
+# ``Char._equal``, so a shared instance is equivalent to a fresh ``Char()``
+# while allocating nothing per frame.
+_GRAPH_BLANK = Char(" ", "")
+_GRAPH_CONTINUATION = Char("", "")
+# Geometry changes rarely; two hyperlink-marker variants of one viewport plus
+# slack for a resize in flight is plenty.
+_MAX_GRAPHEME_PLANS = 4
+
+
 class _GraphemeWindow(Window):
     """Window that installs extended graphemes as atomic terminal cells.
 
@@ -210,7 +258,22 @@ class _GraphemeWindow(Window):
     a valid grapheme at the viewport edge. The transcript model already wraps
     on extended-grapheme boundaries; this final screen projection preserves
     those boundaries and supplies the terminal cluster width to the renderer.
+
+    During animation the transcript's ``UIContent`` is identical frame after
+    frame (its fragment and content caches hit), yet the base ``_copy_body``
+    re-derives every cell write — and this window used to call it first and
+    then overwrite its work. The fast path below derives each row's writes once
+    per ``(content, geometry)`` into a ``_GraphemePaintPlan`` and replays the
+    plan into each fresh screen, so steady-state frames allocate almost
+    nothing. Any configuration the plan does not model falls back to the
+    original derive-every-frame path.
     """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._grapheme_plans: OrderedDict[tuple[int, int, int, int, int], _GraphemePaintPlan] = (
+            OrderedDict()
+        )
 
     def _copy_body(
         self,
@@ -229,6 +292,55 @@ class _GraphemeWindow(Window):
         align: WindowAlign = WindowAlign.LEFT,
         get_line_prefix: Callable[[int, int], AnyFormattedText] | None = None,
     ) -> tuple[dict[int, tuple[int, int]], dict[tuple[int, int], tuple[int, int]]]:
+        # The base implementation's cursor/menu handling is a no-op without
+        # focus (this window is never focusable) and without a menu position;
+        # its cursor_position is Point(0, 0) even for cursor-free content.
+        if (
+            not wrap_lines
+            and vertical_scroll == 0
+            and vertical_scroll_2 == 0
+            and horizontal_scroll == 0
+            and get_line_prefix is None
+            and align == WindowAlign.LEFT
+            and not has_focus
+            and ui_content.menu_position is None
+        ):
+            return self._copy_body_from_plan(ui_content, new_screen, write_position, move_x, width)
+        return self._copy_body_derive(
+            ui_content,
+            new_screen,
+            write_position,
+            move_x,
+            width,
+            vertical_scroll,
+            horizontal_scroll,
+            wrap_lines,
+            highlight_lines,
+            vertical_scroll_2,
+            always_hide_cursor,
+            has_focus,
+            align,
+            get_line_prefix,
+        )
+
+    def _copy_body_derive(
+        self,
+        ui_content: UIContent,
+        new_screen: Screen,
+        write_position: WritePosition,
+        move_x: int,
+        width: int,
+        vertical_scroll: int = 0,
+        horizontal_scroll: int = 0,
+        wrap_lines: bool = False,
+        highlight_lines: bool = False,
+        vertical_scroll_2: int = 0,
+        always_hide_cursor: bool = False,
+        has_focus: bool = False,
+        align: WindowAlign = WindowAlign.LEFT,
+        get_line_prefix: Callable[[int, int], AnyFormattedText] | None = None,
+    ) -> tuple[dict[int, tuple[int, int]], dict[tuple[int, int], tuple[int, int]]]:
+        """Derive every cell write from scratch (the original projection)."""
         mappings = super()._copy_body(
             ui_content,
             new_screen,
@@ -306,6 +418,126 @@ class _GraphemeWindow(Window):
 
         return visible_lines, grapheme_coordinates
 
+    def _copy_body_from_plan(
+        self,
+        ui_content: UIContent,
+        new_screen: Screen,
+        write_position: WritePosition,
+        move_x: int,
+        width: int,
+    ) -> tuple[dict[int, tuple[int, int]], dict[tuple[int, int], tuple[int, int]]]:
+        """Replay a derived paint plan into the fresh per-frame screen.
+
+        With the base ``Window`` shape this transcript window always renders
+        (no wrap, no scroll, no prefix, LEFT, no cursor/menu), the plan's
+        ``visible_lines`` and per-row writes are fully determined by the
+        ``(content, geometry)`` pair — so identical frames derive once and then
+        replay with plain ``dict.update`` stores, allocating nothing. The
+        returned mappings are the plan's own read-only projections, matching
+        the derive path's contract (consumers treat them as immutable).
+        """
+        ypos = write_position.ypos
+        height = write_position.height
+        key = (id(ui_content), move_x, write_position.xpos, ypos, width, height)
+        plans = self._grapheme_plans
+        plan = plans.get(key)
+        if plan is None or plan.ui_content is not ui_content:
+            plan = self._build_grapheme_paint_plan(ui_content, write_position, move_x, width)
+            plans[key] = plan
+            while len(plans) > _MAX_GRAPHEME_PLANS:
+                plans.popitem(last=False)
+        else:
+            plans.move_to_end(key)
+        blank_map = plan.blank_map
+        escape_clear_range = plan.escape_clear_range
+        for screen_y, writes, escapes in plan.row_writes:
+            row = new_screen.data_buffer[ypos + screen_y]
+            row.update(blank_map)
+            row.update(writes)
+            escape_row = new_screen.zero_width_escapes[ypos + screen_y]
+            for screen_x in escape_clear_range:
+                escape_row.pop(screen_x, None)
+            for x, sequence in escapes.items():
+                escape_row[x] = sequence
+        # The base implementation keeps the screen height in sync for the
+        # renderer; the fast path owns the whole body write so it must too.
+        new_screen.height = max(new_screen.height, ypos + height)
+        return plan.visible_lines, plan.grapheme_coordinates
+
+    def _build_grapheme_paint_plan(
+        self,
+        ui_content: UIContent,
+        write_position: WritePosition,
+        move_x: int,
+        width: int,
+    ) -> _GraphemePaintPlan:
+        """Derive the replayable cell writes for one ``(content, geometry)``.
+
+        Mirrors ``_copy_body_derive`` exactly — same visible-line enumeration
+        (``vertical_scroll == 0`` means screen row ``y`` paints line ``y``),
+        same erase-then-atom ordering, same escape clearing and coordinates —
+        but into plan structures instead of a live screen. The regression test
+        asserts both paths paint byte-identical screens.
+        """
+        xpos = write_position.xpos + move_x
+        ypos = write_position.ypos
+        height = write_position.height
+        visible_lines: dict[int, tuple[int, int]] = {}
+        grapheme_coordinates: dict[tuple[int, int], tuple[int, int]] = {}
+        blank_map: dict[int, Char] = dict.fromkeys(range(xpos, xpos + width), _GRAPH_BLANK)
+        row_writes: list[tuple[int, dict[int, Char], dict[int, str]]] = []
+        for screen_y in range(min(height, ui_content.line_count)):
+            line_number = screen_y
+            visible_lines[screen_y] = (line_number, 0)
+            fragments = ui_content.get_line(line_number)
+            styled_chars: list[tuple[str, str]] = []
+            raw_at_offset: dict[int, str] = {}
+            for style, text, *_rest in fragments:
+                if "[ZeroWidthEscape]" in style:
+                    raw_at_offset[len(styled_chars)] = raw_at_offset.get(
+                        len(styled_chars), ""
+                    ) + str(text)
+                else:
+                    styled_chars.extend((style, char) for char in text)
+            writes: dict[int, Char] = {}
+            escapes: dict[int, str] = {}
+            x = xpos
+            logical_cell = 0
+            for start, stop, cells in FullscreenTranscriptModel._grapheme_spans(styled_chars):
+                cluster = "".join(char for _style, char in styled_chars[start:stop])
+                if cluster == "\n":
+                    break
+                cells = max(0, cells)
+                if cells > width:
+                    cluster = "…"
+                    cells = 1
+                elif x + cells > xpos + width:
+                    break
+                atom = Char(cluster, styled_chars[start][0] if start < stop else "")
+                atom.width = cells
+                if x < xpos + width:
+                    if sequence := raw_at_offset.get(start):
+                        escapes[x] = sequence
+                    writes[x] = atom
+                    for continuation in range(cells):
+                        grapheme_coordinates[line_number, logical_cell + continuation] = (
+                            ypos + screen_y,
+                            x + continuation,
+                        )
+                    for continuation in range(1, cells):
+                        writes[x + continuation] = _GRAPH_CONTINUATION
+                x += cells
+                logical_cell += cells
+            row_writes.append((screen_y, writes, escapes))
+        return _GraphemePaintPlan(
+            ui_content,
+            visible_lines,
+            grapheme_coordinates,
+            blank_map,
+            row_writes,
+            range(xpos, xpos + width + 1),
+        )
+
 
 class _FullscreenTranscriptControl(FormattedTextControl):
     """Transcript control owning wheel navigation and drag selection."""
@@ -332,6 +564,14 @@ class _FullscreenTranscriptControl(FormattedTextControl):
         self._render_width: int | None = None
         self._render_height: int | None = None
         self._formatted_geometry: tuple[int, int | None] | None = None
+        # Memoized blank-row-preserving wrappers around the base control's
+        # content, keyed by the identity of the model's ``FormattedText``
+        # object (it is a list subclass and not directly hashable). The base
+        # content is cached per (fragments, width) key; the wrapper used to be
+        # rebuilt per call, which also defeated the grapheme paint-plan cache
+        # (a fresh UIContent identity every frame). Two slots cover the
+        # model's two alternating hyperlink-marker variants per geometry.
+        self._wrapped_by_text: OrderedDict[int, tuple[Any, int, UIContent]] = OrderedDict()
         self._dragging = False
         self._drag_moved = False
         self._drag_position = (0, 0)
@@ -356,24 +596,41 @@ class _FullscreenTranscriptControl(FormattedTextControl):
         if geometry != self._formatted_geometry:
             self._fragment_cache.clear()
             self._formatted_geometry = geometry
+        # The base implementation re-splits the fragment list and rebuilds its
+        # whole-list cache key on every call, even when the model returned an
+        # already-cached ``FormattedText`` (steady-state animation frames).
+        # Return the memoized wrapper directly when the same text object is
+        # served at the same width; the wrapper carries the identity the
+        # grapheme paint plan caches on.
+        text = self.text() if callable(self.text) else None
+        if text is not None:
+            cached = self._wrapped_by_text.get(id(text))
+            if cached is not None and cached[0] is text and cached[1] == width:
+                self._wrapped_by_text.move_to_end(id(text))
+                return cached[2]
         content = super().create_content(width, height)
 
         def get_line(index: int):
             line = content.get_line(index)
-            if any(text for _style, text, *_rest in line):
+            if any(fragment_text for _style, fragment_text, *_rest in line):
                 return line
             # prompt_toolkit only installs coordinate mappings for painted
             # cells. A visually blank space keeps logical blank transcript
             # rows mouse-addressable without changing model/exported text.
             return [("", " ")]
 
-        return UIContent(
+        wrapped = UIContent(
             get_line=get_line,
             line_count=content.line_count,
             cursor_position=content.cursor_position,
             menu_position=content.menu_position,
             show_cursor=content.show_cursor,
         )
+        if text is not None:
+            self._wrapped_by_text[id(text)] = (text, width, wrapped)
+            while len(self._wrapped_by_text) > 2:
+                self._wrapped_by_text.popitem(last=False)
+        return wrapped
 
     def mouse_handler(self, mouse_event: MouseEvent):
         # Terminals commonly reserve Option/Alt (or Shift in tmux) to bypass

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -383,6 +383,7 @@ class _GraphemeWindow(Window):
         grapheme_coordinates: dict[tuple[int, int], tuple[int, int]] = {}
         xpos = write_position.xpos + move_x
         ypos = write_position.ypos
+        pending_tail_escape: list[str] = []
         for screen_y, (line_number, _column) in visible_lines.items():
             if screen_y < 0 or screen_y >= write_position.height:
                 continue
@@ -408,6 +409,7 @@ class _GraphemeWindow(Window):
                 escape_row.pop(screen_x, None)
             x = xpos
             logical_cell = 0
+            row_wrote = False
             for start, stop, cells in FullscreenTranscriptModel._grapheme_spans(styled_chars):
                 cluster = "".join(char for _style, char in styled_chars[start:stop])
                 if cluster == "\n":
@@ -425,9 +427,18 @@ class _GraphemeWindow(Window):
                 atom = Char(cluster, styled_chars[start][0] if start < stop else "")
                 atom.width = cells
                 if x < xpos + width:
-                    if sequence := raw_at_offset.get(start):
+                    sequence = raw_at_offset.get(start, "")
+                    if not row_wrote and pending_tail_escape:
+                        # A previous row ended with a trailing zero-width
+                        # escape (no cluster of its own to attach to). Emit
+                        # it before this row's first glyph so the terminal
+                        # sees e.g. an OSC-8 close before later content.
+                        sequence = "".join(pending_tail_escape) + sequence
+                        pending_tail_escape.clear()
+                    if sequence:
                         escape_row[x] += sequence
                     row[x] = atom
+                    row_wrote = True
                     for continuation in range(cells):
                         grapheme_coordinates[line_number, logical_cell + continuation] = (
                             ypos + screen_y,
@@ -437,6 +448,12 @@ class _GraphemeWindow(Window):
                         row[x + continuation] = Char("")
                 x += cells
                 logical_cell += cells
+            # Trailing zero-width escapes sit at an offset no cluster starts
+            # at, so the loop above never emits them. The renderer only emits
+            # escapes on changed cells, so dropping them could leave a later
+            # row inheriting an open hyperlink; carry them to the next row.
+            if tail := raw_at_offset.get(len(styled_chars)):
+                pending_tail_escape.append(tail)
 
         return visible_lines, grapheme_coordinates
 
@@ -519,6 +536,7 @@ class _GraphemeWindow(Window):
         grapheme_coordinates: dict[tuple[int, int], tuple[int, int]] = {}
         blank_map: dict[int, Char] = dict.fromkeys(range(xpos, xpos + width), _GRAPH_BLANK)
         row_writes: list[tuple[int, dict[int, Char], dict[int, str]]] = []
+        pending_tail_escape: list[str] = []
         for screen_y in range(min(height, ui_content.line_count)):
             line_number = screen_y
             visible_lines[screen_y] = (line_number, 0)
@@ -536,6 +554,7 @@ class _GraphemeWindow(Window):
             escapes: dict[int, str] = {}
             x = xpos
             logical_cell = 0
+            row_wrote = False
             for start, stop, cells in FullscreenTranscriptModel._grapheme_spans(styled_chars):
                 cluster = "".join(char for _style, char in styled_chars[start:stop])
                 if cluster == "\n":
@@ -549,7 +568,15 @@ class _GraphemeWindow(Window):
                 atom = Char(cluster, styled_chars[start][0] if start < stop else "")
                 atom.width = cells
                 if x < xpos + width:
-                    if sequence := raw_at_offset.get(start):
+                    sequence = raw_at_offset.get(start, "")
+                    if not row_wrote and pending_tail_escape:
+                        # Mirror the derive path: a previous row's trailing
+                        # zero-width escape (no cluster of its own to attach
+                        # to) is emitted before this row's first glyph so an
+                        # OSC-8 close cannot leak onto later content.
+                        sequence = "".join(pending_tail_escape) + sequence
+                        pending_tail_escape.clear()
+                    if sequence:
                         # Zero-cell clusters (lone combining marks, orphan
                         # ZWJ/keycap fragments) do not advance x, so several
                         # clusters' escapes can land on one column. The
@@ -557,6 +584,7 @@ class _GraphemeWindow(Window):
                         # match it so replay stays byte-identical.
                         escapes[x] = escapes.get(x, "") + sequence
                     writes[x] = atom
+                    row_wrote = True
                     for continuation in range(cells):
                         grapheme_coordinates[line_number, logical_cell + continuation] = (
                             ypos + screen_y,
@@ -566,6 +594,11 @@ class _GraphemeWindow(Window):
                         writes[x + continuation] = _GRAPH_CONTINUATION
                 x += cells
                 logical_cell += cells
+            # Trailing zero-width escapes sit at an offset no cluster starts
+            # at, so the loop above never emits them; carry to the next row
+            # exactly like the derive path does.
+            if tail := raw_at_offset.get(len(styled_chars)):
+                pending_tail_escape.append(tail)
             row_writes.append((screen_y, writes, escapes))
         return _GraphemePaintPlan(
             ui_content,

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -27,7 +27,7 @@ import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, NamedTuple
 
 from prompt_toolkit.application import Application
 from prompt_toolkit.buffer import Buffer
@@ -232,12 +232,21 @@ class _GraphemePaintPlan:
         row_writes: list[tuple[int, dict[int, Char], dict[int, str]]],
         escape_clear_range: range,
     ) -> None:
+        """Store the derived projection; all arguments are treated read-only."""
         self.ui_content = ui_content
         self.visible_lines = visible_lines
         self.grapheme_coordinates = grapheme_coordinates
         self.blank_map = blank_map
         self.row_writes = row_writes
         self.escape_clear_range = escape_clear_range
+
+
+class _WrappedContentEntry(NamedTuple):
+    """One memoized ``UIContent`` wrapper for a (text identity, width)."""
+
+    text: AnyFormattedText
+    width: int
+    content: UIContent
 
 
 # Shared blank/continuation cells: the renderer compares painted cells with
@@ -270,10 +279,12 @@ class _GraphemeWindow(Window):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the window and its empty paint-plan cache."""
         super().__init__(*args, **kwargs)
-        self._grapheme_plans: OrderedDict[tuple[int, int, int, int, int], _GraphemePaintPlan] = (
-            OrderedDict()
-        )
+        # Keyed by (content identity, geometry); see ``_copy_body_from_plan``.
+        self._grapheme_plans: OrderedDict[
+            tuple[int, int, int, int, int, int], _GraphemePaintPlan
+        ] = OrderedDict()
 
     def _copy_body(
         self,
@@ -292,9 +303,17 @@ class _GraphemeWindow(Window):
         align: WindowAlign = WindowAlign.LEFT,
         get_line_prefix: Callable[[int, int], AnyFormattedText] | None = None,
     ) -> tuple[dict[int, tuple[int, int]], dict[tuple[int, int], tuple[int, int]]]:
-        # The base implementation's cursor/menu handling is a no-op without
-        # focus (this window is never focusable) and without a menu position;
-        # its cursor_position is Point(0, 0) even for cursor-free content.
+        """Copy the body via a cached paint plan when this window's shape allows.
+
+        The base implementation's cursor/menu handling is a no-op without
+        focus (this window is never focusable) and without a menu position;
+        its ``cursor_position`` is ``Point(0, 0)`` even for cursor-free
+        content. ``_highlight_cursorlines`` is the one focus-independent
+        cursor side effect, so ``cursorline``/``cursorcolumn`` (and
+        ``colorcolumns``) must be off for the plan path; anything else —
+        wrapping, scrolling, a line prefix, another alignment, or live
+        highlight options — falls back to ``_copy_body_derive``.
+        """
         if (
             not wrap_lines
             and vertical_scroll == 0
@@ -303,6 +322,9 @@ class _GraphemeWindow(Window):
             and get_line_prefix is None
             and align == WindowAlign.LEFT
             and not has_focus
+            and not self.cursorline()
+            and not self.cursorcolumn()
+            and not self.colorcolumns
             and ui_content.menu_position is None
         ):
             return self._copy_body_from_plan(ui_content, new_screen, write_position, move_x, width)
@@ -443,6 +465,10 @@ class _GraphemeWindow(Window):
         plan = plans.get(key)
         if plan is None or plan.ui_content is not ui_content:
             plan = self._build_grapheme_paint_plan(ui_content, write_position, move_x, width)
+            # An id() collision with a dead UIContent can hit a stale key;
+            # replacing the value alone would keep the key's old LRU slot, so
+            # remove it first and let the insert re-order the fresh plan last.
+            plans.pop(key, None)
             plans[key] = plan
             while len(plans) > _MAX_GRAPHEME_PLANS:
                 plans.popitem(last=False)
@@ -478,6 +504,13 @@ class _GraphemeWindow(Window):
         same erase-then-atom ordering, same escape clearing and coordinates —
         but into plan structures instead of a live screen. The regression test
         asserts both paths paint byte-identical screens.
+
+        One deliberate divergence from the base path: when a multi-width
+        grapheme starts at the final column, the base writes its continuation
+        cells one column past the window edge. The plan (like the derive
+        override) does not reproduce that stray write; it is out of the
+        window's region and clipped by the renderer, and reproducing it would
+        require invoking the base projection the plan exists to skip.
         """
         xpos = write_position.xpos + move_x
         ypos = write_position.ypos
@@ -517,7 +550,12 @@ class _GraphemeWindow(Window):
                 atom.width = cells
                 if x < xpos + width:
                     if sequence := raw_at_offset.get(start):
-                        escapes[x] = sequence
+                        # Zero-cell clusters (lone combining marks, orphan
+                        # ZWJ/keycap fragments) do not advance x, so several
+                        # clusters' escapes can land on one column. The
+                        # derive path concatenates at the same coordinate;
+                        # match it so replay stays byte-identical.
+                        escapes[x] = escapes.get(x, "") + sequence
                     writes[x] = atom
                     for continuation in range(cells):
                         grapheme_coordinates[line_number, logical_cell + continuation] = (
@@ -553,6 +591,7 @@ class _FullscreenTranscriptControl(FormattedTextControl):
         copy_code_callback: Callable[[str], None],
         **kwargs: Any,
     ) -> None:
+        """Capture the transcript interaction callbacks and cache state."""
         super().__init__(*args, **kwargs)
         self._scroll_callback = scroll_callback
         self._mouse_navigation_enabled = mouse_navigation_enabled
@@ -571,7 +610,7 @@ class _FullscreenTranscriptControl(FormattedTextControl):
         # rebuilt per call, which also defeated the grapheme paint-plan cache
         # (a fresh UIContent identity every frame). Two slots cover the
         # model's two alternating hyperlink-marker variants per geometry.
-        self._wrapped_by_text: OrderedDict[int, tuple[Any, int, UIContent]] = OrderedDict()
+        self._wrapped_by_text: OrderedDict[int, _WrappedContentEntry] = OrderedDict()
         self._dragging = False
         self._drag_moved = False
         self._drag_position = (0, 0)
@@ -585,10 +624,17 @@ class _FullscreenTranscriptControl(FormattedTextControl):
         return self._render_width, self._render_height
 
     def create_content(self, width: int, height: int | None):
-        # ``preferred_height`` asks for content with ``height=None`` before the
-        # concrete window height is allocated. Keep that measurement useful,
-        # but do not let its render-counter cache poison the paint that follows
-        # when bottom chrome changed this frame.
+        """Return the viewport content, memoized per (text identity, width).
+
+        ``preferred_height`` asks for content with ``height=None`` before the
+        concrete window height is allocated. Keep that measurement useful,
+        but do not let its render-counter cache poison the paint that follows
+        when bottom chrome changed this frame. A memo hit skips the base
+        implementation entirely: a hit proves the same ``FormattedText``
+        object is served, so the base's ``_fragments`` (only read by its
+        ``mouse_handler`` fallback, and never carrying per-fragment handlers
+        in the transcript) cannot be stale.
+        """
         self._render_width = max(1, width)
         if height is not None:
             self._render_height = max(1, height)
@@ -627,7 +673,7 @@ class _FullscreenTranscriptControl(FormattedTextControl):
             show_cursor=content.show_cursor,
         )
         if text is not None:
-            self._wrapped_by_text[id(text)] = (text, width, wrapped)
+            self._wrapped_by_text[id(text)] = _WrappedContentEntry(text, width, wrapped)
             while len(self._wrapped_by_text) > 2:
                 self._wrapped_by_text.popitem(last=False)
         return wrapped

--- a/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
+++ b/packages/nooa-cli/src/nooa_cli/tui/tui_application.py
@@ -657,6 +657,7 @@ class _FullscreenTranscriptControl(FormattedTextControl):
         content = super().create_content(width, height)
 
         def get_line(index: int):
+            """Return one content row, substituting a blank space for empty rows."""
             line = content.get_line(index)
             if any(fragment_text for _style, fragment_text, *_rest in line):
                 return line

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -4528,15 +4528,24 @@ def test_grapheme_paint_plan_replays_identical_screen() -> None:
 
     model = FullscreenTranscriptModel(show_trailing_blank=False)
     for start in range(0, 60, 10):
-        model.append(
-            "\n".join(
-                f"\x1b[36mrow {i}: the quick brown fox\x1b[0m"
-                if i % 3
-                else f"see \x1b]8;;https://example.invalid/{i}\x1b\\link {i}\x1b]8;;\x1b\\ tail"
-                for i in range(start, min(start + 10, 60))
-            )
-            + "\n"
-        )
+        rows = []
+        for i in range(start, min(start + 10, 60)):
+            if i % 3:
+                rows.append(f"\x1b[36mrow {i}: the quick brown fox\x1b[0m")
+            else:
+                rows.append(
+                    f"see \x1b]8;;https://example.invalid/{i}\x1b\\link {i}\x1b]8;;\x1b\\ tail"
+                )
+            if i % 5 == 0:
+                # Multi-width graphemes (emoji/flags/ZWJ sequences) pin the
+                # plan's continuation cells and width clipping, and a lone
+                # combining mark after a hyperlink close pins co-located
+                # zero-width escapes (two clusters painting at one column).
+                rows.append(
+                    "\x1b]8;;https://example.invalid/wide\x1b\\e\u0301"
+                    "\U0001f1e8\U0001f1ed\U0001f469\u200d\U0001f4bb\x1b]8;;\x1b\\"
+                )
+        model.append("\n".join(rows) + "\n")
     width, height = 40, 6
     formatted = model.formatted_text(width=width, height=height, render_counter=0)
     control = _FullscreenTranscriptControl(
@@ -4606,8 +4615,194 @@ def test_grapheme_paint_plan_replays_identical_screen() -> None:
     # One plan for this (content, geometry) pair, built once.
     assert len(window._grapheme_plans) == 1
 
+    # The fast path owns the whole body write, so it must replicate the
+    # base's screen-height bookkeeping.
+    assert screen_b.height == write_position.height
+    assert screen_c.height == write_position.height
+
     # A different geometry derives a fresh plan rather than replaying stale writes.
     narrow = WritePosition(xpos=0, ypos=0, width=20, height=height)
     screen_d = Screen()
     window._copy_body_from_plan(content, screen_d, narrow, 0, 20)
     assert len(window._grapheme_plans) == 2
+
+
+def _make_paint_plan_window(width: int = 40, height: int = 6):
+    """Shared fixture: a transcript control + grapheme window over a small model."""
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+    from nooa_cli.tui.tui_application import _FullscreenTranscriptControl, _GraphemeWindow
+
+    model = FullscreenTranscriptModel(show_trailing_blank=False)
+    for start in range(0, 30, 10):
+        model.append(
+            "\n".join(
+                f"\x1b[36mrow {i}: the quick brown fox\x1b[0m"
+                if i % 3
+                else f"see \x1b]8;;https://example.invalid/{i}\x1b\\link {i}\x1b]8;;\x1b\\ tail"
+                for i in range(start, min(start + 10, 30))
+            )
+            + "\n"
+        )
+    formatted_holder = [model.formatted_text(width=width, height=height, render_counter=0)]
+    control = _FullscreenTranscriptControl(
+        lambda: formatted_holder[0],
+        focusable=False,
+        show_cursor=False,
+        scroll_callback=lambda delta: None,
+        mouse_navigation_enabled=lambda: False,
+        selection_callback=lambda *args: None,
+        link_callback=lambda x, y: False,
+        code_action_at=lambda x, y: None,
+        copy_code_callback=lambda text: None,
+    )
+    window = _GraphemeWindow(
+        control,
+        wrap_lines=False,
+        get_vertical_scroll=lambda _window: 0,
+        always_hide_cursor=True,
+    )
+    return model, formatted_holder, control, window
+
+
+def test_transcript_control_create_content_memoizes_wrapper_identity() -> None:
+    """The create_content memo must serve the same wrapper for the same text+width.
+
+    A regression that rebuilds the wrapper per call would silently defeat both
+    the base fragment cache and the grapheme paint-plan cache — the entire
+    point of the fast path — with every existing test still green.
+    """
+    model, formatted_holder, control, _window = _make_paint_plan_window(width=40, height=6)
+    with create_app_session(input=DummyInput(), output=DummyOutput()):
+        # Same FormattedText object at the same width: one memoized wrapper.
+        first = control.create_content(40, 6)
+        second = control.create_content(40, 6)
+        assert first is second
+        # The alternating hyperlink-marker variant is a different text object:
+        # each variant gets its own wrapper, served stably across calls.
+        formatted_holder[0] = model.formatted_text(width=40, height=6, render_counter=1)
+        variant_b = control.create_content(40, 6)
+        assert variant_b is not first
+        formatted_holder[0] = model.formatted_text(width=40, height=6, render_counter=0)
+        variant_a_again = control.create_content(40, 6)
+        assert variant_a_again is first
+        # A different width rebuilds rather than serving the other width's wrapper.
+        narrower = control.create_content(20, 6)
+        assert narrower is not first and narrower is not variant_b
+        # The memo stays bounded regardless of how many widths cycle through.
+        for width in (10, 15, 20, 25, 30, 35):
+            control.create_content(width, 6)
+        assert len(control._wrapped_by_text) <= 2
+
+
+def test_grapheme_plan_id_reuse_cannot_replay_stale_writes() -> None:
+    """A recycled id() must not alias a stale plan onto new content."""
+    from nooa_cli.tui.tui_application import _GraphemePaintPlan
+    from prompt_toolkit.formatted_text.utils import split_lines
+    from prompt_toolkit.layout.controls import UIContent
+    from prompt_toolkit.layout.screen import Screen, WritePosition
+
+    _model, _holder, _control, window = _make_paint_plan_window(width=40, height=6)
+    fragments = [("", "ZZZZ"), ("", "\n"), ("", "ZZZZ"), ("", "\n")]
+    lines = list(split_lines(fragments))
+    content = UIContent(
+        get_line=lambda i: lines[i],
+        line_count=len(lines),
+        show_cursor=False,
+        cursor_position=None,
+        menu_position=None,
+    )
+    write_position = WritePosition(xpos=0, ypos=0, width=40, height=6)
+    # A DIFFERENT (simulated dead) UIContent whose id collided with the new
+    # content's — exactly the recycle the identity guard exists to catch.
+    stale_content = UIContent(
+        get_line=lambda i: [("class:stale", "stale")],
+        line_count=1,
+        show_cursor=False,
+        cursor_position=None,
+        menu_position=None,
+    )
+    key = (id(content), 0, 0, 0, 40, 6)
+    # Plant a STALE plan under the exact key the new content will produce.
+    window._grapheme_plans[key] = _GraphemePaintPlan(
+        stale_content,
+        {0: (999, 0)},
+        {},
+        {},
+        [],
+        range(0, 41),
+    )
+    screen = Screen()
+    visible, _coordinates = window._copy_body_from_plan(content, screen, write_position, 0, 40)
+    # The identity re-validation must have rebuilt instead of replaying the
+    # stale plan: visible rows come from the NEW content ("ZZZZ\nZZZZ\n"
+    # splits into two text rows plus the trailing empty line), not (999, 0).
+    assert visible == {0: (0, 0), 1: (1, 0), 2: (2, 0)}
+    rebuilt = window._grapheme_plans[key]
+    assert rebuilt is not None and rebuilt.ui_content is content
+
+
+def test_grapheme_plan_lru_is_bounded() -> None:
+    """Distinct geometries evict oldest plans; the cache stays at its cap."""
+    from prompt_toolkit.layout.screen import Screen, WritePosition
+
+    _model, _holder, _control, window = _make_paint_plan_window(width=40, height=6)
+    from nooa_cli.tui.tui_application import _MAX_GRAPHEME_PLANS
+
+    for index in range(_MAX_GRAPHEME_PLANS + 3):
+        write_position = WritePosition(xpos=0, ypos=0, width=10 + index, height=6)
+        screen = Screen()
+        content = window.content.create_content(10 + index, 6)
+        window._copy_body_from_plan(content, screen, write_position, 0, 10 + index)
+    assert len(window._grapheme_plans) <= _MAX_GRAPHEME_PLANS
+
+
+def test_grapheme_window_copy_body_guard_falls_back_to_derive() -> None:
+    """Configurations the plan does not model must route to the derive path."""
+    import inspect
+
+    from prompt_toolkit.layout.screen import Screen, WritePosition
+
+    _model, _holder, _control, window = _make_paint_plan_window(width=40, height=6)
+    content = window.content.create_content(40, 6)
+    write_position = WritePosition(xpos=0, ypos=0, width=40, height=6)
+    plans_before = len(window._grapheme_plans)
+
+    # wrap_lines=True is not modeled by the plan path: it must fall back.
+    screen = Screen()
+    window._copy_body(content, screen, write_position, 0, 40, wrap_lines=True)
+    assert len(window._grapheme_plans) == plans_before, "wrapped config must not create plans"
+    # The fallback is the derive implementation, with its full mapping contract.
+    assert screen.height >= write_position.height
+
+    # The structural guard keeps matching the derive path's signature.
+    derive_signature = inspect.signature(window._copy_body_derive)
+    copy_signature = inspect.signature(window._copy_body)
+    assert tuple(copy_signature.parameters) == tuple(derive_signature.parameters)
+
+
+def test_grapheme_plan_returned_mappings_are_not_mutated_by_replay() -> None:
+    """The shared plan mappings must remain unchanged across replays (contract)."""
+    from prompt_toolkit.layout.screen import Screen, WritePosition
+
+    _model, _holder, _control, window = _make_paint_plan_window(width=40, height=6)
+    content = window.content.create_content(40, 6)
+    write_position = WritePosition(xpos=0, ypos=0, width=40, height=6)
+
+    screen_one = Screen()
+    visible_one, coordinates_one = window._copy_body_from_plan(
+        content, screen_one, write_position, 0, 40
+    )
+    snapshot_visible = dict(visible_one)
+    snapshot_coordinates = dict(coordinates_one)
+    snapshot_ids = (id(visible_one), id(coordinates_one))
+
+    # A second replay with a DIFFERENT screen must not touch the plan maps.
+    screen_two = Screen()
+    visible_two, coordinates_two = window._copy_body_from_plan(
+        content, screen_two, write_position, 0, 40
+    )
+    assert (id(visible_two), id(coordinates_two)) == snapshot_ids
+    assert visible_two == snapshot_visible
+    assert coordinates_two == snapshot_coordinates
+    assert dict(visible_one) == snapshot_visible
+    assert dict(coordinates_one) == snapshot_coordinates

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -4576,6 +4576,7 @@ def test_grapheme_paint_plan_replays_identical_screen() -> None:
     write_position = WritePosition(xpos=0, ypos=0, width=width, height=height)
 
     def paint_derive() -> tuple[Screen, object, object]:
+        """Paint via the derive path and return (screen, visible, coordinates)."""
         screen = Screen()
         visible, coordinates = window._copy_body_derive(content, screen, write_position, 0, width)
         return screen, visible, coordinates
@@ -4591,6 +4592,7 @@ def test_grapheme_paint_plan_replays_identical_screen() -> None:
     )
 
     def dump(screen: Screen) -> tuple[list[str], list[list[tuple[int, str, str, int]]]]:
+        """Serialize rows, per-cell tuples, and zero-width escapes for equality checks."""
         rows = []
         cells = []
         for y in range(write_position.height):

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -4509,3 +4509,105 @@ def test_prepend_preserves_visible_tail_and_record_anchor() -> None:
     model.prepend("oldest\n", record_id=5)
     assert model.viewport.anchor == anchor
     assert model.formatted_text(width=20, height=2) == anchored_before
+
+
+def test_grapheme_paint_plan_replays_identical_screen() -> None:
+    """The fast-path paint plan must reproduce the derive path exactly.
+
+    The fullscreen transcript window's ``_copy_body`` fast path derives each
+    row's cell writes once per ``(content, geometry)`` and replays them into
+    the fresh per-frame screen. That replay is only safe if it paints
+    byte-identical screens to the original derive-every-frame projection, and
+    if repeated frames replay the memoized plan instead of rebuilding it.
+    """
+    from nooa_cli.tui.fullscreen_transcript import FullscreenTranscriptModel
+    from nooa_cli.tui.tui_application import _FullscreenTranscriptControl, _GraphemeWindow
+    from prompt_toolkit.formatted_text.utils import split_lines
+    from prompt_toolkit.layout.controls import UIContent
+    from prompt_toolkit.layout.screen import Screen, WritePosition
+
+    model = FullscreenTranscriptModel(show_trailing_blank=False)
+    for start in range(0, 60, 10):
+        model.append(
+            "\n".join(
+                f"\x1b[36mrow {i}: the quick brown fox\x1b[0m"
+                if i % 3
+                else f"see \x1b]8;;https://example.invalid/{i}\x1b\\link {i}\x1b]8;;\x1b\\ tail"
+                for i in range(start, min(start + 10, 60))
+            )
+            + "\n"
+        )
+    width, height = 40, 6
+    formatted = model.formatted_text(width=width, height=height, render_counter=0)
+    control = _FullscreenTranscriptControl(
+        lambda: formatted,
+        focusable=False,
+        show_cursor=False,
+        scroll_callback=lambda delta: None,
+        mouse_navigation_enabled=lambda: False,
+        selection_callback=lambda *args: None,
+        link_callback=lambda x, y: False,
+        code_action_at=lambda x, y: None,
+        copy_code_callback=lambda text: None,
+    )
+    window = _GraphemeWindow(
+        control,
+        wrap_lines=False,
+        get_vertical_scroll=lambda _window: 0,
+        always_hide_cursor=True,
+    )
+    fragment_lines = list(split_lines(formatted))
+    content = UIContent(
+        get_line=lambda i: fragment_lines[i],
+        line_count=len(fragment_lines),
+        show_cursor=False,
+        cursor_position=None,
+        menu_position=None,
+    )
+    write_position = WritePosition(xpos=0, ypos=0, width=width, height=height)
+
+    def paint_derive() -> tuple[Screen, object, object]:
+        screen = Screen()
+        visible, coordinates = window._copy_body_derive(content, screen, write_position, 0, width)
+        return screen, visible, coordinates
+
+    screen_a, visible_a, coordinates_a = paint_derive()
+    screen_b = Screen()
+    visible_b, coordinates_b = window._copy_body_from_plan(
+        content, screen_b, write_position, 0, width
+    )
+    screen_c = Screen()
+    visible_c, coordinates_c = window._copy_body_from_plan(
+        content, screen_c, write_position, 0, width
+    )
+
+    def dump(screen: Screen) -> tuple[list[str], list[list[tuple[int, str, str, int]]]]:
+        rows = []
+        cells = []
+        for y in range(write_position.height):
+            row = screen.data_buffer[y]
+            rows.append("".join(row[x].char if x in row else " " for x in range(width)))
+            cells.append([(x, row[x].char, row[x].style, row[x].width) for x in sorted(row)])
+        escapes = [dict(screen.zero_width_escapes[y].items()) for y in range(write_position.height)]
+        return rows + [repr(escapes)], cells
+
+    rows_a, cells_a = dump(screen_a)
+    rows_b, cells_b = dump(screen_b)
+    rows_c, cells_c = dump(screen_c)
+
+    assert rows_a == rows_b, "plan path must paint the same text as the derive path"
+    assert rows_a == rows_c, "plan replay must stay identical across frames"
+    assert cells_a == cells_b and cells_a == cells_c
+    assert visible_a == visible_b and visible_b == visible_c
+    assert coordinates_a == coordinates_b and coordinates_b == coordinates_c
+    # Replay proof: the second fast-path call serves the memoized mappings.
+    assert visible_b is visible_c
+    assert coordinates_b is coordinates_c
+    # One plan for this (content, geometry) pair, built once.
+    assert len(window._grapheme_plans) == 1
+
+    # A different geometry derives a fresh plan rather than replaying stale writes.
+    narrow = WritePosition(xpos=0, ypos=0, width=20, height=height)
+    screen_d = Screen()
+    window._copy_body_from_plan(content, screen_d, narrow, 0, 20)
+    assert len(window._grapheme_plans) == 2

--- a/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
+++ b/packages/nooa-cli/tests/tui/test_fullscreen_transcript.py
@@ -4808,3 +4808,71 @@ def test_grapheme_plan_returned_mappings_are_not_mutated_by_replay() -> None:
     assert coordinates_two == snapshot_coordinates
     assert dict(visible_one) == snapshot_visible
     assert dict(coordinates_one) == snapshot_coordinates
+
+
+def test_trailing_zero_width_escape_carries_to_next_row_glyph() -> None:
+    """A row-final zero-width escape must be emitted before the next row's glyph.
+
+    A trailing OSC-8 close has no grapheme cluster of its own (its offset is
+    ``len(styled_chars)``), so neither path emits it in-row. The renderer only
+    writes escapes on changed cells, so dropping it would let the following
+    transcript row inherit the open hyperlink. Both paths carry it forward.
+    """
+    from nooa_cli.tui.tui_application import _FullscreenTranscriptControl, _GraphemeWindow
+    from prompt_toolkit.formatted_text.utils import split_lines
+    from prompt_toolkit.layout.controls import UIContent
+    from prompt_toolkit.layout.screen import Screen, WritePosition
+
+    osc8_close = chr(27) + "]8;;" + chr(27) + chr(92)
+    fragments = [
+        ("", "A"),
+        ("", "B"),
+        ("[ZeroWidthEscape]", osc8_close),
+        ("", "\n"),
+        ("", "C"),
+        ("", "D"),
+        ("", "\n"),
+    ]
+    lines = list(split_lines(fragments))
+    content = UIContent(
+        get_line=lambda i: lines[i],
+        line_count=len(lines),
+        show_cursor=False,
+        cursor_position=None,
+        menu_position=None,
+    )
+    control = _FullscreenTranscriptControl(
+        lambda: fragments,
+        focusable=False,
+        show_cursor=False,
+        scroll_callback=lambda delta: None,
+        mouse_navigation_enabled=lambda: False,
+        selection_callback=lambda *args: None,
+        link_callback=lambda x, y: False,
+        code_action_at=lambda x, y: None,
+        copy_code_callback=lambda text: None,
+    )
+    window = _GraphemeWindow(
+        control,
+        wrap_lines=False,
+        get_vertical_scroll=lambda _window: 0,
+        always_hide_cursor=True,
+    )
+    write_position = WritePosition(xpos=0, ypos=0, width=20, height=4)
+
+    screen_a = Screen()
+    window._copy_body_derive(content, screen_a, write_position, 0, 20)
+    screen_b = Screen()
+    window._copy_body_from_plan(content, screen_b, write_position, 0, 20)
+
+    for name, screen in (("derive", screen_a), ("plan", screen_b)):
+        first_row_escapes = dict(screen.zero_width_escapes[0])
+        next_row_escapes = dict(screen.zero_width_escapes[1])
+        # The trailing close never lands on its own row...
+        assert "\x1b]8;;\x1b\\" not in "".join(first_row_escapes.values())
+        # ...and does appear before the next row's first glyph (x=0).
+        assert next_row_escapes.get(0) == "\x1b]8;;\x1b\\", name
+    # Both paths agree byte-for-byte.
+    assert {y: dict(screen_a.zero_width_escapes[y]) for y in range(4)} == {
+        y: dict(screen_b.zero_width_escapes[y]) for y in range(4)
+    }


### PR DESCRIPTION
## Problem

Each spinner-driven fullscreen render re-derived every transcript cell write, even though the transcript content is identical frame after frame during animation:

- the grapheme window called the base `Window._copy_body` **first** — allocating ~5.9k discarded cell writes plus a 10k-entry rowcol map it then overwrote,
- erased with a fresh `Char()` per cell, rebuilt per-char styled lists, fresh `Char` atoms, and a fresh coordinate map,
- the base `FormattedTextControl.create_content` re-split the fragment list and rebuilt its whole-list cache key on every call, and the control allocated a fresh `UIContent` per frame.

Together: **~14k allocations per render** of steady-state animation. At the spinner's ~12.5 renders/s this churn also feeds the allocator pressure behind GC pauses on the single UI thread.

## Change

prompt_toolkit deliberately builds a fresh `Screen` per frame — the old-vs-new `Char` diff is what emits minimal terminal output — so buffer reuse must happen above the renderer. The transcript window now:

- derives each row's cell writes **once per (content identity, geometry)** into a `_GraphemePaintPlan` (shared blank/continuation cells, memoized atoms, escapes, coordinates, visible-line mappings; LRU-bounded),
- **replays** the plan into each fresh screen with plain `dict.update` stores,
- the control memoizes its blank-row-preserving `UIContent` wrapper keyed by the model `FormattedText` identity + width (two slots cover the alternating hyperlink-marker variants), which is what lets the plan cache hit across frames,
- any configuration the fast path does not model (wrap, scroll, prefix, non-LEFT align, focus, menu) falls back to the original derive path unchanged.

## Results (10k-line benchmark)

| Metric | Before | After |
|---|---|---|
| Allocations per render | ~14,033 | **~267 (−98%)** |
| Median fullscreen render | 6.2 ms | **1.4 ms** |

## Testing

- New regression test asserts the fast path paints **byte-identical** screens (cells, escapes, mappings) to the original derive path, and that repeated frames replay the memoized plan rather than rebuilding it (identity assertions + plan-count checks).
- Full TUI suite: **1,570 passed**.
- Ruff check + format clean; DCO signed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved fullscreen transcript rendering by reusing prepared grapheme layouts for matching content and screen dimensions.
  * Reduced repeated processing and allocations during transcript display.

* **Bug Fixes**
  * Preserved correct clipping, formatting, hyperlinks, visibility mappings, and coordinate behavior.
  * Maintained accurate handling of combining marks, multi-width characters, and zero-width formatting sequences.

* **Tests**
  * Added coverage for rendering consistency, cache limits, stale content, screen dimensions, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->