### PR TITLE
fix(nooa-cli): make RepoTools path validation session-aware

### DIFF
--- a/packages/nooa-cli/src/nooa_cli/tools/_tree_sitter_backend.py
+++ b/packages/nooa-cli/src/nooa_cli/tools/_tree_sitter_backend.py
@@ -164,18 +164,25 @@ def _query_captures(query: ts.Query, root_node: ts.Node) -> list[tuple[ts.Node, 
     return _normalize_captures(ts.QueryCursor(query).captures(root_node))
 
 
-def ts_extract_symbols(path: Path, lang: str, max_symbols: int = 200) -> list[str] | None:
+def ts_extract_symbols(
+    path: Path, lang: str, max_symbols: int = 200, source: bytes | None = None
+) -> list[str] | None:
     """Extract symbol definitions using tree-sitter AST parsing.
 
     Returns a list of formatted symbol lines, or None if tree-sitter
     is not available for this language (caller should fall back to regex).
+
+    ``source`` lets callers supply already-read file bytes (e.g. content
+    fetched through a sandbox session); when omitted the file is read from
+    the host filesystem.
     """
     parser = _get_parser(lang)
     if parser is None:
         return None
 
     try:
-        source = path.read_bytes()
+        if source is None:
+            source = path.read_bytes()
         tree = parser.parse(source)
     except (OSError, Exception) as e:
         logger.debug(f"tree-sitter parse failed for {path}: {e}")

--- a/packages/nooa-cli/src/nooa_cli/tools/repo_tools.py
+++ b/packages/nooa-cli/src/nooa_cli/tools/repo_tools.py
@@ -7,6 +7,7 @@ Use ``symbols()`` to find definitions and ``refs()`` to find usages. Both return
 ``self.shell.replace(result[i], new_text)``.
 """
 
+import base64
 import logging
 import re
 import shlex
@@ -273,6 +274,7 @@ def _tree_sitter_available() -> bool:
 
 
 def _line_match(path: Path, line_no: int) -> Match | None:
+    """Build a ``Match`` for one line of a host-readable file; None if unreadable."""
     try:
         lines = path.read_text(errors="replace").splitlines(keepends=True)
     except OSError:
@@ -282,11 +284,26 @@ def _line_match(path: Path, line_no: int) -> Match | None:
     return Match(str(path), line_no, line_no, lines[line_no - 1], resolved_path=path)
 
 
+def _line_match_from_lines(path: Path, line_no: int, lines: list[str]) -> Match | None:
+    """Build a ``Match`` from already-read lines (e.g. session-fetched content)."""
+    if not (1 <= line_no <= len(lines)):
+        return None
+    return Match(str(path), line_no, line_no, lines[line_no - 1], resolved_path=path)
+
+
 def _symbol_anchor_pairs(path: Path, symbols: list[str]) -> list[tuple[str, Match]]:
+    """Pair formatted symbol lines with anchors read from the host filesystem."""
     try:
         lines = path.read_text(errors="replace").splitlines(keepends=True)
     except OSError:
         return []
+    return _symbol_anchor_pairs_from_lines(path, symbols, lines)
+
+
+def _symbol_anchor_pairs_from_lines(
+    path: Path, symbols: list[str], lines: list[str]
+) -> list[tuple[str, Match]]:
+    """Pair formatted symbol lines with anchors built from pre-read content."""
     pairs: list[tuple[str, Match]] = []
     for symbol in symbols:
         line_text = symbol.strip()
@@ -360,8 +377,14 @@ def _is_definition_line(content: str, name: str = "") -> bool:
     )
 
 
-def _extract_symbols(path: Path, lang: str, max_symbols: int = 200) -> list[str]:
-    """Extract symbol definitions from a file using tree-sitter AST (with regex fallback)."""
+def _extract_symbols(
+    path: Path, lang: str, max_symbols: int = 200, source: bytes | None = None
+) -> list[str]:
+    """Extract symbol definitions from a file using tree-sitter AST (with regex fallback).
+
+    ``source`` supplies already-read file bytes (e.g. content fetched through a
+    sandbox session); when omitted the file is read from the host filesystem.
+    """
     # Try tree-sitter first (AST-aware, more accurate)
     try:
         from nooa_cli.tools._tree_sitter_backend import (
@@ -370,7 +393,7 @@ def _extract_symbols(path: Path, lang: str, max_symbols: int = 200) -> list[str]
         )
 
         if TREE_SITTER_AVAILABLE:
-            ts_result = ts_extract_symbols(path, lang, max_symbols)
+            ts_result = ts_extract_symbols(path, lang, max_symbols, source=source)
             if ts_result is not None:
                 return ts_result
     except ImportError:
@@ -382,7 +405,10 @@ def _extract_symbols(path: Path, lang: str, max_symbols: int = 200) -> list[str]
         return []
 
     try:
-        text = path.read_text(errors="replace")
+        if source is None:
+            text = path.read_text(errors="replace")
+        else:
+            text = source.decode("utf-8", errors="replace")
     except (OSError, PermissionError):
         return []
 
@@ -465,7 +491,12 @@ class RepoTools(Skill):
         resolved = self._resolve(path)
         if not await self._path_exists(resolved):
             diagnostic = PathResolutionError(
-                "symbols", path, resolved, base_name="self.repo.root", base_path=self._root
+                "symbols",
+                path,
+                resolved,
+                base_name="self.repo.root",
+                base_path=self._root,
+                reason="not_found",
             )
             return RepoResult(query=path, lines=[], diagnostic=diagnostic)
         query_lower = query.lower()
@@ -520,7 +551,12 @@ class RepoTools(Skill):
         resolved = self._resolve(path)
         if not await self._path_exists(resolved):
             diagnostic = PathResolutionError(
-                "refs", path, resolved, base_name="self.repo.root", base_path=self._root
+                "refs",
+                path,
+                resolved,
+                base_name="self.repo.root",
+                base_path=self._root,
+                reason="not_found",
             )
             return RepoResult(query=name, lines=[], diagnostic=diagnostic)
         result = await self._search_references(name, path=path, max_results=max_results)
@@ -541,8 +577,6 @@ class RepoTools(Skill):
         the session when one is wired; fall back to the host otherwise.
         """
         if self._session:
-            import shlex
-
             _, _, code = await self._session.run(
                 f"test -e {shlex.quote(str(resolved))}", timeout=10
             )
@@ -552,13 +586,71 @@ class RepoTools(Skill):
     async def _path_is_file(self, resolved: Path) -> bool:
         """File (not directory) probe, session-aware like ``_path_exists``."""
         if self._session:
-            import shlex
-
             _, _, code = await self._session.run(
                 f"test -f {shlex.quote(str(resolved))}", timeout=10
             )
             return code == 0
         return resolved.is_file()
+
+    async def _path_is_dir(self, resolved: Path) -> bool:
+        """Directory probe, session-aware like ``_path_exists``."""
+        if self._session:
+            _, _, code = await self._session.run(
+                f"test -d {shlex.quote(str(resolved))}", timeout=10
+            )
+            return code == 0
+        return resolved.is_dir()
+
+    async def _read_bytes(self, resolved: Path) -> bytes | None:
+        """Read file bytes through the wired session, or from the host.
+
+        Session reads travel as base64 payloads so only the base64 alphabet
+        crosses the process boundary (the same transfer the Gym sandbox
+        shell uses). Returns None when the read fails on either side.
+        """
+        if self._session:
+            stdout, _, code = await self._session.run(
+                f"base64 -w 0 {shlex.quote(str(resolved))}", timeout=30
+            )
+            if code != 0 or not stdout.strip():
+                return None
+            try:
+                return base64.b64decode(stdout.strip())
+            except (ValueError, TypeError):
+                return None
+        try:
+            return resolved.read_bytes()
+        except OSError:
+            return None
+
+    async def _read_lines(self, resolved: Path) -> list[str] | None:
+        """Read a file as newline-kept lines, session-aware; None on failure."""
+        data = await self._read_bytes(resolved)
+        if data is None:
+            return None
+        return data.decode("utf-8", errors="replace").splitlines(keepends=True)
+
+    async def _anchor_from_match_line(self, line: str) -> Match | None:
+        """Build a ``Match`` from a ``file:line: content`` search result.
+
+        Session-aware: the referenced file is read through the wired session
+        when one is configured, so anchors are not dropped for files that
+        only exist in the session's filesystem.
+        """
+        path_text, sep, rest = line.partition(":")
+        if not sep:
+            return None
+        m = re.match(r"\s*(\d+)\b", rest)
+        if not m:
+            return None
+        fpath = Path(path_text)
+        if not fpath.is_absolute():
+            fpath = self._root / fpath
+        line_no = int(m.group(1))
+        lines = await self._read_lines(fpath)
+        if lines is None:
+            return None
+        return _line_match_from_lines(fpath, line_no, lines)
 
     async def _check_rg(self) -> bool:
         """Check if rg (ripgrep) is available, caching the result."""
@@ -593,7 +685,7 @@ class RepoTools(Skill):
             r = await self.repo._filemap("internal/llm/tools/edit.go")
         """
         resolved = self._resolve(path)
-        if not resolved.is_file():
+        if not await self._path_is_file(resolved):
             from nooa.runtime.harness_metrics import get_harness_metrics
 
             get_harness_metrics().repo_failure(
@@ -604,10 +696,21 @@ class RepoTools(Skill):
             )
 
         lang = _detect_lang(resolved)
-        symbols = _extract_symbols(resolved, lang, max_symbols=max_symbols)
+        source = await self._read_bytes(resolved)
+        if source is None:
+            from nooa.runtime.harness_metrics import get_harness_metrics
+
+            get_harness_metrics().repo_failure(
+                "filemap:read_failed", f"Could not read: {path}", path
+            )
+            return FileMapResult(
+                path=path, language=lang, symbols=[f"Error: could not read {path}"]
+            )
+        symbols = _extract_symbols(resolved, lang, max_symbols=max_symbols, source=source)
         truncated = len(symbols) >= max_symbols
 
-        symbol_anchor_pairs = _symbol_anchor_pairs(resolved, symbols)
+        lines = source.decode("utf-8", errors="replace").splitlines(keepends=True)
+        symbol_anchor_pairs = _symbol_anchor_pairs_from_lines(resolved, symbols, lines)
         return FileMapResult(
             path=path,
             language=lang,
@@ -652,7 +755,7 @@ class RepoTools(Skill):
 
         for sp in search_paths:
             resolved = self._resolve(sp)
-            if not resolved.is_dir():
+            if not await self._path_is_dir(resolved):
                 continue
             # Use rg to find files respecting gitignore, or fall back to walking
             if self._session and await self._check_rg():
@@ -662,12 +765,22 @@ class RepoTools(Skill):
                 )
                 for line in stdout.splitlines():
                     p = Path(line.strip())
-                    if p.is_file() and _detect_lang(p) != "unknown":
+                    if _detect_lang(p) != "unknown":
                         all_files.append(p)
-                # Sort by mtime (newest first) — rg --sort requires v14+
-                all_files.sort(key=lambda f: f.stat().st_mtime, reverse=True)
+                # Session-only paths have no host mtime, so the listing order
+                # is kept as-is.
+            elif self._session:
+                # Session image without rg (common in minimal images): use find.
+                stdout, _, _ = await self._session.run(
+                    f"find {shlex.quote(str(resolved))} -type f 2>/dev/null | head -{max_files * 3}",
+                    timeout=15,
+                )
+                for line in stdout.splitlines():
+                    p = Path(line.strip())
+                    if _detect_lang(p) != "unknown":
+                        all_files.append(p)
             else:
-                # Fallback: walk directory (rg not available or no session)
+                # Fallback: walk directory (no session configured)
                 for ext in _LANG_MAP:
                     for p in sorted(resolved.rglob(f"*{ext}"))[:max_files]:
                         all_files.append(p)
@@ -691,8 +804,13 @@ class RepoTools(Skill):
             except ValueError:
                 rel = fpath
             lang = _detect_lang(fpath)
-            symbols = _extract_symbols(fpath, lang, max_symbols=max_symbols_per_file)
-            symbol_anchor_pairs = _symbol_anchor_pairs(fpath, symbols)
+            source = await self._read_bytes(fpath)
+            if source is None:
+                sections.append(f"\n{rel}: ({lang}, unreadable)")
+                continue
+            symbols = _extract_symbols(fpath, lang, max_symbols=max_symbols_per_file, source=source)
+            lines = source.decode("utf-8", errors="replace").splitlines(keepends=True)
+            symbol_anchor_pairs = _symbol_anchor_pairs_from_lines(fpath, symbols, lines)
             if symbol_anchor_pairs:
                 sections.append(f"\n{rel}:")
                 sections.extend(symbol for symbol, _ in symbol_anchor_pairs)
@@ -746,14 +864,20 @@ class RepoTools(Skill):
         resolved = self._resolve(path)
         matches: list[str] = []
 
-        # Use grep to find definition patterns matching the name
-        if self._session and await self._check_rg():
+        if self._session:
             # Build a regex that matches common definition patterns
             pattern = f"(def|class|function|func|struct|trait|interface|type|impl|module|const)\\s+\\w*{re.escape(name)}\\w*"
-            stdout, _, _ = await self._session.run(
-                f"rg -n -i --color=never {shlex.quote(pattern)} {shlex.quote(str(resolved))} 2>/dev/null | head -{max_results * 2}",
-                timeout=30,
-            )
+            if await self._check_rg():
+                stdout, _, _ = await self._session.run(
+                    f"rg -n -i --color=never {shlex.quote(pattern)} {shlex.quote(str(resolved))} 2>/dev/null | head -{max_results * 2}",
+                    timeout=30,
+                )
+            else:
+                # GNU grep is present in images where rg is not (e.g. SWE-bench).
+                stdout, _, _ = await self._session.run(
+                    f"grep -rnE -i {shlex.quote(pattern)} {shlex.quote(str(resolved))} 2>/dev/null | head -{max_results * 2}",
+                    timeout=30,
+                )
             for line in stdout.splitlines():
                 if line.strip():
                     matches.append(line.strip())
@@ -779,13 +903,13 @@ class RepoTools(Skill):
                     break
 
         total = len(matches)
-        paired = [
-            (match, anchor)
-            for match, anchor in (
-                (m, _anchor_from_match_line(m, self._root)) for m in matches[:max_results]
-            )
-            if anchor is not None
-        ]
+        paired: list[tuple[str, Match]] = []
+        for match in matches[:max_results]:
+            # Session-aware anchor creation: the referenced file is read
+            # through the wired session when one is configured.
+            anchor = await self._anchor_from_match_line(match)
+            if anchor is not None:
+                paired.append((match, anchor))
         if total == 0:
             from nooa.runtime.harness_metrics import get_harness_metrics
 
@@ -834,14 +958,16 @@ class RepoTools(Skill):
         """
         resolved = self._resolve(path)
 
-        # Try tree-sitter first for accurate AST-aware reference finding
+        # Try tree-sitter first for accurate AST-aware reference finding.
+        # The AST branch walks the host filesystem, so it only applies when no
+        # session is wired; session results come from rg/grep below instead.
         try:
             from nooa_cli.tools._tree_sitter_backend import (
                 TREE_SITTER_AVAILABLE,
                 ts_find_references,
             )
 
-            if TREE_SITTER_AVAILABLE:
+            if TREE_SITTER_AVAILABLE and not self._session:
                 all_matches: list[str] = []
                 for fpath in self._iter_source_files(resolved, max_files=500):
                     lang = _detect_lang(fpath)
@@ -884,7 +1010,11 @@ class RepoTools(Skill):
         pattern = f"\\b{search_name}\\b"
 
         if self._session:
-            cmd = f"rg -n --color=never {shlex.quote(pattern)} {shlex.quote(str(resolved))} 2>/dev/null | head -{max_results * 3}"
+            if await self._check_rg():
+                cmd = f"rg -n --color=never {shlex.quote(pattern)} {shlex.quote(str(resolved))} 2>/dev/null | head -{max_results * 3}"
+            else:
+                # GNU grep is present in images where rg is not (e.g. SWE-bench).
+                cmd = f"grep -rnE {shlex.quote(pattern)} {shlex.quote(str(resolved))} 2>/dev/null | head -{max_results * 3}"
             stdout, _, code = await self._session.run(cmd, timeout=30)
             if code != 0 or not stdout:
                 return ReferenceSearchResult(query=name, matches=[], total_matches=0)
@@ -919,7 +1049,7 @@ class RepoTools(Skill):
             stripped = content.lstrip()
             if stripped.startswith("#") or stripped.startswith("//"):
                 continue
-            anchor = _anchor_from_match_line(raw, self._root)
+            anchor = await self._anchor_from_match_line(raw)
             if anchor is None:
                 continue
             matches.append(f"{parts[0]}:{parts[1]}: {content}")

--- a/packages/nooa-cli/src/nooa_cli/tools/repo_tools.py
+++ b/packages/nooa-cli/src/nooa_cli/tools/repo_tools.py
@@ -463,14 +463,14 @@ class RepoTools(Skill):
         ``await self.shell.replace(result[0], new_text)`` to edit a hit.
         """
         resolved = self._resolve(path)
-        if not resolved.exists():
+        if not await self._path_exists(resolved):
             diagnostic = PathResolutionError(
                 "symbols", path, resolved, base_name="self.repo.root", base_path=self._root
             )
             return RepoResult(query=path, lines=[], diagnostic=diagnostic)
         query_lower = query.lower()
 
-        if resolved.is_file():
+        if await self._path_is_file(resolved):
             file_result = await self._filemap(path, max_symbols=max_results if not query else 500)
             pairs = [
                 (symbol, anchor)
@@ -518,7 +518,7 @@ class RepoTools(Skill):
         ``await self.shell.replace(result[0], new_text)`` to edit a hit.
         """
         resolved = self._resolve(path)
-        if not resolved.exists():
+        if not await self._path_exists(resolved):
             diagnostic = PathResolutionError(
                 "refs", path, resolved, base_name="self.repo.root", base_path=self._root
             )
@@ -531,6 +531,34 @@ class RepoTools(Skill):
             total_matches=result.total_matches,
             truncated=result.truncated,
         )
+
+    async def _path_exists(self, resolved: Path) -> bool:
+        """Existence probe that works for sandbox-mounted roots.
+
+        With a shared session the repo root lives in the session's filesystem
+        (e.g. a Gym-hosted seeded sandbox), where a host-side
+        ``Path.exists()`` would wrongly report paths as missing. Probe via
+        the session when one is wired; fall back to the host otherwise.
+        """
+        if self._session:
+            import shlex
+
+            _, _, code = await self._session.run(
+                f"test -e {shlex.quote(str(resolved))}", timeout=10
+            )
+            return code == 0
+        return resolved.exists()
+
+    async def _path_is_file(self, resolved: Path) -> bool:
+        """File (not directory) probe, session-aware like ``_path_exists``."""
+        if self._session:
+            import shlex
+
+            _, _, code = await self._session.run(
+                f"test -f {shlex.quote(str(resolved))}", timeout=10
+            )
+            return code == 0
+        return resolved.is_file()
 
     async def _check_rg(self) -> bool:
         """Check if rg (ripgrep) is available, caching the result."""

--- a/packages/nooa-cli/tests/test_repo_tools_session_paths.py
+++ b/packages/nooa-cli/tests/test_repo_tools_session_paths.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Session-aware path validation in RepoTools.
+
+When a shared session is wired (e.g. a Gym-hosted seeded sandbox), the repo
+root lives in the session's filesystem and a host-side ``Path.exists()`` probe
+wrongly reports valid paths as missing. The existence and file probes must go
+through the session when one is wired, and fall back to the host otherwise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+from nooa_cli.tools.repo_tools import RepoTools
+
+
+class _FakeSession:
+    """Records ``test -e``/``test -f`` probes; answers from a fake filesystem."""
+
+    def __init__(self, existing: set[str], files: set[str]) -> None:
+        self.existing = existing
+        self.files = files
+        self.calls: list[str] = []
+
+    async def run(self, command: str, timeout: float = 30.0) -> Tuple[str, str, int]:
+        self.calls.append(command)
+        import shlex
+
+        parts = shlex.split(command)
+        if len(parts) >= 3 and parts[0] == "test":
+            target = parts[-1]
+            if parts[1] == "-e":
+                return ("", "", 0 if target in self.existing else 1)
+            if parts[1] == "-f":
+                return ("", "", 0 if target in self.files else 1)
+        return ("", "", 1)
+
+
+@pytest.mark.asyncio
+async def test_symbols_probes_paths_via_session_when_wired() -> None:
+    # Root is a container path that does NOT exist on the host.
+    session = _FakeSession(existing={"/app"}, files=set())
+    repo = RepoTools(root="/app", session=session)  # type: ignore[arg-type]
+
+    # symbols(".") must probe "." via the session, not the host filesystem.
+    result = await repo.symbols(".")
+
+    assert any("test -e" in c for c in session.calls), session.calls
+    # The result is NOT a path-resolution failure: the session saw /app.
+    assert result.diagnostic is None
+
+
+@pytest.mark.asyncio
+async def test_symbols_reports_diagnostic_when_session_says_missing() -> None:
+    session = _FakeSession(existing=set(), files=set())
+    repo = RepoTools(root="/app", session=session)  # type: ignore[arg-type]
+
+    result = await repo.symbols("missing/pkg")
+
+    assert result.diagnostic is not None
+    assert result.diagnostic.code == "PATH_NOT_FOUND"  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_refs_probes_paths_via_session_when_wired() -> None:
+    session = _FakeSession(existing={"/app/src"}, files=set())
+    repo = RepoTools(root="/app", session=session)  # type: ignore[arg-type]
+
+    result = await repo.refs("handler", path="/app/src")
+
+    assert any("test -e" in c for c in session.calls), session.calls
+    assert result.diagnostic is None
+
+
+@pytest.mark.asyncio
+async def test_host_fallback_still_works_without_session(tmp_path: Path) -> None:
+    repo = RepoTools(root=tmp_path)
+
+    result = await repo.symbols("missing/package")
+
+    assert result.diagnostic is not None
+    assert result.diagnostic.resolved_path == str((tmp_path / "missing/package").resolve())  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_file_probe_uses_session_when_wired() -> None:
+    session = _FakeSession(existing={"/app/a.py"}, files={"/app/a.py"})
+    repo = RepoTools(root="/app", session=session)  # type: ignore[arg-type]
+
+    # Direct probe helpers.
+    assert await repo._path_exists(Path("/app/a.py")) is True
+    assert await repo._path_is_file(Path("/app/a.py")) is True
+    assert await repo._path_exists(Path("/app/missing.py")) is False
+    assert any("test -f" in c for c in session.calls), session.calls

--- a/packages/nooa-cli/tests/test_repo_tools_session_paths.py
+++ b/packages/nooa-cli/tests/test_repo_tools_session_paths.py
@@ -1,61 +1,137 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Session-aware path validation in RepoTools.
+"""Session-aware repository processing in RepoTools.
 
 When a shared session is wired (e.g. a Gym-hosted seeded sandbox), the repo
-root lives in the session's filesystem and a host-side ``Path.exists()`` probe
-wrongly reports valid paths as missing. The existence and file probes must go
-through the session when one is wired, and fall back to the host otherwise.
+root lives in the session filesystem: host-side ``Path`` probes and reads
+would wrongly report paths as missing or drop results. Validation, file
+reads, searches, and anchor creation must all go through the session when
+one is wired, and fall back to the host otherwise.
 """
 
 from __future__ import annotations
 
+import base64
+import re as _re
+import shlex
 from pathlib import Path
-from typing import Tuple
 
 import pytest
 from nooa_cli.tools.repo_tools import RepoTools
 
 
-class _FakeSession:
-    """Records ``test -e``/``test -f`` probes; answers from a fake filesystem."""
+class FakeSession:
+    """A scripted session over an in-memory filesystem.
 
-    def __init__(self, existing: set[str], files: set[str]) -> None:
-        self.existing = existing
-        self.files = files
+    Answers the exact command vocabulary RepoTools issues: ``test -e/-f/-d``
+    probes, ``base64 -w 0`` reads, ``command -v rg``, ``rg``/``grep`` searches,
+    and ``rg --files``/``find`` listings. Records every command for assertions.
+    """
+
+    def __init__(self, fs: dict[str, str], *, has_rg: bool = True) -> None:
+        """Build the fake session from a mapping of absolute path to content."""
+        self.fs = fs
+        self.has_rg = has_rg
         self.calls: list[str] = []
 
-    async def run(self, command: str, timeout: float = 30.0) -> Tuple[str, str, int]:
-        self.calls.append(command)
-        import shlex
+    def _is_dir(self, target: str) -> bool:
+        """Return True when any fake file lives under *target*."""
+        return any(f.startswith(target.rstrip("/") + "/") for f in self.fs)
 
-        parts = shlex.split(command)
-        if len(parts) >= 3 and parts[0] == "test":
+    async def run(self, command: str, timeout: float = 30.0) -> tuple[str, str, int]:
+        """Answer one session command against the in-memory filesystem."""
+        self.calls.append(command)
+        try:
+            tokens = shlex.split(command)
+        except ValueError:
+            return ("", "", 1)
+        # Truncate at a bare pipe (e.g. the "| head -N" suffix); note the
+        # regex pattern itself may contain quoted pipes, hence shlex first.
+        if "|" in tokens:
+            tokens = tokens[: tokens.index("|")]
+        parts = [t for t in tokens if not t.startswith("2>")]
+        if not parts:
+            return ("", "", 1)
+
+        if parts[0] == "test" and len(parts) >= 3:
+            flag, target = parts[1], parts[-1]
+            if flag == "-e":
+                ok = target in self.fs or self._is_dir(target)
+            elif flag == "-f":
+                ok = target in self.fs
+            elif flag == "-d":
+                ok = self._is_dir(target)
+            else:
+                ok = False
+            return ("", "", 0 if ok else 1)
+
+        if parts[0] == "command":
+            return ("", "", 0 if self.has_rg else 1)
+
+        if parts[0] == "base64":
             target = parts[-1]
-            if parts[1] == "-e":
-                return ("", "", 0 if target in self.existing else 1)
-            if parts[1] == "-f":
-                return ("", "", 0 if target in self.files else 1)
+            if target in self.fs:
+                return (base64.b64encode(self.fs[target].encode()).decode(), "", 0)
+            return ("", "", 1)
+
+        if parts[0] == "rg" and "--files" in parts:
+            root = parts[parts.index("--files") + 1]
+            files = sorted(f for f in self.fs if f.startswith(root))
+            return ("\n".join(files), "", 0 if files else 1)
+
+        if parts[0] == "find":
+            root = parts[1]
+            files = sorted(f for f in self.fs if f.startswith(root))
+            return ("\n".join(files), "", 0 if files else 1)
+
+        if parts[0] in ("rg", "grep"):
+            pattern: str | None = None
+            path: str | None = None
+            for tok in parts[1:]:
+                if tok.startswith("-") or tok.startswith("2>") or tok == "/dev/null":
+                    continue
+                if pattern is None:
+                    pattern = tok
+                else:
+                    path = tok
+            out: list[str] = []
+            if pattern:
+                for f in sorted(self.fs):
+                    if path and not f.startswith(path):
+                        continue
+                    for i, line in enumerate(self.fs[f].splitlines(), 1):
+                        try:
+                            if _re.search(pattern, line, _re.IGNORECASE):
+                                out.append(f"{f}:{i}:{line}")
+                        except _re.error:
+                            continue
+            return ("\n".join(out), "", 0 if out else 1)
+
         return ("", "", 1)
+
+
+FS = {
+    "/app/mod.py": "def handler():\n    pass\n\n\nclass Widget:\n    def run(self):\n        pass\n",
+    "/app/caller.py": "from mod import handler\n\nhandler()\n",
+}
 
 
 @pytest.mark.asyncio
 async def test_symbols_probes_paths_via_session_when_wired() -> None:
-    # Root is a container path that does NOT exist on the host.
-    session = _FakeSession(existing={"/app"}, files=set())
+    """symbols() must probe existence through the session, not the host."""
+    session = FakeSession(FS)
     repo = RepoTools(root="/app", session=session)  # type: ignore[arg-type]
 
-    # symbols(".") must probe "." via the session, not the host filesystem.
     result = await repo.symbols(".")
 
-    assert any("test -e" in c for c in session.calls), session.calls
-    # The result is NOT a path-resolution failure: the session saw /app.
+    assert any(c.startswith("test -e") for c in session.calls), session.calls
     assert result.diagnostic is None
 
 
 @pytest.mark.asyncio
 async def test_symbols_reports_diagnostic_when_session_says_missing() -> None:
-    session = _FakeSession(existing=set(), files=set())
+    """A session-reported missing path still yields a structured diagnostic."""
+    session = FakeSession({})
     repo = RepoTools(root="/app", session=session)  # type: ignore[arg-type]
 
     result = await repo.symbols("missing/pkg")
@@ -66,17 +142,19 @@ async def test_symbols_reports_diagnostic_when_session_says_missing() -> None:
 
 @pytest.mark.asyncio
 async def test_refs_probes_paths_via_session_when_wired() -> None:
-    session = _FakeSession(existing={"/app/src"}, files=set())
+    """refs() must probe existence through the session, not the host."""
+    session = FakeSession(FS)
     repo = RepoTools(root="/app", session=session)  # type: ignore[arg-type]
 
-    result = await repo.refs("handler", path="/app/src")
+    result = await repo.refs("handler", path="/app")
 
-    assert any("test -e" in c for c in session.calls), session.calls
+    assert any(c.startswith("test -e") for c in session.calls), session.calls
     assert result.diagnostic is None
 
 
 @pytest.mark.asyncio
 async def test_host_fallback_still_works_without_session(tmp_path: Path) -> None:
+    """Without a session, validation stays host-side and unchanged."""
     repo = RepoTools(root=tmp_path)
 
     result = await repo.symbols("missing/package")
@@ -87,11 +165,83 @@ async def test_host_fallback_still_works_without_session(tmp_path: Path) -> None
 
 @pytest.mark.asyncio
 async def test_file_probe_uses_session_when_wired() -> None:
-    session = _FakeSession(existing={"/app/a.py"}, files={"/app/a.py"})
+    """The existence and file probes route through the wired session."""
+    session = FakeSession(FS)
     repo = RepoTools(root="/app", session=session)  # type: ignore[arg-type]
 
-    # Direct probe helpers.
-    assert await repo._path_exists(Path("/app/a.py")) is True
-    assert await repo._path_is_file(Path("/app/a.py")) is True
+    assert await repo._path_exists(Path("/app/mod.py")) is True
+    assert await repo._path_is_file(Path("/app/mod.py")) is True
     assert await repo._path_exists(Path("/app/missing.py")) is False
-    assert any("test -f" in c for c in session.calls), session.calls
+    assert any(c.startswith("test -f") for c in session.calls), session.calls
+
+
+@pytest.mark.asyncio
+async def test_symbols_file_reads_session_only_content() -> None:
+    """A session-only file yields symbols and anchors with real content."""
+    session = FakeSession(FS)
+    repo = RepoTools(root="/app", session=session)  # type: ignore[arg-type]
+
+    result = await repo.symbols("/app/mod.py")
+
+    assert result.diagnostic is None
+    assert result.matches, "expected symbol anchors from session content"
+    assert "def handler" in result.text
+    # Anchors carry the session-fetched line content, not empty host reads.
+    assert any("handler" in anchor.text for anchor in result.matches)
+
+
+@pytest.mark.asyncio
+async def test_symbols_search_returns_session_only_results() -> None:
+    """A definition search over session-only files returns matches and anchors."""
+    session = FakeSession(FS)
+    repo = RepoTools(root="/app", session=session)  # type: ignore[arg-type]
+
+    result = await repo.symbols(".", query="handler")
+
+    assert result.diagnostic is None
+    assert result.total_matches >= 1
+    assert result.matches, "expected anchors built from session search results"
+
+
+@pytest.mark.asyncio
+async def test_refs_returns_session_only_results() -> None:
+    """Reference search over session-only files returns matches and anchors."""
+    session = FakeSession(FS)
+    repo = RepoTools(root="/app", session=session)  # type: ignore[arg-type]
+
+    result = await repo.refs("handler", path="/app")
+
+    assert result.diagnostic is None
+    assert result.total_matches >= 1
+    # The call site in caller.py must appear with content from the session.
+    assert any("handler" in line for line in result.lines)
+
+
+@pytest.mark.asyncio
+async def test_repo_map_lists_session_files_without_rg() -> None:
+    """repo_map falls back to find() when the session image lacks rg."""
+    session = FakeSession(FS, has_rg=False)
+    repo = RepoTools(root="/app", session=session)  # type: ignore[arg-type]
+
+    result = await repo._repo_map()
+
+    assert any("mod.py" in section for section in result.summary.splitlines())
+    assert any(c.startswith("find") for c in session.calls), session.calls
+
+
+@pytest.mark.asyncio
+async def test_missing_path_diagnostic_is_not_found_on_host_collision(tmp_path: Path) -> None:
+    """A path existing on the host but not in the session reports PATH_NOT_FOUND.
+
+    Without the explicit ``reason`` the error would infer from the host
+    filesystem and misclassify this collision as PATH_NOT_FILE.
+    """
+    (tmp_path / "pkg").mkdir()
+    session = FakeSession({})  # session sees nothing under the root
+    repo = RepoTools(root=tmp_path, session=session)  # type: ignore[arg-type]
+
+    result = await repo.symbols("pkg")
+
+    assert result.diagnostic is not None
+    assert result.diagnostic.code == "PATH_NOT_FOUND"  # type: ignore[attr-defined]
+    assert result.diagnostic.reason == "not_found"  # type: ignore[attr-defined]


### PR DESCRIPTION
### What

`RepoTools.symbols()`/`refs()` validated their path argument with a host-side `Path.exists()`/`is_file()` probe. When a shared session is wired — e.g. the NeMo Gym adapter constructs `RepoTools(root=<container path>, session=sandbox_session)` for a seeded sandbox — the repo root lives in the session's filesystem, so the host probe wrongly reports valid paths as missing and every call returns a `PATH_NOT_FOUND` diagnostic instead of searching. Search execution was already session-backed (`rg` via `self._session.run(...)`); only the entry validation was host-side.

### Change

Two small helpers on `RepoTools`:
- `_path_exists(resolved)` — probes `test -e` through the wired session when one exists, falls back to host `Path.exists()`.
- `_path_is_file(resolved)` — same shape with `test -f` / `Path.is_file()`.

`symbols()` and `refs()` use these instead of the direct host probes. No behavior change without a session.

### Evidence

Found live in SWE-bench Pro Gym rollouts (`nooa_swebench_pro`): the agent's `self.repo` is wired to a seeded sandbox at `/app`, which does not exist on the host. The agent didn't call repo tools in those runs (CodeAct leans on shell/read/replace), so it never fired — but the wiring gap is real and one model decision away from confusing `PATH_NOT_FOUND` output.

### Testing

New `packages/nooa-cli/tests/test_repo_tools_session_paths.py` (5 tests): probes route through the session; diagnostics still fire when the session reports the path missing; host fallback unchanged. Plus the existing `test_repo_tools_diagnostics.py` suite (3 tests) — 8/8 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository processing for remote or session-based environments, including symbol extraction, reference searches, repository maps, and anchors.
  * Added support for session-only files and directories through content-based reads and search fallbacks.
  * Restricted syntax-aware reference searches to local filesystem operation.
  * Missing paths now return consistent not-found results across session and local filesystem checks.
  * Preserved local filesystem support when no shared session is available.

* **Tests**
  * Expanded coverage for session-based repository processing and local filesystem fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->