### PR TITLE
fix(mcp): support MCP 2.x timeouts 🤖🤖🤖

### DIFF
--- a/examples/assets/wiki_mcp_server.py
+++ b/examples/assets/wiki_mcp_server.py
@@ -10,9 +10,14 @@ Usage (standalone test):
     uv run python examples/assets/wiki_mcp_server.py
 """
 
-from mcp.server import FastMCP
+from importlib import import_module
 
-mcp = FastMCP("wiki")
+try:
+    _MCPServer = import_module("mcp.server.mcpserver").MCPServer
+except ImportError:
+    _MCPServer = import_module("mcp.server").FastMCP
+
+mcp = _MCPServer("wiki")
 
 # -- Canned knowledge base ---------------------------------------------------
 

--- a/src/nooa/mcp/client.py
+++ b/src/nooa/mcp/client.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from datetime import timedelta
+from importlib.metadata import version as distribution_version
 from typing import Any, Literal, override
 
 import httpx
@@ -20,6 +21,17 @@ from mcp.client.streamable_http import streamable_http_client
 # Establishing the connection is not a tool call, so it keeps its own short budget.
 # Matches the connect timeout the MCP SDK's own SSE transport defaults to.
 CONNECT_TIMEOUT_SECONDS = 5.0
+
+# MCP 1.x accepts ``timedelta`` while MCP 2.x accepts numeric seconds. Keep
+# NOOA's public timeout API stable and adapt only at the SDK boundary.
+_MCP_READ_TIMEOUT_USES_FLOAT = int(distribution_version("mcp").split(".", 1)[0]) >= 2
+
+
+def _session_read_timeout(timeout: timedelta) -> Any:
+    """Return the timeout representation expected by the installed MCP SDK."""
+    if _MCP_READ_TIMEOUT_USES_FLOAT:
+        return timeout.total_seconds()
+    return timeout
 
 
 class MCPBaseClient(ABC):
@@ -124,7 +136,11 @@ class MCPSSEClient(MCPBaseClient):
                 url=self._url,
                 headers=self._headers if self._headers else None,
             ) as (read, write),
-            ClientSession(read, write, read_timeout_seconds=self._tool_call_timeout) as session,
+            ClientSession(
+                read,
+                write,
+                read_timeout_seconds=_session_read_timeout(self._tool_call_timeout),
+            ) as session,
         ):
             await session.initialize()
             yield session
@@ -201,7 +217,11 @@ class MCPStdioClient(MCPBaseClient):
         )
         async with (
             stdio_client(server_params) as (read, write),
-            ClientSession(read, write, read_timeout_seconds=self._tool_call_timeout) as session,
+            ClientSession(
+                read,
+                write,
+                read_timeout_seconds=_session_read_timeout(self._tool_call_timeout),
+            ) as session,
         ):
             await session.initialize()
             yield session
@@ -303,7 +323,9 @@ class MCPStreamableHTTPClient(MCPBaseClient):
                 # Store the session ID callback for later retrieval
                 self._get_mcp_session_id = get_session_id
                 async with ClientSession(
-                    read, write, read_timeout_seconds=self._tool_call_timeout
+                    read,
+                    write,
+                    read_timeout_seconds=_session_read_timeout(self._tool_call_timeout),
                 ) as session:
                     await session.initialize()
                     yield session

--- a/src/nooa/mcp/client.py
+++ b/src/nooa/mcp/client.py
@@ -314,12 +314,10 @@ class MCPStreamableHTTPClient(MCPBaseClient):
         try:
             async with (
                 http_client,
-                streamable_http_client(url=self._url, http_client=http_client) as (
-                    read,
-                    write,
-                    get_session_id,
-                ),
+                streamable_http_client(url=self._url, http_client=http_client) as transport_streams,
             ):
+                read, write = transport_streams[:2]
+                get_session_id = transport_streams[2] if len(transport_streams) > 2 else None
                 # Store the session ID callback for later retrieval
                 self._get_mcp_session_id = get_session_id
                 async with ClientSession(

--- a/src/nooa/mcp/tool.py
+++ b/src/nooa/mcp/tool.py
@@ -714,7 +714,7 @@ def _create_tool_instance(
     """
     tool_specs = []
     for tool in tools_result.tools:
-        input_schema = tool.inputSchema if isinstance(tool.inputSchema, dict) else {}
+        input_schema = _tool_input_schema(tool)
         tool_specs.append(
             MCPToolSpec(
                 name=tool.name,
@@ -728,6 +728,15 @@ def _create_tool_instance(
     instance = object.__new__(dynamic_class)
     instance.__init__(client, server_name, refresh_ctx=refresh_ctx)
     return instance
+
+
+def _tool_input_schema(tool: Any) -> dict[str, Any]:
+    """Return a tool schema across MCP SDK field naming conventions."""
+    for attribute in ("input_schema", "inputSchema"):
+        schema = getattr(tool, attribute, None)
+        if isinstance(schema, dict):
+            return schema
+    return {}
 
 
 async def _list_server_tools(server_name: str, client: Any) -> Any:

--- a/tests/test_mcp/test_client.py
+++ b/tests/test_mcp/test_client.py
@@ -11,8 +11,11 @@ import pytest
 pytest.importorskip("mcp")
 
 from datetime import timedelta  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
 from typing import Literal  # noqa: E402
 from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+from mcp.types import Tool as MCPRemoteTool  # noqa: E402
 
 from nooa.mcp import client as client_module  # noqa: E402
 from nooa.mcp import oauth  # noqa: E402
@@ -23,7 +26,13 @@ from nooa.mcp.client import (  # noqa: E402
     MCPStreamableHTTPClient,
     create_mcp_client,
 )
-from nooa.mcp.tool import MCPManager, MCPTool, MCPToolSpec, _make_dynamic_class  # noqa: E402
+from nooa.mcp.tool import (  # noqa: E402
+    MCPManager,
+    MCPTool,
+    MCPToolSpec,
+    _make_dynamic_class,
+    _tool_input_schema,
+)
 
 
 # Fixtures
@@ -475,21 +484,22 @@ def test_create_mcp_client_forwards_tool_call_timeout(kwargs: dict[str, str]):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("provides_session_id", [False, True])
 async def test_streamable_http_connect_context_manager(
     streamable_http_client: MCPStreamableHTTPClient,
     mock_client_session: AsyncMock,
+    provides_session_id: bool,
 ):
-    """connect_to_server() is a proper async context manager for streamable-http."""
+    """MCP 1.x and 2.x stream tuples both establish a usable session."""
     mock_read = MagicMock()
     mock_write = MagicMock()
     mock_get_session_id = MagicMock(return_value="session-123")
+    transport_streams = (mock_read, mock_write, mock_get_session_id)
+    if not provides_session_id:
+        transport_streams = transport_streams[:2]
 
     with patch("nooa.mcp.client.streamable_http_client") as mock_http:
-        mock_http.return_value.__aenter__.return_value = (
-            mock_read,
-            mock_write,
-            mock_get_session_id,
-        )
+        mock_http.return_value.__aenter__.return_value = transport_streams
 
         with patch("nooa.mcp.client.ClientSession") as mock_session_class:
             mock_session_class.return_value.__aenter__.return_value = mock_client_session
@@ -501,7 +511,8 @@ async def test_streamable_http_connect_context_manager(
                 assert session is not None
                 mock_client_session.initialize.assert_awaited_once()
                 # During connection, mcp_session_id should be available
-                assert streamable_http_client.mcp_session_id == "session-123"
+                expected_session_id = "session-123" if provides_session_id else None
+                assert streamable_http_client.mcp_session_id == expected_session_id
 
             # After connection, mcp_session_id should be cleared
             assert streamable_http_client.mcp_session_id is None
@@ -815,18 +826,28 @@ def test_create_from_server_keeps_and_copies_nested_inline_config(monkeypatch):
     assert canary not in repr(transport_args)
 
 
+@pytest.mark.parametrize("attribute", ["inputSchema", "input_schema"])
+def test_tool_input_schema_supports_mcp_sdk_field_names(attribute: str):
+    """MCP 1.x and 2.x expose the input schema under different field names."""
+    schema = {"type": "object", "properties": {}}
+    remote_tool = SimpleNamespace(**{attribute: schema})
+
+    assert _tool_input_schema(remote_tool) is schema
+
+
 @pytest.mark.asyncio
-async def test_create_stdio_server_builds_tool_without_blocking_wrapper():
+async def test_create_stdio_server_builds_tool_from_real_sdk_model():
     session = AsyncMock()
     schema = {
         "type": "object",
         "properties": {"query": {"type": "string"}},
         "required": ["query"],
     }
-    remote_tool = MagicMock()
-    remote_tool.name = "lookup"
-    remote_tool.description = "Look up a value"
-    remote_tool.inputSchema = schema
+    remote_tool = MCPRemoteTool(
+        name="lookup",
+        description="Look up a value",
+        inputSchema=schema,
+    )
     session.list_tools.return_value.tools = [remote_tool]
     client = MagicMock()
 

--- a/tests/test_mcp/test_client.py
+++ b/tests/test_mcp/test_client.py
@@ -14,6 +14,7 @@ from datetime import timedelta  # noqa: E402
 from typing import Literal  # noqa: E402
 from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
 
+from nooa.mcp import client as client_module  # noqa: E402
 from nooa.mcp import oauth  # noqa: E402
 from nooa.mcp.client import (  # noqa: E402
     MCPBaseClient,
@@ -312,6 +313,24 @@ def test_tool_call_timeout_default(client_class: type[MCPBaseClient], client_kwa
     assert client.tool_call_timeout == timedelta(seconds=60)
 
 
+@pytest.mark.parametrize(
+    ("uses_float_seconds", "expected"),
+    [
+        (False, timedelta(seconds=7.5)),
+        (True, 7.5),
+    ],
+)
+def test_session_timeout_matches_mcp_sdk_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    uses_float_seconds: bool,
+    expected: timedelta | float,
+):
+    """MCP 1.x expects timedelta while MCP 2.x expects float seconds."""
+    monkeypatch.setattr(client_module, "_MCP_READ_TIMEOUT_USES_FLOAT", uses_float_seconds)
+
+    assert client_module._session_read_timeout(timedelta(seconds=7.5)) == expected
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "client_fixture, transport_patch",
@@ -401,7 +420,9 @@ async def test_streamable_http_applies_tool_call_timeout(
     assert timeout.write == 90
     # Opening the connection is not a tool call and keeps its own short budget.
     assert timeout.connect == 5.0
-    assert mock_session_class.call_args.kwargs["read_timeout_seconds"] == timedelta(seconds=90)
+    assert mock_session_class.call_args.kwargs[
+        "read_timeout_seconds"
+    ] == client_module._session_read_timeout(timedelta(seconds=90))
 
 
 @pytest.mark.asyncio
@@ -433,7 +454,9 @@ async def test_session_enforces_tool_call_timeout(
         async with client.connect_to_server():
             pass
 
-    assert mock_session_class.call_args.kwargs["read_timeout_seconds"] == expected_timeout
+    assert mock_session_class.call_args.kwargs[
+        "read_timeout_seconds"
+    ] == client_module._session_read_timeout(expected_timeout)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mcp/test_real_transports.py
+++ b/tests/test_mcp/test_real_transports.py
@@ -32,9 +32,12 @@ import sys
 
 from examples.assets.wiki_mcp_server import mcp
 
-mcp.settings.host = "127.0.0.1"
-mcp.settings.port = int(sys.argv[1])
-mcp.run(transport="streamable-http")
+if hasattr(mcp.settings, "host"):
+    mcp.settings.host = "127.0.0.1"
+    mcp.settings.port = int(sys.argv[1])
+    mcp.run(transport="streamable-http")
+else:
+    mcp.run(transport="streamable-http", host="127.0.0.1", port=int(sys.argv[1]))
 """
 
 


### PR DESCRIPTION
## What does this PR do?

- Adapts `ClientSession` read timeouts for the MCP 1.x and 2.x contracts.
- Accepts both `Tool.inputSchema` and `Tool.input_schema` during tool discovery.
- Handles the three-value MCP 1.x and two-value MCP 2.x streamable HTTP transport tuples.
- Keeps the bundled real MCP server compatible with the MCP 2.x `MCPServer` rename.
- Adds regression coverage using a real `mcp.types.Tool` and both transport tuple shapes.

## Related issues

Closes #262

## Validation

- MCP 1.28.1: `tests/test_mcp` passed, 107 tests.
- MCP 2.1.1: `tests/test_mcp` passed, 107 tests, including real stdio and streamable HTTP invocation.
- MCP 2.2.0: `tests/test_mcp` passed, 107 tests, including real stdio and streamable HTTP invocation.
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python scripts/check_license_headers.py`
- Focused Pyright passes for `client.py` and the bundled server; `tool.py` still reports existing errors on untouched lines.

## Checklist

- [x] Code follows the project style (`uv run ruff check .` and `uv run ruff format --check .` pass)
- [x] Tests added/updated and passing (`uv run pytest`)
- [x] Docs updated if behavior or public APIs changed (not applicable; no public API change)
- [x] New source files carry an SPDX license header (not applicable; no new source files)

🤖🤖🤖