### PR TITLE
feat(llm): mark explicit cache boundaries before dynamic context

### DIFF
--- a/skills/nooa-context-and-state/SKILL.md
+++ b/skills/nooa-context-and-state/SKILL.md
@@ -71,6 +71,12 @@ stable content in the prefix: changing a prefix block invalidates cache reuse
 for that block and everything after it. Keep live or frequently changing blocks
 in the volatile suffix so the stable prefix remains reusable.
 
+The cached renderer automatically marks where that volatile suffix begins.
+Registry entries may translate the neutral marker with `cache_breakpoint:
+openai` for the Responses API or `cache_breakpoint: anthropic` for Chat. Gemini
+has no inline breakpoint mapping; its implicit prefix cache still benefits from
+the same stable-first layout.
+
 Per-method overrides via `ScopedContext`:
 
 ```python

--- a/src/nooa/_llm_state.py
+++ b/src/nooa/_llm_state.py
@@ -18,15 +18,27 @@ LLM_STATE_KEY = "_nooa_llm_state"
 
 
 class ReplayCarryingMessage(dict[str, Any]):
-    """A public wire message with replay metadata outside its mapping."""
+    """A public wire message with internal metadata outside its mapping.
 
-    __slots__ = ("llm_state", "reasoning", "replay_batch_id", "replay_batch_size")
+    Generic JSON serializers see only the ordinary dictionary fields. Built-in
+    UnifiedLLM clients read the attributes, gate opaque state by issuer, and
+    translate a provider-neutral cache boundary at the final wire edge.
+    """
+
+    __slots__ = (
+        "llm_state",
+        "reasoning",
+        "cache_boundary_before",
+        "replay_batch_id",
+        "replay_batch_size",
+    )
 
     def __init__(
         self,
         message: dict[str, Any],
         llm_state: dict[str, Any] | None = None,
         reasoning: str | None = None,
+        cache_boundary_before: bool = False,
         *,
         replay_batch_id: str | None = None,
         replay_batch_size: int = 0,
@@ -36,6 +48,7 @@ class ReplayCarryingMessage(dict[str, Any]):
         # adapter owns serialization and must not mutate caller input.
         self.llm_state = llm_state
         self.reasoning = reasoning
+        self.cache_boundary_before = cache_boundary_before
         self.replay_batch_id = replay_batch_id
         self.replay_batch_size = replay_batch_size
 
@@ -129,3 +142,8 @@ def demote_responses_batch(
         ]
     demote_reasoning_text(message, reasoning)
     return clean
+
+
+def carried_cache_boundary(message: Any) -> bool:
+    """Return whether the volatile suffix begins at this rendered message."""
+    return getattr(message, "cache_boundary_before", False) is True

--- a/src/nooa/context_blocks/formatter.py
+++ b/src/nooa/context_blocks/formatter.py
@@ -27,10 +27,10 @@ from typing import TYPE_CHECKING, Any, TypeGuard
 
 from nooa._llm_state import (
     ReplayCarryingMessage,
-    carry_replay_batch,
     carried_reasoning,
     carried_replay_batch,
     carried_state,
+    carry_replay_batch,
 )
 
 if TYPE_CHECKING:

--- a/src/nooa/context_blocks/formatter.py
+++ b/src/nooa/context_blocks/formatter.py
@@ -25,7 +25,13 @@ from collections.abc import Callable
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, TypeGuard
 
-from nooa._llm_state import ReplayCarryingMessage, carry_replay_batch
+from nooa._llm_state import (
+    ReplayCarryingMessage,
+    carry_replay_batch,
+    carried_reasoning,
+    carried_replay_batch,
+    carried_state,
+)
 
 if TYPE_CHECKING:
     from nooa.config.truncation_config import FormatConfig
@@ -556,12 +562,30 @@ def _with_replay_data(
     return ReplayCarryingMessage(message, state, reasoning) if state or reasoning else message
 
 
+def _carry_cache_boundary(
+    output: list[dict[str, Any]], start: int, message: RenderedMessage
+) -> None:
+    """Attach a before-message boundary to its first emitted wire item."""
+    if message.cache_boundary_before and len(output) > start:
+        item = output[start]
+        batch = carried_replay_batch(item)
+        output[start] = ReplayCarryingMessage(
+            dict(item),
+            carried_state(item),
+            carried_reasoning(item),
+            True,
+            replay_batch_id=batch[0] if batch else None,
+            replay_batch_size=batch[1] if batch else 0,
+        )
+
+
 class OpenAIProviderFormatter(ProviderFormatter):
     """Emit OpenAI-compatible messages (``list[dict]``)."""
 
     def format(self, messages: list[RenderedMessage]) -> list[dict]:
         out: list[dict] = []
         for msg in messages:
+            start = len(out)
             if msg.tool_calls:
                 assistant_message = {
                     "role": "assistant",
@@ -599,6 +623,7 @@ class OpenAIProviderFormatter(ProviderFormatter):
                         msg.reasoning,
                     )
                 )
+            _carry_cache_boundary(out, start, msg)
         return out
 
 
@@ -614,6 +639,7 @@ class AnthropicProviderFormatter(ProviderFormatter):
                     system_parts.append(msg.content)
                 continue
 
+            start = len(out)
             if msg.tool_calls:
                 content: list[dict[str, Any]] = []
                 if msg.content:
@@ -667,6 +693,7 @@ class AnthropicProviderFormatter(ProviderFormatter):
                         msg.reasoning,
                     )
                 )
+            _carry_cache_boundary(out, start, msg)
 
         return {"system": "\n\n".join(system_parts), "messages": out}
 
@@ -686,8 +713,10 @@ class ResponsesProviderFormatter(ProviderFormatter):
     def format(self, messages: list[RenderedMessage]) -> list[dict]:
         out: list[dict] = []
         for msg in messages:
+            start = len(out)
             if msg.role == Role.SYSTEM:
                 out.append({"role": "system", "content": msg.content or ""})
+                _carry_cache_boundary(out, start, msg)
                 continue
 
             if msg.tool_calls:
@@ -755,4 +784,5 @@ class ResponsesProviderFormatter(ProviderFormatter):
                     out.extend(carry_replay_batch([message], msg.llm_state, msg.reasoning))
                 else:
                     out.append(message)
+            _carry_cache_boundary(out, start, msg)
         return out

--- a/src/nooa/context_blocks/models.py
+++ b/src/nooa/context_blocks/models.py
@@ -303,6 +303,7 @@ class RenderedMessage(BaseModel):
     llm_state: SkipValidation[dict[str, Any] | None] = Field(
         default=None,
         repr=False,
+        exclude=True,
         description=(
             "Borrowed immutable opaque state carried through the UnifiedLLM replay boundary"
         ),
@@ -310,10 +311,12 @@ class RenderedMessage(BaseModel):
     reasoning: str | None = Field(
         default=None,
         repr=False,
+        exclude=True,
         description="Plain reasoning carried to UnifiedLLM for replay as assistant text",
     )
     cache_boundary_before: bool = Field(
         default=False,
+        exclude=True,
         description="The provider-cacheable prefix ends before this message",
     )
     tool_call_id: str | None = Field(

--- a/src/nooa/context_blocks/models.py
+++ b/src/nooa/context_blocks/models.py
@@ -312,6 +312,10 @@ class RenderedMessage(BaseModel):
         repr=False,
         description="Plain reasoning carried to UnifiedLLM for replay as assistant text",
     )
+    cache_boundary_before: bool = Field(
+        default=False,
+        description="The provider-cacheable prefix ends before this message",
+    )
     tool_call_id: str | None = Field(
         default=None, description="Tool-call id this message is a result for"
     )

--- a/src/nooa/context_blocks/renderers/cached.py
+++ b/src/nooa/context_blocks/renderers/cached.py
@@ -139,7 +139,14 @@ class CachedBlockFormatter(BlockFormatter):
             # mutate the bytes of a historical event message whenever a later
             # turn becomes the new trailing event, breaking provider prompt
             # caching for the entire event tail (issue #208).
-            messages.append(RenderedMessage(role=Role.USER, content=suffix, parts=envelope_parts))
+            messages.append(
+                RenderedMessage(
+                    role=Role.USER,
+                    content=suffix,
+                    parts=envelope_parts,
+                    cache_boundary_before=True,
+                )
+            )
 
         return messages
 

--- a/src/nooa/llm_types.py
+++ b/src/nooa/llm_types.py
@@ -81,7 +81,14 @@ class LLMUsage(BaseModel):
                 or 0
             ),
             cache_write_input_tokens=int(
-                first(value, "cache_write_input_tokens", "cache_creation_input_tokens") or 0
+                first(value, "cache_write_input_tokens", "cache_creation_input_tokens")
+                or first(
+                    prompt_details,
+                    "cache_write_tokens",
+                    "cache_write_input_tokens",
+                    "cache_creation_input_tokens",
+                )
+                or 0
             ),
             reasoning_tokens=int(
                 first(value, "reasoning_tokens")

--- a/src/nooa/unifiedllm/registry.py
+++ b/src/nooa/unifiedllm/registry.py
@@ -41,6 +41,7 @@ YAML schema::
         store: false                         # optional Responses API control
         include:                             # optional Responses API output fields
           - reasoning.encrypted_content
+        cache_breakpoint: openai             # optional: openai or anthropic wire mapping
 
 Set a model to ``null`` in a later layer to remove it.
 """
@@ -390,6 +391,7 @@ def get_llm_client(name: str, *, client_type: str | None = None, **overrides) ->
         "extra_body",
         "store",
         "include",
+        "cache_breakpoint",
     ):
         if key in config and key not in overrides:
             params[key] = config[key]

--- a/src/nooa/unifiedllm/replay_state.py
+++ b/src/nooa/unifiedllm/replay_state.py
@@ -22,6 +22,8 @@ import litellm
 
 from nooa._llm_state import (
     LLM_STATE_KEY,
+    ReplayCarryingMessage,
+    carried_cache_boundary,
     carried_reasoning,
     carried_state,
     demote_reasoning_text,
@@ -700,6 +702,7 @@ def prepare_chat_messages(messages: list[dict[str, Any]], scope: str | None) -> 
     public_call_ids: dict[str, str] = {}
     private_call_ids: dict[str, str] = {}
     for original in messages:
+        cache_boundary = carried_cache_boundary(original)
         state = carried_state(original)
         reasoning = carried_reasoning(original)
         message = copy.deepcopy(dict(original))
@@ -747,7 +750,11 @@ def prepare_chat_messages(messages: list[dict[str, Any]], scope: str | None) -> 
             and not message.get("tool_calls")
         ):
             continue
-        prepared.append(message)
+        prepared.append(
+            ReplayCarryingMessage(message, cache_boundary_before=True)
+            if cache_boundary
+            else message
+        )
     return prepared
 
 

--- a/src/nooa/unifiedllm/replay_state.py
+++ b/src/nooa/unifiedllm/replay_state.py
@@ -749,6 +749,8 @@ def prepare_chat_messages(messages: list[dict[str, Any]], scope: str | None) -> 
             and not message.get("content")
             and not message.get("tool_calls")
         ):
+            if cache_boundary:
+                prepared.append(ReplayCarryingMessage({}, cache_boundary_before=True))
             continue
         prepared.append(
             ReplayCarryingMessage(message, cache_boundary_before=True)

--- a/src/nooa/unifiedllm/unifiedllm.py
+++ b/src/nooa/unifiedllm/unifiedllm.py
@@ -19,6 +19,8 @@ from pydantic import BaseModel, RootModel
 
 from nooa._llm_state import (
     LLM_STATE_KEY,
+    ReplayCarryingMessage,
+    carried_cache_boundary,
     carried_reasoning,
     carried_replay_batch,
     carried_state,
@@ -1132,13 +1134,65 @@ def _update_token_calibration(
         logger.debug("token calibration skipped (estimate failed)", exc_info=True)
 
 
+def _mark_responses_text(content: Any) -> tuple[Any, bool]:
+    """Attach an OpenAI explicit breakpoint to the last input-text block."""
+    marker = {"mode": "explicit"}
+    if isinstance(content, str):
+        return [
+            {
+                "type": "input_text",
+                "text": content,
+                "prompt_cache_breakpoint": marker,
+            }
+        ], True
+    if isinstance(content, list):
+        updated = copy.deepcopy(content)
+        for block in reversed(updated):
+            if isinstance(block, dict) and block.get("type") == "input_text":
+                block["prompt_cache_breakpoint"] = marker
+                return updated, True
+    return content, False
+
+
+def _mark_responses_cache_breakpoint(messages: list[dict[str, Any]], boundary: int) -> bool:
+    """Mark the latest eligible Responses input block before ``boundary``."""
+    for item in reversed(messages[:boundary]):
+        if item.get("type") == "function_call_output":
+            output, marked = _mark_responses_text(item.get("output"))
+            if marked:
+                item["output"] = output
+                return True
+        # Assistant output uses output_text, which is not an eligible input block.
+        if item.get("role") in {"system", "developer", "user"}:
+            content, marked = _mark_responses_text(item.get("content"))
+            if marked:
+                item["content"] = content
+                return True
+    return False
+
+
+def _enable_openai_explicit_cache(api_params: dict[str, Any]) -> None:
+    """Set the Responses cache mode through LiteLLM's SDK escape hatch."""
+    extra_body = copy.deepcopy(api_params.get("extra_body"))
+    if not isinstance(extra_body, dict):
+        extra_body = {}
+    options = extra_body.get("prompt_cache_options")
+    if not isinstance(options, dict):
+        options = {}
+    options["mode"] = "explicit"
+    extra_body["prompt_cache_options"] = options
+    api_params["extra_body"] = extra_body
+
+
 class UnifiedLLM(ABC):
     _registry_config: dict[str, Any] | None
+    cache_breakpoint: Literal["openai", "anthropic"] | None
 
     def __init__(self, model: str, **config):
         self.model = model
         self.config = config
         self._registry_config = None
+        self.cache_breakpoint = None
         # Cache control injection — shared by CompletionClient and ResponsesClient
         self.cache_control_injection_points: list[dict[str, Any]] = (
             DEFAULT_CACHE_CONTROL_INJECTION_POINTS
@@ -1331,6 +1385,52 @@ class UnifiedLLM(ABC):
                     break
 
         return prepared
+
+    def _prepare_cache_boundary(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        responses: bool,
+        instructions: str | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None, bool]:
+        """Consume the neutral stable-prefix marker at the provider edge."""
+        boundary: int | None = None
+        clean: list[dict[str, Any]] = []
+        for message in messages:
+            if carried_cache_boundary(message) and boundary is None:
+                boundary = len(clean)
+            item = copy.deepcopy(dict(message))
+            if item:
+                clean.append(item)
+
+        if boundary is None or self.cache_breakpoint is None:
+            return clean, instructions, False
+        if self.cache_breakpoint == "anthropic":
+            if boundary:
+                self._inject_cache_control_on_content(clean[boundary - 1])
+            return clean, instructions, False
+        if not responses:
+            return clean, instructions, False
+
+        marked = _mark_responses_cache_breakpoint(clean, boundary)
+        if not marked and instructions:
+            clean.insert(
+                0,
+                {
+                    "role": "system",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": instructions,
+                            "prompt_cache_breakpoint": {"mode": "explicit"},
+                        }
+                    ],
+                },
+            )
+            instructions = None
+        # Explicit mode without a marker intentionally disables implicit writes
+        # through a volatile suffix when no stable input block is eligible.
+        return clean, instructions, True
 
     def count_tokens(self, text: str) -> int:
         """Count tokens using model-appropriate tokenizer.
@@ -1734,6 +1834,7 @@ class CompletionClient(UnifiedLLM):
         http_config: HttpConfig | None = None,
         # use system as default for cache_control_injection_points
         cache_control_injection_points: list[dict[str, Any]] | None = None,
+        cache_breakpoint: Literal["anthropic"] | None = None,
         **config,
     ):
         """
@@ -1758,10 +1859,15 @@ class CompletionClient(UnifiedLLM):
                 enable prompt caching (for example: {"role": "system"} or
                 {"role": "tool", "position": "last"}). Applied to all calls.
                 Note: Do NOT manually add cache_control to message content when using this.
+            cache_breakpoint: Set to ``"anthropic"`` to map the cached
+                renderer's stable-prefix boundary to native ``cache_control``.
             **config: Additional configuration passed to litellm (api_key, api_base, etc.)
         """
+        if cache_breakpoint not in {None, "anthropic"}:
+            raise ValueError("CompletionClient supports only the 'anthropic' cache mapping")
         super().__init__(model, **config)
         self.retry_config = retry_config or RetryConfig()
+        self.cache_breakpoint = cache_breakpoint
         self._http_config = http_config or HttpConfig()
         self._http = _ClientHttp.for_completion(self.model, self.config, self._http_config)
         # Only set default if explicitly None (not if empty list is passed)
@@ -1823,6 +1929,9 @@ class CompletionClient(UnifiedLLM):
         )
         prepared_messages = self._inject_cache_control(
             messages, cache_points, model=effective_model
+        )
+        prepared_messages, _, _ = self._prepare_cache_boundary(
+            prepared_messages, responses=False
         )
 
         api_params = {
@@ -1998,6 +2107,9 @@ class CompletionClient(UnifiedLLM):
         )
         prepared_messages = self._inject_cache_control(
             messages, cache_points, model=effective_model
+        )
+        prepared_messages, _, _ = self._prepare_cache_boundary(
+            prepared_messages, responses=False
         )
 
         api_params = {
@@ -2242,6 +2354,7 @@ class ResponsesClient(UnifiedLLM):
         retry_config: RetryConfig | None = None,
         http_config: HttpConfig | None = None,
         cache_control_injection_points: list[dict[str, Any]] | None = None,
+        cache_breakpoint: Literal["openai"] | None = None,
         **config,
     ):
         """
@@ -2267,10 +2380,15 @@ class ResponsesClient(UnifiedLLM):
             cache_control_injection_points: Optional list of role/position rules to
                 enable prompt caching (for example: {"role": "system"} or
                 {"role": "tool", "position": "last"}). Applied to all calls.
+            cache_breakpoint: Set to ``"openai"`` to map the cached renderer's
+                stable-prefix boundary to a Responses explicit breakpoint.
             **config: Additional configuration passed to litellm (api_key, api_base, etc.)
         """
+        if cache_breakpoint not in {None, "openai"}:
+            raise ValueError("ResponsesClient supports only the 'openai' cache mapping")
         super().__init__(model, **config)
         self.retry_config = retry_config or RetryConfig()
+        self.cache_breakpoint = cache_breakpoint
         self._http_config = http_config or HttpConfig()
         self._http = _ClientHttp.for_responses(self.model, self.config, self._http_config)
         # Only set default if explicitly None (not if empty list is passed)
@@ -2343,6 +2461,9 @@ class ResponsesClient(UnifiedLLM):
         else:
             prepared_messages = messages
         input_messages, instructions = self._transform_messages(prepared_messages, state_scope)
+        input_messages, instructions, openai_explicit = self._prepare_cache_boundary(
+            input_messages, responses=True, instructions=instructions
+        )
 
         api_params = {
             "model": self.model,
@@ -2351,6 +2472,8 @@ class ResponsesClient(UnifiedLLM):
             **kwargs,
             "input": input_messages,
         }
+        if openai_explicit:
+            _enable_openai_explicit_cache(api_params)
 
         if instructions:
             api_params["instructions"] = instructions
@@ -2477,6 +2600,9 @@ class ResponsesClient(UnifiedLLM):
         else:
             prepared_messages = messages
         input_messages, instructions = self._transform_messages(prepared_messages, state_scope)
+        input_messages, instructions, openai_explicit = self._prepare_cache_boundary(
+            input_messages, responses=True, instructions=instructions
+        )
 
         api_params = {
             "model": self.model,
@@ -2485,6 +2611,8 @@ class ResponsesClient(UnifiedLLM):
             **kwargs,
             "input": input_messages,
         }
+        if openai_explicit:
+            _enable_openai_explicit_cache(api_params)
 
         if instructions:
             api_params["instructions"] = instructions
@@ -2604,6 +2732,10 @@ class ResponsesClient(UnifiedLLM):
             if skip_batch_items:
                 skip_batch_items -= 1
                 continue
+            if carried_cache_boundary(original):
+                # Keep the boundary anchored before this logical message even
+                # when replay expands its carrier into several Responses items.
+                transformed.append(ReplayCarryingMessage({}, cache_boundary_before=True))
             state = carried_state(original)
             reasoning = carried_reasoning(original)
 

--- a/src/nooa/unifiedllm/unifiedllm.py
+++ b/src/nooa/unifiedllm/unifiedllm.py
@@ -1366,11 +1366,11 @@ class UnifiedLLM(ABC):
 
         def copy_message(index: int, *, copy_last_content_block: bool = False) -> dict[str, Any]:
             nonlocal prepared
-            if index not in copied:
+            if index not in copied or copy_last_content_block:
                 if prepared is messages:
                     prepared = list(messages)
                 prepared[index] = _copy_cache_marker_target(
-                    messages[index], copy_last_content_block=copy_last_content_block
+                    prepared[index], copy_last_content_block=copy_last_content_block
                 )
                 copied.add(index)
             message = prepared[index]
@@ -2775,15 +2775,17 @@ class ResponsesClient(UnifiedLLM):
         Handles two input formats:
         1. Native Responses format (from ResponsesProviderFormatter): messages contain
            "type": "function_call" / "function_call_output" items alongside role-based messages.
-           System messages have {"role": "system", ...} and are extracted to instructions.
+           System messages before the dynamic-context boundary are extracted to
+           instructions; system messages in the suffix stay in input order.
         2. Legacy OpenAI Chat format: messages use {"role": "tool", "tool_call_id": ...} and
            {"role": "assistant", "tool_calls": [...]}. These are converted to native format.
 
         Returns (input_messages, instructions) where instructions is the concatenated
-        system message content (or None if no system messages).
+        stable system message content (or None if no stable system messages).
         """
         instructions_parts: list[str] = []
         transformed: list[dict[str, Any]] = []
+        in_dynamic_suffix = False
 
         skip_batch_items = 0
         for index, original in enumerate(messages):
@@ -2791,6 +2793,7 @@ class ResponsesClient(UnifiedLLM):
                 skip_batch_items -= 1
                 continue
             if carried_cache_boundary(original):
+                in_dynamic_suffix = True
                 # Keep the boundary anchored before this logical message even
                 # when replay expands its carrier into several Responses items.
                 transformed.append(ReplayCarryingMessage({}, cache_boundary_before=True))
@@ -2831,8 +2834,9 @@ class ResponsesClient(UnifiedLLM):
                 )
                 msg.pop("reasoning_items")
 
-            # System messages → extract to instructions
-            if msg.get("role") == "system":
+            # Only stable system messages belong in the leading instructions;
+            # lifting live state out of the suffix would invalidate that prefix.
+            if msg.get("role") == "system" and not in_dynamic_suffix:
                 content = msg.get("content", "")
                 if content:
                     instructions_parts.append(content)

--- a/src/nooa/unifiedllm/unifiedllm.py
+++ b/src/nooa/unifiedllm/unifiedllm.py
@@ -1445,11 +1445,20 @@ class UnifiedLLM(ABC):
         if boundary is None or self.cache_breakpoint is None:
             return clean, instructions, False
         if self.cache_breakpoint == "anthropic":
-            if boundary:
-                clean[boundary - 1] = _copy_cache_marker_target(
-                    clean[boundary - 1], copy_last_content_block=True
-                )
-                self._inject_cache_control_on_content(clean[boundary - 1])
+            # LiteLLM drops message-level markers on tool-call-only turns.
+            # Thinking blocks cannot be marked directly either: use the latest
+            # eligible public content without inventing an empty text block.
+            for index in range(boundary - 1, -1, -1):
+                content = clean[index].get("content")
+                if not content or (
+                    isinstance(content, list)
+                    and isinstance(content[-1], dict)
+                    and content[-1].get("type") in {"thinking", "redacted_thinking"}
+                ):
+                    continue
+                clean[index] = _copy_cache_marker_target(clean[index], copy_last_content_block=True)
+                self._inject_cache_control_on_content(clean[index])
+                break
             return clean, instructions, False
         if not responses:
             return clean, instructions, False

--- a/src/nooa/unifiedllm/unifiedllm.py
+++ b/src/nooa/unifiedllm/unifiedllm.py
@@ -5,6 +5,7 @@ import copy
 import inspect
 import json
 import logging
+import math
 import re
 import warnings
 from abc import ABC, abstractmethod
@@ -1717,21 +1718,37 @@ def _finish_reason_for_tool_calls(
     return "tool_calls"
 
 
+def _extract_usage(raw_response: Any) -> LLMUsage | None:
+    """Normalize provider usage plus LiteLLM's per-response cost metadata."""
+    usage = LLMUsage.from_provider(getattr(raw_response, "usage", None))
+    if usage is None:
+        return None
+
+    hidden = getattr(raw_response, "_hidden_params", None)
+    response_cost = hidden.get("response_cost") if isinstance(hidden, Mapping) else None
+    if response_cost is None:
+        return usage
+    if (
+        isinstance(response_cost, bool)
+        or not isinstance(response_cost, (int, float))
+        or not math.isfinite(response_cost)
+        or response_cost < 0
+    ):
+        logger.warning("Ignoring malformed LiteLLM response_cost metadata: %r", response_cost)
+        return usage
+    return usage.model_copy(update={"cost_usd": float(response_cost)})
+
+
 def _extract_reasoning_and_usage(raw_response: Any) -> tuple[str | None, LLMUsage | None]:
-    """Extract reasoning and usage from raw LLM response."""
+    """Extract reasoning and normalized usage from a raw LLM response."""
     reasoning = None
-    usage: LLMUsage | None = None
 
     # Extract reasoning (o1-style or DeepSeek/QwQ)
     if hasattr(raw_response, "choices") and raw_response.choices:
         msg = raw_response.choices[0].message
         reasoning = getattr(msg, "reasoning", None) or getattr(msg, "reasoning_content", None)
 
-    # Extract usage
-    if hasattr(raw_response, "usage") and raw_response.usage:
-        usage = LLMUsage.from_provider(raw_response.usage)
-
-    return reasoning, usage
+    return reasoning, _extract_usage(raw_response)
 
 
 def _item_field(item: Any, name: str) -> Any:
@@ -2547,7 +2564,7 @@ class ResponsesClient(UnifiedLLM):
                 else _make_call()
             )
 
-        usage = LLMUsage.from_provider(getattr(raw_response, "usage", None))
+        usage = _extract_usage(raw_response)
         if usage:
             _update_token_calibration(
                 effective_model, messages, usage, tools=api_params.get("tools")
@@ -2687,7 +2704,7 @@ class ResponsesClient(UnifiedLLM):
                 else await _make_call()
             )
 
-        usage = LLMUsage.from_provider(getattr(raw_response, "usage", None))
+        usage = _extract_usage(raw_response)
         if usage:
             _update_token_calibration(
                 effective_model, messages, usage, tools=api_params.get("tools")

--- a/src/nooa/unifiedllm/unifiedllm.py
+++ b/src/nooa/unifiedllm/unifiedllm.py
@@ -8,7 +8,7 @@ import logging
 import re
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -1137,8 +1137,8 @@ def _update_token_calibration(
 def _copy_cache_marker_target(
     message: dict[str, Any], *, copy_last_content_block: bool = False
 ) -> dict[str, Any]:
-    """Shallow-copy one marker target and the content block we may mutate."""
-    copied = dict(message)
+    """Copy one marker target without discarding private replay metadata."""
+    copied = copy.copy(message)
     content = copied.get("content")
     if copy_last_content_block and isinstance(content, list) and content:
         blocks = list(content)
@@ -1189,12 +1189,20 @@ def _mark_responses_cache_breakpoint(messages: list[dict[str, Any]], boundary: i
 
 def _enable_openai_explicit_cache(api_params: dict[str, Any]) -> None:
     """Set the Responses cache mode through LiteLLM's SDK escape hatch."""
-    extra_body = copy.deepcopy(api_params.get("extra_body"))
-    if not isinstance(extra_body, dict):
+    configured_extra_body = api_params.get("extra_body")
+    if configured_extra_body is None:
         extra_body = {}
+    elif isinstance(configured_extra_body, Mapping):
+        extra_body = copy.deepcopy(dict(configured_extra_body))
+    else:
+        raise ValueError("extra_body must be a mapping")
     options = extra_body.get("prompt_cache_options")
-    if not isinstance(options, dict):
+    if options is None:
         options = {}
+    elif isinstance(options, Mapping):
+        options = copy.deepcopy(dict(options))
+    else:
+        raise ValueError("extra_body.prompt_cache_options must be a mapping")
     options["mode"] = "explicit"
     extra_body["prompt_cache_options"] = options
     api_params["extra_body"] = extra_body
@@ -1224,6 +1232,14 @@ class UnifiedLLM(ABC):
             raise ValueError("model must be a non-empty string")
         return model
 
+    def _validate_cache_breakpoint_model(self, effective_model: str) -> None:
+        """Reject applying a model-declared cache mapping to a call override."""
+        if self.cache_breakpoint is not None and effective_model != self.model:
+            raise ValueError(
+                "cache_breakpoint is declared for the client model and cannot be used "
+                "with a per-call model override"
+            )
+
     @staticmethod
     def _validate_request_config(name: str, call_config: dict[str, Any]) -> None:
         """Keep provider payloads and routing on their validated top-level paths."""
@@ -1233,7 +1249,9 @@ class UnifiedLLM(ABC):
                 "the messages argument"
             )
         extra_body = call_config.get("extra_body")
-        if isinstance(extra_body, dict) and (reserved := {name, "model"} & set(extra_body)):
+        if extra_body is not None and not isinstance(extra_body, Mapping):
+            raise ValueError("extra_body must be a mapping")
+        if isinstance(extra_body, Mapping) and (reserved := {name, "model"} & set(extra_body)):
             fields = ", ".join(repr(field) for field in sorted(reserved))
             raise ValueError(
                 f"extra_body may not override reserved field(s) {fields}; pass model at "
@@ -1407,12 +1425,21 @@ class UnifiedLLM(ABC):
         clean: list[dict[str, Any]] = []
         for message in messages:
             starts_suffix = carried_cache_boundary(message)
-            if starts_suffix and boundary is None:
+            if starts_suffix and boundary is not None:
+                raise ValueError("Rendered history contains more than one cache boundary")
+            if starts_suffix:
                 boundary = len(clean)
-            if message:
-                # Strip the out-of-band boundary attribute from its one carrier;
-                # all other history stays borrowed.
-                clean.append(dict(message) if starts_suffix else message)
+            if starts_suffix:
+                if not message:
+                    continue
+                # Consume only the private boundary flag. Other private replay
+                # metadata remains attached until its owning adapter consumes it.
+                item = copy.copy(message)
+                if isinstance(item, ReplayCarryingMessage):
+                    item.cache_boundary_before = False
+                clean.append(item)
+            else:
+                clean.append(message)
 
         if boundary is None or self.cache_breakpoint is None:
             return clean, instructions, False
@@ -1932,6 +1959,7 @@ class CompletionClient(UnifiedLLM):
         call_config = {**self.config, **kwargs}
         self._validate_request_config("messages", call_config)
         effective_model = self._effective_model(call_config)
+        self._validate_cache_breakpoint_model(effective_model)
         state_scope = replay_state.replay_scope(effective_model, "chat", call_config)
         messages = replay_state.prepare_chat_messages(messages, state_scope)
 
@@ -1944,9 +1972,7 @@ class CompletionClient(UnifiedLLM):
         prepared_messages = self._inject_cache_control(
             messages, cache_points, model=effective_model
         )
-        prepared_messages, _, _ = self._prepare_cache_boundary(
-            prepared_messages, responses=False
-        )
+        prepared_messages, _, _ = self._prepare_cache_boundary(prepared_messages, responses=False)
 
         api_params = {
             "model": self.model,
@@ -2110,6 +2136,7 @@ class CompletionClient(UnifiedLLM):
         call_config = {**self.config, **kwargs}
         self._validate_request_config("messages", call_config)
         effective_model = self._effective_model(call_config)
+        self._validate_cache_breakpoint_model(effective_model)
         state_scope = replay_state.replay_scope(effective_model, "chat", call_config)
         messages = replay_state.prepare_chat_messages(messages, state_scope)
 
@@ -2122,9 +2149,7 @@ class CompletionClient(UnifiedLLM):
         prepared_messages = self._inject_cache_control(
             messages, cache_points, model=effective_model
         )
-        prepared_messages, _, _ = self._prepare_cache_boundary(
-            prepared_messages, responses=False
-        )
+        prepared_messages, _, _ = self._prepare_cache_boundary(prepared_messages, responses=False)
 
         api_params = {
             "model": self.model,
@@ -2462,6 +2487,7 @@ class ResponsesClient(UnifiedLLM):
         call_config = {**self.config, **kwargs}
         self._validate_request_config("input", call_config)
         effective_model = self._effective_model(call_config)
+        self._validate_cache_breakpoint_model(effective_model)
         state_scope = replay_state.replay_scope(effective_model, "responses", call_config)
         if _is_anthropic_model(effective_model):
             cache_points = (
@@ -2601,6 +2627,7 @@ class ResponsesClient(UnifiedLLM):
         call_config = {**self.config, **kwargs}
         self._validate_request_config("input", call_config)
         effective_model = self._effective_model(call_config)
+        self._validate_cache_breakpoint_model(effective_model)
         state_scope = replay_state.replay_scope(effective_model, "responses", call_config)
         if _is_anthropic_model(effective_model):
             cache_points = (

--- a/src/nooa/unifiedllm/unifiedllm.py
+++ b/src/nooa/unifiedllm/unifiedllm.py
@@ -1134,6 +1134,20 @@ def _update_token_calibration(
         logger.debug("token calibration skipped (estimate failed)", exc_info=True)
 
 
+def _copy_cache_marker_target(
+    message: dict[str, Any], *, copy_last_content_block: bool = False
+) -> dict[str, Any]:
+    """Shallow-copy one marker target and the content block we may mutate."""
+    copied = dict(message)
+    content = copied.get("content")
+    if copy_last_content_block and isinstance(content, list) and content:
+        blocks = list(content)
+        if isinstance(blocks[-1], dict):
+            blocks[-1] = dict(blocks[-1])
+        copied["content"] = blocks
+    return copied
+
+
 def _mark_responses_text(content: Any) -> tuple[Any, bool]:
     """Attach an OpenAI explicit breakpoint to the last input-text block."""
     marker = {"mode": "explicit"}
@@ -1146,27 +1160,29 @@ def _mark_responses_text(content: Any) -> tuple[Any, bool]:
             }
         ], True
     if isinstance(content, list):
-        updated = copy.deepcopy(content)
-        for block in reversed(updated):
+        for index in range(len(content) - 1, -1, -1):
+            block = content[index]
             if isinstance(block, dict) and block.get("type") == "input_text":
-                block["prompt_cache_breakpoint"] = marker
+                updated = list(content)
+                updated[index] = {**block, "prompt_cache_breakpoint": marker}
                 return updated, True
     return content, False
 
 
 def _mark_responses_cache_breakpoint(messages: list[dict[str, Any]], boundary: int) -> bool:
     """Mark the latest eligible Responses input block before ``boundary``."""
-    for item in reversed(messages[:boundary]):
+    for index in range(boundary - 1, -1, -1):
+        item = messages[index]
         if item.get("type") == "function_call_output":
             output, marked = _mark_responses_text(item.get("output"))
             if marked:
-                item["output"] = output
+                messages[index] = {**item, "output": output}
                 return True
         # Assistant output uses output_text, which is not an eligible input block.
         if item.get("role") in {"system", "developer", "user"}:
             content, marked = _mark_responses_text(item.get("content"))
             if marked:
-                item["content"] = content
+                messages[index] = {**item, "content": content}
                 return True
     return False
 
@@ -1334,18 +1350,11 @@ class UnifiedLLM(ABC):
             if index not in copied:
                 if prepared is messages:
                     prepared = list(messages)
-                # A shallow copy is enough here and preserves private replay
-                # metadata carried by our dict subclass. Nested content is
-                # detached below before it is changed.
-                prepared[index] = copy.copy(messages[index])
+                prepared[index] = _copy_cache_marker_target(
+                    messages[index], copy_last_content_block=copy_last_content_block
+                )
                 copied.add(index)
             message = prepared[index]
-            content = message.get("content")
-            if copy_last_content_block and isinstance(content, list) and content:
-                blocks = list(content)
-                if isinstance(blocks[-1], dict):
-                    blocks[-1] = dict(blocks[-1])
-                message["content"] = blocks
             return message
 
         # Map role names to native Responses API type equivalents
@@ -1397,16 +1406,21 @@ class UnifiedLLM(ABC):
         boundary: int | None = None
         clean: list[dict[str, Any]] = []
         for message in messages:
-            if carried_cache_boundary(message) and boundary is None:
+            starts_suffix = carried_cache_boundary(message)
+            if starts_suffix and boundary is None:
                 boundary = len(clean)
-            item = copy.deepcopy(dict(message))
-            if item:
-                clean.append(item)
+            if message:
+                # Strip the out-of-band boundary attribute from its one carrier;
+                # all other history stays borrowed.
+                clean.append(dict(message) if starts_suffix else message)
 
         if boundary is None or self.cache_breakpoint is None:
             return clean, instructions, False
         if self.cache_breakpoint == "anthropic":
             if boundary:
+                clean[boundary - 1] = _copy_cache_marker_target(
+                    clean[boundary - 1], copy_last_content_block=True
+                )
                 self._inject_cache_control_on_content(clean[boundary - 1])
             return clean, instructions, False
         if not responses:

--- a/tests/integration/test_cache_resume_live.py
+++ b/tests/integration/test_cache_resume_live.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in NVIDIA Hub cache/reasoning checks across a real SQLite close/reopen.
+
+Run with NVIDIA_INFERENCE_API_KEY and NOOA_RUN_CACHE_RESUME_LIVE=1:
+    uv run pytest tests/integration/test_cache_resume_live.py -m integration -s
+
+Three calls per provider: obtain a signed tool turn, warm its stable prefix,
+then reopen the event archive and repeat with changed trailing live context.
+Only usage and equality checks are printed; opaque payloads stay in memory or
+the temporary session database. Roughly 90k input tokens across all providers.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from nooa.context_blocks.events import EventBase, ToolCallEvent, ToolResult, UserEvent
+from nooa.context_blocks.formatter import OpenAIProviderFormatter, ResponsesProviderFormatter
+from nooa.context_blocks.models import BlockMetadata, ResolvedBlock, Role
+from nooa.context_blocks.renderer import render_context
+from nooa.context_blocks.renderers.cached import CachedBlockFormatter
+from nooa.storage import SQLiteStorageManager
+from nooa.unifiedllm import CompletionClient, LLMResponse, ResponsesClient, Tool
+from nooa.unifiedllm.http_config import HttpConfig
+from nooa.unifiedllm.retry_config import RetryConfig
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.getenv("NOOA_RUN_CACHE_RESUME_LIVE") != "1",
+        reason="set NOOA_RUN_CACHE_RESUME_LIVE=1 to spend inference tokens",
+    ),
+]
+
+MODELS = {
+    "openai": "openai/openai/openai/gpt-5.6-sol",
+    "anthropic": "anthropic/azure/anthropic/claude-sonnet-5",
+    "gemini": "openai/gcp/google/gemini-3.1-pro-preview",
+}
+
+
+def _execute_python(code: str) -> str:
+    return code
+
+
+TOOL = Tool(name="execute_python", description="Evaluate Python code", callable=_execute_python)
+
+
+def _client(family):
+    config = {
+        "model": MODELS[family],
+        "api_base": "https://inference-api.nvidia.com/v1",
+        "api_key": os.environ["NVIDIA_INFERENCE_API_KEY"],
+        "http_config": HttpConfig(read_timeout=120),
+        "num_retries": 0,
+        "retry_config": RetryConfig(max_retries=0, rate_limit_extra_retries=0),
+    }
+    if family == "openai":
+        return ResponsesClient(
+            **config,
+            reasoning={"effort": "medium"},
+            include=["reasoning.encrypted_content"],
+            store=False,
+            max_output_tokens=1024,
+            cache_breakpoint="openai",
+        )
+    if family == "anthropic":
+        config["api_base"] = "https://inference-api.nvidia.com"
+        return CompletionClient(
+            **config,
+            max_tokens=2048,
+            thinking={"type": "adaptive"},
+            output_config={"effort": "high"},
+            cache_breakpoint="anthropic",
+        )
+    return CompletionClient(**config, max_tokens=2048)
+
+
+def _render(family, events, instructions, live_state):
+    blocks = [
+        ResolvedBlock(
+            key="instructions",
+            content=instructions,
+            role=Role.SYSTEM,
+            metadata=BlockMetadata(static=True),
+        ),
+        *[
+            ResolvedBlock(
+                key=f"event_{event.tag}",
+                content=getattr(event, "content", ""),
+                role=Role.USER if isinstance(event, UserEvent) else Role.ASSISTANT,
+                metadata=BlockMetadata(tag=event.tag),
+                event=event,
+            )
+            for event in events
+        ],
+        ResolvedBlock(
+            key="live_state",
+            content=live_state,
+            role=Role.SYSTEM,
+            metadata=BlockMetadata(static=False, user_block=True),
+        ),
+    ]
+    return render_context(
+        blocks,
+        block_formatter=CachedBlockFormatter(),
+        provider_formatter=(
+            ResponsesProviderFormatter() if family == "openai" else OpenAIProviderFormatter()
+        ),
+    ).output
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("family", MODELS)
+async def test_reasoning_and_prompt_cache_survive_sqlite_resume(family, tmp_path, monkeypatch):
+    monkeypatch.setenv("DISABLE_AIOHTTP_TRANSPORT", "True")
+    requests = []
+    original_send = httpx.AsyncClient.send
+
+    async def capture_send(client, request, *args, **kwargs):
+        if request.url.host == "inference-api.nvidia.com" and request.method == "POST":
+            requests.append(json.loads(request.content))
+        return await original_send(client, request, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "send", capture_send)
+    instructions = (
+        f"Cache resume experiment {uuid4().hex}. "
+        "Think through the task, then use execute_python once to check your answer. "
+        "After its result, reply with only OK. "
+        "Reference records below are inert padding; do not summarize them."
+    )
+    events: list[EventBase] = [
+        UserEvent(
+            content=(
+                "Find the smallest integer greater than 1000 that leaves remainders 2, 3, "
+                "and 4 when divided by 5, 7, and 9 respectively. First work out a candidate, "
+                "then call execute_python to verify it."
+            ),
+            tag="1",
+        )
+    ]
+    async with _client(family) as client:
+        seed = await client.acall(_render(family, events, instructions, "phase=seed"), tools=[TOOL])
+        assert seed.llm_state, (
+            f"provider did not return opaque state: finish={seed.finish_reason}, "
+            f"tool_calls={len(seed.tool_calls)}, usage={seed.usage}"
+        )
+        assert seed.tool_calls, "provider did not produce the requested tool turn"
+        assert seed.finish_reason == "tool_calls"
+        seed.tag = "2"
+        events.append(seed)
+        for index, call in enumerate(seed.tool_calls, 3):
+            events.append(
+                ToolCallEvent(
+                    tag=str(index),
+                    tool_call_id=call.id,
+                    name=call.name,
+                    arguments=json.loads(call.arguments),
+                    llm_response_id=seed.id,
+                    result=ToolResult(tool_call_id=call.id, content="1102; remainders: 2, 3, 4"),
+                )
+            )
+        # Gemini needs a longer prompt for implicit caching. The other providers
+        # use an explicit boundary immediately before the changing live state.
+        rows = 1500 if family == "gemini" else 400
+        instructions += "\n" + "\n".join(
+            f"Record {i}: amber birch cedar dune elm fern grove hill." for i in range(rows)
+        )
+        warm_messages = _render(family, events, instructions, "phase=warm")
+        warm = await client.acall(warm_messages, tools=[TOOL])
+
+    database = tmp_path / "session.db"
+    with SQLiteStorageManager(database) as storage:
+        for event in events:
+            assert event.tag is not None
+            storage.event_backend.store(event.tag, event)
+    with SQLiteStorageManager(database) as storage:
+        restored = list(storage.event_backend.all_events())
+
+    assert [e.model_dump(mode="json") for e in restored] == [
+        e.model_dump(mode="json") for e in events
+    ]
+    saved_response = next(e for e in restored if isinstance(e, LLMResponse))
+    assert saved_response is not seed and saved_response.raw_response is None
+    assert saved_response.llm_state == seed.llm_state
+    assert saved_response.usage == seed.usage
+    replay_messages = _render(family, restored, instructions, "phase=resumed")
+    assert warm_messages[:-1] == replay_messages[:-1]
+    assert warm_messages[-1] != replay_messages[-1]
+    async with _client(family) as client:
+        resumed = await client.acall(replay_messages, tools=[TOOL])
+
+    assert len(requests) == 3, "unexpected retries or uncaptured provider requests"
+    warm_wire, resumed_wire = copy.deepcopy(requests[1:])
+    field = "input" if family == "openai" else "messages"
+
+    def remove_live_suffix(body):
+        # Native Anthropic coalesces the trailing live-state user message with
+        # the preceding tool results. Remove only that last text block.
+        message = body[field][-1]
+        if isinstance(message.get("content"), list):
+            suffix = message["content"].pop()
+            if not message["content"]:
+                body[field].pop()
+            return suffix
+        return body[field].pop()
+
+    warm_suffix = remove_live_suffix(warm_wire)
+    resumed_suffix = remove_live_suffix(resumed_wire)
+    assert "phase=warm" in json.dumps(warm_suffix)
+    assert "phase=resumed" in json.dumps(resumed_suffix)
+    assert warm_suffix != resumed_suffix
+    assert warm_wire == resumed_wire, "SQLite resume changed the stable provider request"
+    assert saved_response.llm_state is not None
+    payload = saved_response.llm_state["payload"]
+    if family == "openai":
+        for item in payload["items"]:
+            assert item in resumed_wire[field], "encrypted reasoning was not replayed"
+    else:
+        if family == "anthropic":
+            assistant = next(m for m in resumed_wire[field] if m.get("role") == "assistant")
+            assert [
+                block
+                for block in assistant["content"]
+                if block["type"] in {"thinking", "redacted_thinking"}
+            ] == payload["thinking_blocks"]
+        else:
+            assistant = next(m for m in resumed_wire[field] if m.get("tool_calls"))
+            for call, state in zip(assistant["tool_calls"], payload["tool_calls"], strict=True):
+                assert call["provider_specific_fields"] == state["provider_specific_fields"]
+                assert call["id"].endswith("__thought__" + state["inline_thought_signature"])
+            assert [m["tool_call_id"] for m in resumed_wire[field] if m.get("role") == "tool"] == [
+                call["id"] for call in assistant["tool_calls"]
+            ]
+    assert seed.llm_state == saved_response.llm_state, "request construction mutated the archive"
+    assert warm.finish_reason == resumed.finish_reason == "stop"
+    assert resumed.usage is not None
+    print(
+        json.dumps(
+            {
+                "family": family,
+                "model": MODELS[family],
+                "sqlite_events_equal": True,
+                "stable_wire_equal": True,
+                "opaque_state_equal": True,
+                "usage": [r.usage.model_dump() if r.usage else None for r in (seed, warm, resumed)],
+            }
+        )
+    )
+    assert resumed.usage.cached_input_tokens > 0, "provider reported no cache hit after resume"

--- a/tests/test_nemo_relay_middleware.py
+++ b/tests/test_nemo_relay_middleware.py
@@ -18,10 +18,16 @@ import pytest
 nemo_relay = pytest.importorskip("nemo_relay", reason="nemo_relay not installed")
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
-from nooa._llm_state import carried_replay_batch, carried_state, carry_replay_batch
+from nooa._llm_state import (
+    ReplayCarryingMessage,
+    carried_cache_boundary,
+    carried_replay_batch,
+    carried_state,
+    carry_replay_batch,
+)
 from nooa.nemo_relay_middleware import (
     install_nemo_relay,
     nemo_relay_agent_call_middleware,
@@ -139,6 +145,7 @@ class TestLLMRequestIntercepts:
             {"scope": "issuer", "payload": {"encrypted_content": "opaque"}},
             None,
         )
+        cast(ReplayCarryingMessage, messages[0]).cache_boundary_before = True
         ctx = _make_llm_ctx(messages=messages)
         seen: list[list[dict[str, Any]]] = []
 
@@ -156,6 +163,7 @@ class TestLLMRequestIntercepts:
         }
         assert carried_replay_batch(seen[0][0]) is not None
         assert carried_replay_batch(seen[0][1]) == carried_replay_batch(seen[0][0])
+        assert carried_cache_boundary(seen[0][0]) is True
 
     @pytest.mark.asyncio
     async def test_request_intercept_injects_header(self):

--- a/tests/unifiedllm/test_explicit_cache_boundary.py
+++ b/tests/unifiedllm/test_explicit_cache_boundary.py
@@ -86,9 +86,7 @@ def test_cache_mapping_must_match_the_client_api_style() -> None:
 
 @pytest.mark.asyncio
 async def test_openai_marks_the_stable_prefix_before_dynamic_context() -> None:
-    client = ResponsesClient(
-        model="openai/gpt-5.6", api_key="test", cache_breakpoint="openai"
-    )
+    client = ResponsesClient(model="openai/gpt-5.6", api_key="test", cache_breakpoint="openai")
     try:
         with patch("litellm.aresponses", new_callable=AsyncMock) as request:
             request.return_value = _responses_output()
@@ -99,9 +97,7 @@ async def test_openai_marks_the_stable_prefix_before_dynamic_context() -> None:
         assert first["extra_body"]["prompt_cache_options"] == {"mode": "explicit"}
         assert first["input"][:-1] == second["input"][:-1]
         assert first["input"][-1] != second["input"][-1]
-        assert first["input"][-2]["content"][-1]["prompt_cache_breakpoint"] == {
-            "mode": "explicit"
-        }
+        assert first["input"][-2]["content"][-1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
         assert "prompt_cache_breakpoint" not in first["input"][-1]["content"]
     finally:
         await client.aclose()
@@ -182,9 +178,7 @@ async def test_openai_fields_reach_the_serialized_http_body() -> None:
                         "type": "message",
                         "status": "completed",
                         "role": "assistant",
-                        "content": [
-                            {"type": "output_text", "text": "ok", "annotations": []}
-                        ],
+                        "content": [{"type": "output_text", "text": "ok", "annotations": []}],
                     }
                 ],
                 "parallel_tool_calls": False,
@@ -217,9 +211,7 @@ async def test_openai_fields_reach_the_serialized_http_body() -> None:
         await client.aclose()
 
     assert bodies[0]["prompt_cache_options"] == {"mode": "explicit"}
-    assert bodies[0]["input"][-2]["content"][-1]["prompt_cache_breakpoint"] == {
-        "mode": "explicit"
-    }
+    assert bodies[0]["input"][-2]["content"][-1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
     assert "cache_boundary" not in repr(bodies[0])
 
 
@@ -365,9 +357,7 @@ def test_replay_expansion_stays_inside_the_stable_prefix() -> None:
 
 
 def test_gemini_gets_no_invented_inline_cache_field() -> None:
-    client = CompletionClient(
-        model="gemini/gemini-2.5-pro", cache_control_injection_points=[]
-    )
+    client = CompletionClient(model="gemini/gemini-2.5-pro", cache_control_injection_points=[])
     messages, _, enabled = client._prepare_cache_boundary(_render("state-a"), responses=False)
 
     assert enabled is False
@@ -384,9 +374,7 @@ async def test_gemini_boundary_is_inert_on_the_actual_call_path() -> None:
     extension point. Disable it here so this regression pins only the automatic
     dynamic-context boundary introduced by this change.
     """
-    client = CompletionClient(
-        model="gemini/gemini-2.5-pro", cache_control_injection_points=[]
-    )
+    client = CompletionClient(model="gemini/gemini-2.5-pro", cache_control_injection_points=[])
     response = litellm.ModelResponse(
         model="gemini-2.5-pro",
         choices=[

--- a/tests/unifiedllm/test_explicit_cache_boundary.py
+++ b/tests/unifiedllm/test_explicit_cache_boundary.py
@@ -13,7 +13,7 @@ import pytest
 from nooa._llm_state import ReplayCarryingMessage, carried_cache_boundary, carry_replay_batch
 from nooa.context_blocks.events import UserEvent
 from nooa.context_blocks.formatter import OpenAIProviderFormatter
-from nooa.context_blocks.models import BlockMetadata, ResolvedBlock, Role
+from nooa.context_blocks.models import BlockMetadata, RenderedMessage, ResolvedBlock, Role
 from nooa.context_blocks.renderer import render_context
 from nooa.context_blocks.renderers.cached import CachedBlockFormatter
 from nooa.unifiedllm import CompletionClient, ResponsesClient
@@ -74,6 +74,22 @@ def test_cached_renderer_marks_only_the_dynamic_suffix_outside_json() -> None:
     assert "cache_boundary" not in json.dumps(messages)
 
 
+def test_rendered_message_serialization_excludes_private_transport_fields() -> None:
+    message = RenderedMessage(
+        role=Role.ASSISTANT,
+        content="public",
+        llm_state={"encrypted_content": "opaque"},
+        reasoning="private reasoning",
+        cache_boundary_before=True,
+    )
+
+    dumped = message.model_dump()
+    assert "llm_state" not in dumped
+    assert "reasoning" not in dumped
+    assert "cache_boundary_before" not in dumped
+    assert "opaque" not in message.model_dump_json()
+
+
 def test_cache_mapping_must_match_the_client_api_style() -> None:
     with pytest.raises(ValueError, match="CompletionClient.*'anthropic'"):
         CompletionClient(model="openai/gpt-5.6", cache_breakpoint="openai")  # type: ignore[arg-type]
@@ -82,6 +98,100 @@ def test_cache_mapping_must_match_the_client_api_style() -> None:
             model="anthropic/claude-sonnet-4",
             cache_breakpoint="anthropic",  # type: ignore[arg-type]
         )
+
+
+def test_cache_marker_copy_preserves_private_replay_metadata() -> None:
+    state = {"version": 1, "scope": "chat:anthropic:test"}
+    original = ReplayCarryingMessage(
+        {"role": "system", "content": "stable"},
+        llm_state=state,
+        reasoning="private reasoning",
+        replay_batch_id="batch",
+        replay_batch_size=1,
+    )
+    with CompletionClient(model="anthropic/claude-sonnet-4-5") as client:
+        prepared = client._inject_cache_control(
+            [original], [{"role": "system"}], model=client.model
+        )
+
+    assert isinstance(prepared[0], ReplayCarryingMessage)
+    assert prepared[0].llm_state is state
+    assert prepared[0].reasoning == "private reasoning"
+    assert prepared[0].replay_batch_id == "batch"
+    assert prepared[0].replay_batch_size == 1
+    assert "cache_control" not in original
+
+
+def test_boundary_consumption_preserves_ordinary_empty_messages_and_private_state() -> None:
+    state = {"version": 1, "scope": "responses:openai:test"}
+    boundary = ReplayCarryingMessage(
+        {"role": "user", "content": "live state"},
+        llm_state=state,
+        reasoning="private reasoning",
+        cache_boundary_before=True,
+    )
+    with ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai") as client:
+        messages, _, enabled = client._prepare_cache_boundary([{}, boundary], responses=True)
+
+    assert enabled is True
+    assert messages[0] == {}
+    assert isinstance(messages[1], ReplayCarryingMessage)
+    assert messages[1].llm_state is state
+    assert messages[1].reasoning == "private reasoning"
+    assert not carried_cache_boundary(messages[1])
+
+
+def test_multiple_cache_boundaries_fail_loudly() -> None:
+    messages: list[dict] = [
+        ReplayCarryingMessage({"role": "user", "content": "one"}, cache_boundary_before=True),
+        ReplayCarryingMessage({"role": "user", "content": "two"}, cache_boundary_before=True),
+    ]
+    with ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai") as client:
+        with pytest.raises(ValueError, match="more than one cache boundary"):
+            client._prepare_cache_boundary(messages, responses=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("api_style", ["chat", "responses"])
+async def test_cache_mapping_rejects_per_call_model_overrides(api_style: str) -> None:
+    if api_style == "chat":
+        client = CompletionClient(model="anthropic/claude-sonnet-4-5", cache_breakpoint="anthropic")
+        target = "litellm.acompletion"
+    else:
+        client = ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai")
+        target = "litellm.aresponses"
+
+    try:
+        with patch(target, new_callable=AsyncMock) as request:
+            with pytest.raises(ValueError, match="per-call model override"):
+                await client.acall(_render("state-a"), model="openai/a-different-model")
+        request.assert_not_awaited()
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("extra_body", "message"),
+    [
+        ([], "extra_body must be a mapping"),
+        (
+            {"prompt_cache_options": "explicit"},
+            "extra_body.prompt_cache_options must be a mapping",
+        ),
+    ],
+)
+async def test_openai_cache_config_rejects_malformed_mappings(
+    extra_body: object, message: str
+) -> None:
+    client = ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai")
+    try:
+        with patch("litellm.aresponses", new_callable=AsyncMock) as request:
+            with pytest.raises(ValueError, match=message):
+                await client.acall(_render("state-a"), extra_body=extra_body)
+        request.assert_not_awaited()
+    finally:
+        await client.aclose()
 
 
 @pytest.mark.asyncio
@@ -98,7 +208,7 @@ async def test_openai_marks_the_stable_prefix_before_dynamic_context() -> None:
         assert first["input"][:-1] == second["input"][:-1]
         assert first["input"][-1] != second["input"][-1]
         assert first["input"][-2]["content"][-1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
-        assert "prompt_cache_breakpoint" not in first["input"][-1]["content"]
+        assert "prompt_cache_breakpoint" not in repr(first["input"][-1]["content"])
     finally:
         await client.aclose()
 
@@ -184,11 +294,14 @@ async def test_openai_fields_reach_the_serialized_http_body() -> None:
                 "store": False,
                 "tools": [],
                 "usage": {
-                    "input_tokens": 2,
-                    "input_tokens_details": {"cached_tokens": 0},
+                    "input_tokens": 100,
+                    "input_tokens_details": {
+                        "cached_tokens": 50,
+                        "cache_write_tokens": 25,
+                    },
                     "output_tokens": 1,
                     "output_tokens_details": {"reasoning_tokens": 0},
-                    "total_tokens": 3,
+                    "total_tokens": 101,
                 },
             },
         )
@@ -205,13 +318,16 @@ async def test_openai_fields_reach_the_serialized_http_body() -> None:
     client._http.httpx_async = transport
     client._http.async_client.client = transport
     try:
-        await client.acall(_render("state-a"))
+        response = await client.acall(_render("state-a"))
     finally:
         await client.aclose()
 
     assert bodies[0]["prompt_cache_options"] == {"mode": "explicit"}
     assert bodies[0]["input"][-2]["content"][-1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
     assert "cache_boundary" not in repr(bodies[0])
+    assert response.usage is not None
+    assert response.usage.cached_input_tokens == 50
+    assert response.usage.cache_write_input_tokens == 25
 
 
 @pytest.mark.asyncio
@@ -311,7 +427,12 @@ def test_replay_expansion_stays_inside_the_stable_prefix() -> None:
             "items": [{"type": "reasoning", "encrypted_content": "opaque"}],
             "order": [
                 {"type": "reasoning", "index": 0},
-                {"type": "function_call", "call_id": "c1"},
+                {
+                    "type": "function_call",
+                    "call_id": "c1",
+                    "name": "run",
+                    "arguments": "{}",
+                },
             ],
         },
     }

--- a/tests/unifiedllm/test_explicit_cache_boundary.py
+++ b/tests/unifiedllm/test_explicit_cache_boundary.py
@@ -10,7 +10,7 @@ import httpx
 import litellm
 import pytest
 
-from nooa._llm_state import ReplayCarryingMessage, carried_cache_boundary
+from nooa._llm_state import ReplayCarryingMessage, carried_cache_boundary, carry_replay_batch
 from nooa.context_blocks.events import UserEvent
 from nooa.context_blocks.formatter import OpenAIProviderFormatter
 from nooa.context_blocks.models import BlockMetadata, ResolvedBlock, Role
@@ -320,18 +320,17 @@ def test_replay_expansion_stays_inside_the_stable_prefix() -> None:
     transformed, instructions = client._transform_messages(
         [
             {"role": "user", "content": "run it"},
-            ReplayCarryingMessage(
-                {
-                    "_batch": [
-                        {
-                            "type": "function_call",
-                            "call_id": "c1",
-                            "name": "run",
-                            "arguments": "{}",
-                        }
-                    ]
-                },
+            *carry_replay_batch(
+                [
+                    {
+                        "type": "function_call",
+                        "call_id": "c1",
+                        "name": "run",
+                        "arguments": "{}",
+                    }
+                ],
                 state,
+                None,
             ),
             {"type": "function_call_output", "call_id": "c1", "output": "done"},
             ReplayCarryingMessage(

--- a/tests/unifiedllm/test_explicit_cache_boundary.py
+++ b/tests/unifiedllm/test_explicit_cache_boundary.py
@@ -1,0 +1,373 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Stable-prefix boundaries from dynamic context to provider wire payload."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from nooa._llm_state import ReplayCarryingMessage, carried_cache_boundary
+from nooa.context_blocks.events import UserEvent
+from nooa.context_blocks.formatter import OpenAIProviderFormatter
+from nooa.context_blocks.models import BlockMetadata, ResolvedBlock, Role
+from nooa.context_blocks.renderer import render_context
+from nooa.context_blocks.renderers.cached import CachedBlockFormatter
+from nooa.unifiedllm import CompletionClient, ResponsesClient
+
+
+def _render(dynamic: str) -> list[dict]:
+    event = UserEvent(content="solve this", tag="1")
+    blocks = [
+        ResolvedBlock(
+            key="instructions",
+            content="stable instructions",
+            role=Role.SYSTEM,
+            metadata=BlockMetadata(static=True),
+        ),
+        ResolvedBlock(
+            key="event_1",
+            content=event.content,
+            role=Role.USER,
+            metadata=BlockMetadata(tag="1"),
+            event=event,
+        ),
+        ResolvedBlock(
+            key="live_state",
+            content=dynamic,
+            role=Role.SYSTEM,
+            metadata=BlockMetadata(static=False, user_block=True),
+        ),
+    ]
+    return render_context(
+        blocks,
+        block_formatter=CachedBlockFormatter(),
+        provider_formatter=OpenAIProviderFormatter(),
+    ).output
+
+
+def _responses_output() -> SimpleNamespace:
+    return SimpleNamespace(
+        output=[
+            {
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "ok"}],
+            }
+        ],
+        output_text="ok",
+        status="completed",
+        usage=None,
+    )
+
+
+def test_cached_renderer_marks_only_the_dynamic_suffix_outside_json() -> None:
+    messages = _render("state-a")
+
+    assert not carried_cache_boundary(messages[-2])
+    assert carried_cache_boundary(messages[-1])
+    assert "state-a" in messages[-1]["content"]
+    assert "cache_boundary" not in json.dumps(messages)
+
+
+def test_cache_mapping_must_match_the_client_api_style() -> None:
+    with pytest.raises(ValueError, match="CompletionClient.*'anthropic'"):
+        CompletionClient(model="openai/gpt-5.6", cache_breakpoint="openai")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="ResponsesClient.*'openai'"):
+        ResponsesClient(
+            model="anthropic/claude-sonnet-4",
+            cache_breakpoint="anthropic",  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
+async def test_openai_marks_the_stable_prefix_before_dynamic_context() -> None:
+    client = ResponsesClient(
+        model="openai/gpt-5.6", api_key="test", cache_breakpoint="openai"
+    )
+    try:
+        with patch("litellm.aresponses", new_callable=AsyncMock) as request:
+            request.return_value = _responses_output()
+            await client.acall(_render("state-a"))
+            await client.acall(_render("state-b"))
+
+        first, second = (call.kwargs for call in request.await_args_list)
+        assert first["extra_body"]["prompt_cache_options"] == {"mode": "explicit"}
+        assert first["input"][:-1] == second["input"][:-1]
+        assert first["input"][-1] != second["input"][-1]
+        assert first["input"][-2]["content"][-1]["prompt_cache_breakpoint"] == {
+            "mode": "explicit"
+        }
+        assert "prompt_cache_breakpoint" not in first["input"][-1]["content"]
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_boundary_is_inert_without_capability_opt_in() -> None:
+    client = ResponsesClient(model="openai/gpt-5.6", api_key="test")
+    try:
+        with patch("litellm.aresponses", new_callable=AsyncMock) as request:
+            request.return_value = _responses_output()
+            await client.acall(_render("state-a"))
+        assert request.await_args is not None
+        sent = request.await_args.kwargs
+        assert "extra_body" not in sent
+        assert "prompt_cache_breakpoint" not in repr(sent["input"])
+        assert not any(carried_cache_boundary(item) for item in sent["input"])
+    finally:
+        await client.aclose()
+
+
+def test_openai_can_mark_a_system_only_stable_prefix() -> None:
+    rendered = _render("state-a")
+    rendered.pop(1)  # no history yet: stable instructions + volatile suffix
+    client = ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai")
+
+    transformed, instructions = client._transform_messages(rendered)
+    messages, instructions, enabled = client._prepare_cache_boundary(
+        transformed, responses=True, instructions=instructions
+    )
+
+    assert enabled is True
+    assert instructions is None
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"][0]["prompt_cache_breakpoint"] == {"mode": "explicit"}
+    assert "state-a" in messages[-1]["content"]
+
+
+def test_openai_falls_back_to_instructions_behind_ineligible_output() -> None:
+    client = ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai")
+    messages, instructions, enabled = client._prepare_cache_boundary(
+        [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "stable output"}],
+            },
+            ReplayCarryingMessage({}, cache_boundary_before=True),
+            {"role": "user", "content": "live state"},
+        ],
+        responses=True,
+        instructions="stable instructions",
+    )
+
+    assert enabled is True
+    assert instructions is None
+    assert messages[0]["content"][0]["prompt_cache_breakpoint"] == {"mode": "explicit"}
+    assert messages[1]["content"][0] == {"type": "output_text", "text": "stable output"}
+
+
+@pytest.mark.asyncio
+async def test_openai_fields_reach_the_serialized_http_body() -> None:
+    bodies: list[dict] = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp_test",
+                "object": "response",
+                "created_at": 0,
+                "status": "completed",
+                "model": "gpt-5.6",
+                "output": [
+                    {
+                        "id": "msg_test",
+                        "type": "message",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_text", "text": "ok", "annotations": []}
+                        ],
+                    }
+                ],
+                "parallel_tool_calls": False,
+                "store": False,
+                "tools": [],
+                "usage": {
+                    "input_tokens": 2,
+                    "input_tokens_details": {"cached_tokens": 0},
+                    "output_tokens": 1,
+                    "output_tokens_details": {"reasoning_tokens": 0},
+                    "total_tokens": 3,
+                },
+            },
+        )
+
+    client = ResponsesClient(
+        model="openai/gpt-5.6",
+        api_key="test",
+        base_url="https://example.test/v1",
+        cache_breakpoint="openai",
+    )
+    assert client._http is not None
+    await client._http.httpx_async.aclose()
+    transport = httpx.AsyncClient(transport=httpx.MockTransport(respond))
+    client._http.httpx_async = transport
+    client._http.async_client.client = transport
+    try:
+        await client.acall(_render("state-a"))
+    finally:
+        await client.aclose()
+
+    assert bodies[0]["prompt_cache_options"] == {"mode": "explicit"}
+    assert bodies[0]["input"][-2]["content"][-1]["prompt_cache_breakpoint"] == {
+        "mode": "explicit"
+    }
+    assert "cache_boundary" not in repr(bodies[0])
+
+
+@pytest.mark.asyncio
+async def test_anthropic_breakpoint_survives_user_message_coalescing() -> None:
+    bodies: list[dict] = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-5",
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 2, "output_tokens": 1},
+            },
+        )
+
+    client = CompletionClient(
+        model="anthropic/claude-sonnet-4-5",
+        api_key="test",
+        api_base="https://example.test",
+        cache_breakpoint="anthropic",
+    )
+    assert client._http is not None
+    await client._http.httpx_async.aclose()
+    transport = httpx.AsyncClient(transport=httpx.MockTransport(respond))
+    client._http.httpx_async = transport
+    client._http.async_client.client = transport
+    try:
+        await client.acall(_render("state-a"))
+        system_only = _render("state-b")
+        system_only.pop(1)
+        await client.acall(system_only)
+    finally:
+        await client.aclose()
+
+    content = bodies[0]["messages"][0]["content"]
+    assert "solve this" in content[0]["text"]
+    assert content[0]["cache_control"] == {"type": "ephemeral"}
+    assert "state-a" in content[1]["text"]
+    assert "cache_control" not in content[1]
+    assert bodies[1]["system"][0]["cache_control"] == {"type": "ephemeral"}
+    assert "state-b" in bodies[1]["messages"][0]["content"][0]["text"]
+    assert "cache_control" not in bodies[1]["messages"][0]["content"][0]
+
+
+def test_openai_skips_assistant_output_and_marks_latest_input() -> None:
+    boundary = ReplayCarryingMessage({}, cache_boundary_before=True)
+    client = ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai")
+    messages, _, enabled = client._prepare_cache_boundary(
+        [
+            {"role": "user", "content": "stable input"},
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "prior answer"}],
+            },
+            boundary,
+            {"role": "user", "content": "live state"},
+        ],
+        responses=True,
+    )
+
+    assert enabled is True
+    assert messages[0]["content"][-1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
+    assert "prompt_cache_breakpoint" not in messages[1]["content"][0]
+
+
+def test_openai_can_mark_a_stable_function_result() -> None:
+    boundary = ReplayCarryingMessage({}, cache_boundary_before=True)
+    client = ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai")
+    messages, _, enabled = client._prepare_cache_boundary(
+        [
+            {"type": "function_call_output", "call_id": "c1", "output": "done"},
+            boundary,
+            {"role": "user", "content": "live state"},
+        ],
+        responses=True,
+    )
+
+    assert enabled is True
+    assert messages[0]["output"][-1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
+
+
+def test_replay_expansion_stays_inside_the_stable_prefix() -> None:
+    scope = "responses:openai:sha256:test"
+    state = {
+        "version": 1,
+        "scope": scope,
+        "format": "openai-responses",
+        "payload": {
+            "items": [{"type": "reasoning", "encrypted_content": "opaque"}],
+            "order": [
+                {"type": "reasoning", "index": 0},
+                {"type": "function_call", "call_id": "c1"},
+            ],
+        },
+    }
+    client = ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai")
+    transformed, instructions = client._transform_messages(
+        [
+            {"role": "user", "content": "run it"},
+            ReplayCarryingMessage(
+                {
+                    "_batch": [
+                        {
+                            "type": "function_call",
+                            "call_id": "c1",
+                            "name": "run",
+                            "arguments": "{}",
+                        }
+                    ]
+                },
+                state,
+            ),
+            {"type": "function_call_output", "call_id": "c1", "output": "done"},
+            ReplayCarryingMessage(
+                {"role": "user", "content": "live state"}, cache_boundary_before=True
+            ),
+        ],
+        scope,
+    )
+    messages, _, enabled = client._prepare_cache_boundary(
+        transformed, responses=True, instructions=instructions
+    )
+
+    assert enabled is True
+    assert [item.get("type", item.get("role")) for item in messages] == [
+        "user",
+        "reasoning",
+        "function_call",
+        "function_call_output",
+        "user",
+    ]
+    assert messages[-2]["output"][-1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
+    assert messages[-1] == {"role": "user", "content": "live state"}
+
+
+def test_gemini_gets_no_invented_inline_cache_field() -> None:
+    client = CompletionClient(model="gemini/gemini-2.5-pro")
+    messages, _, enabled = client._prepare_cache_boundary(_render("state-a"), responses=False)
+
+    assert enabled is False
+    assert "cache_control" not in repr(messages)
+    assert "prompt_cache_breakpoint" not in repr(messages)
+    assert not any(carried_cache_boundary(item) for item in messages)

--- a/tests/unifiedllm/test_explicit_cache_boundary.py
+++ b/tests/unifiedllm/test_explicit_cache_boundary.py
@@ -17,6 +17,7 @@ from nooa.context_blocks.models import BlockMetadata, RenderedMessage, ResolvedB
 from nooa.context_blocks.renderer import render_context
 from nooa.context_blocks.renderers.cached import CachedBlockFormatter
 from nooa.unifiedllm import CompletionClient, ResponsesClient
+from nooa.unifiedllm.replay_state import prepare_chat_messages
 from nooa.unifiedllm.unifiedllm import _extract_usage
 
 
@@ -121,6 +122,92 @@ def test_cache_marker_copy_preserves_private_replay_metadata() -> None:
     assert prepared[0].replay_batch_id == "batch"
     assert prepared[0].replay_batch_size == 1
     assert "cache_control" not in original
+
+
+def test_overlapping_cache_injection_does_not_mutate_original_content() -> None:
+    original = {
+        "role": "tool",
+        "content": [{"type": "text", "text": "first"}, {"type": "text", "text": "last"}],
+    }
+    before = json.dumps(original)
+    with CompletionClient(model="anthropic/claude-sonnet-4-5") as client:
+        prepared = client._inject_cache_control(
+            [original], [{"role": "tool"}, {"role": "tool", "position": "last"}]
+        )
+
+    assert json.dumps(original) == before
+    assert prepared[0]["content"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert prepared[0]["content"][0] is original["content"][0]
+
+
+def test_dropped_opaque_assistant_preserves_its_cache_boundary() -> None:
+    messages = [
+        {"role": "user", "content": "stable"},
+        ReplayCarryingMessage(
+            {"role": "assistant", "content": ""},
+            llm_state={
+                "version": 1,
+                "scope": "chat:anthropic:test",
+                "format": "litellm-chat",
+                "payload": {
+                    "thinking_blocks": [
+                        {"type": "thinking", "thinking": "private", "signature": "sig"}
+                    ],
+                    "carrier": {"content": "", "tool_calls": []},
+                    "state_only": True,
+                },
+            },
+            cache_boundary_before=True,
+        ),
+        {"role": "user", "content": "live state"},
+    ]
+    prepared = prepare_chat_messages(messages, None)
+    with CompletionClient(
+        model="anthropic/claude-sonnet-4-5", cache_breakpoint="anthropic"
+    ) as client:
+        wire, _, _ = client._prepare_cache_boundary(prepared, responses=False)
+
+    assert wire == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "stable", "cache_control": {"type": "ephemeral"}}],
+        },
+        {"role": "user", "content": "live state"},
+    ]
+
+
+@pytest.mark.parametrize("static_prefix", [False, True])
+def test_dynamic_system_messages_remain_after_the_cache_boundary(static_prefix: bool) -> None:
+    prefix = [{"role": "system", "content": "stable instructions"}] if static_prefix else []
+    with ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai") as client:
+        transformed, instructions = client._transform_messages(
+            [
+                *prefix,
+                ReplayCarryingMessage(
+                    {"role": "system", "content": "live state"}, cache_boundary_before=True
+                ),
+                {"role": "system", "content": "more live state"},
+            ]
+        )
+        assert instructions == ("stable instructions" if static_prefix else None)
+        wire, instructions, enabled = client._prepare_cache_boundary(
+            transformed, responses=True, instructions=instructions
+        )
+
+    assert enabled is True
+    assert instructions is None
+    assert wire[-2:] == [
+        {"role": "system", "content": "live state"},
+        {"role": "system", "content": "more live state"},
+    ]
+    if static_prefix:
+        assert wire[0]["content"][0] == {
+            "type": "input_text",
+            "text": "stable instructions",
+            "prompt_cache_breakpoint": {"mode": "explicit"},
+        }
+    else:
+        assert "prompt_cache_breakpoint" not in repr(wire)
 
 
 def test_boundary_consumption_preserves_ordinary_empty_messages_and_private_state() -> None:

--- a/tests/unifiedllm/test_explicit_cache_boundary.py
+++ b/tests/unifiedllm/test_explicit_cache_boundary.py
@@ -17,7 +17,7 @@ from nooa.context_blocks.models import BlockMetadata, RenderedMessage, ResolvedB
 from nooa.context_blocks.renderer import render_context
 from nooa.context_blocks.renderers.cached import CachedBlockFormatter
 from nooa.unifiedllm import CompletionClient, ResponsesClient
-from nooa.unifiedllm.replay_state import prepare_chat_messages
+from nooa.unifiedllm.replay_state import capture_chat_state, prepare_chat_messages, replay_scope
 from nooa.unifiedllm.unifiedllm import _extract_usage
 
 
@@ -507,6 +507,66 @@ def test_openai_skips_assistant_output_and_marks_latest_input() -> None:
     assert enabled is True
     assert messages[0]["content"][-1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
     assert "prompt_cache_breakpoint" not in messages[1]["content"][0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_tool_call", [False, True])
+async def test_anthropic_boundary_skips_assistants_without_public_content(with_tool_call) -> None:
+    bodies = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-5",
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 2, "output_tokens": 1},
+            },
+        )
+
+    client = CompletionClient(
+        model="anthropic/claude-sonnet-4-5",
+        api_key="test",
+        api_base="https://example.test",
+        cache_breakpoint="anthropic",
+        cache_control_injection_points=[],
+    )
+    assistant = {"role": "assistant", "content": None if with_tool_call else ""}
+    suffix = {"role": "user", "content": "live state"}
+    if with_tool_call:
+        assistant["tool_calls"] = [
+            {"id": "c1", "type": "function", "function": {"name": "run", "arguments": "{}"}}
+        ]
+        suffix = {"role": "tool", "tool_call_id": "c1", "content": "live result"}
+    thinking = [{"type": "thinking", "thinking": "Check the inputs.", "signature": "sig"}]
+    state = capture_chat_state(
+        {**assistant, "thinking_blocks": thinking}, replay_scope(client.model, "chat", {})
+    )
+    assert client._http is not None
+    await client._http.httpx_async.aclose()
+    transport = httpx.AsyncClient(transport=httpx.MockTransport(respond))
+    client._http.httpx_async = transport
+    client._http.async_client.client = transport
+    try:
+        await client.acall(
+            [
+                {"role": "user", "content": "stable input"},
+                ReplayCarryingMessage(assistant, llm_state=state),
+                ReplayCarryingMessage(suffix, cache_boundary_before=True),
+            ]
+        )
+    finally:
+        await client.aclose()
+
+    messages = bodies[0]["messages"]
+    assert messages[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+    assert "cache_control" not in repr(messages[1:])
+    assert messages[1]["content"][0] == thinking[0]
 
 
 def test_openai_can_mark_a_stable_function_result() -> None:

--- a/tests/unifiedllm/test_explicit_cache_boundary.py
+++ b/tests/unifiedllm/test_explicit_cache_boundary.py
@@ -17,6 +17,7 @@ from nooa.context_blocks.models import BlockMetadata, RenderedMessage, ResolvedB
 from nooa.context_blocks.renderer import render_context
 from nooa.context_blocks.renderers.cached import CachedBlockFormatter
 from nooa.unifiedllm import CompletionClient, ResponsesClient
+from nooa.unifiedllm.unifiedllm import _extract_usage
 
 
 def _render(dynamic: str) -> list[dict]:
@@ -294,14 +295,14 @@ async def test_openai_fields_reach_the_serialized_http_body() -> None:
                 "store": False,
                 "tools": [],
                 "usage": {
-                    "input_tokens": 100,
+                    "input_tokens": 1000,
                     "input_tokens_details": {
-                        "cached_tokens": 50,
-                        "cache_write_tokens": 25,
+                        "cached_tokens": 500,
+                        "cache_write_tokens": 250,
                     },
-                    "output_tokens": 1,
+                    "output_tokens": 100,
                     "output_tokens_details": {"reasoning_tokens": 0},
-                    "total_tokens": 101,
+                    "total_tokens": 1100,
                 },
             },
         )
@@ -326,8 +327,28 @@ async def test_openai_fields_reach_the_serialized_http_body() -> None:
     assert bodies[0]["input"][-2]["content"][-1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
     assert "cache_boundary" not in repr(bodies[0])
     assert response.usage is not None
-    assert response.usage.cached_input_tokens == 50
-    assert response.usage.cache_write_input_tokens == 25
+    assert response.usage.cached_input_tokens == 500
+    assert response.usage.cache_write_input_tokens == 250
+    hidden_cost = response.raw_response._hidden_params["response_cost"]
+    assert isinstance(hidden_cost, (int, float)) and hidden_cost > 0
+    assert response.usage.cost_usd == hidden_cost
+
+
+@pytest.mark.parametrize("bad_cost", [True, "unknown", float("nan"), -1.0])
+def test_malformed_litellm_response_cost_warns_without_losing_usage(
+    bad_cost: object, caplog: pytest.LogCaptureFixture
+) -> None:
+    raw_response = SimpleNamespace(
+        usage={"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
+        _hidden_params={"response_cost": bad_cost},
+    )
+
+    usage = _extract_usage(raw_response)
+
+    assert usage is not None
+    assert usage.input_tokens == 10
+    assert usage.cost_usd == 0.0
+    assert "Ignoring malformed LiteLLM response_cost metadata" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/unifiedllm/test_explicit_cache_boundary.py
+++ b/tests/unifiedllm/test_explicit_cache_boundary.py
@@ -122,12 +122,11 @@ async def test_boundary_is_inert_without_capability_opt_in() -> None:
 def test_openai_can_mark_a_system_only_stable_prefix() -> None:
     rendered = _render("state-a")
     rendered.pop(1)  # no history yet: stable instructions + volatile suffix
-    client = ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai")
-
-    transformed, instructions = client._transform_messages(rendered)
-    messages, instructions, enabled = client._prepare_cache_boundary(
-        transformed, responses=True, instructions=instructions
-    )
+    with ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai") as client:
+        transformed, instructions = client._transform_messages(rendered)
+        messages, instructions, enabled = client._prepare_cache_boundary(
+            transformed, responses=True, instructions=instructions
+        )
 
     assert enabled is True
     assert instructions is None
@@ -137,20 +136,20 @@ def test_openai_can_mark_a_system_only_stable_prefix() -> None:
 
 
 def test_openai_falls_back_to_instructions_behind_ineligible_output() -> None:
-    client = ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai")
-    messages, instructions, enabled = client._prepare_cache_boundary(
-        [
-            {
-                "type": "message",
-                "role": "assistant",
-                "content": [{"type": "output_text", "text": "stable output"}],
-            },
-            ReplayCarryingMessage({}, cache_boundary_before=True),
-            {"role": "user", "content": "live state"},
-        ],
-        responses=True,
-        instructions="stable instructions",
-    )
+    with ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai") as client:
+        messages, instructions, enabled = client._prepare_cache_boundary(
+            [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "stable output"}],
+                },
+                ReplayCarryingMessage({}, cache_boundary_before=True),
+                {"role": "user", "content": "live state"},
+            ],
+            responses=True,
+            instructions="stable instructions",
+        )
 
     assert enabled is True
     assert instructions is None
@@ -266,20 +265,20 @@ async def test_anthropic_breakpoint_survives_user_message_coalescing() -> None:
 
 def test_openai_skips_assistant_output_and_marks_latest_input() -> None:
     boundary = ReplayCarryingMessage({}, cache_boundary_before=True)
-    client = ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai")
-    messages, _, enabled = client._prepare_cache_boundary(
-        [
-            {"role": "user", "content": "stable input"},
-            {
-                "type": "message",
-                "role": "assistant",
-                "content": [{"type": "output_text", "text": "prior answer"}],
-            },
-            boundary,
-            {"role": "user", "content": "live state"},
-        ],
-        responses=True,
-    )
+    with ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai") as client:
+        messages, _, enabled = client._prepare_cache_boundary(
+            [
+                {"role": "user", "content": "stable input"},
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "prior answer"}],
+                },
+                boundary,
+                {"role": "user", "content": "live state"},
+            ],
+            responses=True,
+        )
 
     assert enabled is True
     assert messages[0]["content"][-1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
@@ -288,15 +287,15 @@ def test_openai_skips_assistant_output_and_marks_latest_input() -> None:
 
 def test_openai_can_mark_a_stable_function_result() -> None:
     boundary = ReplayCarryingMessage({}, cache_boundary_before=True)
-    client = ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai")
-    messages, _, enabled = client._prepare_cache_boundary(
-        [
-            {"type": "function_call_output", "call_id": "c1", "output": "done"},
-            boundary,
-            {"role": "user", "content": "live state"},
-        ],
-        responses=True,
-    )
+    with ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai") as client:
+        messages, _, enabled = client._prepare_cache_boundary(
+            [
+                {"type": "function_call_output", "call_id": "c1", "output": "done"},
+                boundary,
+                {"role": "user", "content": "live state"},
+            ],
+            responses=True,
+        )
 
     assert enabled is True
     assert messages[0]["output"][-1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
@@ -316,32 +315,32 @@ def test_replay_expansion_stays_inside_the_stable_prefix() -> None:
             ],
         },
     }
-    client = ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai")
-    transformed, instructions = client._transform_messages(
-        [
-            {"role": "user", "content": "run it"},
-            *carry_replay_batch(
-                [
-                    {
-                        "type": "function_call",
-                        "call_id": "c1",
-                        "name": "run",
-                        "arguments": "{}",
-                    }
-                ],
-                state,
-                None,
-            ),
-            {"type": "function_call_output", "call_id": "c1", "output": "done"},
-            ReplayCarryingMessage(
-                {"role": "user", "content": "live state"}, cache_boundary_before=True
-            ),
-        ],
-        scope,
-    )
-    messages, _, enabled = client._prepare_cache_boundary(
-        transformed, responses=True, instructions=instructions
-    )
+    with ResponsesClient(model="openai/gpt-5.6", cache_breakpoint="openai") as client:
+        transformed, instructions = client._transform_messages(
+            [
+                {"role": "user", "content": "run it"},
+                *carry_replay_batch(
+                    [
+                        {
+                            "type": "function_call",
+                            "call_id": "c1",
+                            "name": "run",
+                            "arguments": "{}",
+                        }
+                    ],
+                    state,
+                    None,
+                ),
+                {"type": "function_call_output", "call_id": "c1", "output": "done"},
+                ReplayCarryingMessage(
+                    {"role": "user", "content": "live state"}, cache_boundary_before=True
+                ),
+            ],
+            scope,
+        )
+        messages, _, enabled = client._prepare_cache_boundary(
+            transformed, responses=True, instructions=instructions
+        )
 
     assert enabled is True
     assert [item.get("type", item.get("role")) for item in messages] == [
@@ -356,8 +355,10 @@ def test_replay_expansion_stays_inside_the_stable_prefix() -> None:
 
 
 def test_gemini_gets_no_invented_inline_cache_field() -> None:
-    client = CompletionClient(model="gemini/gemini-2.5-pro", cache_control_injection_points=[])
-    messages, _, enabled = client._prepare_cache_boundary(_render("state-a"), responses=False)
+    with CompletionClient(
+        model="gemini/gemini-2.5-pro", cache_control_injection_points=[]
+    ) as client:
+        messages, _, enabled = client._prepare_cache_boundary(_render("state-a"), responses=False)
 
     assert enabled is False
     assert "cache_control" not in repr(messages)

--- a/tests/unifiedllm/test_explicit_cache_boundary.py
+++ b/tests/unifiedllm/test_explicit_cache_boundary.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import httpx
+import litellm
 import pytest
 
 from nooa._llm_state import ReplayCarryingMessage, carried_cache_boundary
@@ -364,10 +365,46 @@ def test_replay_expansion_stays_inside_the_stable_prefix() -> None:
 
 
 def test_gemini_gets_no_invented_inline_cache_field() -> None:
-    client = CompletionClient(model="gemini/gemini-2.5-pro")
+    client = CompletionClient(
+        model="gemini/gemini-2.5-pro", cache_control_injection_points=[]
+    )
     messages, _, enabled = client._prepare_cache_boundary(_render("state-a"), responses=False)
 
     assert enabled is False
     assert "cache_control" not in repr(messages)
     assert "prompt_cache_breakpoint" not in repr(messages)
     assert not any(carried_cache_boundary(item) for item in messages)
+
+
+@pytest.mark.asyncio
+async def test_gemini_boundary_is_inert_on_the_actual_call_path() -> None:
+    """The neutral boundary must not become a native Gemini wire field.
+
+    ``cache_control_injection_points`` is an older, separate gateway-level
+    extension point. Disable it here so this regression pins only the automatic
+    dynamic-context boundary introduced by this change.
+    """
+    client = CompletionClient(
+        model="gemini/gemini-2.5-pro", cache_control_injection_points=[]
+    )
+    response = litellm.ModelResponse(
+        model="gemini-2.5-pro",
+        choices=[
+            litellm.Choices(
+                index=0,
+                finish_reason="stop",
+                message=litellm.Message(role="assistant", content="ok"),
+            )
+        ],
+    )
+    try:
+        with patch("litellm.acompletion", new_callable=AsyncMock) as request:
+            request.return_value = response
+            await client.acall(_render("state-a"))
+        assert request.await_args is not None
+        sent = request.await_args.kwargs["messages"]
+        assert "cache_control" not in repr(sent)
+        assert "prompt_cache_breakpoint" not in repr(sent)
+        assert not any(carried_cache_boundary(item) for item in sent)
+    finally:
+        await client.aclose()

--- a/tests/unifiedllm/test_model_registry.py
+++ b/tests/unifiedllm/test_model_registry.py
@@ -254,6 +254,7 @@ class TestGetLlmClient:
                 store: false
                 include:
                   - reasoning.encrypted_content
+                cache_breakpoint: anthropic
             """,
         )
         reload_registry(path)
@@ -266,6 +267,8 @@ class TestGetLlmClient:
         assert llm.config["extra_body"] == {"trace": True}
         assert llm.config["store"] is False
         assert llm.config["include"] == ["reasoning.encrypted_content"]
+        assert llm.cache_breakpoint == "anthropic"
+        assert "cache_breakpoint" not in llm.config
 
     def test_drop_params_default_true(self):
         llm = get_llm_client("gpt-4o-mini")


### PR DESCRIPTION
## Summary

- mark the start of `CachedBlockFormatter`'s volatile trailing context with one provider-neutral IR bit
- carry that marker outside public JSON through formatting, reasoning replay, and no-op middleware
- translate it only at the UnifiedLLM provider edge:
  - OpenAI Responses: explicit breakpoint plus explicit-only cache mode
  - Anthropic Chat: native `cache_control` on the last stable block
  - Gemini/undeclared routes: consume the marker without inventing a wire field
- let a registry/client entry declare `cache_breakpoint: openai|anthropic`
- fail loudly on ambiguous boundaries, malformed cache configuration, or incompatible per-call model overrides
- persist normalized input, output, cached-input, cache-write, reasoning, total-token, and cost telemetry on `LLMResponse.usage`

## Why this layer exists

NOOA deliberately renders live state—timestamps, progress, environment state—as a separate trailing message. That keeps the preceding prompt byte-stable, but ordering alone is not a complete cache policy. OpenAI explicit caching needs a breakpoint at the last reusable input and explicit-only mode. Anthropic expresses the same semantic boundary by marking the last stable content block. Gemini uses implicit caching (or a separately managed CachedContent resource), so it needs the stable layout but no fabricated per-message field.

The renderer is the only layer that reliably knows “dynamic context starts here.” It publishes that one semantic fact in the provider-independent message IR. UnifiedLLM translates it at the final wire edge, where provider syntax belongs. Events, SQLite archives, agents, and ordinary middleware remain unaware of provider cache formats.

A boundary after every message would be noisier and less correct: it consumes provider cache slots, obscures the volatile suffix, and risks marking changing content. One automatically computed boundary immediately before the live suffix expresses the real stability contract.

The boundary must also survive exact reasoning replay. A canonical assistant turn can expand into several provider-native reasoning/message/tool items, so a raw list index would drift. Keeping the marker on the logical message and resolving it after replay preserves both the provider's exact turn and the reusable prefix.

Finally, cache behavior is only operationally useful if NOOA records what happened. Provider usage shapes differ, and LiteLLM reports computed cost outside its usage object. Normalizing all of them once onto durable `LLMResponse.usage` gives future TUI/observability code one stable source without another provider abstraction.

## Code walkthrough: what changed and why

1. **Identify the volatile suffix.**  
   **What:** `CachedBlockFormatter` keeps dynamic context as its own trailing message and marks it with `cache_boundary_before=True`.  
   **Why:** inferring stability later from roles or text is brittle; the context renderer already knows the stable/dynamic partition.

2. **Carry intent outside public JSON.**  
   **What:** provider formatters transfer the bit as a private attribute on `ReplayCarryingMessage`. Transient message serialization excludes reasoning, opaque state, and the marker.  
   **Why:** custom serializers and tracing must see an ordinary provider-independent message, never NOOA control fields or provider blobs.

3. **Preserve the anchor through replay and middleware.**  
   **What:** Chat preparation carries the marker with the logical message. Responses uses an out-of-band sentinel so replay expansion remains entirely on the stable side. No-op Relay and copy-on-write cache decoration preserve private sidecars; a real public mutation drops them.  
   **Why:** one stored turn can expand to multiple provider items, and cache decoration must never duplicate or discard reasoning state.

4. **Map OpenAI Responses policy.**  
   **What:** UnifiedLLM walks backward from the boundary to the latest eligible stable input/function result, marks it, and enables explicit cache mode. With no eligible stable input it still enables explicit-only mode.  
   **Why:** this prevents implicit write-through of the volatile suffix, including the edge case where the stable prefix contains only assistant output that cannot legally become `input_text`.

5. **Map Anthropic Chat policy.**  
   **What:** UnifiedLLM marks the latest eligible stable public content block, including system-only prefixes, after reasoning replay and before LiteLLM dispatch. It scans past tool-call-only or thinking-only turns that have no markable public content.  
   **Why:** Anthropic puts the breakpoint on a content block; LiteLLM can coalesce adjacent messages and drops a message-level marker on a tool-call-only turn. Selecting an earlier eligible block preserves a usable cache boundary without inventing assistant text or patching the HTTP client.

6. **Keep unsupported behavior honest.**  
   **What:** registry/client configuration declares the mapping. Without it, the neutral marker is consumed and no provider field is emitted; Gemini remains inert. A per-call model override on a mapped client raises before dispatch.  
   **Why:** a routing string is not evidence of cache capability, and a mapping declared for one model must not silently apply to another.

7. **Fail on invalid IR/configuration.**  
   **What:** multiple boundaries, non-mapping `extra_body`, malformed `prompt_cache_options`, and invalid model overrides raise helpful errors. Ordinary empty messages remain; only the tagged sentinel is consumed.  
   **Why:** silently choosing a boundary or repairing bad configuration would hide framework bugs.

8. **Normalize durable usage and cost.**  
   **What:** common Chat/Responses usage shapes map to `LLMUsage`, including nested OpenAI `cache_write_tokens`. A shared extractor overlays finite nonnegative LiteLLM `_hidden_params.response_cost` for sync/async Chat and Responses; malformed cost warns without losing token data. The canonical `LLMResponse` persists this usage with the session.  
   **Why:** cache read/write effectiveness and cost otherwise live in inconsistent provider/LiteLLM locations and disappear before the TUI can display them.

9. **Handle existing sessions without migration.**  
   **What:** the cache boundary is recomputed on every render rather than persisted in old archives.  
   **Why:** stability is a rendering property. Existing sessions adopt the policy on their next request; that first request may warm a new cache entry.

10. **Preserve boundaries across edge cases and resume.**  
   **What:** an empty incompatible turn retains its boundary marker; system messages after the boundary remain in the suffix; overlapping cache rules copy the content block they modify. An opt-in live test closes/reopens SQLite and constructs a fresh client before replay.  
   **Why:** dropping or moving a boundary can put live state into the cacheable prefix, while mutating old content breaks append-only replay. Testing rebuilt HTTP requests and provider cache hits verifies the actual session-resume path.


## Provider behavior

- [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching): explicit content-block breakpoint plus explicit-only mode
- [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching): `cache_control` on the last stable block
- [Gemini context caching](https://ai.google.dev/gemini-api/docs/generate-content/caching): implicit caching or a separately managed CachedContent resource

## Non-goals

- no TUI changes
- no model capability catalog
- no Gemini CachedContent lifecycle manager
- no additional telemetry event type

## Validation

- scrubber/transport follow-up (2026-09-11): **1,056 passed**, 5 deselected, across UnifiedLLM, context blocks, tracing, and Relay (`uv run --extra nemo-relay pytest ...`). Includes 12 actual LiteLLM/HTTP-mocked Responses override cases, nine Unicode/JSON-prefix/fallback cases, and readable-reasoning OTLP coverage. Ruff and targeted Pyright pass; no inference calls.

- compact-binding follow-up (2026-09-11): **1,035 passed**, 5 deselected, across UnifiedLLM, context blocks, tracing, and Relay. Cache-boundary replay uses #310/#311's version-2 fingerprints and the real capture path; stable-prefix expansion and readable-reasoning OTLP tests pass. Native Anthropic/Gemini SDK → SQLite → serialized-request probes pass with mocked HTTP. Ruff and targeted Pyright pass; no inference calls.

- latest combined-stack copy/OTLP regression round (2026-09-11): **1,003 passed**, 5 deselected, across UnifiedLLM, context blocks, tracing, and Relay. Includes 15 copy-ownership regressions and eight readable-reasoning OTLP cases. Native Anthropic/Gemini SDK → SQLite → serialized-request probes also pass with mocked HTTP; no inference tokens used.

- latest regression round: real SDK → JSON/SQLite → serialized HTTP tests cover multi-block text, ordered/phased messages, summary-only reasoning, unsupported whole-turn rejection, and eligible Anthropic cache-marker fallback

- prior combined-tip full suite (before this follow-up): **7,364 passed**, 10 skipped, 239 deselected, 3 expected xfails
- focused cache/Responses/replay set after review: **101 passed**
- Ruff, targeted Pyright, DCO trailers, and diff checks pass
- real LiteLLM serialized Responses regression verifies nested cache-write tokens and computed `response_cost`
- live SQLite-resume tests through NVIDIA Inference Hub: obtain a reasoning-bearing tool turn, warm the stable history, close/reopen SQLite, create a fresh client, and change the trailing dynamic context. Persisted events, opaque state, usage, and the stable serialized HTTP request all compare equal.

  | Model | Resumed input tokens | Cached input tokens |
  | --- | ---: | ---: |
  | GPT-5.6 Sol (Responses) | 6,186 | 6,162 |
  | Claude Sonnet 5 (native Anthropic Messages via hub) | 10,877 | 10,847 |
  | Gemini 3.1 Pro | 24,569 | 24,491 |

- reproducible opt-in runner: `NOOA_RUN_CACHE_RESUME_LIVE=1 uv run --env-file /path/to/.env pytest tests/integration/test_cache_resume_live.py -m integration -s`; requires `NVIDIA_INFERENCE_API_KEY`. Approximately 90k input tokens for all three cases, with endpoint retries disabled.
- Sonnet 5's Chat-compatible gateway path rejected its thinking configuration; the native Anthropic endpoint on the same hub accepted adaptive thinking and exact signed replay. No provider credits outside NVIDIA were used.
- live Nemotron reasoning survived JSON resume, was replayed as ordinary text to GPT-5.6-sol, and the target accepted it

Stacked on #311.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added provider-specific cache boundary support for OpenAI and Anthropic requests.
  - Preserved cache-boundary metadata across rendered messages, replayed conversations, and tool-call batches.
  - Added configuration options for selecting supported cache-breakpoint behavior.
  - Improved usage reporting for Responses API cost metadata.
- **Bug Fixes**
  - Prevented dynamic context suffixes from being incorrectly included in stable cached content.
  - Ensured unsupported providers fail safely without emitting cache controls.
- **Documentation**
  - Documented provider-specific cache behavior and dynamic context markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->